### PR TITLE
feat: add plugin marketplace metadata for /plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,40 @@
+{
+  "name": "gstack",
+  "description": "Full-stack AI development workflow: QA, code review, browser automation, shipping, debugging, and 22 specialized skills.",
+  "owner": {
+    "name": "Garry Tan",
+    "email": "garry@garrytan.com"
+  },
+  "plugins": [
+    {
+      "name": "gstack",
+      "source": "./",
+      "description": "22 development workflow skills for Claude Code: QA testing, code review, browser automation, design review, shipping, debugging, retrospectives, and more.",
+      "category": "development",
+      "tags": ["qa", "review", "browser", "ship", "debug", "workflow", "design"],
+      "skills": [
+        "./browse",
+        "./careful",
+        "./codex",
+        "./design-consultation",
+        "./design-review",
+        "./document-release",
+        "./freeze",
+        "./gstack-upgrade",
+        "./guard",
+        "./investigate",
+        "./office-hours",
+        "./plan-ceo-review",
+        "./plan-design-review",
+        "./plan-eng-review",
+        "./qa",
+        "./qa-only",
+        "./retro",
+        "./review",
+        "./setup-browser-cookies",
+        "./ship",
+        "./unfreeze"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "gstack",
+  "description": "Full-stack AI development workflow skills for Claude Code",
+  "version": "0.9.0",
+  "author": {
+    "name": "Garry Tan"
+  },
+  "repository": "https://github.com/garrytan/gstack",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/` directory with `marketplace.json` and `plugin.json` metadata
- Enables automatic discovery and one-click installation via Claude Code's `/plugin` command
- Registers all 21 skills in the marketplace manifest with proper categorization and tags

## Motivation

Currently gstack requires manual `git clone` + symlink setup. Claude Code's plugin marketplace ecosystem supports automatic discovery, installation, and updates — but requires `.claude-plugin/` metadata in the repository root.

This PR adds the minimal metadata needed to make gstack a compliant plugin marketplace repository, enabling:
- `/plugin` → search "gstack" → one-click install
- Automatic updates via `autoUpdate` 
- All 21 skills auto-registered through the `skills` array

## Files added

- `.claude-plugin/marketplace.json` — marketplace definition with plugin entry, skill paths, category, and tags
- `.claude-plugin/plugin.json` — plugin metadata (name, version 0.9.0, author, repository, license)

## Verification

- All 21 skill paths verified to contain `SKILL.md`
- Structure follows the same pattern as other Claude Code plugin marketplaces (e.g., claude-hud, anthropic-agent-skills)
- No changes to existing files

## Test plan

- [ ] Register fork as marketplace in `~/.claude/plugins/known_marketplaces.json`
- [ ] `/plugin` install gstack and verify all skills load
- [ ] Run `/careful`, `/qa`, `/review` to confirm skills work post-install