### PR TITLE
fix(security): sanitize gstack-slug output against shell injection

### DIFF
--- a/bin/gstack-slug
+++ b/bin/gstack-slug
@@ -3,7 +3,12 @@
 # Usage: eval $(gstack-slug)  → sets SLUG and BRANCH variables
 # Or:    gstack-slug           → prints SLUG=... and BRANCH=... lines
 set -euo pipefail
-SLUG=$(git remote get-url origin 2>/dev/null | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-')
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-')
+
+# Sanitize: strip everything except alphanumeric, dot, hyphen, underscore.
+# Prevents shell injection when the output is consumed via eval.
+sanitize() { tr -cd 'a-zA-Z0-9._-'; }
+
+SLUG=$(git remote get-url origin 2>/dev/null | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-' | sanitize)
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' | sanitize)
 echo "SLUG=$SLUG"
 echo "BRANCH=$BRANCH"


### PR DESCRIPTION
## Summary

Fixes #133 — hardens `bin/gstack-slug` against shell injection when consumed via `eval $(gstack-slug)`.

## Problem

`gstack-slug` derives SLUG and BRANCH from `git remote get-url origin` and `git rev-parse --abbrev-ref HEAD`. The existing pipeline (`sed` + `tr '/' '-'`) does not strip shell metacharacters like `;`, `$()`, backticks, or `|`. Since the output is consumed via `eval` in 14+ skill templates, a malicious remote URL or branch name could execute arbitrary commands.

## Fix

Added a `sanitize()` function that strips everything except `[a-zA-Z0-9._-]` via `tr -cd`. Applied to both SLUG and BRANCH before output. All existing `eval $(gstack-slug)` callers are automatically protected without template changes.

## Risk context

Low severity — GitHub and GitLab enforce alphanumeric naming for orgs/repos/branches, so hosted repos are safe. This is defense-in-depth for self-hosted git servers or exotic remote URLs.