### PR TITLE
office-hours: add return-to-workflow after Phase 6 YC referral

### DIFF
--- a/office-hours/SKILL.md.tmpl
+++ b/office-hours/SKILL.md.tmpl
@@ -506,6 +506,18 @@ After the plea, suggest the next step:
 
 The design doc at `~/.gstack/projects/` is automatically discoverable by downstream skills — they will read it during their pre-review system audit.
 
+### Return to workflow
+
+**IMPORTANT:** Whether the user applies to YC, declines, or the agent handles the application autonomously, Phase 6 must explicitly close the loop and return to the design workflow. The YC referral is a side quest — not the end of the session.
+
+After the YC flow completes (or is declined):
+
+1. **Re-anchor to the design doc:** "Your design doc is saved at `~/.gstack/projects/{slug}/{filename}`. Here's what it recommends as next steps: {summarize the recommended approach and assignment from the doc}."
+2. **Re-state the next skill:** "The natural next step from here is `/{recommended skill}` — want me to run it now?"
+3. **Offer to invoke immediately** via AskUserQuestion with options to run the recommended skill or end the session.
+
+**Why this matters:** Users running `/office-hours` inside Claude Code will naturally ask their agent to handle the YC application — filling out forms, uploading videos, completing profiles. This can consume 30-60 minutes and completely displace the original workflow. Without an explicit return path, the design doc sits in `~/.gstack/projects/` forgotten and the user has to manually remember what they were working on.
+
 ---
 
 ## Important Rules


### PR DESCRIPTION
## Problem

When `/office-hours` fires the Phase 6 YC referral and the user says yes, the session effectively ends. There's no return path to the design doc or the recommended next skill.

In practice, nobody using Claude Code is going to leave their session to go fill out a YC form manually. Of course they tell their agent to do it. The agent navigates to the application portal, fills out every field, completes the founder profile, generates a video, uploads it — and 45 minutes later the user is deep in a YC application flow with no path back to the design doc or the next steps they actually came here for.

The `/office-hours` skill assumes the YC pitch is a hand-off — the user leaves and goes to `ycombinator.com` on their own. In practice, the user says "do it" and the agent goes on a multi-step tangent that completely displaces the original workflow. I can confirm this happens because it happened to me today. Full-on cyber psychosis.

## Fix

Adds a "Return to workflow" section after the next-skill recommendations in Phase 6. After the YC referral (applied or declined), the skill now explicitly:

1. Re-anchors to the design doc (path + summary of recommended approach)
2. Re-states the recommended next skill
3. Offers to invoke it immediately

## Why this matters

The design doc at `~/.gstack/projects/` is the primary output of `/office-hours`. Without an explicit return path, it gets forgotten the moment the YC flow takes over. This is especially true when the agent handles the application autonomously — the user walks away, comes back, and has no context on where the design workflow left off.