### PR TITLE
fix: use three-dot diff for scope drift detection in /review

### DIFF
--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -195,7 +195,7 @@ Before reviewing code quality, check: **did they build what was requested — no
    Read commit messages (`git log origin/<base>..HEAD --oneline`).
    **If no PR exists:** rely on commit messages and TODOS.md for stated intent — this is the common case since /review runs before /ship creates the PR.
 2. Identify the **stated intent** — what was this branch supposed to accomplish?
-3. Run `git diff origin/<base> --stat` and compare the files changed against the stated intent.
+3. Run `git diff origin/<base>...HEAD --stat` and compare the files changed against the stated intent.
 4. Evaluate with skepticism:
 
    **SCOPE CREEP detection:**

--- a/review/SKILL.md.tmpl
+++ b/review/SKILL.md.tmpl
@@ -42,7 +42,7 @@ Before reviewing code quality, check: **did they build what was requested — no
    Read commit messages (`git log origin/<base>..HEAD --oneline`).
    **If no PR exists:** rely on commit messages and TODOS.md for stated intent — this is the common case since /review runs before /ship creates the PR.
 2. Identify the **stated intent** — what was this branch supposed to accomplish?
-3. Run `git diff origin/<base> --stat` and compare the files changed against the stated intent.
+3. Run `git diff origin/<base>...HEAD --stat` and compare the files changed against the stated intent.
 4. Evaluate with skepticism:
 
    **SCOPE CREEP detection:**


### PR DESCRIPTION
## Summary
- `/review` Step 1.5 (Scope Drift Detection) used two-dot `git diff origin/<base> --stat`, which shows the full tree difference between HEAD and the base ref
- On rebased feature branches, this includes commits already on the base branch, producing false-positive "scope drift" findings for changes the author did not introduce
- Switched to three-dot `git diff origin/<base>...HEAD --stat` (merge-base diff), which shows only changes introduced on the feature branch
- This matches what `/ship` already uses for its line-count stat

## How it was found
Contributor mode filed a field report after `/review` flagged unrelated version bumps and date changes as scope drift on a rebased feature branch. The changes came from main via rebase, not from the feature work.

## Test plan
- [x] `bun test` passes
- [x] Validated live: ran `/review` on a rebased feature branch — scope drift step no longer flags rebased-in changes from main