### PR TITLE
fix(update-check): --force now clears snooze so user can upgrade after snoozing

### DIFF
--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -20,9 +20,10 @@ SNOOZE_FILE="$STATE_DIR/update-snoozed"
 VERSION_FILE="$GSTACK_DIR/VERSION"
 REMOTE_URL="${GSTACK_REMOTE_URL:-https://raw.githubusercontent.com/garrytan/gstack/main/VERSION}"
 
-# ─── Force flag (busts cache for standalone /gstack-upgrade) ──
+# ─── Force flag (busts cache + snooze for standalone /gstack-upgrade) ──
 if [ "${1:-}" = "--force" ]; then
   rm -f "$CACHE_FILE"
+  rm -f "$SNOOZE_FILE"
 fi
 
 # ─── Step 0: Check if updates are disabled ────────────────────

--- a/browse/test/gstack-update-check.test.ts
+++ b/browse/test/gstack-update-check.test.ts
@@ -447,6 +447,24 @@ describe('gstack-update-check', () => {
     expect(cache).toContain('UP_TO_DATE');
   });
 
+  test('--force clears snooze so user can upgrade after snoozing', () => {
+    writeFileSync(join(gstackDir, 'VERSION'), '0.3.3\n');
+    writeFileSync(join(gstackDir, 'REMOTE_VERSION'), '0.4.0\n');
+    writeSnooze('0.4.0', 1, nowEpoch() - 60); // snoozed 1 min ago (within 24h)
+
+    // Without --force: snoozed, silent
+    const snoozed = run();
+    expect(snoozed.exitCode).toBe(0);
+    expect(snoozed.stdout).toBe('');
+
+    // With --force: snooze cleared, outputs upgrade
+    const forced = run({}, ['--force']);
+    expect(forced.exitCode).toBe(0);
+    expect(forced.stdout).toBe('UPGRADE_AVAILABLE 0.3.3 0.4.0');
+    // Snooze file should be deleted
+    expect(existsSync(join(stateDir, 'update-snoozed'))).toBe(false);
+  });
+
   // ─── Split TTL tests ─────────────────────────────────────────
 
   test('UP_TO_DATE cache expires after 60 min (not 720)', () => {


### PR DESCRIPTION
## Summary
- `--force` flag now clears both cache AND snooze file
- Allows users who snoozed an upgrade to still run `/gstack-upgrade` directly when they change their mind

## Evidence
When a user snoozes an upgrade ("Not now") but then 10 minutes later runs `/gstack-upgrade`, the `--force` flag only cleared the cache but still respected the snooze — leaving the user unable to upgrade until the snooze expired (24h-7d).

## Pre-Landing Review
No issues found.

## Test Coverage
- Added 1 new test: `--force clears snooze so user can upgrade after snoozing`
- All 33 tests pass (32 existing + 1 new)

## Test plan
- [x] All bun tests pass (`bun test browse/test/gstack-update-check.test.ts`)
- [x] Manual verification: snooze active → `--force` → upgrade available

🤖 Generated with [Claude Code](https://claude.com/claude-code)