### PR TITLE
feat: add Codex bootstrap support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# gstack for Codex
+
+## Commands
+
+```bash
+bun install          # install dependencies
+bun test             # run free tests (browse + snapshot + skill validation)
+bun run test:evals   # run paid evals: LLM judge + E2E (diff-based, ~$4/run max)
+bun run test:e2e     # run E2E tests only (diff-based, ~$3.85/run max)
+bun run dev <cmd>    # run CLI in dev mode, e.g. bun run dev goto https://example.com
+bun run build        # gen docs + compile binaries
+bun run gen:skill-docs  # regenerate SKILL.md files from templates
+bun run skill:check  # health dashboard for all skills
+```
+
+## Codex install
+
+```bash
+git clone https://github.com/garrytan/gstack.git ~/src/gstack
+cd ~/src/gstack
+./setup --host codex
+```
+
+This installs the root skill at `$HOME/.codex/skills/gstack/` and creates
+Codex aliases like:
+
+- `$gstack-browse`
+- `$gstack-review`
+- `$gstack-ship`
+- `$gstack-qa`
+- `$gstack-plan-ceo-review`
+- `$gstack-plan-eng-review`
+- `$gstack-plan-design-review`
+- `$gstack-design-consultation`
+- `$gstack-design-review`
+- `$gstack-office-hours`
+- `$gstack-debug`
+- `$gstack-document-release`
+- `$gstack-retro`
+- `$gstack-setup-browser-cookies`
+- `$gstack-upgrade`
+
+## Browser interaction
+
+When you need to interact with a browser (QA, dogfooding, cookie setup), use the
+installed gstack browse skill or run the browse binary directly via `$B <command>`.
+Never use `mcp__claude-in-chrome__*` tools in this repo.
+
+## Active install
+
+The active Codex skill lives at `$HOME/.codex/skills/gstack/`. After making changes:
+
+1. Push your branch
+2. Refresh the checkout you want Codex to use
+3. Re-run `./setup --host codex`
+4. Rebuild with `bun run build` if you changed browse code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for wanting to make gstack better. Whether you're fixing a typo in a skil
 
 ## Quick start
 
-gstack skills are Markdown files that Claude Code discovers from a `skills/` directory. Normally they live at `~/.claude/skills/gstack/` (your global install). But when you're developing gstack itself, you want Claude Code to use the skills *in your working tree* — so edits take effect instantly without copying or deploying anything.
+gstack skills are Markdown files that Claude Code discovers from a `skills/` directory. Normally they live at `~/.claude/skills/gstack/` (your global install). Codex can also discover them from `$HOME/.codex/skills/` via `./setup --host codex`. But when you're developing gstack itself, you usually want Claude Code to use the skills *in your working tree* — so edits take effect instantly without copying or deploying anything.
 
 That's what dev mode does. It symlinks your repo into the local `.claude/skills/` directory so Claude Code reads skills straight from your checkout.
 
@@ -19,6 +19,14 @@ Now edit any `SKILL.md`, invoke it in Claude Code (e.g. `/review`), and see your
 ```bash
 bin/dev-teardown               # deactivate — back to your global install
 ```
+
+To install the current checkout for Codex:
+
+```bash
+./setup --host codex
+```
+
+This creates `gstack` and `gstack-*` aliases under `$HOME/.codex/skills/`. See [AGENTS.md](/Users/andrewcampbell/workspace/gstack-codex-v2/AGENTS.md) for the Codex-facing usage guide.
 
 ## Contributor mode
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,36 @@ Expect first useful run in under 5 minutes on any repo with tests already set up
 
 **Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+
 
