### PR TITLE
fix: redact sensitive values in storage read command

### DIFF
--- a/browse/src/read-commands.ts
+++ b/browse/src/read-commands.ts
@@ -289,6 +289,17 @@ export async function handleReadCommand(
         localStorage: { ...localStorage },
         sessionStorage: { ...sessionStorage },
       }));
+      const showSecrets = args.includes('--show-secrets');
+      if (!showSecrets) {
+        const sensitivePattern = /token|secret|key|password|auth|credential|session/i;
+        for (const store of [storage.localStorage, storage.sessionStorage]) {
+          for (const k of Object.keys(store)) {
+            if (sensitivePattern.test(k)) {
+              store[k] = '[redacted]';
+            }
+          }
+        }
+      }
       return JSON.stringify(storage, null, 2);
     }
 


### PR DESCRIPTION
## Summary

Addresses #18 (remaining unfixed part).

Most of issue #18 was already fixed in prior commits:
- ✅ `cookie` — redacts value as `****`
- ✅ `header` — redacts sensitive headers
- ✅ `type` — returns only character count
- ✅ `forms` — redacts password field values
- ✅ `storage set` — doesn't output the value

**Remaining:** The `storage` read command dumps all `localStorage`/`sessionStorage` values without redaction via `JSON.stringify(storage, null, 2)`, potentially exposing tokens, API keys, and session data into stdout and model transcripts.

## Changes

| File | Change |
|------|--------|
| `browse/src/read-commands.ts` | Redact values for keys matching sensitive patterns; add `--show-secrets` flag |

**Redacted patterns** (case-insensitive): `token`, `secret`, `key`, `password`, `auth`, `credential`, `session`

Key names are preserved so agents can see what's stored without seeing the secret values. Example output:

```json
{
  "localStorage": {
    "theme": "dark",
    "authToken": "[redacted]",
    "api_key": "[redacted]"
  }
}
```

A `--show-secrets` flag bypasses redaction when explicitly needed.

## Test plan

- [x] All 173 tests in `browse/test/commands.test.ts` pass
- [x] Pre-existing `gstack-config` failure confirmed on `main` (not related)
- [ ] Verify `storage` command redacts keys containing "token", "password", etc.
- [ ] Verify `storage --show-secrets` shows full values

🤖 Generated with [Claude Code](https://claude.com/claude-code)