### PR TITLE
fix(cookie-picker): pass port explicitly to jsonResponse and errorResponse

### DIFF
--- a/browse/src/cookie-picker-routes.ts
+++ b/browse/src/cookie-picker-routes.ts
@@ -26,18 +26,18 @@ const importedCounts = new Map<string, number>();
 
 // ─── JSON Helpers ───────────────────────────────────────────────
 
-function jsonResponse(data: any, status = 200): Response {
+function jsonResponse(data: any, port: number, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
     headers: {
       'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': `http://127.0.0.1:${parseInt(url.port, 10) || 9400}`,
+      'Access-Control-Allow-Origin': `http://127.0.0.1:${port}`,
     },
   });
 }
 
-function errorResponse(message: string, code: string, status = 400, action?: string): Response {
-  return jsonResponse({ error: message, code, ...(action ? { action } : {}) }, status);
+function errorResponse(message: string, code: string, port: number, status = 400, action?: string): Response {
+  return jsonResponse({ error: message, code, ...(action ? { action } : {}) }, port, status);
 }
 
 // ─── Route Handler ──────────────────────────────────────────────
@@ -47,6 +47,7 @@ export async function handleCookiePickerRoute(
   req: Request,
   bm: BrowserManager,
 ): Promise<Response> {
+  const port = parseInt(url.port, 10) || 9400;
   const pathname = url.pathname;
 
   // CORS preflight
@@ -54,7 +55,7 @@ export async function handleCookiePickerRoute(
     return new Response(null, {
       status: 204,
       headers: {
-        'Access-Control-Allow-Origin': `http://127.0.0.1:${parseInt(url.port, 10) || 9400}`,
+        'Access-Control-Allow-Origin': `http://127.0.0.1:${port}`,
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
         'Access-Control-Allow-Headers': 'Content-Type',
       },
@@ -64,7 +65,6 @@ export async function handleCookiePickerRoute(
   try {
     // GET /cookie-picker — serve the picker UI
     if (pathname === '/cookie-picker' && req.method === 'GET') {
-      const port = parseInt(url.port, 10) || 9400;
       const html = getCookiePickerHTML(port);
       return new Response(html, {
         status: 200,
@@ -80,20 +80,20 @@ export async function handleCookiePickerRoute(
           name: b.name,
           aliases: b.aliases,
         })),
-      });
+      }, port);
     }
 
     // GET /cookie-picker/domains?browser=<name> — list domains + counts
     if (pathname === '/cookie-picker/domains' && req.method === 'GET') {
       const browserName = url.searchParams.get('browser');
       if (!browserName) {
-        return errorResponse("Missing 'browser' parameter", 'missing_param');
+        return errorResponse("Missing 'browser' parameter", 'missing_param', port);
       }
       const result = listDomains(browserName);
       return jsonResponse({
         browser: result.browser,
         domains: result.domains,
-      });
+      }, port);
     }
 
     // POST /cookie-picker/import — decrypt + import to Playwright session
@@ -102,13 +102,13 @@ export async function handleCookiePickerRoute(
       try {
         body = await req.json();
       } catch {
-        return errorResponse('Invalid JSON body', 'bad_request');
+        return errorResponse('Invalid JSON body', 'bad_request', port);
       }
 
       const { browser, domains } = body;
-      if (!browser) return errorResponse("Missing 'browser' field", 'missing_param');
+      if (!browser) return errorResponse("Missing 'browser' field", 'missing_param', port);
       if (!domains || !Array.isArray(domains) || domains.length === 0) {
-        return errorResponse("Missing or empty 'domains' array", 'missing_param');
+        return errorResponse("Missing or empty 'domains' array", 'missing_param', port);
       }
 
       // Decrypt cookies from the browser DB
@@ -122,7 +122,7 @@ export async function handleCookiePickerRoute(
           message: result.failed > 0
             ? `All ${result.failed} cookies failed to decrypt`
             : 'No cookies found for the specified domains',
-        });
+        }, port);
       }
 
       // Add to Playwright context
@@ -141,7 +141,7 @@ export async function handleCookiePickerRoute(
         imported: result.count,
         failed: result.failed,
         domainCounts: result.domainCounts,
-      });
+      }, port);
     }
 
     // POST /cookie-picker/remove — clear cookies for domains
@@ -150,12 +150,12 @@ export async function handleCookiePickerRoute(
       try {
         body = await req.json();
       } catch {
-        return errorResponse('Invalid JSON body', 'bad_request');
+        return errorResponse('Invalid JSON body', 'bad_request', port);
       }
 
       const { domains } = body;
       if (!domains || !Array.isArray(domains) || domains.length === 0) {
-        return errorResponse("Missing or empty 'domains' array", 'missing_param');
+        return errorResponse("Missing or empty 'domains' array", 'missing_param', port);
       }
 
       const page = bm.getPage();
@@ -171,7 +171,7 @@ export async function handleCookiePickerRoute(
       return jsonResponse({
         removed: domains.length,
         domains,
-      });
+      }, port);
     }
 
     // GET /cookie-picker/imported — currently imported domains + counts
@@ -186,15 +186,15 @@ export async function handleCookiePickerRoute(
         domains: entries,
         totalDomains: entries.length,
         totalCookies: entries.reduce((sum, e) => sum + e.count, 0),
-      });
+      }, port);
     }
 
     return new Response('Not found', { status: 404 });
   } catch (err: any) {
     if (err instanceof CookieImportError) {
-      return errorResponse(err.message, err.code, 400, err.action);
+      return errorResponse(err.message, err.code, port, 400, err.action);
     }
     console.error(`[cookie-picker] Error: ${err.message}`);
-    return errorResponse(err.message || 'Internal error', 'internal_error', 500);
+    return errorResponse(err.message || 'Internal error', 'internal_error', port, 500);
   }
 }


### PR DESCRIPTION
## Bug

The cookie picker API routes fail with `ReferenceError: url is not defined` because the `jsonResponse()` and `errorResponse()` helper functions reference `url` which is not in their scope - it only exists as a parameter in `handleCookiePickerRoute()`.

Every API call (`/cookie-picker/browsers`, `/domains`, `/import`, `/remove`, `/imported`) throws `ReferenceError`.

## Fix

Extract `port` at the top of `handleCookiePickerRoute()` and pass it explicitly to all `jsonResponse()` and `errorResponse()` calls.

Fixes #32