### PR TITLE
fix: resolve snap bun filesystem confinement breaking setup

### DIFF
--- a/setup
+++ b/setup
@@ -6,10 +6,17 @@ GSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$(dirname "$GSTACK_DIR")"
 BROWSE_BIN="$GSTACK_DIR/browse/dist/browse"
 
+# Prefer ~/.bun/bin/bun over snap bun (snap has filesystem confinement issues)
+if [ -x "$HOME/.bun/bin/bun" ]; then
+  BUN="$HOME/.bun/bin/bun"
+else
+  BUN="$(command -v bun)"
+fi
+
 ensure_playwright_browser() {
   (
     cd "$GSTACK_DIR"
-    bun --eval 'import { chromium } from "playwright"; const browser = await chromium.launch(); await browser.close();'
+    "$BUN" --eval 'import { chromium } from "playwright"; const browser = await chromium.launch(); await browser.close();'
   ) >/dev/null 2>&1
 }
 
@@ -29,8 +36,12 @@ if [ "$NEEDS_BUILD" -eq 1 ]; then
   echo "Building browse binary..."
   (
     cd "$GSTACK_DIR"
-    bun install
-    bun run build
+    "$BUN" install
+    "$BUN" scripts/gen-skill-docs.ts
+    "$BUN" build --compile browse/src/cli.ts --outfile browse/dist/browse
+    "$BUN" build --compile browse/src/find-browse.ts --outfile browse/dist/find-browse
+    git rev-parse HEAD > browse/dist/.version 2>/dev/null || true
+    rm -f .*.bun-build
   )
   # Safety net: write .version if build script didn't (e.g., git not available during build)
   if [ ! -f "$GSTACK_DIR/browse/dist/.version" ]; then
@@ -48,7 +59,7 @@ if ! ensure_playwright_browser; then
   echo "Installing Playwright Chromium..."
   (
     cd "$GSTACK_DIR"
-    bunx playwright install chromium
+    "$BUN" x playwright install chromium
   )
 fi
 


### PR DESCRIPTION
## Problem

On Linux systems where `bun` is installed via **snap**, `./setup` fails with cryptic errors:

- `EACCES: Permission denied while opening package.json` — snap sandbox blocks file access under `~/.claude/`
- `CouldntReadCurrentDirectory` — `bun run <script>` hits the same confinement wall
- Same errors with `bunx playwright install chromium`

Snap apps run in a constricted sandbox that restricts filesystem access to approved paths. The `~/.claude/` directory is not in that list.

## Fix

1. **Resolve bun at setup start** — prefer `~/.bun/bin/bun` (the official installer's target) over whatever `bun` is in `$PATH`. Falls back to PATH bun if `~/.bun/bin/bun` doesn't exist, so non-snap installs are unaffected.

2. **Inline the build steps** instead of using `bun run build` — `bun run` fails with `CouldntReadCurrentDirectory` even with the non-snap bun on some Linux setups. The inlined commands (`bun scripts/gen-skill-docs.ts`, `bun build --compile ...`) work correctly.

3. **Replace `bunx`** with `"$BUN" x` for the Playwright install step.

## Test plan

- [ ] Fresh setup on a system with snap bun in PATH and `~/.bun/bin/bun` also installed → uses `~/.bun/bin/bun`, succeeds
- [ ] Setup on a system with only non-snap bun → falls back to PATH bun, unaffected
- [ ] `bunx playwright install chromium` path → replaced with `"$BUN" x`, no snap confinement issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)