### PR TITLE
test(skills): enforce allowed-tools contracts for generated skills

### DIFF
--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -8,6 +8,7 @@ description: |
   expansions), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials).
 allowed-tools:
   - Read
+  - Write
   - Grep
   - Glob
   - Bash

--- a/plan-ceo-review/SKILL.md.tmpl
+++ b/plan-ceo-review/SKILL.md.tmpl
@@ -8,6 +8,7 @@ description: |
   expansions), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials).
 allowed-tools:
   - Read
+  - Write
   - Grep
   - Glob
   - Bash

--- a/test/helpers/skill-parser.ts
+++ b/test/helpers/skill-parser.ts
@@ -29,6 +29,32 @@ export interface ValidationResult {
   warnings: string[];
 }
 
+export interface AllowedToolsContractResult {
+  allowedTools: string[];
+  unknownAllowedTools: string[];
+  missingRequiredTools: Array<{ tool: string; reason: string }>;
+}
+
+const VALID_ALLOWED_TOOLS = new Set([
+  'Bash',
+  'Read',
+  'Write',
+  'Edit',
+  'Grep',
+  'Glob',
+  'AskUserQuestion',
+  'WebSearch',
+]);
+
+function extractFrontmatter(content: string): { frontmatter: string; body: string } {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) return { frontmatter: '', body: content };
+  return {
+    frontmatter: match[1],
+    body: content.slice(match[0].length),
+  };
+}
+
 /**
  * Extract all $B invocations from bash code blocks in a SKILL.md file.
  */
@@ -131,6 +157,61 @@ export function validateSkill(skillPath: string): ValidationResult {
   }
 
   return result;
