### PR TITLE
feat: add handoff artifact generation for session persistence

### DIFF
--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -445,6 +445,46 @@ List every ASCII diagram in files this plan touches. Still accurate?
 ### Unresolved Decisions
 If any AskUserQuestion goes unanswered, note it here. Never silently default.
 
+## Handoff Artifact Generation (Automatic)
+Before concluding the review, ALWAYS generate a comprehensive handoff artifact that persists the full analysis context for future sessions.
+
+### Artifact Files to Generate
+Create the following files in the project root:
+
+1. **`REVIEW_ARTIFACT.md`** - Full markdown report containing:
+   - Executive summary of the review
+   - All section findings (Architecture, Error Map, Security, etc.)
+   - Key decisions made
+   - Unresolved questions
+   - TODOs and deferred items
+   - Diagrams (as ASCII art)
+
+2. **`REVIEW_CONTEXT.json`** - Machine-readable context containing:
+   - Review mode (EXPANSION/HOLD/REDUCTION)
+   - Critical findings by category
+   - File paths referenced
+   - Action items with priority
+
+### When to Generate
+Run this automatically at the very end of the review, after Section 10 and before concluding. Use Bash to write these files.
+
+### Example Artifact Header
+```markdown
+# Review Handoff Artifact
+Generated: [timestamp]
+Mode: [EXPANSION|HOLD|REDUCTION]
+Reviewer: gstack plan-ceo-review
+
+## Executive Summary
+[2-3 sentence overview of the review outcome]
+
+## Critical Findings
+- [category]: [finding]
+
+## Next Steps
+- [ ] [action item]
+```
+
 ## Formatting Rules
 * NUMBER issues (1, 2, 3...) and LETTERS for options (A, B, C...).
 * Label with NUMBER + LETTER (e.g., "3A", "3B").

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -160,3 +160,43 @@ Check the git log for this branch. If there are prior commits suggesting a previ
 
 ## Unresolved decisions
 If the user does not respond to an AskUserQuestion or interrupts to move on, note which decisions were left unresolved. At the end of the review, list these as "Unresolved decisions that may bite you later" — never silently default to an option.
+
+## Handoff Artifact Generation (Automatic)
+Before concluding the review, ALWAYS generate a comprehensive handoff artifact that persists the full analysis context for future sessions.
+
+### Artifact Files to Generate
+Create the following files in the project root:
+
+1. **`REVIEW_ARTIFACT.md`** - Full markdown report containing:
+   - Executive summary of the review
+   - All section findings (Architecture, Code Quality, Tests, Performance, etc.)
+   - Key decisions made
+   - Unresolved questions
+   - TODOs and deferred items
+   - Diagrams (as ASCII art)
+
+2. **`REVIEW_CONTEXT.json`** - Machine-readable context containing:
+   - Review type (engineering)
+   - Critical findings by category
+   - File paths referenced
+   - Action items with priority
+
+### When to Generate
+Run this automatically at the very end of the review, after the completion summary and before concluding. Use Bash to write these files.
+
+### Example Artifact Header
+```markdown
+# Engineering Review Handoff Artifact
+Generated: [timestamp]
+Type: Engineering Review
+Reviewer: gstack plan-eng-review
+
+## Executive Summary
+[2-3 sentence overview of the review outcome]
+
+## Critical Findings
+- [category]: [finding]
+
+## Next Steps
+- [ ] [action item]
+```


### PR DESCRIPTION
## Summary
This PR adds automatic handoff artifact generation to solve issue #6 - persisting review context between sessions.

## Changes
- Add `REVIEW_ARTIFACT.md` generation to `plan-ceo-review` SKILL
- Add `REVIEW_CONTEXT.json` generation to `plan-ceo-review` SKILL  
- Add same artifact generation to `plan-eng-review` SKILL
- Artifacts capture full review context including:
  - Executive summary
  - All section findings
  - Key decisions
  - Unresolved questions
  - TODOs and deferred items
  - Diagrams

## Why This Helps
Currently, after running `/plan-ceo-review` or `/plan-eng-review`, only a short TODO.md remains. When the session is cleared, all the detailed analysis is lost. This PR adds automatic artifact generation that saves a comprehensive report before the review concludes, so future sessions can load the full context.

Fixes #6