### PR TITLE
Fix browse setup when Playwright Chromium is missing

### DIFF
--- a/BROWSER.md
+++ b/BROWSER.md
@@ -152,7 +152,7 @@ The browser automation layer is built on [Playwright](https://playwright.dev/) b
 ### Prerequisites
 
 - [Bun](https://bun.sh/) v1.0+
-- Playwright's Chromium (installed automatically by `bun install`)
+- Playwright's Chromium (installed by `./setup`, or manually via `bunx playwright install chromium`)
 
 ### Quick start
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This is not a prompt pack for beginners. It is an operating system for people wh
 
 ## Install
 
-**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+. `/browse` compiles a native binary — works on macOS and Linux (x64 and arm64).
+**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+. `/browse` compiles a native binary and `./setup` installs Playwright Chromium — works on macOS and Linux (x64 and arm64).
 
 ### Step 1: Install on your machine
 
@@ -95,6 +95,7 @@ Real files get committed to your repo (not a submodule), so `git clone` just wor
 - Skill files (Markdown prompts) in `~/.claude/skills/gstack/` (or `.claude/skills/gstack/` for project installs)
 - Symlinks at `~/.claude/skills/browse`, `~/.claude/skills/review`, etc. pointing into the gstack directory
 - Browser binary at `browse/dist/browse` (~58MB, gitignored)
+- Playwright Chromium (installed by `./setup` if missing)
 - `node_modules/` (gitignored)
 - `/retro` saves JSON snapshots to `.context/retros/` in your project for trend tracking
 

--- a/setup
+++ b/setup
@@ -6,6 +6,13 @@ GSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$(dirname "$GSTACK_DIR")"
 BROWSE_BIN="$GSTACK_DIR/browse/dist/browse"
 
+ensure_playwright_browser() {
+  (
+    cd "$GSTACK_DIR"
+    bun --eval 'import { chromium } from "playwright"; const browser = await chromium.launch(); await browser.close();'
+  ) >/dev/null 2>&1
+}
+
 # 1. Build browse binary if needed
 NEEDS_BUILD=0
 if [ ! -x "$BROWSE_BIN" ]; then
@@ -32,7 +39,21 @@ if [ ! -x "$BROWSE_BIN" ]; then
   exit 1
 fi
 
-# 2. Only create skill symlinks if we're inside a .claude/skills directory
+# 2. Ensure Playwright's Chromium is available for the browser daemon
+if ! ensure_playwright_browser; then
+  echo "Installing Playwright Chromium..."
+  (
+    cd "$GSTACK_DIR"
+    bunx playwright install chromium
+  )
+fi
+
+if ! ensure_playwright_browser; then
+  echo "gstack setup failed: Playwright Chromium could not be launched" >&2
+  exit 1
+fi
+
+# 3. Only create skill symlinks if we're inside a .claude/skills directory
 SKILLS_BASENAME="$(basename "$SKILLS_DIR")"
 if [ "$SKILLS_BASENAME" = "skills" ]; then
   linked=()


### PR DESCRIPTION
## Summary
- make `./setup` verify that Playwright Chromium can actually launch
- install Chromium automatically if the browser runtime is missing
- update the install docs to match the new setup behavior

## Why
On a clean install, `./setup` can succeed after compiling `browse`, but the first `browse` command can still fail because the Playwright browser binaries were never downloaded.

I reproduced it by running `./setup` with an empty `PLAYWRIGHT_BROWSERS_PATH`, then calling `browse/dist/browse goto https://example.com`. `setup` exited successfully, but `browse` failed with `Executable doesn't exist ... chrome-headless-shell`.

This patch makes `./setup` act like a reliable one-shot installer for `/browse`, which is what the README already suggests.

## Verification
- `bun test`
- clean temp clone with empty `PLAYWRIGHT_BROWSERS_PATH`:
  - `./setup`
  - `browse/dist/browse goto https://example.com`
  - `browse/dist/browse text`