### PR TITLE
feat(plan): add pre-flight check for duplicate upstream PRs and Issues

### DIFF
--- a/bin/gstack-check-duplicates
+++ b/bin/gstack-check-duplicates
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo "=== Recent Open Pull Requests ==="
+if command -v gh >/dev/null 2>&1; then
+  gh pr list --state open --limit 10 || echo "(Failed to fetch PRs. Are you logged in with 'gh auth login'?)"
+else
+  echo "(GitHub CLI 'gh' not installed. Skipping PR check.)"
+fi
+
+echo ""
+echo "=== Recent Open Issues ==="
+if command -v gh >/dev/null 2>&1; then
+  gh issue list --state open --limit 10 || echo "(Failed to fetch Issues. Are you logged in with 'gh auth login'?)"
+else
+  echo "(GitHub CLI 'gh' not installed. Skipping Issue check.)"
+fi

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -65,11 +65,12 @@ Never skip Step 0, the system audit, the error/rescue map, or the failure modes 
 ## PRE-REVIEW SYSTEM AUDIT (before Step 0)
 Before doing anything else, run a system audit. This is not the plan review — it is the context you need to review the plan intelligently.
 Run the following commands:
-```
+```bash
 git log --oneline -30                          # Recent history
 git diff main --stat                           # What's already changed
 git stash list                                 # Any stashed work
 grep -r "TODO\|FIXME\|HACK\|XXX" --include="*.rb" --include="*.js" -l
+~/.claude/skills/gstack/bin/gstack-check-duplicates   # Check for existing PRs and Issues
 find . -name "*.rb" -newer Gemfile.lock | head -20  # Recently touched files
 ```
 Then read CLAUDE.md, TODOS.md, and any existing architecture docs. Map:

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -44,6 +44,13 @@ If you are running low on context or the user asks you to compress: Step 0 > Tes
 
 ## BEFORE YOU START:
 
+### PRE-REVIEW SYSTEM AUDIT (before Step 0)
+Run this command to check for existing Pull Requests and Issues:
+```bash
+~/.claude/skills/gstack/bin/gstack-check-duplicates
+```
+Check the output to ensure this plan does not duplicate work that is already being handled elsewhere.
+
 ### Step 0: Scope Challenge
 Before reviewing anything, answer these questions:
 1. **What existing code already partially or fully solves each sub-problem?** Can we capture outputs from existing flows rather than building parallel ones?


### PR DESCRIPTION
## Summary
- Added a new [gstack-check-duplicates](/gstack/bin/gstack-check-duplicates:0:0-0:0) command that uses the GitHub CLI to list recent open Pull Requests and Issues on the upstream repository.
- Integrated the command into the PRE-REVIEW SYSTEM AUDIT phase of both the CEO and Engineering plan review skills.
- Agents now automatically check for overlapping work before writing a new spec.
- Gracefully handles cases where the GitHub CLI is not installed or not authenticated.
## Test plan
- [x] Verified the command lists open PRs and Issues when the GitHub CLI is authenticated.
- [x] Verified the command prints a helpful fallback message when the GitHub CLI is not installed.
- [x] Verified the command prints a helpful fallback message when not authenticated.
🤖 Authored via Spec-Driven Development