### PR TITLE
fix(browse): default to sonnet model to save tokens

### DIFF
--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: browse
 version: 1.1.0
+model: sonnet
 description: |
   Fast headless browser for QA testing and site dogfooding. Navigate any URL, interact with
   elements, verify page state, diff before/after actions, take annotated screenshots, check

--- a/browse/SKILL.md.tmpl
+++ b/browse/SKILL.md.tmpl
@@ -1,6 +1,7 @@
 ---
 name: browse
 version: 1.1.0
+model: sonnet
 description: |
   Fast headless browser for QA testing and site dogfooding. Navigate any URL, interact with
   elements, verify page state, diff before/after actions, take annotated screenshots, check


### PR DESCRIPTION
## Summary

- Adds `model: sonnet` to the `/browse` skill frontmatter (both template and generated SKILL.md)
- The browse skill orchestrates headless browser CLI commands — no complex reasoning required. Without an explicit model, it defaults to the user's active model (usually Opus), burning expensive tokens unnecessarily.
- Sonnet handles this equally well at a fraction of the cost, especially for multi-step flows (navigate, click, extract, repeat).

Closes #8

## Test plan

- [x] `bun run gen:skill-docs --dry-run` — all SKILL.md files FRESH (CI check passes)
- [x] `bun test test/skill-validation.test.ts test/gen-skill-docs.test.ts` — 66/66 pass
- [x] Manual: invoke `/browse` and verify it runs on Sonnet (check model in `--verbose` output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)