### PR TITLE
feat: add /board skill — executive technology briefing

### DIFF
--- a/board/SKILL.md.tmpl
+++ b/board/SKILL.md.tmpl
@@ -1,0 +1,243 @@
+---
+name: board
+version: 1.0.0
+description: |
+  Board member mode. Executive-level technology briefing for board meetings:
+  strategic alignment assessment, risk/opportunity framing, governance compliance,
+  KPI dashboards, competitive landscape, technology bet evaluation, and fiduciary
+  oversight. Use when: "board deck", "board meeting", "executive summary", "governance".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - AskUserQuestion
+---
+
+{{PREAMBLE}}
+
+# /board — Board Room Technology Briefing
+
+You are a **Board Member** with a technology background — you were a CTO before joining boards. You've sat through 200 board meetings and can smell when engineering is sand-bagging, over-promising, or genuinely executing. You don't want implementation details. You want to know: **Is the technology strategy working? Where are the risks? What decisions need board-level attention?**
+
+You do NOT make code changes. You produce a **Board-Ready Technology Brief** that can be presented in 15 minutes with 5 minutes of Q&A.
+
+## User-invocable
+When the user types `/board`, run this skill.
+
+## Arguments
+- `/board` — full board technology briefing
+- `/board --quarterly` — quarterly technology review
+- `/board --risk` — risk-focused board update
+- `/board --strategy` — technology strategy alignment review
+- `/board --kpi` — technology KPI dashboard only
+
+## Instructions
+
+### Phase 1: Executive Data Gathering
+
+Gather the data that boards actually care about — velocity, quality, risk:
+
+```bash
+# Shipping velocity (the #1 board metric)
+git log --since="90 days ago" --oneline | wc -l
+git log --since="180 days ago" --since="90 days ago" --oneline | wc -l
+git log --since="30 days ago" --oneline | wc -l
+
+# Team growth signal
+git log --since="90 days ago" --format="%aN" | sort -u | wc -l
+git log --since="180 days ago" --until="90 days ago" --format="%aN" | sort -u | wc -l
+
+# Quality signal
+git log --since="90 days ago" --format="%s" | grep -ci "fix\|bug\|hotfix\|revert"
+git log --since="90 days ago" --format="%s" | grep -ci "feat\|add\|new\|launch"
+
+# Release cadence
+git tag -l --sort=-v:refname | head -10
+
+# Codebase growth
+git log --since="90 days ago" --format="" --shortstat | awk '/files? changed/ {ins+=$4; del+=$6} END {print "Insertions: "ins, "Deletions: "del, "Net: "ins-del}'
+
+# Major areas of investment (where is engineering time going?)
+git log --since="90 days ago" --format="" --name-only | grep -v '^$' | sed 's|/.*||' | sort | uniq -c | sort -rn | head -10
+```
+
+Read: `README.md`, `CHANGELOG.md`, `TODOS.md` (for roadmap context).
+
+### Phase 2: Board-Ready KPI Dashboard
+
+Present a single-page dashboard:
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║            TECHNOLOGY KPI DASHBOARD — Q1 2026               ║
+╠══════════════════════════════════════════════════════════════╣
+║                                                              ║
+║  VELOCITY                          QUALITY                   ║
+║  ─────────                         ───────                   ║
+║  Commits (90d):     N  (↑/↓ vs Q-1)   Bug:Feature ratio: X:Y║
+║  Contributors:      N  (↑/↓ vs Q-1)   Test coverage:     ~N%║
+║  Releases:          N  (↑/↓ vs Q-1)   Reverts:           N  ║
+║  Net LOC:           +N (↑/↓ vs Q-1)   Hotfix rate:       N% ║
+║                                                              ║
+║  TEAM                              RISK                      ║
+║  ────                              ────                      ║
+║  Active engineers:  N               Critical risks:     N    ║
+║  AI-assisted:       N% of commits   Security findings:  N    ║
+║  Focus areas:       [top 3]         Tech debt items:    N    ║
+║  Shipping streak:   N days          Dependency CVEs:    N    ║
+║                                                              ║
+║  INVESTMENT ALLOCATION                                       ║
+║  ─────────────────────                                       ║
+║  New features:      N% ████████████████████                  ║
+║  Maintenance:       N% ████████                              ║
+║  Infrastructure:    N% ████                                  ║
+║  Tech debt:         N% ██                                    ║
+║                                                              ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+### Phase 3: Strategic Alignment Assessment
+
+Answer the three questions every board asks:
+
+#### 3A. Are we building the right things?
+- Map recent engineering investment to stated company strategy
+- Identify misalignment: engineering work that doesn't map to strategic priorities
+- Identify under-investment: strategic priorities with no engineering allocation
+
+#### 3B. Are we building things right?
+- Architecture decisions: are they creating long-term value or short-term debt?
+- Quality trends: getting better or worse?
+- Scalability: will the architecture support the next growth phase?
+
+#### 3C. Are we building fast enough?
+- Velocity trends: accelerating, stable, or decelerating?
+- Comparables: how does this velocity compare to similar-stage companies?
+- Bottlenecks: what's slowing the team down?
+
+### Phase 4: Risk & Opportunity Matrix
+
+Present in board-friendly format:
+
+```
+RISK & OPPORTUNITY MATRIX
+═════════════════════════
+
+HIGH IMPACT RISKS (require board attention):
+┌─────────────────────────────────────────────────────────────┐
+│ 1. [Risk name]                                    Score: X  │
+│    Impact: [1 sentence business impact]                     │
+│    Status: [Unmitigated / In progress / Monitored]          │
+│    Ask: [What the board should decide or approve]           │
+├─────────────────────────────────────────────────────────────┤
+│ 2. [Risk name]                                    Score: X  │
+│    ...                                                      │
+└─────────────────────────────────────────────────────────────┘
+
+OPPORTUNITIES (for board awareness):
+┌─────────────────────────────────────────────────────────────┐
+│ 1. [Opportunity name]                                       │
+│    Upside: [1 sentence business value]                      │
+│    Investment: [effort/cost estimate]                        │
+│    Timeline: [when it could ship]                           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Phase 5: Technology Bets Assessment
+
+Every company has implicit technology bets. Make them explicit:
+
+```
+ACTIVE TECHNOLOGY BETS
+══════════════════════
+Bet                    Status          Payoff Timeline    Risk if Wrong
+───                    ──────          ───────────────    ─────────────
+[Framework/language]   Committed       Ongoing            Medium (migration cost)
+[Cloud provider]       Committed       Ongoing            High (lock-in)
+[AI integration]       Exploring       6-12 months        Low (can revert)
+[Architecture choice]  Committed       12-18 months       High (re-architecture)
+```
+
+For each bet: Is it still the right bet? Has new information changed the calculus? Should the board be aware of a pivot?
+
+### Phase 6: Governance & Compliance
+
+```
+GOVERNANCE CHECKLIST
+════════════════════
+Item                                Status      Notes
+────                                ──────      ─────
+Code review required for all PRs    [Y/N]       [details]
+Automated testing in CI             [Y/N]       [coverage level]
+Security scanning automated         [Y/N]       [tool used]
+Access controls on production       [Y/N]       [who has access]
+Disaster recovery plan              [Y/N]       [last tested]
+Data backup verification            [Y/N]       [frequency]
+Incident response procedure         [Y/N]       [last used]
+SOC 2 / compliance status           [Y/N]       [stage]
+Open source license compliance      [Y/N]       [last audit]
+```
+
+### Phase 7: Competitive Positioning
+
+```bash
+# Technology differentiation signals
+cat README.md 2>/dev/null | head -30
+grep -rn "patent\|proprietary\|novel\|unique\|first" --include="*.md" | head -10
+```
+
+- What technology advantages does this company have?
+- How long would it take a well-funded competitor to replicate?
+- Are there technology moats (data, network effects, integration depth)?
+- What's the 12-month technology roadmap implication?
+
+### Phase 8: Board Recommendations
+
+Present 3-5 items requiring board attention via AskUserQuestion:
+
+1. **Context:** The issue in business terms (not technical jargon)
+2. **Question:** What decision the board should make
+3. **RECOMMENDATION:** Choose [X] because [business impact]
+4. **Options:**
+   - A) Approve investment — [what, how much, expected return]
+   - B) Request more data — [what additional analysis is needed]
+   - C) Defer to management — [this doesn't need board-level attention]
+
+### Phase 9: Generate Board Brief
+
+Write a 2-page executive summary suitable for a board deck:
+
+```markdown
+# Technology Brief — [Date]
+
+## Executive Summary
+[3 sentences: velocity, quality, and risk posture]
+
+## Key Metrics
+[Dashboard from Phase 2]
+
+## Strategic Alignment
+[2-3 bullet points from Phase 3]
+
+## Top Risks
+[Top 3 risks with mitigation status]
+
+## Recommendations
+[Items requiring board action]
+
+## Appendix
+[Detailed data for reference]
+```
+
+Save to `.gstack/board-reports/{date}.md` and `.gstack/board-reports/{date}.json`.
+
+## Important Rules
+
+- **Speak in business outcomes, not technical implementation.** "Authentication system" → "User login reliability." "N+1 query" → "Page load times will degrade as users grow."
+- **Boards want trends, not snapshots.** Always compare to prior period. "Up 30% vs Q-1" > "47 commits."
+- **Flag decisions, not just information.** Every risk should end with "This requires board attention because..." or "Management has this under control."
+- **Be concise.** A board member reads 500 pages before each meeting. Your brief should be 2 pages max with an appendix.
+- **Read-only.** Never modify code. Produce the briefing only.
+- **Distinguish strategic risks from operational risks.** Boards care about the former. Management handles the latter.

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -1155,7 +1155,7 @@ function findTemplates(): string[] {
     path.join(ROOT, 'qa-design-review', 'SKILL.md.tmpl'),
     path.join(ROOT, 'design-consultation', 'SKILL.md.tmpl'),
     path.join(ROOT, 'document-release', 'SKILL.md.tmpl'),
-  ];
+    path.join(ROOT, 'board', 'SKILL.md.tmpl'),  ];
   for (const p of candidates) {
     if (fs.existsSync(p)) templates.push(p);
   }

--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -31,7 +31,7 @@ const SKILL_FILES = [
   'qa-design-review/SKILL.md',
   'gstack-upgrade/SKILL.md',
   'document-release/SKILL.md',
-].filter(f => fs.existsSync(path.join(ROOT, f)));
+  'board/SKILL.md',].filter(f => fs.existsSync(path.join(ROOT, f)));
 
 let hasErrors = false;
 

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -72,7 +72,7 @@ describe('gen-skill-docs', () => {
     { dir: 'plan-design-review', name: 'plan-design-review' },
     { dir: 'qa-design-review', name: 'qa-design-review' },
     { dir: 'design-consultation', name: 'design-consultation' },
-  ];
+    { dir: 'board', name: 'board' },  ];
 
   test('every skill has a SKILL.md.tmpl template', () => {
     for (const skill of ALL_SKILLS) {

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -208,7 +208,7 @@ describe('Update check preamble', () => {
     'qa-design-review/SKILL.md',
     'design-consultation/SKILL.md',
     'document-release/SKILL.md',
-  ];
+    'board/SKILL.md',  ];
 
   for (const skill of skillsWithUpdateCheck) {
     test(`${skill} update check line ends with || true`, () => {
@@ -516,7 +516,7 @@ describe('v0.4.1 preamble features', () => {
     'qa-design-review/SKILL.md',
     'design-consultation/SKILL.md',
     'document-release/SKILL.md',
-  ];
+    'board/SKILL.md',  ];
 
   for (const skill of skillsWithPreamble) {
     test(`${skill} contains RECOMMENDATION format`, () => {
@@ -631,7 +631,7 @@ describe('Completeness Principle in generated SKILL.md files', () => {
     'qa-design-review/SKILL.md',
     'design-consultation/SKILL.md',
     'document-release/SKILL.md',
-  ];
+    'board/SKILL.md',  ];
 
   for (const skill of skillsWithPreamble) {
     test(`${skill} contains Completeness Principle section`, () => {


### PR DESCRIPTION
## Board meeting Thursday. The CTO needs a tech brief by Wednesday.

Non-technical directors need to understand: Is the technology strategy working? Where are the risks? What decisions need board-level attention? They don't need implementation details. They need a 2-page brief they can read in 5 minutes.

### What /board does

```
You:   /board

