### PR TITLE
docs: restructure README for faster conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ I am learning how to get to the edge of what agentic systems can do as of March 
 Fork it. Improve it. Make it yours. Don't player hate, appreciate.
 
 **Who this is for:**
-- **Solo founder** shipping a product alone — you need a team, not a copilot
-- **Tech lead of a small team** — multiply your people with structured agent roles
-- **Staff engineer at a larger org** — bring rigorous review, QA, and release automation to every PR
+- **Founders and CEOs** — especially technical ones who still want to ship. This is how you build like a team of twenty.
+- **First-time Claude Code users** — gstack is the best way to start. Structured roles instead of a blank prompt.
+- **Tech leads and staff engineers** — bring rigorous review, QA, and release automation to every PR
 
 ## Quick start: your first 10 minutes
 


### PR DESCRIPTION
## Summary
- Move install block to first scroll (currently buried 100 lines down)
- Add "Who this is for" (3 bullets) for visitor self-identification
- Add "Quick start: 10 minutes" funnel showing first useful run
- Condense install instructions with bolded commands for scannability
- Move "See it work" and "The team" below install
- Relocate hiring box after "Come ride the wave" section
- Strip redundant `---` dividers between section headers
- Add governance framing ("structured roles vs generic agent chaos")
- Add troubleshooting case for missing skills

## Why
Evaluators who read the intro and think "I want to try this" currently scroll past 75+ lines of demo transcript before finding the install command. This restructures for conversion: self-identify → understand quick-start path → paste install command, all in one scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)