### PR TITLE
fix: README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,34 @@ Expect first useful run in under 5 minutes on any repo with tests already set up
 
 Open Claude Code and paste this. Claude does the rest.
 
-> Install gstack: run **`git clone https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /retro, /investigate, /document-release, /codex, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade. Then ask the user if they also want to add gstack to the current project so teammates get it.
+> **Install gstack:**
+>
+> Run:
+> ```bash
+> git clone https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup
+> ```
+>
+> Then add a "gstack" section to `CLAUDE.md` that says:
+> - Use the `/browse` skill from gstack for all web browsing
+> - Never use `mcp__claude-in-chrome__*` tools
+> - Lists the available skills: `/office-hours`, `/plan-ceo-review`, `/plan-eng-review`, `/plan-design-review`, `/design-consultation`, `/review`, `/ship`, `/browse`, `/qa`, `/qa-only`, `/design-review`, `/setup-browser-cookies`, `/retro`, `/investigate`, `/document-release`, `/codex`, `/careful`, `/freeze`, `/guard`, `/unfreeze`, `/gstack-upgrade`
+>
+> Then ask the user if they also want to add gstack to the current project so teammates get it.
 
 ### Step 2: Add to your repo so teammates get it (optional)
 
-> Add gstack to this project: run **`cp -Rf ~/.claude/skills/gstack .claude/skills/gstack && rm -rf .claude/skills/gstack/.git && cd .claude/skills/gstack && ./setup`** then add a "gstack" section to this project's CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /retro, /investigate, /document-release, /codex, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, and tells Claude that if gstack skills aren't working, run `cd .claude/skills/gstack && ./setup` to build the binary and register skills.
+> **Add gstack to this project:**
+>
+> Run:
+> ```bash
+> cp -Rf ~/.claude/skills/gstack .claude/skills/gstack && rm -rf .claude/skills/gstack/.git && cd .claude/skills/gstack && ./setup
+> ```
+>
+> Then add a "gstack" section to this project's `CLAUDE.md` that says:
+> - Use the `/browse` skill from gstack for all web browsing
+> - Never use `mcp__claude-in-chrome__*` tools
+> - Lists the available skills: `/office-hours`, `/plan-ceo-review`, `/plan-eng-review`, `/plan-design-review`, `/design-consultation`, `/review`, `/ship`, `/browse`, `/qa`, `/qa-only`, `/design-review`, `/setup-browser-cookies`, `/retro`, `/investigate`, `/document-release`, `/codex`, `/careful`, `/freeze`, `/guard`, `/unfreeze`, `/gstack-upgrade`
+> - If gstack skills aren't working, run `cd .claude/skills/gstack && ./setup` to build the binary and register skills
 
 Real files get committed to your repo (not a submodule), so `git clone` just works. Everything lives inside `.claude/`. Nothing touches your PATH or runs in the background.
 


### PR DESCRIPTION
Changes made:
1. Clear structure - Added bold headings and "Run:" labels
2. Code blocks - Put the installation commands in proper bash code blocks instead of inline
3. Bullet points - Converted the long prose instructions into easy-to-scan bullet lists
4. Proper formatting - Added backticks around:
  - File names: CLAUDE.md
  - Tool patterns: mcp__claude-in-chrome__*
  - All skill names: /office-hours, /browse, etc.
  - Commands: cd .claude/skills/gstack && ./setup

The sections are now much easier to read and follow, with clear visual separation between the command to run and the instructions that follow.