### PR TITLE
feat: add /k9-audit skill for causal audit after ship/review

### DIFF
--- a/k9-audit/SKILL.md
+++ b/k9-audit/SKILL.md
@@ -1,0 +1,55 @@
+﻿# /k9-audit
+
+**Mode: Causal Audit**
+
+Run K9 Audit on the current project to detect silent deviations,
+missing imports, staging URLs in production, and scope violations.
+No code execution required.
+
+## When to use
+
+Run after `/ship` or `/review` to add a tamper-proof audit layer.
+Especially useful before merging to main or deploying to production.
+
+## Steps
+
+1. Run static audit across the codebase:
+```
+   k9log audit . --checks staging,secrets,imports,scope,constraints
+```
+
+2. If violations found, trace root cause:
+```
+   k9log trace --last
+```
+
+3. For causal chain analysis across steps:
+```
+   k9log causal --last
+```
+
+4. Verify ledger integrity:
+```
+   k9log verify-log
+```
+
+5. Generate full HTML report if needed:
+```
+   k9log audit . --output audit-report.html
+```
+
+## What K9 checks
+
+- **Staging URLs** in production configs (exit 0 hides these)
+- **Hardcoded secrets** — API keys, tokens, passwords
+- **Missing imports** that will fail at runtime
+- **Scope violations** — files written outside declared paths
+- **CONSTRAINTS.md violations** — intent contract breaches
+
+## Install
+```
+pip install k9audit-hook
+```
+
+Zero code changes. Drops into `.claude/settings.json` hooks.
+Full docs: https://github.com/liuhaotian2024-prog/K9Audit


### PR DESCRIPTION
gstack specializes Claude Code into cognitive modes — founder, eng manager, paranoid reviewer, release machine. This PR adds /k9-audit, a complementary audit mode that closes a gap none of the existing skills address: silent deviations that exit 0.
When /ship pushes a branch, CI passes and tests are green — but a staging URL silently in a production config, a missing import that will fail at runtime, or a file written outside declared scope won't be caught. /k9-audit runs K9 Audit's deterministic static analysis on the codebase and surfaces these before they reach production.
What it does:

Detects staging/internal URLs in production configs
Finds hardcoded secrets and API keys
Identifies missing imports that pass CI but raise NameError at runtime
Flags files written outside declared scope
Checks CONSTRAINTS.md intent contract violations

What it doesn't do: It does not use LLM-as-judge. Assessment is deterministic — mathematical fact, not a probability score. Zero tokens consumed.
Install: pip install k9audit-hook — drops into .claude/settings.json, zero code changes.
Related: #38