### PR TITLE
Add Codex and Claude install compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,33 @@ Expect first useful run in under 5 minutes on any repo with tests already set up
 
 ## Install — takes 30 seconds
 
-**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+
+**Requirements:** [Codex](https://openai.com/codex/) or [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+
 
 ### Step 1: Install on your machine
 
-Open Claude Code and paste this. Claude does the rest.
+Pick the host app you use:
 
-> Install gstack: run **`git clone https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /retro, /debug, /document-release. Then ask the user if they also want to add gstack to the current project so teammates get it.
+**For Codex:** prefer `~/.agents/skills/gstack` on your machine and `.agents/skills/gstack` in repos. `~/.codex/skills/gstack` and `.codex/skills/gstack` still work as compatibility paths.
+
+> Install gstack in Codex: run **`mkdir -p ~/.agents/skills && git clone https://github.com/garrytan/gstack.git ~/.agents/skills/gstack && cd ~/.agents/skills/gstack && ./setup`** then add a "gstack" section to AGENTS.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /retro, /debug, /document-release. Then ask the user if they also want to add gstack to the current project so teammates get it.
+
+**For Claude Code:** clone into `~/.claude/skills/gstack`, run `./setup`, then add a `gstack` section to `CLAUDE.md`.
+
+> Install gstack in Claude Code: run **`git clone https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /retro, /debug, /document-release. Then ask the user if they also want to add gstack to the current project so teammates get it.
+
+`./setup` supports Codex and Claude layouts. For Codex installs it also creates compatibility links between `.agents`, `.codex`, and `.claude` skill roots when possible, so the existing gstack helper scripts and generated skill docs keep working.
 
 ### Step 2: Add to your repo so teammates get it (optional)
 
-> Add gstack to this project: run **`cp -Rf ~/.claude/skills/gstack .claude/skills/gstack && rm -rf .claude/skills/gstack/.git && cd .claude/skills/gstack && ./setup`** then add a "gstack" section to this project's CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /retro, /debug, /document-release, and tells Claude that if gstack skills aren't working, run `cd .claude/skills/gstack && ./setup` to build the binary and register skills.
+**For Codex repos:** prefer `.agents/skills/gstack` and document it in `AGENTS.md`. `.codex/skills/gstack` also works.
 
-Real files get committed to your repo (not a submodule), so `git clone` just works. Everything lives inside `.claude/`. Nothing touches your PATH or runs in the background.
+> Add gstack to this Codex project: run **`mkdir -p .agents/skills && cp -Rf ~/.agents/skills/gstack .agents/skills/gstack && rm -rf .agents/skills/gstack/.git && cd .agents/skills/gstack && ./setup`** then add a "gstack" section to this project's AGENTS.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /retro, /debug, /document-release, and tells Codex that if gstack skills aren't working, run `cd .agents/skills/gstack && ./setup` to build the binary and register skills.
+
+**For Claude Code repos:** vendor into `.claude/skills/gstack` and document it in `CLAUDE.md`.
+
+> Add gstack to this Claude Code project: run **`mkdir -p .claude/skills && cp -Rf ~/.claude/skills/gstack .claude/skills/gstack && rm -rf .claude/skills/gstack/.git && cd .claude/skills/gstack && ./setup`** then add a "gstack" section to this project's CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /retro, /debug, /document-release, and tells Claude that if gstack skills aren't working, run `cd .claude/skills/gstack && ./setup` to build the binary and register skills.
+
+Real files get committed to your repo (not a submodule), so `git clone` just works. Everything lives inside `.agents/`, `.codex/`, or `.claude/`. Nothing touches your PATH or runs in the background.
 
 ## See it work
 
@@ -181,13 +195,13 @@ Fifteen specialists. All slash commands. All Markdown. All free. **[github.com/g
 
 ## Troubleshooting
 
-**Skill not showing up?** `cd ~/.claude/skills/gstack && ./setup`
+**Skill not showing up?** Run `./setup` from your install directory: `~/.agents/skills/gstack` for Codex preferred, `~/.codex/skills/gstack` for Codex compatibility, or `~/.claude/skills/gstack` for Claude Code.
 
-**`/browse` fails?** `cd ~/.claude/skills/gstack && bun install && bun run build`
+**`/browse` fails?** Rebuild from your install directory: `cd ~/.agents/skills/gstack && bun install && bun run build` for Codex preferred, `cd ~/.codex/skills/gstack && bun install && bun run build` for Codex compatibility, or `cd ~/.claude/skills/gstack && bun install && bun run build` for Claude Code.
 
 **Stale install?** Run `/gstack-upgrade` — or set `auto_upgrade: true` in `~/.gstack/config.yaml`
 
-**Claude says it can't see the skills?** Make sure your project's `CLAUDE.md` has a gstack section. Add this:
+**Host app says it can't see the skills?** Make sure your project includes the gstack section in the right file: `AGENTS.md` for Codex or `CLAUDE.md` for Claude Code. Add this:
 
 ```
 ## gstack

--- a/SKILL.md
+++ b/SKILL.md
@@ -153,11 +153,16 @@ Auto-shuts down after 30 min idle. State persists between calls (cookies, tabs, 
 ## SETUP (run this check BEFORE any browse command)
 
 ```bash
+_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
-[ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
-[ -z "$B" ] && B=~/.claude/skills/gstack/browse/dist/browse
-if [ -x "$B" ]; then
+[ -n "$_ROOT" ] && [ -x "$_ROOT/.agents/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.codex/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.codex/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.agents/skills/gstack/browse/dist/browse" ] && B="$HOME/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$_CODEX_HOME/skills/gstack/browse/dist/browse" ] && B="$_CODEX_HOME/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.claude/skills/gstack/browse/dist/browse" ] && B="$HOME/.claude/skills/gstack/browse/dist/browse"
+if [ -n "$B" ]; then
   echo "READY: $B"
 else
   echo "NEEDS_SETUP"

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -154,11 +154,16 @@ State persists between calls (cookies, tabs, login sessions).
 ## SETUP (run this check BEFORE any browse command)
 
 ```bash
+_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
-[ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
-[ -z "$B" ] && B=~/.claude/skills/gstack/browse/dist/browse
-if [ -x "$B" ]; then
+[ -n "$_ROOT" ] && [ -x "$_ROOT/.agents/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.codex/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.codex/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.agents/skills/gstack/browse/dist/browse" ] && B="$HOME/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$_CODEX_HOME/skills/gstack/browse/dist/browse" ] && B="$_CODEX_HOME/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.claude/skills/gstack/browse/dist/browse" ] && B="$HOME/.claude/skills/gstack/browse/dist/browse"
+if [ -n "$B" ]; then
   echo "READY: $B"
 else
   echo "NEEDS_SETUP"

--- a/browse/bin/find-browse
+++ b/browse/bin/find-browse
@@ -7,8 +7,17 @@ if test -x "$DIR/find-browse"; then
 fi
 # Fallback: basic discovery
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-if [ -n "$ROOT" ] && test -x "$ROOT/.claude/skills/gstack/browse/dist/browse"; then
+CODEX_HOME_DIR="${CODEX_HOME:-$HOME/.codex}"
+if [ -n "$ROOT" ] && test -x "$ROOT/.agents/skills/gstack/browse/dist/browse"; then
+  echo "$ROOT/.agents/skills/gstack/browse/dist/browse"
+elif [ -n "$ROOT" ] && test -x "$ROOT/.codex/skills/gstack/browse/dist/browse"; then
+  echo "$ROOT/.codex/skills/gstack/browse/dist/browse"
+elif [ -n "$ROOT" ] && test -x "$ROOT/.claude/skills/gstack/browse/dist/browse"; then
   echo "$ROOT/.claude/skills/gstack/browse/dist/browse"
+elif test -x "$HOME/.agents/skills/gstack/browse/dist/browse"; then
+  echo "$HOME/.agents/skills/gstack/browse/dist/browse"
+elif test -x "$CODEX_HOME_DIR/skills/gstack/browse/dist/browse"; then
+  echo "$CODEX_HOME_DIR/skills/gstack/browse/dist/browse"
 elif test -x "$HOME/.claude/skills/gstack/browse/dist/browse"; then
   echo "$HOME/.claude/skills/gstack/browse/dist/browse"
 else

--- a/browse/src/find-browse.ts
+++ b/browse/src/find-browse.ts
@@ -24,19 +24,37 @@ function getGitRoot(): string | null {
   }
 }
 
