### PR TITLE
Default browse skill to Sonnet to save tokens

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -7,6 +7,7 @@ description: |
   inspect CSS/DOM, capture console/network logs, and more. ~100ms per command after
   first call. Use when you need to check a website, verify a deployment, read docs,
   or interact with any web page. No MCP, no Chrome extension — just fast CLI.
+model: sonnet
 allowed-tools:
   - Bash
   - Read

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -7,6 +7,7 @@ description: |
   inspect CSS/DOM, capture console/network logs, and more. ~100ms per command after
   first call. Use when you need to check a website, verify a deployment, read docs,
   or interact with any web page. No MCP, no Chrome extension — just fast CLI.
+model: sonnet
 allowed-tools:
   - Bash
   - Read


### PR DESCRIPTION
## Summary
- Adds `model: sonnet` to `browse/SKILL.md` and root `SKILL.md` frontmatter
- The browse skill only orchestrates CLI commands (goto, click, screenshot) — no heavy reasoning needed, so Sonnet is more than sufficient
- Prevents burning Opus tokens on simple browsing tasks

Closes #8

## Test plan
- [ ] Run `/browse` and verify it uses Sonnet instead of the user default model
- [ ] Confirm multi-step browse flows (navigate, snapshot, click, screenshot) still work correctly with Sonnet

Generated with [Claude Code](https://claude.com/claude-code)