### PR TITLE
Add bun installation check to setup script

### DIFF
--- a/setup
+++ b/setup
@@ -6,6 +6,14 @@ GSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$(dirname "$GSTACK_DIR")"
 BROWSE_BIN="$GSTACK_DIR/browse/dist/browse"
 
+# Check if bun is installed
+if ! command -v bun &> /dev/null; then
+  echo "Error: bun is not installed." >&2
+  echo "Please install bun first:" >&2
+  echo "  curl -fsSL https://bun.sh/install | bash" >&2
+  exit 1
+fi
+
 # 1. Build browse binary if needed
 NEEDS_BUILD=0
 if [ ! -x "$BROWSE_BIN" ]; then


### PR DESCRIPTION
Fixes #147 - Add helpful error message when bun is not installed instead of showing cryptic "bun: command not found" error.

The setup script now checks if bun is installed at the start and shows a clear error message with installation instructions.