+### Codex install
+
+Clone the repo anywhere convenient, then install the Codex skill aliases:
+
+```bash
+git clone https://github.com/garrytan/gstack.git ~/src/gstack
+cd ~/src/gstack
+./setup --host codex
+```
+
+This creates skills at `$HOME/.codex/skills/`:
+
+- `gstack`
+- `gstack-browse`
+- `gstack-review`
+- `gstack-ship`
+- `gstack-qa`
+- `gstack-qa-only`
+- `gstack-plan-ceo-review`
+- `gstack-plan-eng-review`
+- `gstack-plan-design-review`
+- `gstack-design-consultation`
+- `gstack-design-review`
+- `gstack-office-hours`
+- `gstack-debug`
+- `gstack-document-release`
+- `gstack-retro`
+- `gstack-setup-browser-cookies`
+- `gstack-upgrade`
+
 ### Step 1: Install on your machine
 
 Open Claude Code and paste this. Claude does the rest.
@@ -181,9 +211,13 @@ Fifteen specialists. All slash commands. All Markdown. All free. **[github.com/g
 
 ## Troubleshooting
 
-**Skill not showing up?** `cd ~/.claude/skills/gstack && ./setup`
+**Claude skill not showing up?** `cd ~/.claude/skills/gstack && ./setup`
 
-**`/browse` fails?** `cd ~/.claude/skills/gstack && bun install && bun run build`
+**Codex skill not showing up?** `cd ~/src/gstack && ./setup --host codex`
+
+**Claude `/browse` fails?** `cd ~/.claude/skills/gstack && bun install && bun run build`
+
+**Codex `gstack-browse` fails?** `cd ~/src/gstack && bun install && bun run build && ./setup --host codex`
 
 **Stale install?** Run `/gstack-upgrade` — or set `auto_upgrade: true` in `~/.gstack/config.yaml`
 

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "gstack"
+  short_description: "Ship, review, QA, plan, and retro — powered by a headless browser"
+  brand_color: "#18181B"
+  default_prompt: "What would you like to ship today?"

--- a/browse/bin/find-browse
+++ b/browse/bin/find-browse
@@ -7,11 +7,17 @@ if test -x "$DIR/find-browse"; then
 fi
 # Fallback: basic discovery
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-if [ -n "$ROOT" ] && test -x "$ROOT/.claude/skills/gstack/browse/dist/browse"; then
-  echo "$ROOT/.claude/skills/gstack/browse/dist/browse"
-elif test -x "$HOME/.claude/skills/gstack/browse/dist/browse"; then
-  echo "$HOME/.claude/skills/gstack/browse/dist/browse"
-else
-  echo "ERROR: browse binary not found. Run: cd <skill-dir> && ./setup" >&2
-  exit 1
-fi
+for candidate in \
+  "${ROOT:+$ROOT/.codex/skills/gstack/browse/dist/browse}" \
+  "${ROOT:+$ROOT/.claude/skills/gstack/browse/dist/browse}" \
+  "$HOME/.codex/skills/gstack/browse/dist/browse" \
+  "$HOME/.claude/skills/gstack/browse/dist/browse"
+do
+  if [ -n "$candidate" ] && test -x "$candidate"; then
+    echo "$candidate"
+    exit 0
+  fi
+done
+
+echo "ERROR: browse binary not found. Run: cd <skill-dir> && ./setup" >&2
+exit 1

--- a/browse/src/find-browse.ts
+++ b/browse/src/find-browse.ts
@@ -5,7 +5,7 @@
  * Outputs the absolute path to the browse binary on stdout, or exits 1 if not found.
  */
 
-import { existsSync } from 'fs';
+import { accessSync, constants } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
@@ -24,19 +24,35 @@ function getGitRoot(): string | null {
   }
 }
 
