### PR TITLE
feat: add /ai-council skill — AI advisory board with 5 specialist perspectives

### DIFF
--- a/ai-council/SKILL.md.tmpl
+++ b/ai-council/SKILL.md.tmpl
@@ -1,0 +1,171 @@
+---
+name: ai-council
+version: 1.0.0
+description: |
+  AI Advisory Council. Convenes multiple AI-specialist personas to evaluate AI
+  architecture decisions, model selection, prompt strategy, safety tradeoffs, and
+  cost optimization. Each council member brings a different perspective and they
+  debate to reach a recommendation. Use when: "AI council", "AI strategy",
+  "model decision", "AI architecture review", "should we use AI for this".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - AskUserQuestion
+---
+
+{{PREAMBLE}}
+
+# /ai-council — AI Advisory Council
+
+You are convening an **AI Advisory Council** — a panel of specialists who evaluate AI decisions from different angles. Each council member has deep expertise in one domain and genuine opinions that sometimes conflict. The council debates, challenges assumptions, and produces a unified recommendation.
+
+This is not a rubber stamp. Council members disagree. The value is in the disagreement — it surfaces tradeoffs that a single perspective would miss.
+
+## User-invocable
+When the user types `/ai-council`, run this skill.
+
+## Arguments
+- `/ai-council` — full council review of AI architecture
+- `/ai-council --decision <question>` — convene council on a specific decision
+- `/ai-council --model-selection` — which model for which task
+- `/ai-council --build-vs-api` — build your own vs use API
+- `/ai-council --safety-vs-speed` — safety tradeoff analysis
+
+## Council Members
+
+### The Evaluator (Quality)
+Cares about: output quality, eval coverage, regression detection, user experience.
+Bias: "Is the AI output actually good? Prove it with evals."
+
+### The Safety Officer (Safety)
+Cares about: injection resistance, PII handling, bias, compliance, harmful outputs.
+Bias: "What's the worst case? Have we tested for it?"
+
+### The Cost Analyst (Economics)
+Cares about: model costs, token efficiency, caching, ROI per feature.
+Bias: "Can we use Haiku instead? What's the cost per user?"
+
+### The Architect (Systems)
+Cares about: scalability, latency, reliability, fallback strategies, vendor lock-in.
+Bias: "What happens at 100x scale? What if the API goes down?"
+
+### The Product Owner (Value)
+Cares about: user value, competitive advantage, time to ship, feature priority.
+Bias: "Does this actually help users? Is AI the right tool for this?"
+
+## Instructions
+
+### Phase 1: Gather Context
+
+```bash
+# Understand the AI architecture
+grep -rn "anthropic\|openai\|claude\|gpt\|llm" --include="*.ts" --include="*.js" --include="*.py" --include="*.rb" -l 2>/dev/null | grep -v node_modules | head -20
+find . -name "*prompt*" -o -name "*ai*" -o -name "*llm*" 2>/dev/null | grep -v node_modules | grep -v .git | head -20
+cat README.md 2>/dev/null | head -50
+```
+
+Read relevant AI integration files to understand the current architecture.
+
+### Phase 2: Council Deliberation
+
+Present each council member's perspective on the current AI architecture or specific decision:
+
+```
+AI COUNCIL DELIBERATION
+═══════════════════════
+
+TOPIC: [Current AI architecture / specific decision]
+
+THE EVALUATOR (Quality):
+  Assessment: [specific evaluation of AI output quality]
+  Concern: [quality risk they see]
+  Recommendation: [what they'd change]
+
+THE SAFETY OFFICER (Safety):
+  Assessment: [safety posture of AI integrations]
+  Concern: [safety risk they see]
+  Recommendation: [what they'd add]
+
+THE COST ANALYST (Economics):
+  Assessment: [cost efficiency of current AI usage]
+  Concern: [cost risk they see]
+  Recommendation: [where to optimize]
+
+THE ARCHITECT (Systems):
+  Assessment: [system design of AI integrations]
+  Concern: [scalability/reliability risk]
+  Recommendation: [architectural change]
+
+THE PRODUCT OWNER (Value):
+  Assessment: [user value of AI features]
+  Concern: [product risk they see]
+  Recommendation: [priority change]
+```
+
+### Phase 3: Points of Agreement
+
+```
+COUNCIL CONSENSUS
+═════════════════
+All members agree:
+  1. [point of agreement]
+  2. [point of agreement]
+```
+
+### Phase 4: Points of Disagreement
+
+```
+COUNCIL DEBATE
+══════════════
+DISAGREEMENT 1: [topic]
+  Cost Analyst: "Use Haiku for chat — saves $2K/month"
+  Evaluator: "Haiku quality is 30% worse on complex queries"
+  Resolution: "Use Haiku for simple queries, Sonnet for complex — route by query length"
+
+DISAGREEMENT 2: [topic]
+  Safety Officer: "Add content filtering on all outputs — non-negotiable"
+  Product Owner: "Filtering adds 200ms latency, hurts UX"
+  Architect: "Async filtering — check after rendering, flag retroactively"
+  Resolution: "Async filtering for non-safety-critical, sync for high-risk"
+```
+
+### Phase 5: Council Recommendation
+
+```
+AI COUNCIL RECOMMENDATION
+═════════════════════════
+Decision:     [specific recommendation]
+Confidence:   [High/Medium/Low]
+Dissent:      [who disagrees and why]
+
+Priority actions:
+1. [action] — Owner: [role] — Timeline: [when]
+2. [action] — Owner: [role] — Timeline: [when]
+3. [action] — Owner: [role] — Timeline: [when]
+
+VOTE:
+  Evaluator:      [Approve / Approve with conditions / Oppose]
+  Safety Officer:  [Approve / Approve with conditions / Oppose]
+  Cost Analyst:    [Approve / Approve with conditions / Oppose]
+  Architect:       [Approve / Approve with conditions / Oppose]
+  Product Owner:   [Approve / Approve with conditions / Oppose]
+
+Result: [Approved X-Y / Approved with conditions / Referred back]
+```
+
+### Phase 6: Save Report
+
+```bash
+mkdir -p .gstack/ai-council-reports
+```
+
+## Important Rules
+- **Disagreement is the point.** If all 5 council members agree, you're not exploring the tradeoff space.
+- **Each member has a genuine perspective.** Don't water down their opinions to reach fake consensus.
+- **Resolutions must be specific.** "Balance cost and quality" is useless. "Route queries >100 tokens to Sonnet, shorter to Haiku" is actionable.
+- **The council advises, the user decides.** Present the recommendation and dissent. Let the user choose.
+- **Read-only.** The council deliberates and recommends. It doesn't implement.
+- **Vote counts matter.** A 5-0 approval is different from a 3-2 approval. Show the vote.

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -1155,6 +1155,7 @@ function findTemplates(): string[] {
     path.join(ROOT, 'qa-design-review', 'SKILL.md.tmpl'),
     path.join(ROOT, 'design-consultation', 'SKILL.md.tmpl'),
     path.join(ROOT, 'document-release', 'SKILL.md.tmpl'),
+    path.join(ROOT, 'ai-council', 'SKILL.md.tmpl'),
   ];
   for (const p of candidates) {
     if (fs.existsSync(p)) templates.push(p);

--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -31,6 +31,7 @@ const SKILL_FILES = [
   'qa-design-review/SKILL.md',
   'gstack-upgrade/SKILL.md',
   'document-release/SKILL.md',
+  'ai-council/SKILL.md',
 ].filter(f => fs.existsSync(path.join(ROOT, f)));
 
 let hasErrors = false;

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -72,6 +72,7 @@ describe('gen-skill-docs', () => {
     { dir: 'plan-design-review', name: 'plan-design-review' },
     { dir: 'qa-design-review', name: 'qa-design-review' },
     { dir: 'design-consultation', name: 'design-consultation' },
+    { dir: 'ai-council', name: 'ai-council' },
   ];
 
   test('every skill has a SKILL.md.tmpl template', () => {

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -208,6 +208,7 @@ describe('Update check preamble', () => {
     'qa-design-review/SKILL.md',
     'design-consultation/SKILL.md',
     'document-release/SKILL.md',
+    'ai-council/SKILL.md',
   ];
 
   for (const skill of skillsWithUpdateCheck) {
@@ -516,6 +517,7 @@ describe('v0.4.1 preamble features', () => {
     'qa-design-review/SKILL.md',
     'design-consultation/SKILL.md',
     'document-release/SKILL.md',
+    'ai-council/SKILL.md',
   ];
 
   for (const skill of skillsWithPreamble) {
@@ -631,6 +633,7 @@ describe('Completeness Principle in generated SKILL.md files', () => {
     'qa-design-review/SKILL.md',
     'design-consultation/SKILL.md',
     'document-release/SKILL.md',
+    'ai-council/SKILL.md',
   ];
 
   for (const skill of skillsWithPreamble) {


### PR DESCRIPTION
## One perspective misses tradeoffs. Five perspectives surface them.

Should you use Opus or Haiku? Build your own model or use the API? Add content filtering that adds 200ms latency? A single perspective gives you one answer. Five specialists debating gives you the tradeoffs — and the tradeoffs are what you actually need to make a good decision.

### What /ai-council does

```
You:   /ai-council --decision "Should we use AI for search ranking?"

Claude: COUNCIL DELIBERATION
        ─────────────────────
        Evaluator:    "Current relevance: 72%. AI could hit 90%."
        Cost Analyst: "That's $800/month for 50K queries."
        Safety:       "Search ranking = bias risk. Need fairness testing."
        Architect:    "Latency budget: 200ms. LLM call: 500ms."
        Product:      "Users complain about search. #1 pain point."

        DEBATE:
        Cost vs Product: "$800/month for the #1 user complaint? Easy ROI."
        Architect vs Product: "Can't add 500ms. Use embeddings, not LLM."
        Safety vs all: "Add fairness eval before launch. Non-negotiable."

        RESOLUTION: Re-rank top 20 with cached embeddings.
        Latency: <100ms. Cost: ~$200/month. Fairness eval required.
        VOTE: Approved 5-0 with conditions
```

### 5 council members, distinct biases

| Member | Cares about | Bias |
|--------|-------------|------|
| **Evaluator** | Output quality, eval coverage | "Prove it with evals" |
| **Safety Officer** | Injection, PII, bias | "What's the worst case?" |
| **Cost Analyst** | Token costs, model selection | "Can we use Haiku?" |
| **Architect** | Latency, reliability, scale | "What happens at 100x?" |
| **Product Owner** | User value, time to ship | "Does this help users?" |

### Extends gstack's "explicit gears" philosophy

gstack already has CEO mode vs Eng Manager mode vs Staff Engineer mode for **code** decisions. `/ai-council` brings the same multi-perspective rigor to **AI** decisions.

Only `.tmpl` committed — `bun run gen:skill-docs` generates the rest.

## Test plan
- [x] `.tmpl` follows template pipeline — uses `{{PREAMBLE}}`
- [x] Registered in `gen-skill-docs.ts`, `skill-check.ts`, both test files
- [x] `bun run gen:skill-docs` generates valid SKILL.md
- [x] All existing tests pass with skill added