### PR TITLE
Security: Redact sensitive values from command output

### DIFF
--- a/browse/src/read-commands.ts
+++ b/browse/src/read-commands.ts
@@ -65,7 +65,7 @@ export async function handleReadCommand(
               id: input.id || undefined,
               placeholder: input.placeholder || undefined,
               required: input.required || undefined,
-              value: input.value || undefined,
+              value: input.type === 'password' ? '[redacted]' : (input.value || undefined),
               options: el.tagName === 'SELECT'
                 ? [...(el as HTMLSelectElement).options].map(o => ({ value: o.value, text: o.text }))
                 : undefined,
@@ -184,7 +184,7 @@ export async function handleReadCommand(
         const key = args[1];
         const value = args[2] || '';
         await page.evaluate(([k, v]) => localStorage.setItem(k, v), [key, value]);
-        return `Set localStorage["${key}"] = "${value}"`;
+        return `Set localStorage["${key}"]`;
       }
       const storage = await page.evaluate(() => ({
         localStorage: { ...localStorage },

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -94,7 +94,7 @@ export async function handleWriteCommand(
       const text = args.join(' ');
       if (!text) throw new Error('Usage: browse type <text>');
       await page.keyboard.type(text);
-      return `Typed "${text}"`;
+      return `Typed ${text.length} characters`;
     }
 
     case 'press': {
@@ -153,7 +153,7 @@ export async function handleWriteCommand(
         domain: url.hostname,
         path: '/',
       }]);
-      return `Cookie set: ${name}=${value}`;
+      return `Cookie set: ${name}=****`;
     }
 
     case 'header': {
@@ -163,7 +163,9 @@ export async function handleWriteCommand(
       const name = headerStr.slice(0, sep).trim();
       const value = headerStr.slice(sep + 1).trim();
       await bm.setExtraHeader(name, value);
-      return `Header set: ${name}: ${value}`;
+      const sensitiveHeaders = ['authorization', 'cookie', 'set-cookie', 'x-api-key', 'x-auth-token'];
+      const redactedValue = sensitiveHeaders.includes(name.toLowerCase()) ? '****' : value;
+      return `Header set: ${name}: ${redactedValue}`;
     }
 
     case 'useragent': {


### PR DESCRIPTION
## Summary

- **`type` command**: No longer echoes typed text; reports character count instead (`Typed 12 characters`)
- **`cookie` command**: Redacts cookie value in output (`Cookie set: name=****`)
- **`header` command**: Redacts values for sensitive headers (Authorization, Cookie, Set-Cookie, X-API-Key, X-Auth-Token); non-sensitive headers remain visible
- **`forms` command**: Replaces password field values with `[redacted]` instead of dumping actual values
- **`storage set` command**: Drops the value from the confirmation message

## Why

In an LLM-agent context, command output is fed back into model context and persisted in logs/transcripts. Commands like `type`, `cookie`, and `header` were reflecting secrets (passwords, auth tokens, API keys) directly into stdout, creating a security risk.

Fixes #18

## Test plan

- [ ] Run `browse type <password>` and verify output says `Typed N characters` without echoing the text
- [ ] Run `browse cookie session=secret123` and verify output shows `Cookie set: session=****`
- [ ] Run `browse header Authorization:Bearer token123` and verify output shows `Header set: Authorization: ****`
- [ ] Run `browse header Content-Type:application/json` and verify non-sensitive header value is still shown
- [ ] Load a page with a password form field via `browse forms` and verify password values show `[redacted]`
- [ ] Run `browse storage set key value` and verify output shows `Set localStorage["key"]` without the value

🤖 Generated with [Claude Code](https://claude.com/claude-code)