### PR TITLE
Fix build script failure on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "browse": "./browse/dist/browse"
   },
   "scripts": {
-    "build": "bun run gen:skill-docs && bun build --compile browse/src/cli.ts --outfile browse/dist/browse && bun build --compile browse/src/find-browse.ts --outfile browse/dist/find-browse && git rev-parse HEAD > browse/dist/.version && rm -f .*.bun-build",
+    "build": "bun run gen:skill-docs && bun build --compile browse/src/cli.ts --outfile browse/dist/browse && bun build --compile browse/src/find-browse.ts --outfile browse/dist/find-browse && git rev-parse HEAD > browse/dist/.version && rm -f .*.bun-build || true",
     "gen:skill-docs": "bun run scripts/gen-skill-docs.ts",
     "dev": "bun run browse/src/cli.ts",
     "server": "bun run browse/src/server.ts",


### PR DESCRIPTION
## Summary

- The `rm -f .*.bun-build` cleanup step in the build script fails on Windows/Git Bash when no files match the glob pattern
- This causes `bun run build` to exit with code 1, which in turn causes `./setup` to abort (due to `set -e`) before creating skill symlinks
- Fix: append `|| true` so the cleanup is non-fatal

## Reproduction

1. Run `./setup` on Windows with Git Bash
2. Build completes successfully but `rm -f .*.bun-build` returns exit code 1
3. `set -e` in setup aborts before skill symlinks are created
4. Skills like `/plan-ceo-review` are not available

## Fix

One-character change: `rm -f .*.bun-build` → `rm -f .*.bun-build || true`