+}
+
+/**
+ * Extract the ordered allowed-tools list from generated SKILL.md frontmatter.
+ */
+export function extractAllowedTools(skillPath: string): string[] {
+  const content = fs.readFileSync(skillPath, 'utf-8');
+  const { frontmatter } = extractFrontmatter(content);
+  if (!frontmatter) return [];
+
+  const lines = frontmatter.split('\n');
+  const tools: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() !== 'allowed-tools:') continue;
+
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j];
+      const match = line.match(/^\s*-\s+(.+?)\s*$/);
+      if (!match) break;
+      tools.push(match[1]);
+    }
+
+    break;
+  }
+
+  return tools;
+}
+
+/**
+ * Validate that explicit tool-usage claims in generated SKILL.md content match
+ * the tools declared in frontmatter.
+ */
+export function validateAllowedToolsContract(skillPath: string): AllowedToolsContractResult {
+  const content = fs.readFileSync(skillPath, 'utf-8');
+  const { body } = extractFrontmatter(content);
+  const allowedTools = extractAllowedTools(skillPath);
+  const unknownAllowedTools = allowedTools.filter(tool => !VALID_ALLOWED_TOOLS.has(tool));
+
+  const requiredTools = [
+    { tool: 'Bash', reason: 'bash code blocks', matches: /```bash\b/.test(body) },
+    { tool: 'AskUserQuestion', reason: 'AskUserQuestion instructions', matches: /\bAskUserQuestion\b/.test(body) },
+    { tool: 'WebSearch', reason: 'WebSearch instructions', matches: /\bWebSearch\b/.test(body) },
+    {
+      tool: 'Write',
+      reason: 'explicit persisted-write instructions',
+      matches: /Write to `|Use the Write tool/.test(body),
+    },
+  ];
+
+  const missingRequiredTools = requiredTools
+    .filter(rule => rule.matches && !allowedTools.includes(rule.tool))
+    .map(rule => ({ tool: rule.tool, reason: rule.reason }));
+
+  return { allowedTools, unknownAllowedTools, missingRequiredTools };
 }
 
 /**

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -1,8 +1,15 @@
 import { describe, test, expect } from 'bun:test';
-import { validateSkill, extractRemoteSlugPatterns, extractWeightsFromTable } from './helpers/skill-parser';
+import {
+  validateSkill,
+  extractAllowedTools,
+  validateAllowedToolsContract,
+  extractRemoteSlugPatterns,
+  extractWeightsFromTable,
+} from './helpers/skill-parser';
 import { ALL_COMMANDS, COMMAND_DESCRIPTIONS, READ_COMMANDS, WRITE_COMMANDS, META_COMMANDS } from '../browse/src/commands';
 import { SNAPSHOT_FLAGS } from '../browse/src/snapshot';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 const ROOT = path.resolve(import.meta.dir, '..');
@@ -205,6 +212,140 @@ describe('Generated SKILL.md freshness', () => {
   test('generated SKILL.md has AUTO-GENERATED header', () => {
     const content = fs.readFileSync(path.join(ROOT, 'SKILL.md'), 'utf-8');
     expect(content).toContain('AUTO-GENERATED');
+  });
+});
+
+describe('allowed-tools contract enforcement', () => {
+  function withTempSkill(content: string, run: (skillPath: string) => void) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-contract-'));
+    const skillPath = path.join(dir, 'SKILL.md');
+    fs.writeFileSync(skillPath, content);
+
+    try {
+      run(skillPath);
+    } finally {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
+  }
+
+  test('rejects unknown tool names in allowed-tools', () => {
+    withTempSkill(`---
+name: test-skill
+description: test
+allowed-tools:
+  - Bash
+  - FakeTool
+---
+
+\`\`\`bash
+echo ok
+\`\`\`
+`, skillPath => {
+      const result = validateAllowedToolsContract(skillPath);
+      expect(result.unknownAllowedTools).toEqual(['FakeTool']);
+      expect(result.missingRequiredTools).toEqual([]);
+    });
+  });
+
+  test('bash code blocks require Bash', () => {
+    withTempSkill(`---
+name: test-skill
+description: test
+allowed-tools:
+  - Read
+---
+
+\`\`\`bash
+echo ok
+\`\`\`
+`, skillPath => {
+      const result = validateAllowedToolsContract(skillPath);
+      expect(result.missingRequiredTools).toEqual([
+        { tool: 'Bash', reason: 'bash code blocks' },
+      ]);
+    });
+  });
+
+  test('AskUserQuestion instructions require AskUserQuestion', () => {
+    withTempSkill(`---
+name: test-skill
+description: test
+allowed-tools:
+  - Bash
+---
+
+Use AskUserQuestion:
+`, skillPath => {
+      const result = validateAllowedToolsContract(skillPath);
+      expect(result.missingRequiredTools).toEqual([
+        { tool: 'AskUserQuestion', reason: 'AskUserQuestion instructions' },
+      ]);
+    });
+  });
+
+  test('WebSearch instructions require WebSearch', () => {
+    withTempSkill(`---
+name: test-skill
+description: test
+allowed-tools:
+  - Bash
+---
+
+Use WebSearch to look this up.
+`, skillPath => {
+      const result = validateAllowedToolsContract(skillPath);
+      expect(result.missingRequiredTools).toEqual([
+        { tool: 'WebSearch', reason: 'WebSearch instructions' },
+      ]);
+    });
+  });
+
+  test('explicit persisted-write instructions require Write', () => {
+    withTempSkill(`---
+name: test-skill
+description: test
+allowed-tools:
+  - Bash
+---
+
+Write to \`/tmp/output.md\`
+`, skillPath => {
+      const result = validateAllowedToolsContract(skillPath);
+      expect(result.missingRequiredTools).toEqual([
+        { tool: 'Write', reason: 'explicit persisted-write instructions' },
+      ]);
+    });
+  });
+
+  test('all generated skills satisfy allowed-tools contract rules', () => {
+    const generatedSkills = [
+      'SKILL.md',
+      'browse/SKILL.md',
+      'qa/SKILL.md',
+      'qa-only/SKILL.md',
+      'ship/SKILL.md',
+      'review/SKILL.md',
+      'retro/SKILL.md',
+      'plan-ceo-review/SKILL.md',
+      'plan-eng-review/SKILL.md',
+      'setup-browser-cookies/SKILL.md',
+      'plan-design-review/SKILL.md',
+      'design-review/SKILL.md',
+      'design-consultation/SKILL.md',
+      'gstack-upgrade/SKILL.md',
+      'document-release/SKILL.md',
+    ];
+
+    for (const skill of generatedSkills) {
+      const result = validateAllowedToolsContract(path.join(ROOT, skill));
+      expect(result.unknownAllowedTools, `${skill} has unknown allowed-tools`).toEqual([]);
+      expect(result.missingRequiredTools, `${skill} is missing required allowed-tools`).toEqual([]);
+    }
+  });
+
+  test('plan-ceo-review declares Write in allowed-tools', () => {
+    const tools = extractAllowedTools(path.join(ROOT, 'plan-ceo-review', 'SKILL.md'));
+    expect(tools).toContain('Write');
   });
 });
 


### PR DESCRIPTION
Related to #24.

## Summary
This PR adds a small, deterministic contract check for generated `SKILL.md` files.

Generated skills already have structural validation and optional E2E / judge evals, but there was no free-tier enforcement that explicit tool-usage claims in the skill body match `allowed-tools` in frontmatter. This change adds that enforcement and fixes one concrete drift already present in `plan-ceo-review`.

## Changes
- parse `allowed-tools` from generated `SKILL.md` frontmatter
- reject unknown tool names in `allowed-tools`
- require `Bash` when a generated skill contains bash code blocks
- require `AskUserQuestion` when a generated skill explicitly references `AskUserQuestion`
- require `WebSearch` when a generated skill explicitly references `WebSearch`
- require `Write` for explicit persisted-write instructions
- fix `plan-ceo-review` to declare `Write`
- regenerate generated skill docs

## Why
This is a narrow first step toward stronger skill contract enforcement.

It adds a deterministic, free-tier validation layer for one concrete class of drift: when a skill explicitly tells the agent to use a tool, but the skill contract does not actually declare that tool in `allowed-tools`.

## Validation
- `bun run gen:skill-docs`
- `bun test`

## Concrete bug fixed
`plan-ceo-review` instructs the agent to persist CEO plans to disk, but its `allowed-tools` frontmatter omitted `Write`. This PR makes that contract explicit and keeps it enforced going forward.