-export function locateBinary(): string | null {
-  const root = getGitRoot();
-  const home = homedir();
+const SKILL_ROOT_MARKERS = [
+  ['.codex', 'skills', 'gstack'],
+  ['.claude', 'skills', 'gstack'],
+] as const;
 
-  // Workspace-local takes priority (for development)
+function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function locateBinary(options: { root?: string | null; home?: string } = {}): string | null {
+  const root = options.root ?? getGitRoot();
+  const home = options.home ?? homedir();
+
   if (root) {
-    const local = join(root, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse');
-    if (existsSync(local)) return local;
+    for (const marker of SKILL_ROOT_MARKERS) {
+      const local = join(root, ...marker, 'browse', 'dist', 'browse');
+      if (isExecutable(local)) return local;
+    }
   }
 
-  // Global fallback
-  const global = join(home, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse');
-  if (existsSync(global)) return global;
+  for (const marker of SKILL_ROOT_MARKERS) {
+    const global = join(home, ...marker, 'browse', 'dist', 'browse');
+    if (isExecutable(global)) return global;
+  }
 
   return null;
 }

--- a/browse/test/find-browse.test.ts
+++ b/browse/test/find-browse.test.ts
@@ -4,7 +4,9 @@
 
 import { describe, test, expect } from 'bun:test';
 import { locateBinary } from '../src/find-browse';
-import { existsSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
 
 describe('locateBinary', () => {
   test('returns null when no binary exists at known paths', () => {
@@ -20,5 +22,39 @@ describe('locateBinary', () => {
     if (result !== null) {
       expect(existsSync(result)).toBe(true);
     }
+  });
+
+  test('prefers workspace-local Codex install over Claude install', () => {
+    const root = mkdtempSync(join(tmpdir(), 'find-browse-root-'));
+    const home = mkdtempSync(join(tmpdir(), 'find-browse-home-'));
+    const codex = join(root, '.codex', 'skills', 'gstack', 'browse', 'dist', 'browse');
+    const claude = join(root, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse');
+
+    for (const file of [claude, codex]) {
+      mkdirSync(dirname(file), { recursive: true });
+      writeFileSync(file, '');
+      chmodSync(file, 0o755);
+    }
+
+    expect(locateBinary({ root, home })).toBe(codex);
+    rmSync(root, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test('falls back to global Codex install before global Claude install', () => {
+    const root = mkdtempSync(join(tmpdir(), 'find-browse-root-empty-'));
+    const home = mkdtempSync(join(tmpdir(), 'find-browse-home-global-'));
+    const codex = join(home, '.codex', 'skills', 'gstack', 'browse', 'dist', 'browse');
+    const claude = join(home, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse');
+
+    for (const file of [claude, codex]) {
+      mkdirSync(dirname(file), { recursive: true });
+      writeFileSync(file, '');
+      chmodSync(file, 0o755);
+    }
+
+    expect(locateBinary({ root, home })).toBe(codex);
+    rmSync(root, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
   });
 });

--- a/setup
+++ b/setup
@@ -1,14 +1,95 @@
 #!/usr/bin/env bash
-# gstack setup — build browser binary + register all skills with Claude Code
+# gstack setup — build browser binary + register skills for Claude Code or Codex
 set -e
 
+HOST="claude"
+if [ "${1:-}" = "--host" ]; then
+  if [ -z "${2:-}" ]; then
+    echo "--host requires a value: claude or codex" >&2
+    exit 1
+  fi
+  HOST="$2"
+fi
+
+case "$HOST" in
+  claude|codex) ;;
+  *)
+    echo "Unknown host: $HOST" >&2
+    exit 1
+    ;;
+esac
+
 GSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
+GSTACK_DIR_REAL="$(cd "$(dirname "$0")" && pwd -P)"
 SKILLS_DIR="$(dirname "$GSTACK_DIR")"
-BROWSE_BIN="$GSTACK_DIR/browse/dist/browse"
+BROWSE_BIN="$GSTACK_DIR_REAL/browse/dist/browse"
+
+link_claude_dir() {
+  local skills_dir="$1"
+  local label="$2"
+
+  mkdir -p "$skills_dir"
+  if [ -L "$skills_dir/gstack" ] || [ ! -e "$skills_dir/gstack" ]; then
+    ln -snf "$GSTACK_DIR_REAL" "$skills_dir/gstack"
+  else
+    echo "  skipped $label root: $skills_dir/gstack already exists"
+  fi
+
+  local linked=()
+  for skill_dir in "$GSTACK_DIR_REAL"/*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      local skill_name
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "node_modules" ] && continue
+      local target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "gstack/$skill_name" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked $label: ${linked[*]}"
+  fi
+}
+
+link_codex_dir() {
+  local skills_dir="$1"
+
+  mkdir -p "$skills_dir"
+  if [ -L "$skills_dir/gstack" ] || [ ! -e "$skills_dir/gstack" ]; then
+    ln -snf "$GSTACK_DIR_REAL" "$skills_dir/gstack"
+  else
+    echo "  skipped Codex root: $skills_dir/gstack already exists"
+  fi
+
+  local linked=()
+  for skill_dir in "$GSTACK_DIR_REAL"/*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      local skill_name
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "node_modules" ] && continue
+      local alias_name="gstack-$skill_name"
+      case "$skill_name" in
+        gstack-*) alias_name="$skill_name" ;;
+      esac
+      local target="$skills_dir/$alias_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$alias_name")
+      fi
+    fi
+  done
+
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked Codex skills: ${linked[*]}"
+  fi
+}
 
 ensure_playwright_browser() {
   (
-    cd "$GSTACK_DIR"
+    cd "$GSTACK_DIR_REAL"
     bun --eval 'import { chromium } from "playwright"; const browser = await chromium.launch(); await browser.close();'
   ) >/dev/null 2>&1
 }
@@ -17,24 +98,24 @@ ensure_playwright_browser() {
 NEEDS_BUILD=0
 if [ ! -x "$BROWSE_BIN" ]; then
   NEEDS_BUILD=1
-elif [ -n "$(find "$GSTACK_DIR/browse/src" -type f -newer "$BROWSE_BIN" -print -quit 2>/dev/null)" ]; then
+elif [ -n "$(find "$GSTACK_DIR_REAL/browse/src" -type f -newer "$BROWSE_BIN" -print -quit 2>/dev/null)" ]; then
   NEEDS_BUILD=1
-elif [ "$GSTACK_DIR/package.json" -nt "$BROWSE_BIN" ]; then
+elif [ "$GSTACK_DIR_REAL/package.json" -nt "$BROWSE_BIN" ]; then
   NEEDS_BUILD=1
-elif [ -f "$GSTACK_DIR/bun.lock" ] && [ "$GSTACK_DIR/bun.lock" -nt "$BROWSE_BIN" ]; then
+elif [ -f "$GSTACK_DIR_REAL/bun.lock" ] && [ "$GSTACK_DIR_REAL/bun.lock" -nt "$BROWSE_BIN" ]; then
   NEEDS_BUILD=1
 fi
 
 if [ "$NEEDS_BUILD" -eq 1 ]; then
   echo "Building browse binary..."
   (
-    cd "$GSTACK_DIR"
+    cd "$GSTACK_DIR_REAL"
     bun install
     bun run build
   )
   # Safety net: write .version if build script didn't (e.g., git not available during build)
-  if [ ! -f "$GSTACK_DIR/browse/dist/.version" ]; then
-    git -C "$GSTACK_DIR" rev-parse HEAD > "$GSTACK_DIR/browse/dist/.version" 2>/dev/null || true
+  if [ ! -f "$GSTACK_DIR_REAL/browse/dist/.version" ]; then
+    git -C "$GSTACK_DIR_REAL" rev-parse HEAD > "$GSTACK_DIR_REAL/browse/dist/.version" 2>/dev/null || true
   fi
 fi
 
@@ -47,7 +128,7 @@ fi
 if ! ensure_playwright_browser; then
   echo "Installing Playwright Chromium..."
   (
-    cd "$GSTACK_DIR"
+    cd "$GSTACK_DIR_REAL"
     bunx playwright install chromium
   )
 fi
@@ -60,33 +141,22 @@ fi
 # 3. Ensure ~/.gstack global state directory exists
 mkdir -p "$HOME/.gstack/projects"
 
-# 4. Only create skill symlinks if we're inside a .claude/skills directory
-SKILLS_BASENAME="$(basename "$SKILLS_DIR")"
-if [ "$SKILLS_BASENAME" = "skills" ]; then
-  linked=()
-  for skill_dir in "$GSTACK_DIR"/*/; do
-    if [ -f "$skill_dir/SKILL.md" ]; then
-      skill_name="$(basename "$skill_dir")"
-      # Skip node_modules
-      [ "$skill_name" = "node_modules" ] && continue
-      target="$SKILLS_DIR/$skill_name"
-      # Create or update symlink; skip if a real file/directory exists
-      if [ -L "$target" ] || [ ! -e "$target" ]; then
-        ln -snf "gstack/$skill_name" "$target"
-        linked+=("$skill_name")
-      fi
-    fi
-  done
+echo "gstack ready."
+echo "  browse: $BROWSE_BIN"
 
-  echo "gstack ready."
-  echo "  browse: $BROWSE_BIN"
-  if [ ${#linked[@]} -gt 0 ]; then
-    echo "  linked skills: ${linked[*]}"
+if [ "$HOST" = "claude" ]; then
+  # Only create Claude symlinks automatically if we're inside a .claude/skills directory.
+  SKILLS_BASENAME="$(basename "$SKILLS_DIR")"
+  if [ "$SKILLS_BASENAME" = "skills" ]; then
+    link_claude_dir "$SKILLS_DIR" "Claude skills"
+  else
+    echo "  (skipped skill symlinks — not inside .claude/skills/)"
   fi
 else
-  echo "gstack ready."
-  echo "  browse: $BROWSE_BIN"
-  echo "  (skipped skill symlinks — not inside .claude/skills/)"
+  link_codex_dir "$HOME/.codex/skills"
+  # Keep the current Claude-layout helper paths available until the skill docs
+  # themselves become fully host-aware.
+  link_claude_dir "$HOME/.claude/skills" "Claude compatibility skills"
 fi
 
 # 4. First-time welcome + legacy cleanup


### PR DESCRIPTION
## Summary

- add a small Codex bootstrap path without touching the skill generator
- install Codex aliases under `$HOME/.codex/skills/` via `./setup --host codex`
- keep `browse` discovery Codex-aware so the installed binary resolves cleanly
- add minimal Codex-facing repo metadata and docs (`AGENTS.md`, `agents/openai.yaml`)

## Why this PR is small

The previous Codex PR grew too large and too stale to review. This is the narrow first slice:

- `setup --host codex`
- Codex-aware `find-browse`
- minimal docs/metadata

I intentionally left generated Codex-native skill docs and template/generator work for a follow-up PR.

## What changed

- `setup`
  - adds `--host codex`
  - creates `gstack` and `gstack-*` symlinks in `$HOME/.codex/skills/`
  - keeps the current Claude-layout helper paths available as compatibility symlinks so existing skill docs still run unchanged
- `browse/src/find-browse.ts`
  - prefers `.codex/skills/gstack` before `.claude/skills/gstack`
  - checks executability instead of mere existence
- `browse/bin/find-browse`
  - mirrors the same Codex-first discovery order in the shell fallback
- `browse/test/find-browse.test.ts`
  - adds Codex-first locator coverage for both workspace-local and global installs
- `README.md` / `CONTRIBUTING.md`
  - document the Codex install path briefly without broader docs churn
- `AGENTS.md` / `agents/openai.yaml`
  - add Codex-facing repo metadata

## Testing

```bash
bun install
bash -n setup browse/bin/find-browse
bun test browse/test/find-browse.test.ts
bun test
TMP_HOME=$(mktemp -d)
HOME="$TMP_HOME" ./setup --host codex
HOME="$TMP_HOME" "$TMP_HOME/.codex/skills/gstack/browse/bin/find-browse"
```

## Notes

- Existing Claude behavior is unchanged when `./setup` is run without `--host`.
- This PR does not add generated `.agents/skills/*` output yet.
- The Codex bootstrap currently uses Claude-layout compatibility symlinks under `~/.claude/skills/` so the existing skill docs continue to work until the skill markdown itself becomes host-aware in a follow-up.
