### PR TITLE
fix: validate navigation URLs to prevent SSRF and local resource access

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -17,6 +17,7 @@
 
 import { chromium, type Browser, type BrowserContext, type BrowserContextOptions, type Page, type Locator } from 'playwright';
 import { addConsoleEntry, addNetworkEntry, addDialogEntry, networkBuffer, type DialogEntry } from './buffers';
+import { validateNavigationUrl } from './url-validation';
 
 export interface RefEntry {
   locator: Locator;
@@ -111,6 +112,7 @@ export class BrowserManager {
     this.wirePageEvents(page);
 
     if (url) {
+      validateNavigationUrl(url);
       await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
     }
 

--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -6,6 +6,7 @@ import type { BrowserManager } from './browser-manager';
 import { handleSnapshot } from './snapshot';
 import { getCleanText } from './read-commands';
 import { READ_COMMANDS, WRITE_COMMANDS, META_COMMANDS } from './commands';
+import { validateNavigationUrl } from './url-validation';
 import * as Diff from 'diff';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -219,6 +220,8 @@ export async function handleMetaCommand(
     case 'diff': {
       const [url1, url2] = args;
       if (!url1 || !url2) throw new Error('Usage: browse diff <url1> <url2>');
+      validateNavigationUrl(url1);
+      validateNavigationUrl(url2);
 
       const page = bm.getPage();
       await page.goto(url1, { waitUntil: 'domcontentloaded', timeout: 15000 });

--- a/browse/src/url-validation.ts
+++ b/browse/src/url-validation.ts
@@ -1,0 +1,77 @@
+/**
+ * URL validation — prevent SSRF and local resource access
+ *
+ * Blocks file:/data:/javascript: schemes and private/internal IPs.
+ * Set BROWSE_ALLOW_PRIVATE=1 to bypass the private-IP check (local dev).
+ */
+
+const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
+
+const BLOCKED_HOSTNAMES = new Set(['localhost']);
+
+/**
+ * Check whether an IPv4 address is private/internal.
+ * Covers 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16,
+ * 169.254.0.0/16 (link-local / cloud metadata), and 0.0.0.0.
+ */
+function isPrivateIP(hostname: string): boolean {
+  // Quick check for 0.0.0.0
+  if (hostname === '0.0.0.0') return true;
+
+  // Parse IPv4 octets
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return false;
+
+  const octets = parts.map(Number);
+  if (octets.some(o => isNaN(o) || o < 0 || o > 255)) return false;
+
+  const [a, b] = octets;
+
+  if (a === 127) return true;              // 127.0.0.0/8
+  if (a === 10) return true;               // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true;  // 192.168.0.0/16
+  if (a === 169 && b === 254) return true;  // 169.254.0.0/16
+
+  return false;
+}
+
+/**
+ * Validate a URL before navigating to it.
+ * Throws a descriptive error if the URL is blocked.
+ */
+export function validateNavigationUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+
+  // Scheme check
+  if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+    throw new Error(
+      `Blocked URL scheme "${parsed.protocol}" — only http: and https: are allowed. ` +
+      `Received: ${url}`
+    );
+  }
+
+  // Private/internal IP check (bypass with BROWSE_ALLOW_PRIVATE=1)
+  if (process.env.BROWSE_ALLOW_PRIVATE === '1') return;
+
+  const hostname = parsed.hostname;
+
+  if (BLOCKED_HOSTNAMES.has(hostname)) {
+    throw new Error(
+      `Blocked navigation to "${hostname}" — internal/private hosts are not allowed. ` +
+      `Set BROWSE_ALLOW_PRIVATE=1 to override for local development.`
+    );
+  }
+
+  if (isPrivateIP(hostname)) {
+    throw new Error(
+      `Blocked navigation to private IP "${hostname}" — internal network access is not allowed. ` +
+      `Set BROWSE_ALLOW_PRIVATE=1 to override for local development.`
+    );
+  }
+}

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -7,6 +7,7 @@
 
 import type { BrowserManager } from './browser-manager';
 import { findInstalledBrowsers, importCookies } from './cookie-import-browser';
+import { validateNavigationUrl } from './url-validation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -21,6 +22,7 @@ export async function handleWriteCommand(
     case 'goto': {
       const url = args[0];
       if (!url) throw new Error('Usage: browse goto <url>');
+      validateNavigationUrl(url);
       const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
       const status = response?.status() || 'unknown';
       return `Navigated to ${url} (${status})`;


### PR DESCRIPTION
## Summary

Closes #17.

- Add URL validation before all `page.goto()` calls to prevent SSRF and local resource access
- Only allow `http:` and `https:` schemes (blocks `file:`, `data:`, `javascript:`, etc.)
- Block private/internal IPs: `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16` (cloud metadata), `0.0.0.0`
- Block `localhost` hostname
- Provide `BROWSE_ALLOW_PRIVATE=1` env var to bypass the private-IP check for local development

## Changes

| File | Change |
|------|--------|
| `browse/src/url-validation.ts` | New: `validateNavigationUrl()` with scheme + private IP checks |
| `browse/src/write-commands.ts` | Add validation before `page.goto()` in `goto` command |
| `browse/src/browser-manager.ts` | Add validation before `page.goto()` in `newTab()` (covers `newtab` command) |
| `browse/src/meta-commands.ts` | Add validation for both URLs in `diff` command |

## Test plan

- [x] All 173 tests in `browse/test/commands.test.ts` pass (with `BROWSE_ALLOW_PRIVATE=1`)
- [x] Pre-existing `gstack-config` failure confirmed on `main` (not related)
- [ ] Verify `file:///etc/passwd` is blocked by `goto`
- [ ] Verify `http://169.254.169.254/` is blocked by `goto`
- [ ] Verify `BROWSE_ALLOW_PRIVATE=1` allows `http://127.0.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)