### PR TITLE
fix: harden gstack-slug against shell injection via eval

### DIFF
--- a/bin/gstack-slug
+++ b/bin/gstack-slug
@@ -3,7 +3,9 @@
 # Usage: eval $(gstack-slug)  → sets SLUG and BRANCH variables
 # Or:    gstack-slug           → prints SLUG=... and BRANCH=... lines
 set -euo pipefail
-SLUG=$(git remote get-url origin 2>/dev/null | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-')
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-')
+# tr -cd strips any shell metacharacters (;$`|&! etc) from git-derived values
+# to prevent injection via eval $(gstack-slug). See: #133
+SLUG=$(git remote get-url origin 2>/dev/null | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-' | tr -cd 'a-zA-Z0-9._-')
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' | tr -cd 'a-zA-Z0-9._-')
 echo "SLUG=$SLUG"
 echo "BRANCH=$BRANCH"

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -793,6 +793,15 @@ describe('gstack-slug', () => {
     expect(lines[0]).toMatch(/^SLUG=.+/);
     expect(lines[1]).toMatch(/^BRANCH=.+/);
   });
+
+  test('output values contain only safe characters (no shell metacharacters)', () => {
+    const result = Bun.spawnSync([SLUG_BIN], { cwd: ROOT, stdout: 'pipe', stderr: 'pipe' });
+    const slug = result.stdout.toString().match(/SLUG=(.*)/)?.[1] ?? '';
+    const branch = result.stdout.toString().match(/BRANCH=(.*)/)?.[1] ?? '';
+    // Only alphanumeric, dot, dash, underscore are allowed (#133)
+    expect(slug).toMatch(/^[a-zA-Z0-9._-]+$/);
+    expect(branch).toMatch(/^[a-zA-Z0-9._-]+$/);
+  });
 });
 
 // --- Test Bootstrap validation ---


### PR DESCRIPTION
## Summary

Addresses garrytan/gstack#133

Hardens `bin/gstack-slug` against shell injection when used with `eval $(gstack-slug)`. Appends `| tr -cd 'a-zA-Z0-9._-'` to the SLUG and BRANCH pipelines, whitelisting only safe characters in the output. Shell metacharacters (`;`, `$`, backticks, `|`, `&`, etc.) are stripped before they reach `eval`.

## Changes

- **`bin/gstack-slug`** — Added character whitelist to both pipelines (+2 lines, inline with existing `tr` calls)
- **`test/skill-validation.test.ts`** — Added assertion that output values contain only safe characters

## Risk

None. Output is unchanged for standard GitHub/GitLab repos — org names, repo names, and branch names already use only safe characters. Only affects edge cases with self-hosted git servers or crafted branch names.

`gstack-diff-scope` uses the same `eval $(...)` pattern but is not affected — it only outputs `true`/`false` literals.

## Test plan

- [x] All 212 validation tests pass (was 211, +1 new)
- [x] Manually verified output: `SLUG=Ty-Robb-gstack BRANCH=fix-shell-injection-gstack-slug`

## Pre-Landing Review

No issues found — change is 2 lines of pipeline hardening + 9 lines of test.