-export function locateBinary(): string | null {
-  const root = getGitRoot();
-  const home = homedir();
+type LocateBinaryOptions = {
+  root?: string | null;
+  home?: string;
+  codexHome?: string;
+  exists?: (path: string) => boolean;
+};
+
+export function locateBinary(options: LocateBinaryOptions = {}): string | null {
+  const root = options.root === undefined ? getGitRoot() : options.root;
+  const home = options.home ?? homedir();
+  const codexHome = options.codexHome ?? process.env.CODEX_HOME ?? join(home, '.codex');
+  const exists = options.exists ?? existsSync;
+  const agentsHome = join(home, '.agents');
+
+  const candidates: string[] = [];
 
   // Workspace-local takes priority (for development)
   if (root) {
-    const local = join(root, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse');
-    if (existsSync(local)) return local;
+    candidates.push(join(root, '.agents', 'skills', 'gstack', 'browse', 'dist', 'browse'));
+    candidates.push(join(root, '.codex', 'skills', 'gstack', 'browse', 'dist', 'browse'));
+    candidates.push(join(root, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse'));
   }
 
   // Global fallback
-  const global = join(home, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse');
-  if (existsSync(global)) return global;
+  candidates.push(join(agentsHome, 'skills', 'gstack', 'browse', 'dist', 'browse'));
+  candidates.push(join(codexHome, 'skills', 'gstack', 'browse', 'dist', 'browse'));
+  candidates.push(join(home, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse'));
+
+  for (const candidate of candidates) {
+    if (exists(candidate)) return candidate;
+  }
 
   return null;
 }
@@ -53,4 +71,6 @@ function main() {
   console.log(bin);
 }
 
-main();
+if (import.meta.main) {
+  main();
+}

--- a/browse/test/find-browse.test.ts
+++ b/browse/test/find-browse.test.ts
@@ -3,22 +3,92 @@
  */
 
 import { describe, test, expect } from 'bun:test';
+import { join } from 'path';
 import { locateBinary } from '../src/find-browse';
-import { existsSync } from 'fs';
 
 describe('locateBinary', () => {
-  test('returns null when no binary exists at known paths', () => {
-    // This test depends on the test environment — if a real binary exists at
-    // ~/.claude/skills/gstack/browse/dist/browse, it will find it.
-    // We mainly test that the function doesn't throw.
-    const result = locateBinary();
-    expect(result === null || typeof result === 'string').toBe(true);
+  const home = '/tmp/home';
+  const root = '/tmp/repo';
+
+  test('prefers workspace-local Codex install', () => {
+    const result = locateBinary({
+      root,
+      home,
+      exists: (candidate) => candidate === join(root, '.agents', 'skills', 'gstack', 'browse', 'dist', 'browse'),
+    });
+
+    expect(result).toBe(join(root, '.agents', 'skills', 'gstack', 'browse', 'dist', 'browse'));
   });
 
-  test('returns string path when binary exists', () => {
-    const result = locateBinary();
-    if (result !== null) {
-      expect(existsSync(result)).toBe(true);
-    }
+  test('falls back to workspace-local .codex install after .agents', () => {
+    const result = locateBinary({
+      root,
+      home,
+      exists: (candidate) => candidate === join(root, '.codex', 'skills', 'gstack', 'browse', 'dist', 'browse'),
+    });
+
+    expect(result).toBe(join(root, '.codex', 'skills', 'gstack', 'browse', 'dist', 'browse'));
+  });
+
+  test('falls back to workspace-local Claude install when Codex path is absent', () => {
+    const result = locateBinary({
+      root,
+      home,
+      exists: (candidate) => candidate === join(root, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse'),
+    });
+
+    expect(result).toBe(join(root, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse'));
+  });
+
+  test('falls back to global Codex install after workspace paths', () => {
+    const result = locateBinary({
+      root,
+      home,
+      exists: (candidate) => candidate === join(home, '.agents', 'skills', 'gstack', 'browse', 'dist', 'browse'),
+    });
+
+    expect(result).toBe(join(home, '.agents', 'skills', 'gstack', 'browse', 'dist', 'browse'));
+  });
+
+  test('falls back to global $CODEX_HOME install after ~/.agents', () => {
+    const result = locateBinary({
+      root,
+      home,
+      exists: (candidate) => candidate === join(home, '.codex', 'skills', 'gstack', 'browse', 'dist', 'browse'),
+    });
+
+    expect(result).toBe(join(home, '.codex', 'skills', 'gstack', 'browse', 'dist', 'browse'));
+  });
+
+  test('uses CODEX_HOME override for global Codex install', () => {
+    const codexHome = '/tmp/custom-codex';
+    const result = locateBinary({
+      root: null,
+      home,
+      codexHome,
+      exists: (candidate) => candidate === join(codexHome, 'skills', 'gstack', 'browse', 'dist', 'browse'),
+    });
+
+    expect(result).toBe(join(codexHome, 'skills', 'gstack', 'browse', 'dist', 'browse'));
+  });
+
+  test('falls back to global Claude install last', () => {
+    const result = locateBinary({
+      root: null,
+      home,
+      exists: (candidate) => candidate === join(home, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse'),
+    });
+
+    expect(result).toBe(join(home, '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse'));
+  });
+
+  test('returns null when no candidate exists', () => {
+    const result = locateBinary({
+      root,
+      home,
+      exists: () => false,
+    });
+
+    expect(result).toBeNull();
   });
 });

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -193,11 +193,16 @@ If the codebase is empty and purpose is unclear, say: *"I don't have a clear pic
 ## SETUP (run this check BEFORE any browse command)
 
 ```bash
+_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
-[ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
-[ -z "$B" ] && B=~/.claude/skills/gstack/browse/dist/browse
-if [ -x "$B" ]; then
+[ -n "$_ROOT" ] && [ -x "$_ROOT/.agents/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.codex/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.codex/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.agents/skills/gstack/browse/dist/browse" ] && B="$HOME/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$_CODEX_HOME/skills/gstack/browse/dist/browse" ] && B="$_CODEX_HOME/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.claude/skills/gstack/browse/dist/browse" ] && B="$HOME/.claude/skills/gstack/browse/dist/browse"
+if [ -n "$B" ]; then
   echo "READY: $B"
 else
   echo "NEEDS_SETUP"

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -186,11 +186,16 @@ fi
 ## SETUP (run this check BEFORE any browse command)
 
 ```bash
+_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
-[ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
-[ -z "$B" ] && B=~/.claude/skills/gstack/browse/dist/browse
-if [ -x "$B" ]; then
+[ -n "$_ROOT" ] && [ -x "$_ROOT/.agents/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.codex/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.codex/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.agents/skills/gstack/browse/dist/browse" ] && B="$HOME/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$_CODEX_HOME/skills/gstack/browse/dist/browse" ] && B="$_CODEX_HOME/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.claude/skills/gstack/browse/dist/browse" ] && B="$HOME/.claude/skills/gstack/browse/dist/browse"
+if [ -n "$B" ]; then
   echo "READY: $B"
 else
   echo "NEEDS_SETUP"

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -167,11 +167,16 @@ You are a QA engineer. Test web applications like a real user — click everythi
 ## SETUP (run this check BEFORE any browse command)
 
 ```bash
+_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
-[ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
-[ -z "$B" ] && B=~/.claude/skills/gstack/browse/dist/browse
-if [ -x "$B" ]; then
+[ -n "$_ROOT" ] && [ -x "$_ROOT/.agents/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.codex/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.codex/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.agents/skills/gstack/browse/dist/browse" ] && B="$HOME/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$_CODEX_HOME/skills/gstack/browse/dist/browse" ] && B="$_CODEX_HOME/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.claude/skills/gstack/browse/dist/browse" ] && B="$HOME/.claude/skills/gstack/browse/dist/browse"
+if [ -n "$B" ]; then
   echo "READY: $B"
 else
   echo "NEEDS_SETUP"

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -206,11 +206,16 @@ fi
 ## SETUP (run this check BEFORE any browse command)
 
 ```bash
+_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
-[ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
-[ -z "$B" ] && B=~/.claude/skills/gstack/browse/dist/browse
-if [ -x "$B" ]; then
+[ -n "$_ROOT" ] && [ -x "$_ROOT/.agents/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.codex/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.codex/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.agents/skills/gstack/browse/dist/browse" ] && B="$HOME/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$_CODEX_HOME/skills/gstack/browse/dist/browse" ] && B="$_CODEX_HOME/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.claude/skills/gstack/browse/dist/browse" ] && B="$HOME/.claude/skills/gstack/browse/dist/browse"
+if [ -n "$B" ]; then
   echo "READY: $B"
 else
   echo "NEEDS_SETUP"

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -229,11 +229,16 @@ function generateBrowseSetup(): string {
   return `## SETUP (run this check BEFORE any browse command)
 
 \`\`\`bash
+_CODEX_HOME="\${CODEX_HOME:-$HOME/.codex}"
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
-[ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
-[ -z "$B" ] && B=~/.claude/skills/gstack/browse/dist/browse
-if [ -x "$B" ]; then
+[ -n "$_ROOT" ] && [ -x "$_ROOT/.agents/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.codex/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.codex/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.agents/skills/gstack/browse/dist/browse" ] && B="$HOME/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$_CODEX_HOME/skills/gstack/browse/dist/browse" ] && B="$_CODEX_HOME/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.claude/skills/gstack/browse/dist/browse" ] && B="$HOME/.claude/skills/gstack/browse/dist/browse"
+if [ -n "$B" ]; then
   echo "READY: $B"
 else
   echo "NEEDS_SETUP"

--- a/setup
+++ b/setup
@@ -1,16 +1,108 @@
 #!/usr/bin/env bash
-# gstack setup — build browser binary + register all skills with Claude Code
+# gstack setup — build browser binary + register all skills with Codex/Claude
 set -e
 
 GSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$(dirname "$GSTACK_DIR")"
 BROWSE_BIN="$GSTACK_DIR/browse/dist/browse"
+CODEX_HOME_DIR="${CODEX_HOME:-$HOME/.codex}"
+HOME_CODEX_SKILLS="$CODEX_HOME_DIR/skills"
+HOME_CLAUDE_SKILLS="$HOME/.claude/skills"
+HOME_AGENTS_SKILLS="$HOME/.agents/skills"
 
 ensure_playwright_browser() {
   (
     cd "$GSTACK_DIR"
     bun --eval 'import { chromium } from "playwright"; const browser = await chromium.launch(); await browser.close();'
   ) >/dev/null 2>&1
+}
+
+link_skill_tree() {
+  local skills_dir="$1"
+  local create_root_link="${2:-0}"
+  local linked=()
+
+  mkdir -p "$skills_dir"
+
+  if [ "$create_root_link" = "1" ]; then
+    local gstack_target="$skills_dir/gstack"
+    if [ -e "$gstack_target" ] && [ ! -L "$gstack_target" ]; then
+      local resolved_target
+      resolved_target="$(cd "$gstack_target" && pwd -P)"
+      local resolved_source
+      resolved_source="$(cd "$GSTACK_DIR" && pwd -P)"
+      if [ "$resolved_target" != "$resolved_source" ]; then
+        printf '%s\n' ""
+        return 0
+      fi
+    fi
+    if [ -L "$gstack_target" ] || [ ! -e "$gstack_target" ]; then
+      ln -snf "$GSTACK_DIR" "$gstack_target"
+      linked+=("gstack")
+    fi
+  fi
+
+  for skill_dir in "$GSTACK_DIR"/*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      local skill_name
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "node_modules" ] && continue
+
+      local target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "gstack/$skill_name" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+
+  printf '%s\n' "${linked[*]}"
+}
+
+resolve_mirror_dirs() {
+  local skills_dir="$1"
+  local parent_dir
+  parent_dir="$(dirname "$skills_dir")"
+  local parent_name
+  parent_name="$(basename "$parent_dir")"
+
+  if [ "$skills_dir" = "$HOME_CODEX_SKILLS" ]; then
+    printf '%s\n' "$HOME_CLAUDE_SKILLS"
+    printf '%s\n' "$HOME_AGENTS_SKILLS"
+    return 0
+  fi
+
+  if [ "$skills_dir" = "$HOME_CLAUDE_SKILLS" ]; then
+    printf '%s\n' "$HOME_CODEX_SKILLS"
+    printf '%s\n' "$HOME_AGENTS_SKILLS"
+    return 0
+  fi
+
+  if [ "$skills_dir" = "$HOME_AGENTS_SKILLS" ]; then
+    printf '%s\n' "$HOME_CODEX_SKILLS"
+    printf '%s\n' "$HOME_CLAUDE_SKILLS"
+    return 0
+  fi
+
+  if [ "$parent_name" = ".codex" ]; then
+    printf '%s\n' "$(dirname "$parent_dir")/.claude/skills"
+    printf '%s\n' "$(dirname "$parent_dir")/.agents/skills"
+    return 0
+  fi
+
+  if [ "$parent_name" = ".claude" ]; then
+    printf '%s\n' "$(dirname "$parent_dir")/.codex/skills"
+    printf '%s\n' "$(dirname "$parent_dir")/.agents/skills"
+    return 0
+  fi
+
+  if [ "$parent_name" = ".agents" ]; then
+    printf '%s\n' "$(dirname "$parent_dir")/.codex/skills"
+    printf '%s\n' "$(dirname "$parent_dir")/.claude/skills"
+    return 0
+  fi
+
+  printf '%s\n' ""
 }
 
 # 1. Build browse binary if needed (smart rebuild: stale sources, package.json, lock)
@@ -60,33 +152,30 @@ fi
 # 3. Ensure ~/.gstack global state directory exists
 mkdir -p "$HOME/.gstack/projects"
 
-# 4. Only create skill symlinks if we're inside a .claude/skills directory
+# 4. Create skill symlinks when installed from a skills directory
 SKILLS_BASENAME="$(basename "$SKILLS_DIR")"
 if [ "$SKILLS_BASENAME" = "skills" ]; then
-  linked=()
-  for skill_dir in "$GSTACK_DIR"/*/; do
-    if [ -f "$skill_dir/SKILL.md" ]; then
-      skill_name="$(basename "$skill_dir")"
-      # Skip node_modules
-      [ "$skill_name" = "node_modules" ] && continue
-      target="$SKILLS_DIR/$skill_name"
-      # Create or update symlink; skip if a real file/directory exists
-      if [ -L "$target" ] || [ ! -e "$target" ]; then
-        ln -snf "gstack/$skill_name" "$target"
-        linked+=("$skill_name")
-      fi
-    fi
-  done
+  linked="$(link_skill_tree "$SKILLS_DIR")"
+  mirrored_dirs=()
+  while IFS= read -r mirror_dir; do
+    [ -z "$mirror_dir" ] && continue
+    [ "$mirror_dir" = "$SKILLS_DIR" ] && continue
+    mirrored="$(link_skill_tree "$mirror_dir" 1)"
+    [ -n "$mirrored" ] && mirrored_dirs+=("$mirror_dir")
+  done < <(resolve_mirror_dirs "$SKILLS_DIR")
 
   echo "gstack ready."
   echo "  browse: $BROWSE_BIN"
-  if [ ${#linked[@]} -gt 0 ]; then
-    echo "  linked skills: ${linked[*]}"
+  if [ -n "$linked" ]; then
+    echo "  linked skills: $linked"
+  fi
+  if [ ${#mirrored_dirs[@]} -gt 0 ]; then
+    echo "  mirrored compatibility links into: ${mirrored_dirs[*]}"
   fi
 else
   echo "gstack ready."
   echo "  browse: $BROWSE_BIN"
-  echo "  (skipped skill symlinks — not inside .claude/skills/)"
+  echo "  (skipped skill symlinks — not inside a skills directory)"
 fi
 
 # 4. First-time welcome + legacy cleanup

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -161,11 +161,16 @@ Import logged-in sessions from your real Chromium browser into the headless brow
 ## SETUP (run this check BEFORE any browse command)
 
 ```bash
+_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
-[ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
-[ -z "$B" ] && B=~/.claude/skills/gstack/browse/dist/browse
-if [ -x "$B" ]; then
+[ -n "$_ROOT" ] && [ -x "$_ROOT/.agents/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.codex/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.codex/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.agents/skills/gstack/browse/dist/browse" ] && B="$HOME/.agents/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$_CODEX_HOME/skills/gstack/browse/dist/browse" ] && B="$_CODEX_HOME/skills/gstack/browse/dist/browse"
+[ -z "$B" ] && [ -x "$HOME/.claude/skills/gstack/browse/dist/browse" ] && B="$HOME/.claude/skills/gstack/browse/dist/browse"
+if [ -n "$B" ]; then
   echo "READY: $B"
 else
   echo "NEEDS_SETUP"

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -215,6 +215,16 @@ describe('gen-skill-docs', () => {
     expect(qaContent).toContain('Triage');
     expect(qaContent).toContain('WTF');
   });
+
+  test('generated browse setup supports .agents, .codex, and Claude fallbacks', () => {
+    const content = fs.readFileSync(path.join(ROOT, 'SKILL.md'), 'utf-8');
+    expect(content).toContain('_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"');
+    expect(content).toContain('$_ROOT/.agents/skills/gstack/browse/dist/browse');
+    expect(content).toContain('$_ROOT/.codex/skills/gstack/browse/dist/browse');
+    expect(content).toContain('$HOME/.agents/skills/gstack/browse/dist/browse');
+    expect(content).toContain('$_CODEX_HOME/skills/gstack/browse/dist/browse');
+    expect(content).toContain('$HOME/.claude/skills/gstack/browse/dist/browse');
+  });
 });
 
 describe('BASE_BRANCH_DETECT resolver', () => {


### PR DESCRIPTION
## Summary
- add Codex-compatible gstack installation without dropping Claude support
- align Codex paths with Codex itself: prefer `.agents/skills`, support `.codex/skills` as compatibility, and honor `$CODEX_HOME`
- mirror compatibility links across `.agents`, `.codex`, and `.claude`, and update browse binary discovery plus generated skill setup docs

## Testing
- bun install
- bash -n setup
- bash -n browse/bin/find-browse
- bun test