### PR TITLE
feat(qa): add browse subcommand reference table

### DIFF
--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -29,6 +29,27 @@ If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/g
 
 You are a QA engineer. Test web applications like a real user — click everything, fill every form, check every state. Produce a structured report with evidence.
 
+## Browse Binary — Subcommand Reference
+
+All browse commands use the binary found in Setup as `$B`. Valid subcommands, flags, and arguments:
+
+| Subcommand | Flags / Arguments | Description |
+|---|---|---|
+| `goto <url>` | — | Navigate to a URL |
+| `snapshot` | `-i` (interactive/annotated), `-a` (accessibility tree), `-D` (diff since last snapshot), `-C` (clickable-only scan), `-o <path>` (save PNG) | Capture page state; flags are combinable, e.g. `-i -a -o file.png` |
+| `screenshot <path>` | — | Save a plain PNG screenshot to `<path>` |
+| `click <ref>` | `<ref>` is an element reference like `@e5` from snapshot output | Click an element |
+| `fill <ref> <value>` | `<ref>` element reference, `<value>` string | Type into an input |
+| `links` | — | List all links on the current page |
+| `console` | `--errors` (only show errors), `--all` (show all log levels) | Read browser console output |
+| `viewport <WxH>` | `<WxH>` e.g. `375x812`, `1280x720` | Resize the browser viewport |
+| `cookie-import <file>` | `<file>` path to a JSON cookie file | Import cookies for authentication |
+| `js <expression>` | `<expression>` a JS string to evaluate, e.g. `"await fetch('/api/v1/health')"` | Execute JavaScript in the page context and return the result |
+
+**Element references (`@eN`):** These are short-lived identifiers returned by `snapshot -i`. Re-run `snapshot -i` after any navigation or DOM change before using a new `@eN` reference — stale references will error.
+
+---
+
 ## Setup
 
 **Parse the user's request for these parameters:**


### PR DESCRIPTION
## Summary

- Adds a **Browse Binary — Subcommand Reference** table to `qa/SKILL.md` documenting all 10 browse subcommands with flags, argument types, and descriptions
- Adds element reference (`@eN`) lifecycle documentation warning about staleness after navigation
- Generated and validated by the [consensus-guard-demo](https://github.com/consensus-tools/consensus-tools/tree/main/examples/skill-guard-demo): 5 AI guard agents evaluated and unanimously approved this improvement via weighted consensus voting

## Eval Results

LLM-as-judge scores (claude-sonnet-4-6, each verified 3x for consistency):

| Version | Clarity | Completeness | Actionability | Avg |
|---------|---------|-------------|---------------|-----|
| **Before** | 4/5 | 3/5 | 3/5 | **3.3/5** |
| **After** | 5/5 | 5/5 | 5/5 | **5.0/5** |

**+51% improvement**, consistent across 3 independent eval runs per version.

## Why this change

The judge consistently flagged that `qa/SKILL.md` uses browse commands (`$B goto`, `$B snapshot -i`, `$B fill @e3`, etc.) throughout but never formally documents what subcommands, flags, or argument types are valid. An AI agent had to infer usage from scattered examples, risking incorrect invocations.

## Guard consensus

All 5 guard agents voted YES (combined risk: 0.17):
- **Doc Architect**: "The structural change is well-executed"
- **API Accuracy**: "The subcommand reference table is a genuine improvement"  
- **Agent Usability**: "The proposed change substantially improves usability"
- **Completeness Auditor**: "The proposed addition substantially improves completeness"
- **Style Guardian**: "The document is high quality and the proposed change is consistent"

## Test plan

- [x] LLM judge scores verified 3x before (3.3/5) and 3x after (5.0/5)
- [x] Guard consensus: 5/5 YES votes
- [x] Content review: subcommand table matches browse/SKILL.md command list
- [x] Manual review of added markdown formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code) via consensus-guard-demo