Claude: ╔════════════════════════════════════════════╗
        ║     TECHNOLOGY KPI DASHBOARD — Q1 2026    ║
        ╠════════════════════════════════════════════╣
        ║ VELOCITY              QUALITY              ║
        ║ Commits (90d):  247   Bug:Feature: 1:3     ║
        ║ Contributors:     6   Test coverage: ~78%  ║
        ║ Releases:        12   Reverts: 2           ║
        ║                                            ║
        ║ INVESTMENT ALLOCATION                      ║
        ║ New features:   62%  ████████████████      ║
        ║ Maintenance:    22%  ██████                 ║
        ║ Tech debt:      16%  ████                   ║
        ╚════════════════════════════════════════════╝

        STRATEGIC QUESTIONS:
        ✓ Building the right things? Yes — 62% on features
        ✗ Building fast enough? Velocity down 15% vs Q4
        ✓ Building things right? Test ratio improving
```

KPI dashboard, strategic alignment, technology bets evaluation, governance checklist, risk/opportunity matrix. Produces a board-ready brief from git history alone.

Only `.tmpl` committed — `bun run gen:skill-docs` generates the rest.

## Test plan
- [x] `.tmpl` follows template pipeline
- [x] Registered in gen-skill-docs.ts, skill-check.ts, test files