### PR TITLE
fix(browse): use CDP websocket fallback on Windows

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -42,7 +42,18 @@ export class BrowserManager {
   private dialogPromptText: string | null = null;
 
   async launch() {
-    this.browser = await chromium.launch({ headless: true });
+    const isWindows = process.platform === 'win32';
+
+    if (isWindows) {
+      // Bun's pipe transport hangs on Windows (garrytan/gstack#77).
+      // Use websocket transport instead of the default pipe.
+      this.browser = await chromium.launch({
+        headless: true,
+        args: ['--remote-debugging-port=0'],
+      });
+    } else {
+      this.browser = await chromium.launch({ headless: true });
+    }
 
     // Chromium crash → exit with clear message
     this.browser.on('disconnected', () => {


### PR DESCRIPTION
## Summary

- Detects Windows (`process.platform === 'win32'`) in `browser-manager.ts` and launches Chromium with `--remote-debugging-port=0` to use websocket transport instead of the default pipe transport
- macOS and Linux behavior is unchanged - only Windows gets the fallback

Fixes #77. Bun's child process pipe implementation does not work with Playwright's `--remote-debugging-pipe` on Windows. Chromium launches but the DevTools Protocol pipe never connects, causing an indefinite hang. This adds a platform check that uses websocket transport on Windows, bypassing the broken pipe.

## Test plan

- [ ] Verify `bun test` passes on macOS/Linux (no regression)
- [ ] Verify `browse goto https://example.com` no longer hangs on Windows
- [ ] Verify `isHealthy()` works with CDP-connected browser
- [ ] Verify `recreateContext()` saves/restores state correctly
- [ ] Verify idle timeout shutdown works with CDP connection