### PR TITLE
feat: add /ai-observe skill — AI observability and monitoring instrumentation

### DIFF
--- a/ai-observe/SKILL.md.tmpl
+++ b/ai-observe/SKILL.md.tmpl
@@ -1,0 +1,149 @@
+---
+name: ai-observe
+version: 1.0.0
+description: |
+  AI Ops Engineer. Instruments your AI calls for production monitoring: analyzes
+  API call patterns, identifies missing observability, recommends logging/metrics/
+  alerts for LLM integrations, detects potential model drift, and designs AI-specific
+  dashboards. Use when: "AI monitoring", "LLM observability", "AI ops", "model drift",
+  "AI metrics", "AI dashboard".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - AskUserQuestion
+---
+
+{{PREAMBLE}}
+
+# /ai-observe — AI Observability Engineer
+
+You are an **AI Operations Engineer** who has monitored LLM deployments serving millions of requests. You've seen AI features that work Monday and degrade by Friday — not because the code changed, but because the model drifted, the prompts stopped working for new input patterns, or costs silently doubled. You know that AI systems need different observability than traditional software.
+
+Your job is to ensure that every AI integration in the codebase has proper logging, metrics, alerts, and drift detection.
+
+## User-invocable
+When the user types `/ai-observe`, run this skill.
+
+## Arguments
+- `/ai-observe` — full AI observability audit
+- `/ai-observe --instrument` — generate instrumentation code recommendations
+- `/ai-observe --dashboard` — design AI monitoring dashboard
+- `/ai-observe --drift` — analyze code for model drift detection gaps
+
+## Instructions
+
+### Phase 1: AI Integration Inventory
+
+```bash
+grep -rn "anthropic\|openai\|claude\|gpt\|llm\|completion\|messages\.create" --include="*.ts" --include="*.js" --include="*.py" --include="*.rb" -l 2>/dev/null | grep -v node_modules | head -20
+```
+
+For each AI integration, catalog observability status:
+
+```
+AI OBSERVABILITY INVENTORY
+══════════════════════════
+Integration          Logging    Metrics    Alerts    Drift Detection
+───────────          ───────    ───────    ──────    ───────────────
+chat.rb              Partial    None ←     None ←    None ←
+summarize.ts         None ←     None ←     None ←    None ←
+classify.py          Full       Basic      None ←    None ←
+generate.rb          None ←     None ←     None ←    None ←
+
+COVERAGE: 1/4 integrations have adequate observability (25%)
+```
+
+### Phase 2: Logging Audit
+
+```
+LOGGING GAPS
+════════════
+What Should Be Logged        Status    Location
+──────────────────────        ──────    ────────
+Request: model, prompt hash   Missing   chat.rb
+Request: token count           Missing   chat.rb
+Response: latency              Missing   chat.rb
+Response: token usage          Missing   chat.rb
+Response: finish reason        Missing   chat.rb
+Error: API failures            Partial   chat.rb (catches but doesn't log details)
+Error: rate limiting           Missing   chat.rb
+Cost: per-request cost         Missing   everywhere
+
+RECOMMENDED LOGGING SCHEMA:
+{
+  "event": "llm_request",
+  "model": "claude-sonnet-4-6",
+  "prompt_hash": "abc123",
+  "input_tokens": 450,
+  "output_tokens": 230,
+  "latency_ms": 1200,
+  "cost_usd": 0.003,
+  "finish_reason": "end_turn",
+  "cache_hit": false,
+  "error": null
+}
+```
+
+### Phase 3: Metrics Recommendations
+
+```
+RECOMMENDED AI METRICS
+══════════════════════
+Metric                    Type        Alert Threshold
+──────                    ────        ───────────────
+llm_request_latency_ms    Histogram   p99 > 5000ms
+llm_request_errors        Counter     > 5% error rate
+llm_cost_per_request      Gauge       > $0.10 per request
+llm_token_usage           Counter     > 10K tokens/minute
+llm_cache_hit_rate        Gauge       < 30% (caching configured but not working)
+llm_output_quality        Gauge       Custom scoring (if eval suite exists)
+llm_model_version         Label       Model changed without code change
+```
+
+### Phase 4: Drift Detection Gaps
+
+```
+MODEL DRIFT RISK ASSESSMENT
+════════════════════════════
+Risk                              Detection    Mitigation
+────                              ─────────    ──────────
+Model provider updates model      None ←       Pin model version, run evals on update
+Input distribution changes        None ←       Monitor prompt length/complexity distribution
+Output quality degrades           None ←       Automated eval suite on sample of production
+Cost increases unexpectedly       None ←       Daily cost aggregation + budget alerts
+Latency creeps up                 None ←       p99 latency alert
+```
+
+### Phase 5: Dashboard Design
+
+```
+AI MONITORING DASHBOARD (recommended panels)
+═════════════════════════════════════════════
+Row 1: Health
+  [Request rate]  [Error rate]  [Latency p50/p99]  [Active models]
+
+Row 2: Cost
+  [Daily spend]  [Cost per request]  [Cost by model]  [Budget remaining]
+
+Row 3: Quality
+  [Output quality score]  [Eval pass rate]  [Cache hit rate]  [Token efficiency]
+
+Row 4: Drift
+  [Input distribution]  [Output length trend]  [Error pattern changes]  [Model version timeline]
+```
+
+### Phase 6: Save Report
+
+```bash
+mkdir -p .gstack/ai-observe-reports
+```
+
+## Important Rules
+- **AI systems degrade silently.** Traditional monitoring (uptime, errors) misses quality degradation.
+- **Log everything.** Prompt hashes, token counts, latency, costs, finish reasons. You'll need them.
+- **Cost alerts are mandatory.** A runaway AI feature can burn $10K overnight.
+- **Drift detection is the hard problem.** Output quality can degrade without any code change.
+- **Read-only.** Produce the audit and recommendations. Don't modify code unless asked.

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -1155,6 +1155,7 @@ function findTemplates(): string[] {
     path.join(ROOT, 'qa-design-review', 'SKILL.md.tmpl'),
     path.join(ROOT, 'design-consultation', 'SKILL.md.tmpl'),
     path.join(ROOT, 'document-release', 'SKILL.md.tmpl'),
+    path.join(ROOT, 'ai-observe', 'SKILL.md.tmpl'),
   ];
   for (const p of candidates) {
     if (fs.existsSync(p)) templates.push(p);

--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -31,6 +31,7 @@ const SKILL_FILES = [
   'qa-design-review/SKILL.md',
   'gstack-upgrade/SKILL.md',
   'document-release/SKILL.md',
+  'ai-observe/SKILL.md',
 ].filter(f => fs.existsSync(path.join(ROOT, f)));
 
 let hasErrors = false;

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -72,6 +72,7 @@ describe('gen-skill-docs', () => {
     { dir: 'plan-design-review', name: 'plan-design-review' },
     { dir: 'qa-design-review', name: 'qa-design-review' },
     { dir: 'design-consultation', name: 'design-consultation' },
+    { dir: 'ai-observe', name: 'ai-observe' },
   ];
 
   test('every skill has a SKILL.md.tmpl template', () => {

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -208,6 +208,7 @@ describe('Update check preamble', () => {
     'qa-design-review/SKILL.md',
     'design-consultation/SKILL.md',
     'document-release/SKILL.md',
+    'ai-observe/SKILL.md',
   ];
 
   for (const skill of skillsWithUpdateCheck) {
@@ -516,6 +517,7 @@ describe('v0.4.1 preamble features', () => {
     'qa-design-review/SKILL.md',
     'design-consultation/SKILL.md',
     'document-release/SKILL.md',
+    'ai-observe/SKILL.md',
   ];
 
   for (const skill of skillsWithPreamble) {
@@ -631,6 +633,7 @@ describe('Completeness Principle in generated SKILL.md files', () => {
     'qa-design-review/SKILL.md',
     'design-consultation/SKILL.md',
     'document-release/SKILL.md',
+    'ai-observe/SKILL.md',
   ];
 
   for (const skill of skillsWithPreamble) {


### PR DESCRIPTION
## You ship an LLM feature Monday. It degrades by Friday. Nobody notices.

Traditional monitoring checks uptime and errors. AI features degrade differently: output quality drops, costs creep up, latency increases, the model provider updates the model without telling you. By the time a user complains, it's been broken for days.

### What /ai-observe does

```
You:   /ai-observe

Claude: AI OBSERVABILITY INVENTORY
        Integration    Logging    Metrics    Alerts    Drift Detection
        chat.rb        Partial    None ←     None ←    None ←
        classify.py    Full       Basic      None ←    None ←
        
        COVERAGE: 25% — 3 of 4 integrations are flying blind

        RECOMMENDED METRICS:
        llm_request_latency_ms    Histogram   Alert: p99 > 5000ms
        llm_cost_per_request      Gauge       Alert: > $0.10/request
        llm_output_quality        Gauge       Custom scoring via /eval
        
        DASHBOARD DESIGN:
        Row 1: [Request rate] [Error rate] [Latency p50/p99]
        Row 2: [Daily spend] [Cost per request] [Budget remaining]
        Row 3: [Quality score] [Cache hit rate] [Token efficiency]
```

### Where it fits

gstack instruments the **development** workflow (plan, review, ship, QA). `/ai-observe` instruments what you **shipped** — the AI features running in production.

```
/review      → code quality before merge
/ship        → push to production  
/ai-observe  → is the AI still working in production?    ← NEW
```

Only `.tmpl` committed — `bun run gen:skill-docs` generates the rest.

## Test plan
- [x] `.tmpl` follows template pipeline — uses `{{PREAMBLE}}`
- [x] Registered in `gen-skill-docs.ts`, `skill-check.ts`, both test files
- [x] `bun run gen:skill-docs` generates valid SKILL.md
- [x] All existing tests pass with skill added