### PR TITLE
fix: setup creates skill symlinks when gstack is symlinked from dev checkout

### DIFF
--- a/setup
+++ b/setup
@@ -57,8 +57,21 @@ if ! ensure_playwright_browser; then
   exit 1
 fi
 
-# 3. Only create skill symlinks if we're inside a .claude/skills directory
+# 3. Create skill symlinks in ~/.claude/skills/
+# Resolve SKILLS_DIR: either we're directly inside .claude/skills/, or a symlink
+# in .claude/skills/ points to us (e.g., dev checkout symlinked in).
 SKILLS_BASENAME="$(basename "$SKILLS_DIR")"
+if [ "$SKILLS_BASENAME" != "skills" ]; then
+  # Check if ~/.claude/skills/gstack is a symlink pointing to us
+  CANDIDATE="$HOME/.claude/skills"
+  if [ -L "$CANDIDATE/gstack" ]; then
+    LINK_TARGET="$(cd "$CANDIDATE/gstack" 2>/dev/null && pwd -P)"
+    if [ "$LINK_TARGET" = "$GSTACK_DIR" ]; then
+      SKILLS_DIR="$CANDIDATE"
+      SKILLS_BASENAME="skills"
+    fi
+  fi
+fi
 if [ "$SKILLS_BASENAME" = "skills" ]; then
   linked=()
   for skill_dir in "$GSTACK_DIR"/*/; do


### PR DESCRIPTION
## Summary
- When `~/.claude/skills/gstack` is a symlink to a dev checkout, the setup script resolved `GSTACK_DIR` to the real path, making `SKILLS_DIR` point to the workspace parent instead of `~/.claude/skills/`
- This caused newer skills (`gstack-upgrade`, `qa`, `setup-browser-cookies`) to never get symlinked, so they weren't discoverable by Claude Code
- Fix: detect when `~/.claude/skills/gstack` is a symlink pointing back to us, and create symlinks there

## Test plan
- [x] Verified `bash setup` from dev checkout now outputs `linked skills: browse gstack-upgrade plan-ceo-review plan-eng-review qa retro review setup-browser-cookies ship`
- [x] Verified symlinks created correctly in `~/.claude/skills/`
- [ ] Verify setup still works when gstack is cloned directly into `~/.claude/skills/` (non-symlink case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)