### PR TITLE
docs: 將所有說明文件翻譯為繁體中文（台灣）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,47 @@
-# gstack — AI Engineering Workflow
+# gstack — AI 工程工作流程
 
-gstack is a collection of SKILL.md files that give AI agents structured roles for
-software development. Each skill is a specialist: CEO reviewer, eng manager,
-designer, QA lead, release engineer, debugger, and more.
+gstack 是一系列 SKILL.md 檔案，賦予 AI 代理人在軟體開發中扮演結構化角色。每個技能代表一位專家：CEO 審查者、工程主管、設計師、QA 主管、發布工程師、除錯者等。
 
-## Available skills
+## 可用技能
 
-Skills live in `.agents/skills/`. Invoke them by name (e.g., `/office-hours`).
+技能存放在 `.agents/skills/` 目錄。透過名稱呼叫（例如：`/office-hours`）。
 
-| Skill | What it does |
+| 技能 | 功能說明 |
 |-------|-------------|
-| `/office-hours` | Start here. Reframes your product idea before you write code. |
-| `/plan-ceo-review` | CEO-level review: find the 10-star product in the request. |
-| `/plan-eng-review` | Lock architecture, data flow, edge cases, and tests. |
-| `/plan-design-review` | Rate each design dimension 0-10, explain what a 10 looks like. |
-| `/design-consultation` | Build a complete design system from scratch. |
-| `/review` | Pre-landing PR review. Finds bugs that pass CI but break in prod. |
-| `/debug` | Systematic root-cause debugging. No fixes without investigation. |
-| `/design-review` | Design audit + fix loop with atomic commits. |
-| `/qa` | Open a real browser, find bugs, fix them, re-verify. |
-| `/qa-only` | Same as /qa but report only — no code changes. |
-| `/ship` | Run tests, review, push, open PR. One command. |
-| `/document-release` | Update all docs to match what you just shipped. |
-| `/retro` | Weekly retro with per-person breakdowns and shipping streaks. |
-| `/browse` | Headless browser — real Chromium, real clicks, ~100ms/command. |
-| `/setup-browser-cookies` | Import cookies from your real browser for authenticated testing. |
-| `/careful` | Warn before destructive commands (rm -rf, DROP TABLE, force-push). |
-| `/freeze` | Lock edits to one directory. Hard block, not just a warning. |
-| `/guard` | Activate both careful + freeze at once. |
-| `/unfreeze` | Remove directory edit restrictions. |
-| `/gstack-upgrade` | Update gstack to the latest version. |
+| `/office-hours` | 從這裡開始。在你寫程式前重新框架你的產品概念。 |
+| `/plan-ceo-review` | CEO 層級審查：找出需求中藏著的 10 星產品。 |
+| `/plan-eng-review` | 確立架構、資料流、邊界案例與測試。 |
+| `/plan-design-review` | 為每個設計維度評分 0-10，說明 10 分的標準。 |
+| `/design-consultation` | 從零建立完整設計系統。 |
+| `/review` | 上線前 PR 審查。找出通過 CI 卻在正式環境崩壞的 bug。 |
+| `/debug` | 系統性根本原因除錯。沒調查就沒修復。 |
+| `/design-review` | 設計審查 + 修復迴圈，含原子提交。 |
+| `/qa` | 開啟真實瀏覽器，找到 bug、修復並重新驗證。 |
+| `/qa-only` | 與 /qa 相同，但僅產出報告——不更動程式碼。 |
+| `/ship` | 執行測試、審查、推送、開 PR。一個指令完成。 |
+| `/document-release` | 更新所有文件以符合你剛發布的內容。 |
+| `/retro` | 每週回顧，含每人細分與出貨連勝紀錄。 |
+| `/browse` | 無頭瀏覽器——真實 Chromium、真實點擊、~100ms/指令。 |
+| `/setup-browser-cookies` | 從你的真實瀏覽器匯入 Cookie 以進行已驗證的測試。 |
+| `/careful` | 在執行破壞性指令前警告（rm -rf、DROP TABLE、force-push）。 |
+| `/freeze` | 將編輯鎖定到單一目錄。硬性封鎖，不只是警告。 |
+| `/guard` | 同時啟用 careful + freeze。 |
+| `/unfreeze` | 移除目錄編輯限制。 |
+| `/gstack-upgrade` | 更新 gstack 到最新版本。 |
 
-## Build commands
+## 建置指令
 
 ```bash
-bun install              # install dependencies
-bun test                 # run tests (free, <5s)
-bun run build            # generate docs + compile binaries
-bun run gen:skill-docs   # regenerate SKILL.md files from templates
-bun run skill:check      # health dashboard for all skills
+bun install              # 安裝依賴
+bun test                 # 執行測試（免費，<5 秒）
+bun run build            # 產生文件 + 編譯二進位檔
+bun run gen:skill-docs   # 從模板重新產生 SKILL.md 檔案
+bun run skill:check      # 所有技能的健康儀表板
 ```
 
-## Key conventions
+## 主要慣例
 
-- SKILL.md files are **generated** from `.tmpl` templates. Edit the template, not the output.
-- Run `bun run gen:skill-docs --host codex` to regenerate Codex-specific output.
-- The browse binary provides headless browser access. Use `$B <command>` in skills.
-- Safety skills (careful, freeze, guard) use inline advisory prose — always confirm before destructive operations.
+- SKILL.md 檔案是從 `.tmpl` 模板**產生**的。請編輯模板，不要編輯輸出檔案。
+- 執行 `bun run gen:skill-docs --host codex` 以重新產生 Codex 專用輸出。
+- browse 二進位檔提供無頭瀏覽器存取。在技能中使用 `$B <command>`。
+- 安全技能（careful、freeze、guard）使用內嵌建議說明——在執行破壞性操作前請務必確認。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,12 +1,12 @@
-# Architecture
+# 架構
 
-This document explains **why** gstack is built the way it is. For setup and commands, see CLAUDE.md. For contributing, see CONTRIBUTING.md.
+本文件說明 gstack 為何以現有方式建置。關於設定和指令，請參閱 CLAUDE.md。關於貢獻，請參閱 CONTRIBUTING.md。
 
-## The core idea
+## 核心理念
 
-gstack gives Claude Code a persistent browser and a set of opinionated workflow skills. The browser is the hard part — everything else is Markdown.
+gstack 給予 Claude Code 一個持久的瀏覽器和一組固執己見的工作流程技能。瀏覽器是困難的部分——其他一切都是 Markdown。
 
-The key insight: an AI agent interacting with a browser needs **sub-second latency** and **persistent state**. If every command cold-starts a browser, you're waiting 3-5 seconds per tool call. If the browser dies between commands, you lose cookies, tabs, and login sessions. So gstack runs a long-lived Chromium daemon that the CLI talks to over localhost HTTP.
+關鍵洞察：AI 代理人與瀏覽器互動需要**低於一秒的延遲**和**持久狀態**。如果每個指令都要冷啟動瀏覽器，你每次工具呼叫要等待 3-5 秒。如果瀏覽器在指令之間死掉，你就失去了 Cookie、分頁和登入工作階段。因此 gstack 執行一個長壽的 Chromium 守護程序，CLI 透過本地端的 HTTP 與之通訊。
 
 ```
 Claude Code                     gstack
@@ -33,87 +33,87 @@ Claude Code                     gstack
                                └───────────────────────┘
 ```
 
-First call starts everything (~3s). Every call after: ~100-200ms.
+第一次呼叫啟動所有東西（約 3 秒）。之後的每次呼叫：約 100-200ms。
 
-## Why Bun
+## 為什麼選擇 Bun
 
-Node.js would work. Bun is better here for three reasons:
+Node.js 可以運作。但 Bun 在這裡有三個優勢：
 
-1. **Compiled binaries.** `bun build --compile` produces a single ~58MB executable. No `node_modules` at runtime, no `npx`, no PATH configuration. The binary just runs. This matters because gstack installs into `~/.claude/skills/` where users don't expect to manage a Node.js project.
+1. **編譯二進位檔。** `bun build --compile` 產生一個約 58MB 的執行檔。執行時不需要 `node_modules`、不需要 `npx`、不需要 PATH 設定。二進位檔直接執行。這很重要，因為 gstack 安裝到 `~/.claude/skills/` 中，使用者不希望在那裡管理 Node.js 專案。
 
-2. **Native SQLite.** Cookie decryption reads Chromium's SQLite cookie database directly. Bun has `new Database()` built in — no `better-sqlite3`, no native addon compilation, no gyp. One less thing that breaks on different machines.
+2. **原生 SQLite。** Cookie 解密直接讀取 Chromium 的 SQLite Cookie 資料庫。Bun 內建 `new Database()`——不需要 `better-sqlite3`，不需要原生附加元件編譯，不需要 gyp。少了一個在不同機器上會壞掉的東西。
 
-3. **Native TypeScript.** The server runs as `bun run server.ts` during development. No compilation step, no `ts-node`, no source maps to debug. The compiled binary is for deployment; source files are for development.
+3. **原生 TypeScript。** 伺服器在開發時以 `bun run server.ts` 執行。不需要編譯步驟，不需要 `ts-node`，不需要 source map 來除錯。編譯後的二進位檔用於部署；原始碼檔案用於開發。
 
-4. **Built-in HTTP server.** `Bun.serve()` is fast, simple, and doesn't need Express or Fastify. The server handles ~10 routes total. A framework would be overhead.
+4. **內建 HTTP 伺服器。** `Bun.serve()` 快速、簡單，不需要 Express 或 Fastify。伺服器總共處理約 10 個路由。框架會是多餘的負擔。
 
-The bottleneck is always Chromium, not the CLI or server. Bun's startup speed (~1ms for the compiled binary vs ~100ms for Node) is nice but not the reason we chose it. The compiled binary and native SQLite are.
+瓶頸始終是 Chromium，不是 CLI 或伺服器。Bun 的啟動速度（編譯後二進位檔約 1ms，相對於 Node 的約 100ms）很好，但這不是選擇它的原因。編譯後的二進位檔和原生 SQLite 才是。
 
-## The daemon model
+## 守護程序模型
 
-### Why not start a browser per command?
+### 為什麼不每個指令啟動一個瀏覽器？
 
-Playwright can launch Chromium in ~2-3 seconds. For a single screenshot, that's fine. For a QA session with 20+ commands, it's 40+ seconds of browser startup overhead. Worse: you lose all state between commands. Cookies, localStorage, login sessions, open tabs — all gone.
+Playwright 啟動 Chromium 約需 2-3 秒。對於單一截圖來說，這沒問題。對於擁有 20+ 個指令的 QA 工作階段，這就是 40+ 秒的瀏覽器啟動開銷。更糟的是：指令之間你會失去所有狀態。Cookie、localStorage、登入工作階段、開啟的分頁——全部消失。
 
-The daemon model means:
+守護程序模型的意義：
 
-- **Persistent state.** Log in once, stay logged in. Open a tab, it stays open. localStorage persists across commands.
-- **Sub-second commands.** After the first call, every command is just an HTTP POST. ~100-200ms round-trip including Chromium's work.
-- **Automatic lifecycle.** The server auto-starts on first use, auto-shuts down after 30 minutes idle. No process management needed.
+- **持久狀態。** 登入一次，保持登入。開啟一個分頁，它就保持開啟。localStorage 在指令之間持續存在。
+- **低於一秒的指令。** 第一次呼叫後，每個指令只是一個 HTTP POST。往返約 100-200ms，包含 Chromium 的工作。
+- **自動生命週期。** 伺服器在第一次使用時自動啟動，在閒置 30 分鐘後自動關閉。不需要程序管理。
 
-### State file
+### 狀態檔案
 
-The server writes `.gstack/browse.json` (atomic write via tmp + rename, mode 0o600):
+伺服器寫入 `.gstack/browse.json`（透過 tmp + rename 進行原子寫入，模式 0o600）：
 
 ```json
 { "pid": 12345, "port": 34567, "token": "uuid-v4", "startedAt": "...", "binaryVersion": "abc123" }
 ```
 
-The CLI reads this file to find the server. If the file is missing, stale, or the PID is dead, the CLI spawns a new server.
+CLI 讀取此檔案以找到伺服器。如果檔案缺失、過時或 PID 已死，CLI 會產生一個新伺服器。
 
-### Port selection
+### 連接埠選擇
 
-Random port between 10000-60000 (retry up to 5 on collision). This means 10 Conductor workspaces can each run their own browse daemon with zero configuration and zero port conflicts. The old approach (scanning 9400-9409) broke constantly in multi-workspace setups.
+在 10000-60000 之間隨機選擇連接埠（衝突時最多重試 5 次）。這表示 10 個 Conductor 工作空間可以各自執行自己的 browse 守護程序，零設定，零連接埠衝突。舊方法（掃描 9400-9409）在多工作空間設定中經常出問題。
 
-### Version auto-restart
+### 版本自動重啟
 
-The build writes `git rev-parse HEAD` to `browse/dist/.version`. On each CLI invocation, if the binary's version doesn't match the running server's `binaryVersion`, the CLI kills the old server and starts a new one. This prevents the "stale binary" class of bugs entirely — rebuild the binary, next command picks it up automatically.
+建置時將 `git rev-parse HEAD` 寫入 `browse/dist/.version`。在每次 CLI 呼叫時，如果二進位檔的版本與執行中伺服器的 `binaryVersion` 不符，CLI 會終止舊伺服器並啟動一個新的。這完全防止了「過時二進位檔」這類 bug——重新建置二進位檔，下一個指令就自動使用新的。
 
-## Security model
+## 安全模型
 
-### Localhost only
+### 僅限本地端
 
-The HTTP server binds to `localhost`, not `0.0.0.0`. It's not reachable from the network.
+HTTP 伺服器綁定到 `localhost`，而不是 `0.0.0.0`。無法從網路存取。
 
-### Bearer token auth
+### Bearer token 驗證
 
-Every server session generates a random UUID token, written to the state file with mode 0o600 (owner-only read). Every HTTP request must include `Authorization: Bearer <token>`. If the token doesn't match, the server returns 401.
+每個伺服器工作階段生成一個隨機 UUID token，以模式 0o600（僅擁有者可讀）寫入狀態檔案。每個 HTTP 請求都必須包含 `Authorization: Bearer <token>`。如果 token 不符，伺服器返回 401。
 
-This prevents other processes on the same machine from talking to your browse server. The cookie picker UI (`/cookie-picker`) and health check (`/health`) are exempt — they're localhost-only and don't execute commands.
+這防止同一台機器上的其他程序與你的 browse 伺服器通訊。Cookie 選擇器 UI（`/cookie-picker`）和健康檢查（`/health`）是例外——它們是本地端限定的，不執行指令。
 
-### Cookie security
+### Cookie 安全性
 
-Cookies are the most sensitive data gstack handles. The design:
+Cookie 是 gstack 處理的最敏感資料。設計如下：
 
-1. **Keychain access requires user approval.** First cookie import per browser triggers a macOS Keychain dialog. The user must click "Allow" or "Always Allow." gstack never silently accesses credentials.
+1. **鑰匙圈存取需要使用者批准。** 每個瀏覽器的第一次 Cookie 匯入會觸發 macOS 鑰匙圈對話框。使用者必須點擊「允許」或「總是允許」。gstack 從不靜默存取憑證。
 
-2. **Decryption happens in-process.** Cookie values are decrypted in memory (PBKDF2 + AES-128-CBC), loaded into the Playwright context, and never written to disk in plaintext. The cookie picker UI never displays cookie values — only domain names and counts.
+2. **解密在程序內進行。** Cookie 值在記憶體中解密（PBKDF2 + AES-128-CBC），載入 Playwright 上下文，且從不以明文寫入磁碟。Cookie 選擇器 UI 從不顯示 Cookie 值——只顯示域名和數量。
 
-3. **Database is read-only.** gstack copies the Chromium cookie DB to a temp file (to avoid SQLite lock conflicts with the running browser) and opens it read-only. It never modifies your real browser's cookie database.
+3. **資料庫是唯讀的。** gstack 將 Chromium Cookie 資料庫複製到暫存檔案（以避免與執行中的瀏覽器發生 SQLite 鎖定衝突），並以唯讀方式開啟。它從不修改你真實瀏覽器的 Cookie 資料庫。
 
-4. **Key caching is per-session.** The Keychain password + derived AES key are cached in memory for the server's lifetime. When the server shuts down (idle timeout or explicit stop), the cache is gone.
+4. **金鑰快取是每個工作階段的。** 鑰匙圈密碼和衍生的 AES 金鑰在伺服器的生命週期內快取在記憶體中。當伺服器關閉（閒置逾時或明確停止）時，快取就消失了。
 
-5. **No cookie values in logs.** Console, network, and dialog logs never contain cookie values. The `cookies` command outputs cookie metadata (domain, name, expiry) but values are truncated.
+5. **日誌中沒有 Cookie 值。** 主控台、網路和對話框日誌從不包含 Cookie 值。`cookies` 指令輸出 Cookie 元數據（域名、名稱、到期時間），但值會被截斷。
 
-### Shell injection prevention
+### Shell 注入防護
 
-The browser registry (Comet, Chrome, Arc, Brave, Edge) is hardcoded. Database paths are constructed from known constants, never from user input. Keychain access uses `Bun.spawn()` with explicit argument arrays, not shell string interpolation.
+瀏覽器登錄檔（Comet、Chrome、Arc、Brave、Edge）是硬編碼的。資料庫路徑從已知常數建立，從不從使用者輸入建立。鑰匙圈存取使用 `Bun.spawn()` 搭配明確的參數陣列，而不是 shell 字串插值。
 
-## The ref system
+## 參考系統
 
-Refs (`@e1`, `@e2`, `@c1`) are how the agent addresses page elements without writing CSS selectors or XPath.
+參考（`@e1`、`@e2`、`@c1`）是代理人在不撰寫 CSS 選擇器或 XPath 的情況下定址頁面元素的方式。
 
-### How it works
+### 運作方式
 
 ```
 1. Agent runs: $B snapshot -i
@@ -128,23 +128,23 @@ Later:
 8. Server resolves @e3 → Locator → locator.click()
 ```
 
-### Why Locators, not DOM mutation
+### 為什麼使用 Locator，而不是 DOM 修改
 
-The obvious approach is to inject `data-ref="@e1"` attributes into the DOM. This breaks on:
+明顯的方法是將 `data-ref="@e1"` 屬性注入 DOM。但這在以下情況會出問題：
 
-- **CSP (Content Security Policy).** Many production sites block DOM modification from scripts.
-- **React/Vue/Svelte hydration.** Framework reconciliation can strip injected attributes.
-- **Shadow DOM.** Can't reach inside shadow roots from the outside.
+- **CSP（內容安全政策）。** 許多正式環境網站封鎖來自腳本的 DOM 修改。
+- **React/Vue/Svelte 水合。** 框架協調可能會剝離注入的屬性。
+- **Shadow DOM。** 無法從外部進入 shadow root。
 
-Playwright Locators are external to the DOM. They use the accessibility tree (which Chromium maintains internally) and `getByRole()` queries. No DOM mutation, no CSP issues, no framework conflicts.
+Playwright Locator 對 DOM 是外部的。它們使用無障礙樹（由 Chromium 內部維護）和 `getByRole()` 查詢。沒有 DOM 修改，沒有 CSP 問題，沒有框架衝突。
 
-### Ref lifecycle
+### 參考生命週期
 
-Refs are cleared on navigation (the `framenavigated` event on the main frame). This is correct — after navigation, all locators are stale. The agent must run `snapshot` again to get fresh refs. This is by design: stale refs should fail loudly, not click the wrong element.
+參考在導航時被清除（主框架上的 `framenavigated` 事件）。這是正確的——導航後，所有 Locator 都是過時的。代理人必須再次執行 `snapshot` 以獲取新的參考。這是設計上的決定：過時的參考應該明確地失敗，而不是點擊錯誤的元素。
 
-### Ref staleness detection
+### 參考過時偵測
 
-SPAs can mutate the DOM without triggering `framenavigated` (e.g. React router transitions, tab switches, modal opens). This makes refs stale even though the page URL didn't change. To catch this, `resolveRef()` performs an async `count()` check before using any ref:
+SPA 可以在不觸發 `framenavigated` 的情況下修改 DOM（例如 React router 轉場、分頁切換、modal 開啟）。這使得參考變得過時，即使頁面 URL 沒有改變。為了捕捉這種情況，`resolveRef()` 在使用任何參考之前執行非同步的 `count()` 檢查：
 
 ```
 resolveRef(@e3) → entry = refMap.get("e3")
@@ -153,36 +153,36 @@ resolveRef(@e3) → entry = refMap.get("e3")
                 → if count > 0: return { locator }
 ```
 
-This fails fast (~5ms overhead) instead of letting Playwright's 30-second action timeout expire on a missing element. The `RefEntry` stores `role` and `name` metadata alongside the Locator so the error message can tell the agent what the element was.
+這快速失敗（約 5ms 開銷），而不是等待 Playwright 的 30 秒動作逾時在缺少的元素上到期。`RefEntry` 在 Locator 旁邊儲存 `role` 和 `name` 元數據，這樣錯誤訊息可以告訴代理人該元素是什麼。
 
-### Cursor-interactive refs (@c)
+### 游標互動參考（@c）
 
-The `-C` flag finds elements that are clickable but not in the ARIA tree — things styled with `cursor: pointer`, elements with `onclick` attributes, or custom `tabindex`. These get `@c1`, `@c2` refs in a separate namespace. This catches custom components that frameworks render as `<div>` but are actually buttons.
+`-C` 旗標找到可點擊但不在 ARIA 樹中的元素——使用 `cursor: pointer` 樣式、帶有 `onclick` 屬性或自定義 `tabindex` 的元素。這些在單獨的命名空間中獲得 `@c1`、`@c2` 參考。這能找到框架渲染為 `<div>` 但實際上是按鈕的自定義元件。
 
-## Logging architecture
+## 日誌架構
 
-Three ring buffers (50,000 entries each, O(1) push):
+三個環形緩衝區（各 50,000 個條目，O(1) 推送）：
 
 ```
 Browser events → CircularBuffer (in-memory) → Async flush to .gstack/*.log
 ```
 
-Console messages, network requests, and dialog events each have their own buffer. Flushing happens every 1 second — the server appends only new entries since the last flush. This means:
+主控台訊息、網路請求和對話框事件各有自己的緩衝區。每 1 秒刷新一次——伺服器只附加自上次刷新以來的新條目。這表示：
 
-- HTTP request handling is never blocked by disk I/O
-- Logs survive server crashes (up to 1 second of data loss)
-- Memory is bounded (50K entries × 3 buffers)
-- Disk files are append-only, readable by external tools
+- HTTP 請求處理從不被磁碟 I/O 阻塞
+- 日誌在伺服器崩潰後存活（最多 1 秒的資料遺失）
+- 記憶體有界（50K 條目 × 3 個緩衝區）
+- 磁碟檔案是僅附加的，可由外部工具讀取
 
-The `console`, `network`, and `dialog` commands read from the in-memory buffers, not disk. Disk files are for post-mortem debugging.
+`console`、`network` 和 `dialog` 指令從記憶體緩衝區讀取，而不是磁碟。磁碟檔案用於事後除錯。
 
-## SKILL.md template system
+## SKILL.md 模板系統
 
-### The problem
+### 問題
 
-SKILL.md files tell Claude how to use the browse commands. If the docs list a flag that doesn't exist, or miss a command that was added, the agent hits errors. Hand-maintained docs always drift from code.
+SKILL.md 檔案告訴 Claude 如何使用 browse 指令。如果文件列出一個不存在的旗標，或遺漏了一個已新增的指令，代理人就會遇到錯誤。手動維護的文件總是會與程式碼漂移。
 
-### The solution
+### 解決方案
 
 ```
 SKILL.md.tmpl          (human-written prose + placeholders)
@@ -192,58 +192,58 @@ gen-skill-docs.ts      (reads source code metadata)
 SKILL.md               (committed, auto-generated sections)
 ```
 
-Templates contain the workflows, tips, and examples that require human judgment. Placeholders are filled from source code at build time:
+模板包含需要人類判斷的工作流程、提示和範例。佔位符在建置時從原始碼填入：
 
-| Placeholder | Source | What it generates |
+| 佔位符 | 來源 | 產生什麼 |
 |-------------|--------|-------------------|
-| `{{COMMAND_REFERENCE}}` | `commands.ts` | Categorized command table |
-| `{{SNAPSHOT_FLAGS}}` | `snapshot.ts` | Flag reference with examples |
-| `{{PREAMBLE}}` | `gen-skill-docs.ts` | Startup block: update check, session tracking, contributor mode, AskUserQuestion format |
-| `{{BROWSE_SETUP}}` | `gen-skill-docs.ts` | Binary discovery + setup instructions |
-| `{{BASE_BRANCH_DETECT}}` | `gen-skill-docs.ts` | Dynamic base branch detection for PR-targeting skills (ship, review, qa, plan-ceo-review) |
-| `{{QA_METHODOLOGY}}` | `gen-skill-docs.ts` | Shared QA methodology block for /qa and /qa-only |
-| `{{DESIGN_METHODOLOGY}}` | `gen-skill-docs.ts` | Shared design audit methodology for /plan-design-review and /design-review |
-| `{{REVIEW_DASHBOARD}}` | `gen-skill-docs.ts` | Review Readiness Dashboard for /ship pre-flight |
-| `{{TEST_BOOTSTRAP}}` | `gen-skill-docs.ts` | Test framework detection, bootstrap, CI/CD setup for /qa, /ship, /design-review |
+| `{{COMMAND_REFERENCE}}` | `commands.ts` | 分類指令表 |
+| `{{SNAPSHOT_FLAGS}}` | `snapshot.ts` | 帶範例的旗標參考 |
+| `{{PREAMBLE}}` | `gen-skill-docs.ts` | 啟動區塊：更新檢查、工作階段追蹤、貢獻者模式、AskUserQuestion 格式 |
+| `{{BROWSE_SETUP}}` | `gen-skill-docs.ts` | 二進位檔發現 + 設定說明 |
+| `{{BASE_BRANCH_DETECT}}` | `gen-skill-docs.ts` | 針對 PR 的技能的動態基礎分支偵測（ship、review、qa、plan-ceo-review） |
+| `{{QA_METHODOLOGY}}` | `gen-skill-docs.ts` | /qa 和 /qa-only 的共享 QA 方法區塊 |
+| `{{DESIGN_METHODOLOGY}}` | `gen-skill-docs.ts` | /plan-design-review 和 /design-review 的共享設計審查方法 |
+| `{{REVIEW_DASHBOARD}}` | `gen-skill-docs.ts` | /ship 預飛行的審查就緒儀表板 |
+| `{{TEST_BOOTSTRAP}}` | `gen-skill-docs.ts` | /qa、/ship、/design-review 的測試框架偵測、啟動、CI/CD 設定 |
 
-This is structurally sound — if a command exists in code, it appears in docs. If it doesn't exist, it can't appear.
+這在結構上是合理的——如果指令存在於程式碼中，它就出現在文件中。如果它不存在，它就不能出現。
 
-### The preamble
+### 前言
 
-Every skill starts with a `{{PREAMBLE}}` block that runs before the skill's own logic. It handles four things in a single bash command:
+每個技能都以一個 `{{PREAMBLE}}` 區塊開始，在技能自己的邏輯之前執行。它在單一 bash 指令中處理四件事：
 
-1. **Update check** — calls `gstack-update-check`, reports if an upgrade is available.
-2. **Session tracking** — touches `~/.gstack/sessions/$PPID` and counts active sessions (files modified in the last 2 hours). When 3+ sessions are running, all skills enter "ELI16 mode" — every question re-grounds the user on context because they're juggling windows.
-3. **Contributor mode** — reads `gstack_contributor` from config. When true, the agent files casual field reports to `~/.gstack/contributor-logs/` when gstack itself misbehaves.
-4. **AskUserQuestion format** — universal format: context, question, `RECOMMENDATION: Choose X because ___`, lettered options. Consistent across all skills.
+1. **更新檢查**——呼叫 `gstack-update-check`，如果有升級可用，則報告。
+2. **工作階段追蹤**——觸碰 `~/.gstack/sessions/$PPID` 並計算活躍工作階段數（過去 2 小時內修改的檔案）。當有 3+ 個工作階段在執行時，所有技能進入「ELI16 模式」——每個問題都重新讓使用者了解上下文，因為他們在同時管理多個視窗。
+3. **貢獻者模式**——從設定讀取 `gstack_contributor`。當為 true 時，代理人在 gstack 本身行為不當時向 `~/.gstack/contributor-logs/` 提交隨意的現場報告。
+4. **AskUserQuestion 格式**——通用格式：上下文、問題、`RECOMMENDATION: Choose X because ___`、字母選項。在所有技能中一致。
 
-### Why committed, not generated at runtime?
+### 為什麼是已提交的，而不是在執行時生成的？
 
-Three reasons:
+三個原因：
 
-1. **Claude reads SKILL.md at skill load time.** There's no build step when a user invokes `/browse`. The file must already exist and be correct.
-2. **CI can validate freshness.** `gen:skill-docs --dry-run` + `git diff --exit-code` catches stale docs before merge.
-3. **Git blame works.** You can see when a command was added and in which commit.
+1. **Claude 在技能載入時讀取 SKILL.md。** 當使用者呼叫 `/browse` 時，沒有建置步驟。檔案必須已經存在且正確。
+2. **CI 可以驗證新鮮度。** `gen:skill-docs --dry-run` + `git diff --exit-code` 在合併前捕捉過時的文件。
+3. **Git blame 有效。** 你可以看到指令是何時新增的以及在哪個提交中。
 
-### Template test tiers
+### 模板測試層級
 
-| Tier | What | Cost | Speed |
+| 層級 | 內容 | 費用 | 速度 |
 |------|------|------|-------|
-| 1 — Static validation | Parse every `$B` command in SKILL.md, validate against registry | Free | <2s |
-| 2 — E2E via `claude -p` | Spawn real Claude session, run each skill, check for errors | ~$3.85 | ~20min |
-| 3 — LLM-as-judge | Sonnet scores docs on clarity/completeness/actionability | ~$0.15 | ~30s |
+| 1 — 靜態驗證 | 解析 SKILL.md 中的每個 `$B` 指令，對照登錄檔驗證 | 免費 | <2 秒 |
+| 2 — 透過 `claude -p` 的 E2E | 產生真實 Claude 工作階段，執行每個技能，檢查錯誤 | ~$3.85 | ~20 分鐘 |
+| 3 — LLM 評審 | Sonnet 在清晰度/完整性/可操作性上對文件評分 | ~$0.15 | ~30 秒 |
 
-Tier 1 runs on every `bun test`. Tiers 2+3 are gated behind `EVALS=1`. The idea is: catch 95% of issues for free, use LLMs only for judgment calls.
+第 1 層在每次 `bun test` 上執行。第 2+3 層在 `EVALS=1` 後面管控。理念是：免費抓住 95% 的問題，只在判斷呼叫時使用 LLM。
 
-## Command dispatch
+## 指令分派
 
-Commands are categorized by side effects:
+指令按副作用分類：
 
-- **READ** (text, html, links, console, cookies, ...): No mutations. Safe to retry. Returns page state.
-- **WRITE** (goto, click, fill, press, ...): Mutates page state. Not idempotent.
-- **META** (snapshot, screenshot, tabs, chain, ...): Server-level operations that don't fit neatly into read/write.
+- **READ**（text、html、links、console、cookies、...）：無修改。可安全重試。返回頁面狀態。
+- **WRITE**（goto、click、fill、press、...）：修改頁面狀態。不是冪等的。
+- **META**（snapshot、screenshot、tabs、chain、...）：不整齊地適合讀/寫的伺服器級操作。
 
-This isn't just organizational. The server uses it for dispatch:
+這不只是組織性的。伺服器用它進行分派：
 
 ```typescript
 if (READ_COMMANDS.has(cmd))  → handleReadCommand(cmd, args, bm)
@@ -251,37 +251,37 @@ if (WRITE_COMMANDS.has(cmd)) → handleWriteCommand(cmd, args, bm)
 if (META_COMMANDS.has(cmd))  → handleMetaCommand(cmd, args, bm, shutdown)
 ```
 
-The `help` command returns all three sets so agents can self-discover available commands.
+`help` 指令返回所有三組，讓代理人可以自我發現可用指令。
 
-## Error philosophy
+## 錯誤理念
 
-Errors are for AI agents, not humans. Every error message must be actionable:
+錯誤是給 AI 代理人的，不是給人類的。每個錯誤訊息都必須是可操作的：
 
 - "Element not found" → "Element not found or not interactable. Run `snapshot -i` to see available elements."
 - "Selector matched multiple elements" → "Selector matched multiple elements. Use @refs from `snapshot` instead."
 - Timeout → "Navigation timed out after 30s. The page may be slow or the URL may be wrong."
 
-Playwright's native errors are rewritten through `wrapError()` to strip internal stack traces and add guidance. The agent should be able to read the error and know what to do next without human intervention.
+Playwright 的原生錯誤透過 `wrapError()` 重寫，以剝離內部堆疊追蹤並新增指引。代理人應該能夠讀取錯誤並知道下一步該做什麼，無需人工介入。
 
-### Crash recovery
+### 崩潰復原
 
-The server doesn't try to self-heal. If Chromium crashes (`browser.on('disconnected')`), the server exits immediately. The CLI detects the dead server on the next command and auto-restarts. This is simpler and more reliable than trying to reconnect to a half-dead browser process.
+伺服器不嘗試自我修復。如果 Chromium 崩潰（`browser.on('disconnected')`），伺服器立即退出。CLI 在下一個指令偵測到死掉的伺服器並自動重啟。這比嘗試重新連接到半死的瀏覽器程序更簡單、更可靠。
 
-## E2E test infrastructure
+## E2E 測試基礎設施
 
-### Session runner (`test/helpers/session-runner.ts`)
+### 工作階段執行器（`test/helpers/session-runner.ts`）
 
-E2E tests spawn `claude -p` as a completely independent subprocess — not via the Agent SDK, which can't nest inside Claude Code sessions. The runner:
+E2E 測試將 `claude -p` 作為完全獨立的子程序產生——不是透過 Agent SDK，因為它無法在 Claude Code 工作階段中巢套。執行器：
 
-1. Writes the prompt to a temp file (avoids shell escaping issues)
-2. Spawns `sh -c 'cat prompt | claude -p --output-format stream-json --verbose'`
-3. Streams NDJSON from stdout for real-time progress
-4. Races against a configurable timeout
-5. Parses the full NDJSON transcript into structured results
+1. 將提示詞寫入暫存檔案（避免 shell 跳脫問題）
+2. 產生 `sh -c 'cat prompt | claude -p --output-format stream-json --verbose'`
+3. 從 stdout 串流 NDJSON 以獲得實時進度
+4. 與可設定的逾時競速
+5. 將完整的 NDJSON 記錄解析為結構化結果
 
-The `parseNDJSON()` function is pure — no I/O, no side effects — making it independently testable.
+`parseNDJSON()` 函式是純粹的——沒有 I/O，沒有副作用——使其可以獨立測試。
 
-### Observability data flow
+### 可觀察性資料流
 
 ```
   skill-e2e.test.ts
@@ -321,38 +321,38 @@ The `parseNDJSON()` function is pure — no I/O, no side effects — making it i
   │        (stale >10min? warn)
 ```
 
-**Split ownership:** session-runner owns the heartbeat (current test state), eval-store owns partial results (completed test state). The watcher reads both. Neither component knows about the other — they share data only through the filesystem.
+**分離所有權：** session-runner 擁有心跳（當前測試狀態），eval-store 擁有部分結果（已完成測試狀態）。watcher 讀取兩者。兩個元件都不了解對方——它們只透過檔案系統共享資料。
 
-**Non-fatal everything:** All observability I/O is wrapped in try/catch. A write failure never causes a test to fail. The tests themselves are the source of truth; observability is best-effort.
+**所有事情都不是致命的：** 所有可觀察性 I/O 都包裝在 try/catch 中。寫入失敗永遠不會導致測試失敗。測試本身是真相的來源；可觀察性是盡力而為的。
 
-**Machine-readable diagnostics:** Each test result includes `exit_reason` (success, timeout, error_max_turns, error_api, exit_code_N), `timeout_at_turn`, and `last_tool_call`. This enables `jq` queries like:
+**機器可讀診斷：** 每個測試結果包含 `exit_reason`（success、timeout、error_max_turns、error_api、exit_code_N）、`timeout_at_turn` 和 `last_tool_call`。這使得 `jq` 查詢成為可能：
 ```bash
 jq '.tests[] | select(.exit_reason == "timeout") | .last_tool_call' ~/.gstack-dev/evals/_partial-e2e.json
 ```
 
-### Eval persistence (`test/helpers/eval-store.ts`)
+### Eval 持久化（`test/helpers/eval-store.ts`）
 
-The `EvalCollector` accumulates test results and writes them in two ways:
+`EvalCollector` 累積測試結果並以兩種方式寫入：
 
-1. **Incremental:** `savePartial()` writes `_partial-e2e.json` after each test (atomic: write `.tmp`, `fs.renameSync`). Survives kills.
-2. **Final:** `finalize()` writes a timestamped eval file (e.g. `e2e-20260314-143022.json`). The partial file is never cleaned up — it persists alongside the final file for observability.
+1. **增量：** `savePartial()` 在每次測試後寫入 `_partial-e2e.json`（原子操作：寫入 `.tmp`，`fs.renameSync`）。在被終止後存活。
+2. **最終：** `finalize()` 寫入帶有時間戳記的 eval 檔案（例如 `e2e-20260314-143022.json`）。部分檔案從未被清理——它與最終檔案一起持續存在，用於可觀察性。
 
-`eval:compare` diffs two eval runs. `eval:summary` aggregates stats across all runs in `~/.gstack-dev/evals/`.
+`eval:compare` 比較兩次 eval 執行。`eval:summary` 彙總 `~/.gstack-dev/evals/` 中所有執行的統計資料。
 
-### Test tiers
+### 測試層級
 
-| Tier | What | Cost | Speed |
+| 層級 | 內容 | 費用 | 速度 |
 |------|------|------|-------|
-| 1 — Static validation | Parse `$B` commands, validate against registry, observability unit tests | Free | <5s |
-| 2 — E2E via `claude -p` | Spawn real Claude session, run each skill, scan for errors | ~$3.85 | ~20min |
-| 3 — LLM-as-judge | Sonnet scores docs on clarity/completeness/actionability | ~$0.15 | ~30s |
+| 1 — 靜態驗證 | 解析 `$B` 指令，對照登錄檔驗證，可觀察性單元測試 | 免費 | <5 秒 |
+| 2 — 透過 `claude -p` 的 E2E | 產生真實 Claude 工作階段，執行每個技能，掃描錯誤 | ~$3.85 | ~20 分鐘 |
+| 3 — LLM 評審 | Sonnet 在清晰度/完整性/可操作性上對文件評分 | ~$0.15 | ~30 秒 |
 
-Tier 1 runs on every `bun test`. Tiers 2+3 are gated behind `EVALS=1`. The idea: catch 95% of issues for free, use LLMs only for judgment calls and integration testing.
+第 1 層在每次 `bun test` 上執行。第 2+3 層在 `EVALS=1` 後面管控。理念是：免費抓住 95% 的問題，只在判斷呼叫和整合測試時使用 LLM。
 
-## What's intentionally not here
+## 有意不包含的功能
 
-- **No WebSocket streaming.** HTTP request/response is simpler, debuggable with curl, and fast enough. Streaming would add complexity for marginal benefit.
-- **No MCP protocol.** MCP adds JSON schema overhead per request and requires a persistent connection. Plain HTTP + plain text output is lighter on tokens and easier to debug.
-- **No multi-user support.** One server per workspace, one user. The token auth is defense-in-depth, not multi-tenancy.
-- **No Windows/Linux cookie decryption.** macOS Keychain is the only supported credential store. Linux (GNOME Keyring/kwallet) and Windows (DPAPI) are architecturally possible but not implemented.
-- **No iframe support.** Playwright can handle iframes but the ref system doesn't cross frame boundaries yet. This is the most-requested missing feature.
+- **沒有 WebSocket 串流。** HTTP 請求/回應更簡單，可用 curl 除錯，且夠快。串流會增加複雜性，但邊際收益有限。
+- **沒有 MCP 協定。** MCP 在每個請求上增加 JSON 結構描述開銷，並需要持久連接。純 HTTP + 純文字輸出在 token 上更輕量，更容易除錯。
+- **沒有多使用者支援。** 每個工作空間一個伺服器，一個使用者。Token 驗證是深度防禦，而不是多租戶。
+- **沒有 Windows/Linux Cookie 解密。** macOS 鑰匙圈是唯一支援的憑證儲存。Linux（GNOME Keyring/kwallet）和 Windows（DPAPI）在架構上是可能的，但尚未實作。
+- **沒有 iframe 支援。** Playwright 可以處理 iframe，但參考系統目前尚未跨框架邊界。這是最多人要求的缺失功能。

--- a/BROWSER.md
+++ b/BROWSER.md
@@ -1,29 +1,29 @@
-# Browser — technical details
+# 瀏覽器——技術細節
 
-This document covers the command reference and internals of gstack's headless browser.
+本文件涵蓋 gstack 無頭瀏覽器的指令參考和內部原理。
 
-## Command reference
+## 指令參考
 
-| Category | Commands | What for |
+| 類別 | 指令 | 用途 |
 |----------|----------|----------|
-| Navigate | `goto`, `back`, `forward`, `reload`, `url` | Get to a page |
-| Read | `text`, `html`, `links`, `forms`, `accessibility` | Extract content |
-| Snapshot | `snapshot [-i] [-c] [-d N] [-s sel] [-D] [-a] [-o] [-C]` | Get refs, diff, annotate |
-| Interact | `click`, `fill`, `select`, `hover`, `type`, `press`, `scroll`, `wait`, `viewport`, `upload` | Use the page |
-| Inspect | `js`, `eval`, `css`, `attrs`, `is`, `console`, `network`, `dialog`, `cookies`, `storage`, `perf` | Debug and verify |
-| Visual | `screenshot [--viewport] [--clip x,y,w,h] [sel\|@ref] [path]`, `pdf`, `responsive` | See what Claude sees |
-| Compare | `diff <url1> <url2>` | Spot differences between environments |
-| Dialogs | `dialog-accept [text]`, `dialog-dismiss` | Control alert/confirm/prompt handling |
-| Tabs | `tabs`, `tab`, `newtab`, `closetab` | Multi-page workflows |
-| Cookies | `cookie-import`, `cookie-import-browser` | Import cookies from file or real browser |
-| Multi-step | `chain` (JSON from stdin) | Batch commands in one call |
-| Handoff | `handoff [reason]`, `resume` | Switch to visible Chrome for user takeover |
+| 導航 | `goto`, `back`, `forward`, `reload`, `url` | 前往頁面 |
+| 讀取 | `text`, `html`, `links`, `forms`, `accessibility` | 提取內容 |
+| 快照 | `snapshot [-i] [-c] [-d N] [-s sel] [-D] [-a] [-o] [-C]` | 取得參考、差異比對、標注 |
+| 互動 | `click`, `fill`, `select`, `hover`, `type`, `press`, `scroll`, `wait`, `viewport`, `upload` | 使用頁面 |
+| 檢查 | `js`, `eval`, `css`, `attrs`, `is`, `console`, `network`, `dialog`, `cookies`, `storage`, `perf` | 除錯和驗證 |
+| 視覺 | `screenshot [--viewport] [--clip x,y,w,h] [sel\|@ref] [path]`, `pdf`, `responsive` | 查看 Claude 所看到的 |
+| 比較 | `diff <url1> <url2>` | 找出環境之間的差異 |
+| 對話框 | `dialog-accept [text]`, `dialog-dismiss` | 控制 alert/confirm/prompt 處理 |
+| 分頁 | `tabs`, `tab`, `newtab`, `closetab` | 多頁面工作流程 |
+| Cookies | `cookie-import`, `cookie-import-browser` | 從檔案或真實瀏覽器匯入 Cookie |
+| 多步驟 | `chain`（JSON 來自 stdin） | 在一次呼叫中批次指令 |
+| 交接 | `handoff [reason]`, `resume` | 切換到可見 Chrome 讓使用者接手 |
 
-All selector arguments accept CSS selectors, `@e` refs after `snapshot`, or `@c` refs after `snapshot -C`. 50+ commands total plus cookie import.
+所有選擇器參數接受 CSS 選擇器、`snapshot` 後的 `@e` 參考，或 `snapshot -C` 後的 `@c` 參考。共 50+ 個指令加上 Cookie 匯入。
 
-## How it works
+## 運作方式
 
-gstack's browser is a compiled CLI binary that talks to a persistent local Chromium daemon over HTTP. The CLI is a thin client — it reads a state file, sends a command, and prints the response to stdout. The server does the real work via [Playwright](https://playwright.dev/).
+gstack 的瀏覽器是一個編譯後的 CLI 二進位檔，透過 HTTP 與持久的本地端 Chromium 守護程序通訊。CLI 是一個精簡的客戶端——它讀取狀態檔案，傳送指令，並將回應輸出到 stdout。伺服器透過 [Playwright](https://playwright.dev/) 進行真正的工作。
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -45,176 +45,176 @@ gstack's browser is a compiled CLI binary that talks to a persistent local Chrom
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### Lifecycle
+### 生命週期
 
-1. **First call**: CLI checks `.gstack/browse.json` (in the project root) for a running server. None found — it spawns `bun run browse/src/server.ts` in the background. The server launches headless Chromium via Playwright, picks a random port (10000-60000), generates a bearer token, writes the state file, and starts accepting HTTP requests. This takes ~3 seconds.
+1. **第一次呼叫**：CLI 在專案根目錄中檢查 `.gstack/browse.json` 是否有執行中的伺服器。沒有找到——它在背景產生 `bun run browse/src/server.ts`。伺服器透過 Playwright 啟動無頭 Chromium，選擇一個隨機連接埠（10000-60000），生成 bearer token，寫入狀態檔案，並開始接受 HTTP 請求。這大約需要 3 秒。
 
-2. **Subsequent calls**: CLI reads the state file, sends an HTTP POST with the bearer token, prints the response. ~100-200ms round trip.
+2. **後續呼叫**：CLI 讀取狀態檔案，發送帶有 bearer token 的 HTTP POST，輸出回應。往返約 100-200ms。
 
-3. **Idle shutdown**: After 30 minutes with no commands, the server shuts down and cleans up the state file. Next call restarts it automatically.
+3. **閒置關閉**：30 分鐘沒有指令後，伺服器關閉並清理狀態檔案。下一次呼叫自動重啟它。
 
-4. **Crash recovery**: If Chromium crashes, the server exits immediately (no self-healing — don't hide failure). The CLI detects the dead server on the next call and starts a fresh one.
+4. **崩潰復原**：如果 Chromium 崩潰，伺服器立即退出（不自我修復——不隱藏失敗）。CLI 在下一次呼叫時偵測到死掉的伺服器並啟動一個全新的。
 
-### Key components
+### 關鍵元件
 
 ```
 browse/
 ├── src/
-│   ├── cli.ts              # Thin client — reads state file, sends HTTP, prints response
-│   ├── server.ts           # Bun.serve HTTP server — routes commands to Playwright
-│   ├── browser-manager.ts  # Chromium lifecycle — launch, tabs, ref map, crash handling
-│   ├── snapshot.ts         # Accessibility tree → @ref assignment → Locator map + diff/annotate/-C
-│   ├── read-commands.ts    # Non-mutating commands (text, html, links, js, css, is, dialog, etc.)
-│   ├── write-commands.ts   # Mutating commands (click, fill, select, upload, dialog-accept, etc.)
-│   ├── meta-commands.ts    # Server management, chain, diff, snapshot routing
-│   ├── cookie-import-browser.ts  # Decrypt + import cookies from real Chromium browsers
-│   ├── cookie-picker-routes.ts   # HTTP routes for interactive cookie picker UI
-│   ├── cookie-picker-ui.ts       # Self-contained HTML/CSS/JS for cookie picker
-│   └── buffers.ts          # CircularBuffer<T> + console/network/dialog capture
-├── test/                   # Integration tests + HTML fixtures
+│   ├── cli.ts              # 精簡客戶端——讀取狀態檔案，發送 HTTP，輸出回應
+│   ├── server.ts           # Bun.serve HTTP 伺服器——路由指令到 Playwright
+│   ├── browser-manager.ts  # Chromium 生命週期——啟動、分頁、參考映射、崩潰處理
+│   ├── snapshot.ts         # 無障礙樹 → @ref 分配 → Locator 映射 + diff/annotate/-C
+│   ├── read-commands.ts    # 非修改性指令（text、html、links、js、css、is、dialog 等）
+│   ├── write-commands.ts   # 修改性指令（click、fill、select、upload、dialog-accept 等）
+│   ├── meta-commands.ts    # 伺服器管理、chain、diff、快照路由
+│   ├── cookie-import-browser.ts  # 從真實 Chromium 瀏覽器解密並匯入 Cookie
+│   ├── cookie-picker-routes.ts   # 互動式 Cookie 選擇器 UI 的 HTTP 路由
+│   ├── cookie-picker-ui.ts       # Cookie 選擇器的自包含 HTML/CSS/JS
+│   └── buffers.ts          # CircularBuffer<T> + 主控台/網路/對話框捕捉
+├── test/                   # 整合測試 + HTML 測試裝置
 └── dist/
-    └── browse              # Compiled binary (~58MB, Bun --compile)
+    └── browse              # 編譯後的二進位檔（~58MB，Bun --compile）
 ```
 
-### The snapshot system
+### 快照系統
 
-The browser's key innovation is ref-based element selection, built on Playwright's accessibility tree API:
+瀏覽器的關鍵創新是基於參考的元素選擇，建立在 Playwright 的無障礙樹 API 之上：
 
-1. `page.locator(scope).ariaSnapshot()` returns a YAML-like accessibility tree
-2. The snapshot parser assigns refs (`@e1`, `@e2`, ...) to each element
-3. For each ref, it builds a Playwright `Locator` (using `getByRole` + nth-child)
-4. The ref-to-Locator map is stored on `BrowserManager`
-5. Later commands like `click @e3` look up the Locator and call `locator.click()`
+1. `page.locator(scope).ariaSnapshot()` 返回類似 YAML 的無障礙樹
+2. 快照解析器為每個元素分配參考（`@e1`、`@e2`、...）
+3. 對於每個參考，建立一個 Playwright `Locator`（使用 `getByRole` + nth-child）
+4. 參考到 Locator 的映射儲存在 `BrowserManager` 上
+5. 之後的指令如 `click @e3` 查找 Locator 並呼叫 `locator.click()`
 
-No DOM mutation. No injected scripts. Just Playwright's native accessibility API.
+沒有 DOM 修改。沒有注入的腳本。只使用 Playwright 的原生無障礙 API。
 
-**Ref staleness detection:** SPAs can mutate the DOM without navigation (React router, tab switches, modals). When this happens, refs collected from a previous `snapshot` may point to elements that no longer exist. To handle this, `resolveRef()` runs an async `count()` check before using any ref — if the element count is 0, it throws immediately with a message telling the agent to re-run `snapshot`. This fails fast (~5ms) instead of waiting for Playwright's 30-second action timeout.
+**參考過時偵測：** SPA 可以在不導航的情況下修改 DOM（React router、分頁切換、modal）。當這發生時，從先前的 `snapshot` 收集的參考可能指向已不存在的元素。為了處理這種情況，`resolveRef()` 在使用任何參考之前執行非同步的 `count()` 檢查——如果元素計數為 0，它立即拋出一個訊息，告訴代理人重新執行 `snapshot`。這快速失敗（約 5ms），而不是等待 Playwright 的 30 秒動作逾時。
 
-**Extended snapshot features:**
-- `--diff` (`-D`): Stores each snapshot as a baseline. On the next `-D` call, returns a unified diff showing what changed. Use this to verify that an action (click, fill, etc.) actually worked.
-- `--annotate` (`-a`): Injects temporary overlay divs at each ref's bounding box, takes a screenshot with ref labels visible, then removes the overlays. Use `-o <path>` to control the output path.
-- `--cursor-interactive` (`-C`): Scans for non-ARIA interactive elements (divs with `cursor:pointer`, `onclick`, `tabindex>=0`) using `page.evaluate`. Assigns `@c1`, `@c2`... refs with deterministic `nth-child` CSS selectors. These are elements the ARIA tree misses but users can still click.
+**擴展快照功能：**
+- `--diff`（`-D`）：將每個快照儲存為基準線。在下一次 `-D` 呼叫時，返回顯示變更內容的統一差異。使用此功能來驗證操作（click、fill 等）是否真的有效。
+- `--annotate`（`-a`）：在每個參考的邊界框注入臨時覆蓋 div，截取帶有可見參考標籤的截圖，然後移除覆蓋。使用 `-o <path>` 控制輸出路徑。
+- `--cursor-interactive`（`-C`）：使用 `page.evaluate` 掃描非 ARIA 互動元素（帶 `cursor:pointer`、`onclick`、`tabindex>=0` 的 div）。分配 `@c1`、`@c2`... 參考，帶有確定性的 `nth-child` CSS 選擇器。這些是 ARIA 樹錯過但使用者仍能點擊的元素。
 
-### Screenshot modes
+### 截圖模式
 
-The `screenshot` command supports four modes:
+`screenshot` 指令支援四種模式：
 
-| Mode | Syntax | Playwright API |
+| 模式 | 語法 | Playwright API |
 |------|--------|----------------|
-| Full page (default) | `screenshot [path]` | `page.screenshot({ fullPage: true })` |
-| Viewport only | `screenshot --viewport [path]` | `page.screenshot({ fullPage: false })` |
-| Element crop | `screenshot "#sel" [path]` or `screenshot @e3 [path]` | `locator.screenshot()` |
-| Region clip | `screenshot --clip x,y,w,h [path]` | `page.screenshot({ clip })` |
+| 全頁（預設） | `screenshot [path]` | `page.screenshot({ fullPage: true })` |
+| 僅視窗 | `screenshot --viewport [path]` | `page.screenshot({ fullPage: false })` |
+| 元素裁切 | `screenshot "#sel" [path]` 或 `screenshot @e3 [path]` | `locator.screenshot()` |
+| 區域裁切 | `screenshot --clip x,y,w,h [path]` | `page.screenshot({ clip })` |
 
-Element crop accepts CSS selectors (`.class`, `#id`, `[attr]`) or `@e`/`@c` refs from `snapshot`. Auto-detection: `@e`/`@c` prefix = ref, `.`/`#`/`[` prefix = CSS selector, `--` prefix = flag, everything else = output path.
+元素裁切接受 CSS 選擇器（`.class`、`#id`、`[attr]`）或來自 `snapshot` 的 `@e`/`@c` 參考。自動偵測：`@e`/`@c` 前綴 = 參考，`.`/`#`/`[` 前綴 = CSS 選擇器，`--` 前綴 = 旗標，其他 = 輸出路徑。
 
-Mutual exclusion: `--clip` + selector and `--viewport` + `--clip` both throw errors. Unknown flags (e.g. `--bogus`) also throw.
+互斥：`--clip` + 選擇器，以及 `--viewport` + `--clip` 都會拋出錯誤。未知旗標（例如 `--bogus`）也會拋出錯誤。
 
-### Authentication
+### 驗證
 
-Each server session generates a random UUID as a bearer token. The token is written to the state file (`.gstack/browse.json`) with chmod 600. Every HTTP request must include `Authorization: Bearer <token>`. This prevents other processes on the machine from controlling the browser.
+每個伺服器工作階段生成一個隨機 UUID 作為 bearer token。Token 以 chmod 600 寫入狀態檔案（`.gstack/browse.json`）。每個 HTTP 請求都必須包含 `Authorization: Bearer <token>`。這防止機器上的其他程序控制瀏覽器。
 
-### Console, network, and dialog capture
+### 主控台、網路和對話框捕捉
 
-The server hooks into Playwright's `page.on('console')`, `page.on('response')`, and `page.on('dialog')` events. All entries are kept in O(1) circular buffers (50,000 capacity each) and flushed to disk asynchronously via `Bun.write()`:
+伺服器掛接到 Playwright 的 `page.on('console')`、`page.on('response')` 和 `page.on('dialog')` 事件。所有條目都保存在 O(1) 環形緩衝區中（各 50,000 容量），並透過 `Bun.write()` 非同步刷新到磁碟：
 
-- Console: `.gstack/browse-console.log`
-- Network: `.gstack/browse-network.log`
-- Dialog: `.gstack/browse-dialog.log`
+- 主控台：`.gstack/browse-console.log`
+- 網路：`.gstack/browse-network.log`
+- 對話框：`.gstack/browse-dialog.log`
 
-The `console`, `network`, and `dialog` commands read from the in-memory buffers, not disk.
+`console`、`network` 和 `dialog` 指令從記憶體緩衝區讀取，而不是磁碟。
 
-### User handoff
+### 使用者交接
 
-When the headless browser can't proceed (CAPTCHA, MFA, complex auth), `handoff` opens a visible Chrome window at the exact same page with all cookies, localStorage, and tabs preserved. The user solves the problem manually, then `resume` returns control to the agent with a fresh snapshot.
-
-```bash
-$B handoff "Stuck on CAPTCHA at login page"   # opens visible Chrome
-# User solves CAPTCHA...
-$B resume                                       # returns to headless with fresh snapshot
-```
-
-The browser auto-suggests `handoff` after 3 consecutive failures. State is fully preserved across the switch — no re-login needed.
-
-### Dialog handling
-
-Dialogs (alert, confirm, prompt) are auto-accepted by default to prevent browser lockup. The `dialog-accept` and `dialog-dismiss` commands control this behavior. For prompts, `dialog-accept <text>` provides the response text. All dialogs are logged to the dialog buffer with type, message, and action taken.
-
-### JavaScript execution (`js` and `eval`)
-
-`js` runs a single expression, `eval` runs a JS file. Both support `await` — expressions containing `await` are automatically wrapped in an async context:
+當無頭瀏覽器無法繼續（CAPTCHA、MFA、複雜的身份驗證）時，`handoff` 會在完全相同的頁面上開啟一個可見的 Chrome 視窗，保留所有 Cookie、localStorage 和分頁。使用者手動解決問題，然後 `resume` 將控制權返回給代理人，並帶有新的快照。
 
 ```bash
-$B js "await fetch('/api/data').then(r => r.json())"  # works
-$B js "document.title"                                  # also works (no wrapping needed)
-$B eval my-script.js                                    # file with await works too
+$B handoff "Stuck on CAPTCHA at login page"   # 開啟可見 Chrome
+# 使用者解決 CAPTCHA...
+$B resume                                       # 帶有新快照返回到無頭模式
 ```
 
-For `eval` files, single-line files return the expression value directly. Multi-line files need explicit `return` when using `await`. Comments containing "await" don't trigger wrapping.
+瀏覽器在連續 3 次失敗後自動建議 `handoff`。狀態在切換過程中完全保留——不需要重新登入。
 
-### Multi-workspace support
+### 對話框處理
 
-Each workspace gets its own isolated browser instance with its own Chromium process, tabs, cookies, and logs. State is stored in `.gstack/` inside the project root (detected via `git rev-parse --show-toplevel`).
+對話框（alert、confirm、prompt）預設自動接受，以防止瀏覽器鎖定。`dialog-accept` 和 `dialog-dismiss` 指令控制此行為。對於 prompt，`dialog-accept <text>` 提供回應文字。所有對話框都記錄到對話框緩衝區，帶有類型、訊息和採取的動作。
 
-| Workspace | State file | Port |
+### JavaScript 執行（`js` 和 `eval`）
+
+`js` 執行單一表達式，`eval` 執行 JS 檔案。兩者都支援 `await`——包含 `await` 的表達式自動包裝在非同步上下文中：
+
+```bash
+$B js "await fetch('/api/data').then(r => r.json())"  # 可以運作
+$B js "document.title"                                  # 也可以（不需要包裝）
+$B eval my-script.js                                    # 帶有 await 的檔案也可以運作
+```
+
+對於 `eval` 檔案，單行檔案直接返回表達式值。多行檔案在使用 `await` 時需要明確的 `return`。包含「await」的注釋不會觸發包裝。
+
+### 多工作空間支援
+
+每個工作空間都有自己隔離的瀏覽器實例，有自己的 Chromium 程序、分頁、Cookie 和日誌。狀態儲存在專案根目錄（透過 `git rev-parse --show-toplevel` 偵測）內的 `.gstack/` 中。
+
+| 工作空間 | 狀態檔案 | 連接埠 |
 |-----------|------------|------|
-| `/code/project-a` | `/code/project-a/.gstack/browse.json` | random (10000-60000) |
-| `/code/project-b` | `/code/project-b/.gstack/browse.json` | random (10000-60000) |
+| `/code/project-a` | `/code/project-a/.gstack/browse.json` | 隨機（10000-60000） |
+| `/code/project-b` | `/code/project-b/.gstack/browse.json` | 隨機（10000-60000） |
 
-No port collisions. No shared state. Each project is fully isolated.
+沒有連接埠衝突。沒有共享狀態。每個專案完全隔離。
 
-### Environment variables
+### 環境變數
 
-| Variable | Default | Description |
+| 變數 | 預設值 | 說明 |
 |----------|---------|-------------|
-| `BROWSE_PORT` | 0 (random 10000-60000) | Fixed port for the HTTP server (debug override) |
-| `BROWSE_IDLE_TIMEOUT` | 1800000 (30 min) | Idle shutdown timeout in ms |
-| `BROWSE_STATE_FILE` | `.gstack/browse.json` | Path to state file (CLI passes to server) |
-| `BROWSE_SERVER_SCRIPT` | auto-detected | Path to server.ts |
+| `BROWSE_PORT` | 0（隨機 10000-60000） | HTTP 伺服器的固定連接埠（除錯覆蓋） |
+| `BROWSE_IDLE_TIMEOUT` | 1800000（30 分鐘） | 閒置關閉逾時（毫秒） |
+| `BROWSE_STATE_FILE` | `.gstack/browse.json` | 狀態檔案路徑（CLI 傳遞給伺服器） |
+| `BROWSE_SERVER_SCRIPT` | 自動偵測 | server.ts 的路徑 |
 
-### Performance
+### 效能
 
-| Tool | First call | Subsequent calls | Context overhead per call |
+| 工具 | 第一次呼叫 | 後續呼叫 | 每次呼叫的上下文開銷 |
 |------|-----------|-----------------|--------------------------|
-| Chrome MCP | ~5s | ~2-5s | ~2000 tokens (schema + protocol) |
-| Playwright MCP | ~3s | ~1-3s | ~1500 tokens (schema + protocol) |
-| **gstack browse** | **~3s** | **~100-200ms** | **0 tokens** (plain text stdout) |
+| Chrome MCP | ~5 秒 | ~2-5 秒 | ~2000 tokens（結構描述 + 協定） |
+| Playwright MCP | ~3 秒 | ~1-3 秒 | ~1500 tokens（結構描述 + 協定） |
+| **gstack browse** | **~3 秒** | **~100-200ms** | **0 tokens**（純文字 stdout） |
 
-The context overhead difference compounds fast. In a 20-command browser session, MCP tools burn 30,000-40,000 tokens on protocol framing alone. gstack burns zero.
+上下文開銷差異很快就會累積。在一個 20 個指令的瀏覽器工作階段中，MCP 工具單獨在協定框架上就燒掉 30,000-40,000 個 token。gstack 燒掉零個。
 
-### Why CLI over MCP?
+### 為什麼選擇 CLI 而不是 MCP？
 
-MCP (Model Context Protocol) works well for remote services, but for local browser automation it adds pure overhead:
+MCP（Model Context Protocol）對遠端服務運作良好，但對本地端瀏覽器自動化它只是純粹的開銷：
 
-- **Context bloat**: every MCP call includes full JSON schemas and protocol framing. A simple "get the page text" costs 10x more context tokens than it should.
-- **Connection fragility**: persistent WebSocket/stdio connections drop and fail to reconnect.
-- **Unnecessary abstraction**: Claude Code already has a Bash tool. A CLI that prints to stdout is the simplest possible interface.
+- **上下文膨脹**：每個 MCP 呼叫都包含完整的 JSON 結構描述和協定框架。一個簡單的「取得頁面文字」比它應有的消耗多 10 倍的上下文 token。
+- **連接脆弱性**：持久的 WebSocket/stdio 連接會斷開並且無法重新連接。
+- **不必要的抽象**：Claude Code 已經有一個 Bash 工具。輸出到 stdout 的 CLI 是最簡單的介面。
 
-gstack skips all of this. Compiled binary. Plain text in, plain text out. No protocol. No schema. No connection management.
+gstack 跳過了所有這些。編譯後的二進位檔。純文字進，純文字出。沒有協定。沒有結構描述。沒有連接管理。
 
-## Acknowledgments
+## 致謝
 
-The browser automation layer is built on [Playwright](https://playwright.dev/) by Microsoft. Playwright's accessibility tree API, locator system, and headless Chromium management are what make ref-based interaction possible. The snapshot system — assigning `@ref` labels to accessibility tree nodes and mapping them back to Playwright Locators — is built entirely on top of Playwright's primitives. Thank you to the Playwright team for building such a solid foundation.
+瀏覽器自動化層建立在 Microsoft 的 [Playwright](https://playwright.dev/) 之上。Playwright 的無障礙樹 API、Locator 系統和無頭 Chromium 管理使基於參考的互動成為可能。快照系統——為無障礙樹節點分配 `@ref` 標籤並將它們映射回 Playwright Locator——完全建立在 Playwright 的原語之上。感謝 Playwright 團隊建立如此堅實的基礎。
 
-## Development
+## 開發
 
-### Prerequisites
+### 前置需求
 
 - [Bun](https://bun.sh/) v1.0+
-- Playwright's Chromium (installed automatically by `bun install`)
+- Playwright 的 Chromium（透過 `bun install` 自動安裝）
 
-### Quick start
+### 快速開始
 
 ```bash
-bun install              # install dependencies + Playwright Chromium
-bun test                 # run integration tests (~3s)
-bun run dev <cmd>        # run CLI from source (no compile)
-bun run build            # compile to browse/dist/browse
+bun install              # 安裝依賴 + Playwright Chromium
+bun test                 # 執行整合測試（~3 秒）
+bun run dev <cmd>        # 從原始碼執行 CLI（無需編譯）
+bun run build            # 編譯到 browse/dist/browse
 ```
 
-### Dev mode vs compiled binary
+### 開發模式與編譯後二進位檔
 
-During development, use `bun run dev` instead of the compiled binary. It runs `browse/src/cli.ts` directly with Bun, so you get instant feedback without a compile step:
+開發期間，使用 `bun run dev` 而不是編譯後的二進位檔。它直接用 Bun 執行 `browse/src/cli.ts`，讓你無需編譯步驟就能獲得即時回饋：
 
 ```bash
 bun run dev goto https://example.com
@@ -223,49 +223,49 @@ bun run dev snapshot -i
 bun run dev click @e3
 ```
 
-The compiled binary (`bun run build`) is only needed for distribution. It produces a single ~58MB executable at `browse/dist/browse` using Bun's `--compile` flag.
+編譯後的二進位檔（`bun run build`）只在發布時需要。它使用 Bun 的 `--compile` 旗標在 `browse/dist/browse` 產生一個約 58MB 的執行檔。
 
-### Running tests
+### 執行測試
 
 ```bash
-bun test                         # run all tests
-bun test browse/test/commands              # run command integration tests only
-bun test browse/test/snapshot              # run snapshot tests only
-bun test browse/test/cookie-import-browser # run cookie import unit tests only
+bun test                         # 執行所有測試
+bun test browse/test/commands              # 僅執行指令整合測試
+bun test browse/test/snapshot              # 僅執行快照測試
+bun test browse/test/cookie-import-browser # 僅執行 Cookie 匯入單元測試
 ```
 
-Tests spin up a local HTTP server (`browse/test/test-server.ts`) serving HTML fixtures from `browse/test/fixtures/`, then exercise the CLI commands against those pages. 203 tests across 3 files, ~15 seconds total.
+測試啟動一個本地端 HTTP 伺服器（`browse/test/test-server.ts`），從 `browse/test/fixtures/` 提供 HTML 測試裝置，然後針對這些頁面執行 CLI 指令。203 個測試分布在 3 個檔案中，共約 15 秒。
 
-### Source map
+### 原始碼地圖
 
-| File | Role |
+| 檔案 | 角色 |
 |------|------|
-| `browse/src/cli.ts` | Entry point. Reads `.gstack/browse.json`, sends HTTP to the server, prints response. |
-| `browse/src/server.ts` | Bun HTTP server. Routes commands to the right handler. Manages idle timeout. |
-| `browse/src/browser-manager.ts` | Chromium lifecycle — launch, tab management, ref map, crash detection. |
-| `browse/src/snapshot.ts` | Parses accessibility tree, assigns `@e`/`@c` refs, builds Locator map. Handles `--diff`, `--annotate`, `-C`. |
-| `browse/src/read-commands.ts` | Non-mutating commands: `text`, `html`, `links`, `js`, `css`, `is`, `dialog`, `forms`, etc. Exports `getCleanText()`. |
-| `browse/src/write-commands.ts` | Mutating commands: `goto`, `click`, `fill`, `upload`, `dialog-accept`, `useragent` (with context recreation), etc. |
-| `browse/src/meta-commands.ts` | Server management, chain routing, diff (DRY via `getCleanText`), snapshot delegation. |
-| `browse/src/cookie-import-browser.ts` | Decrypt Chromium cookies via macOS Keychain + PBKDF2/AES-128-CBC. Auto-detects installed browsers. |
-| `browse/src/cookie-picker-routes.ts` | HTTP routes for `/cookie-picker/*` — browser list, domain search, import, remove. |
-| `browse/src/cookie-picker-ui.ts` | Self-contained HTML generator for the interactive cookie picker (dark theme, no frameworks). |
-| `browse/src/buffers.ts` | `CircularBuffer<T>` (O(1) ring buffer) + console/network/dialog capture with async disk flush. |
+| `browse/src/cli.ts` | 入口點。讀取 `.gstack/browse.json`，發送 HTTP 到伺服器，輸出回應。 |
+| `browse/src/server.ts` | Bun HTTP 伺服器。路由指令到正確的處理器。管理閒置逾時。 |
+| `browse/src/browser-manager.ts` | Chromium 生命週期——啟動、分頁管理、參考映射、崩潰偵測。 |
+| `browse/src/snapshot.ts` | 解析無障礙樹，分配 `@e`/`@c` 參考，建立 Locator 映射。處理 `--diff`、`--annotate`、`-C`。 |
+| `browse/src/read-commands.ts` | 非修改性指令：`text`、`html`、`links`、`js`、`css`、`is`、`dialog`、`forms` 等。匯出 `getCleanText()`。 |
+| `browse/src/write-commands.ts` | 修改性指令：`goto`、`click`、`fill`、`upload`、`dialog-accept`、`useragent`（帶上下文重建）等。 |
+| `browse/src/meta-commands.ts` | 伺服器管理、chain 路由、diff（透過 `getCleanText` 的 DRY）、快照委派。 |
+| `browse/src/cookie-import-browser.ts` | 透過 macOS 鑰匙圈 + PBKDF2/AES-128-CBC 解密 Chromium Cookie。自動偵測已安裝的瀏覽器。 |
+| `browse/src/cookie-picker-routes.ts` | `/cookie-picker/*` 的 HTTP 路由——瀏覽器清單、域名搜尋、匯入、移除。 |
+| `browse/src/cookie-picker-ui.ts` | 互動式 Cookie 選擇器的自包含 HTML 生成器（深色主題，無框架）。 |
+| `browse/src/buffers.ts` | `CircularBuffer<T>`（O(1) 環形緩衝區）+ 帶非同步磁碟刷新的主控台/網路/對話框捕捉。 |
 
-### Deploying to the active skill
+### 部署到活躍技能
 
-The active skill lives at `~/.claude/skills/gstack/`. After making changes:
+活躍技能位於 `~/.claude/skills/gstack/`。進行變更後：
 
-1. Push your branch
-2. Pull in the skill directory: `cd ~/.claude/skills/gstack && git pull`
-3. Rebuild: `cd ~/.claude/skills/gstack && bun run build`
+1. 推送你的分支
+2. 在技能目錄中拉取：`cd ~/.claude/skills/gstack && git pull`
+3. 重新建置：`cd ~/.claude/skills/gstack && bun run build`
 
-Or copy the binary directly: `cp browse/dist/browse ~/.claude/skills/gstack/browse/dist/browse`
+或直接複製二進位檔：`cp browse/dist/browse ~/.claude/skills/gstack/browse/dist/browse`
 
-### Adding a new command
+### 新增指令
 
-1. Add the handler in `read-commands.ts` (non-mutating) or `write-commands.ts` (mutating)
-2. Register the route in `server.ts`
-3. Add a test case in `browse/test/commands.test.ts` with an HTML fixture if needed
-4. Run `bun test` to verify
-5. Run `bun run build` to compile
+1. 在 `read-commands.ts`（非修改性）或 `write-commands.ts`（修改性）中新增處理器
+2. 在 `server.ts` 中注冊路由
+3. 如需要，在 `browse/test/commands.test.ts` 中新增帶有 HTML 測試裝置的測試案例
+4. 執行 `bun test` 以驗證
+5. 執行 `bun run build` 以編譯

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,623 +1,614 @@
-# Changelog
+# 更新日誌
 
-## [0.9.0] - 2026-03-19 — Works on Codex, Gemini CLI, and Cursor
+## [0.9.0] - 2026-03-19 — 支援 Codex、Gemini CLI 與 Cursor
 
-**gstack now works on any AI agent that supports the open SKILL.md standard.** Install once, use from Claude Code, OpenAI Codex CLI, Google Gemini CLI, or Cursor. All 21 skills are available in `.agents/skills/` -- just run `./setup --host codex` or `./setup --host auto` and your agent discovers them automatically.
+**gstack 現在可在任何支援開放 SKILL.md 標準的 AI 代理上運作。** 只需安裝一次，即可從 Claude Code、OpenAI Codex CLI、Google Gemini CLI 或 Cursor 使用。全部 21 個技能已提供於 `.agents/skills/` — 只需執行 `./setup --host codex` 或 `./setup --host auto`，您的代理即可自動探索它們。
 
-- **One install, four agents.** Claude Code reads from `.claude/skills/`, everything else reads from `.agents/skills/`. Same skills, same prompts, adapted for each host. Hook-based safety skills (careful, freeze, guard) get inline safety advisory prose instead of hooks -- they work everywhere.
-- **Auto-detection.** `./setup --host auto` detects which agents you have installed and sets up both. Already have Claude Code? It still works exactly the same.
-- **Codex-adapted output.** Frontmatter is stripped to just name + description (Codex doesn't need allowed-tools or hooks). Paths are rewritten from `~/.claude/` to `~/.codex/`. The `/codex` skill itself is excluded from Codex output -- it's a Claude wrapper around `codex exec`, which would be self-referential.
-- **CI checks both hosts.** The freshness check now validates Claude and Codex output independently. Stale Codex docs break the build just like stale Claude docs.
+- **一次安裝，四種代理。** Claude Code 從 `.claude/skills/` 讀取，其他代理則從 `.agents/skills/` 讀取。相同的技能、相同的提示詞，針對每個主機進行調整。基於 Hook 的安全技能（careful、freeze、guard）改為使用內嵌安全建議文字而非 Hook — 可在所有環境中運作。
+- **自動偵測。** `./setup --host auto` 會偵測您已安裝的代理並一併設定。已使用 Claude Code？它仍然完全照常運作。
+- **Codex 最佳化輸出。** Frontmatter 精簡為僅包含名稱與描述（Codex 不需要 allowed-tools 或 hooks）。路徑從 `~/.claude/` 改寫為 `~/.codex/`。`/codex` 技能本身被排除在 Codex 輸出之外 — 它是 Claude 對 `codex exec` 的封裝，若納入將形成自我參照。
+- **CI 同時檢查兩個主機。** 新鮮度檢查現在會獨立驗證 Claude 和 Codex 的輸出。Codex 文件過時會和 Claude 文件過時一樣使建置失敗。
 
 ## [0.8.6] - 2026-03-19
 
-### Added
+### 新增
 
-- **You can now see how you use gstack.** Run `gstack-analytics` to see a personal usage dashboard — which skills you use most, how long they take, your success rate. All data stays local on your machine.
-- **Opt-in community telemetry.** On first run, gstack asks if you want to share anonymous usage data (skill names, duration, crash info — never code or file paths). Choose "yes" and you're part of the community pulse. Change anytime with `gstack-config set telemetry off`.
-- **Community health dashboard.** Run `gstack-community-dashboard` to see what the gstack community is building — most popular skills, crash clusters, version distribution. All powered by Supabase.
-- **Install base tracking via update check.** When telemetry is enabled, gstack fires a parallel ping to Supabase during update checks — giving us an install-base count without adding any latency. Respects your telemetry setting (default off). GitHub remains the primary version source.
-- **Crash clustering.** Errors are automatically grouped by type and version in the Supabase backend, so the most impactful bugs surface first.
-- **Upgrade funnel tracking.** We can now see how many people see upgrade prompts vs actually upgrade — helps us ship better releases.
-- **/retro now shows your gstack usage.** Weekly retrospectives include skill usage stats (which skills you used, how often, success rate) alongside your commit history.
-- **Session-specific pending markers.** If a skill crashes mid-run, the next invocation correctly finalizes only that session — no more race conditions between concurrent gstack sessions.
+- **您現在可以查看自己如何使用 gstack。** 執行 `gstack-analytics` 查看個人使用儀表板 — 最常使用哪些技能、花費多少時間、成功率如何。所有資料保留在您的本機上。
+- **選擇加入的社群遙測。** 首次執行時，gstack 會詢問您是否願意分享匿名使用資料（技能名稱、持續時間、當機資訊 — 絕不包含程式碼或檔案路徑）。選擇「是」即成為社群脈動的一部分。隨時可透過 `gstack-config set telemetry off` 變更設定。
+- **社群健康儀表板。** 執行 `gstack-community-dashboard` 查看 gstack 社群正在建構的內容 — 最熱門技能、當機叢集、版本分佈。全部由 Supabase 驅動。
+- **透過更新檢查追蹤安裝基數。** 啟用遙測後，gstack 在更新檢查期間會並行發送一個 Ping 至 Supabase — 提供安裝基數統計而不增加任何延遲。遵守您的遙測設定（預設關閉）。GitHub 仍為主要版本來源。
+- **當機叢集化。** 錯誤會在 Supabase 後端依類型和版本自動分組，讓影響最大的問題優先浮現。
+- **升級漏斗追蹤。** 我們現在可以看到有多少人看到升級提示與實際升級的比例 — 幫助我們發布更好的版本。
+- **/retro 現在顯示您的 gstack 使用情況。** 每週回顧報告包含技能使用統計（使用了哪些技能、使用頻率、成功率），與您的提交記錄並列呈現。
+- **工作階段專屬的待處理標記。** 若技能在執行中途當機，下次啟動時只會正確結束該工作階段 — 不再出現並發 gstack 工作階段之間的競態條件。
 
 ## [0.8.5] - 2026-03-19
 
-### Fixed
+### 修復
 
-- **`/retro` now counts full calendar days.** Running a retro late at night no longer silently misses commits from earlier in the day. Git treats bare dates like `--since="2026-03-11"` as "11pm on March 11" if you run it at 11pm — now we pass `--since="2026-03-11T00:00:00"` so it always starts from midnight. Compare mode windows get the same fix.
-- **Review log no longer breaks on branch names with `/`.** Branch names like `garrytan/design-system` caused review log writes to fail because Claude Code runs multi-line bash blocks as separate shell invocations, losing variables between commands. New `gstack-review-log` and `gstack-review-read` atomic helpers encapsulate the entire operation in a single command.
-- **All skill templates are now platform-agnostic.** Removed Rails-specific patterns (`bin/test-lane`, `RAILS_ENV`, `.includes()`, `rescue StandardError`, etc.) from `/ship`, `/review`, `/plan-ceo-review`, and `/plan-eng-review`. The review checklist now shows examples for Rails, Node, Python, and Django side-by-side.
-- **`/ship` reads CLAUDE.md to discover test commands** instead of hardcoding `bin/test-lane` and `npm run test`. If no test commands are found, it asks the user and persists the answer to CLAUDE.md.
+- **`/retro` 現在計算完整的日曆天數。** 在深夜執行回顧不再靜默遺漏當天早些時候的提交。Git 將裸日期（如 `--since="2026-03-11"`）在晚上 11 點執行時視為「3 月 11 日晚上 11 點」 — 現在我們改用 `--since="2026-03-11T00:00:00"`，確保始終從午夜開始計算。比較模式的時間窗口也獲得相同修復。
+- **Review log 不再因帶有 `/` 的分支名稱而中斷。** 像 `garrytan/design-system` 這樣的分支名稱會導致 review log 寫入失敗，因為 Claude Code 將多行 bash 區塊作為獨立的 shell 呼叫執行，在命令之間遺失變數。新的 `gstack-review-log` 和 `gstack-review-read` 原子性輔助工具將整個操作封裝在單一命令中。
+- **所有技能模板現在都是平台無關的。** 從 `/ship`、`/review`、`/plan-ceo-review` 和 `/plan-eng-review` 中移除 Rails 特定的模式（`bin/test-lane`、`RAILS_ENV`、`.includes()`、`rescue StandardError` 等）。Review 清單現在並排顯示 Rails、Node、Python 和 Django 的範例。
+- **`/ship` 讀取 CLAUDE.md 來探索測試命令**，而不是硬編碼 `bin/test-lane` 和 `npm run test`。若找不到測試命令，會詢問使用者並將答案儲存到 CLAUDE.md。
 
-### Added
+### 新增
 
-- **Platform-agnostic design principle** codified in CLAUDE.md — skills must read project config, never hardcode framework commands.
-- **`## Testing` section** in CLAUDE.md for `/ship` test command discovery.
+- **平台無關設計原則**已在 CLAUDE.md 中明文規定 — 技能必須讀取專案設定，絕不能硬編碼框架命令。
+- **`## Testing` 章節**已加入 CLAUDE.md，供 `/ship` 測試命令探索使用。
 
 ## [0.8.4] - 2026-03-19
 
-### Added
+### 新增
 
-- **`/ship` now automatically syncs your docs.** After creating the PR, `/ship` runs `/document-release` as Step 8.5 — README, ARCHITECTURE, CONTRIBUTING, and CLAUDE.md all stay current without an extra command. No more stale docs after shipping.
-- **Six new skills in the docs.** README, docs/skills.md, and BROWSER.md now cover `/codex` (multi-AI second opinion), `/careful` (destructive command warnings), `/freeze` (directory-scoped edit lock), `/guard` (full safety mode), `/unfreeze`, and `/gstack-upgrade`. The sprint skill table keeps its 15 specialists; a new "Power tools" section covers the rest.
-- **Browse handoff documented everywhere.** BROWSER.md command table, docs/skills.md deep-dive, and README "What's new" all explain `$B handoff` and `$B resume` for CAPTCHA/MFA/auth walls.
-- **Proactive suggestions know about all skills.** Root SKILL.md.tmpl now suggests `/codex`, `/careful`, `/freeze`, `/guard`, `/unfreeze`, and `/gstack-upgrade` at the right workflow stages.
+- **`/ship` 現在自動同步您的文件。** 建立 PR 後，`/ship` 在步驟 8.5 執行 `/document-release` — README、ARCHITECTURE、CONTRIBUTING 和 CLAUDE.md 全部保持最新，無需額外命令。出貨後不再有過時的文件。
+- **文件中新增六個技能。** README、docs/skills.md 和 BROWSER.md 現在涵蓋 `/codex`（多 AI 第二意見）、`/careful`（破壞性命令警告）、`/freeze`（目錄範圍編輯鎖定）、`/guard`（完整安全模式）、`/unfreeze` 和 `/gstack-upgrade`。衝刺技能表保留其 15 個專業工具；新的「Power tools」章節涵蓋其餘工具。
+- **瀏覽器交接已記錄在各處。** BROWSER.md 命令表、docs/skills.md 深度說明以及 README「新功能」均說明 `$B handoff` 和 `$B resume` 在面對 CAPTCHA/MFA/認證牆時的用法。
+- **主動建議功能了解所有技能。** 根層 SKILL.md.tmpl 現在在適當的工作流程階段建議 `/codex`、`/careful`、`/freeze`、`/guard`、`/unfreeze` 和 `/gstack-upgrade`。
 
 ## [0.8.3] - 2026-03-19
 
-### Added
+### 新增
 
-- **Plan reviews now guide you to the next step.** After running `/plan-ceo-review`, `/plan-eng-review`, or `/plan-design-review`, you get a recommendation for what to run next — eng review is always suggested as the required shipping gate, design review is suggested when UI changes are detected, and CEO review is softly mentioned for big product changes. No more remembering the workflow yourself.
-- **Reviews know when they're stale.** Each review now records the commit it was run at. The dashboard compares that against your current HEAD and tells you exactly how many commits have elapsed — "eng review may be stale — 13 commits since review" instead of guessing.
-- **`skip_eng_review` respected everywhere.** If you've opted out of eng review globally, the chaining recommendations won't nag you about it.
-- **Design review lite now tracks commits too.** The lightweight design check that runs inside `/review` and `/ship` gets the same staleness tracking as full reviews.
+- **計劃審查現在引導您進行下一步。** 執行 `/plan-ceo-review`、`/plan-eng-review` 或 `/plan-design-review` 後，您會獲得下一步操作的建議 — 始終建議將工程審查作為必要的出貨關卡，當偵測到 UI 變更時建議設計審查，大型產品變更則輕度提示 CEO 審查。不再需要自己記住工作流程。
+- **審查功能現在知道自己是否過時。** 每次審查現在都會記錄執行時的提交。儀表板將其與您目前的 HEAD 比較，並精確告知已過了多少次提交 — 「工程審查可能已過時 — 自審查以來已有 13 次提交」，而非靠猜測。
+- **`skip_eng_review` 在所有地方都得到尊重。** 若您已全域選擇退出工程審查，串鏈建議不會再因此打擾您。
+- **簡易設計審查現在也追蹤提交。** 在 `/review` 和 `/ship` 中執行的輕量設計檢查獲得與完整審查相同的過時追蹤功能。
 
-### Fixed
+### 修復
 
-- **Browse no longer navigates to dangerous URLs.** `goto`, `diff`, and `newtab` now block `file://`, `javascript:`, `data:` schemes and cloud metadata endpoints (`169.254.169.254`, `metadata.google.internal`). Localhost and private IPs are still allowed for local QA testing. (Closes #17)
-- **Setup script tells you what's missing.** Running `./setup` without `bun` installed now shows a clear error with install instructions instead of a cryptic "command not found." (Closes #147)
-- **`/debug` renamed to `/investigate`.** Claude Code has a built-in `/debug` command that shadowed the gstack skill. The systematic root-cause debugging workflow now lives at `/investigate`. (Closes #190)
-- **Shell injection surface removed.** All skill templates now use `source <(gstack-slug)` instead of `eval $(gstack-slug)`. Same behavior, no `eval`. (Closes #133)
-- **25 new security tests.** URL validation (16 tests) and path traversal validation (14 tests) now have dedicated unit test suites covering scheme blocking, metadata IP blocking, directory escapes, and prefix collision edge cases.
+- **瀏覽器不再導航至危險的 URL。** `goto`、`diff` 和 `newtab` 現在封鎖 `file://`、`javascript:`、`data:` 協定和雲端中繼資料端點（`169.254.169.254`、`metadata.google.internal`）。本機 QA 測試仍允許 localhost 和私有 IP。（修復 #17）
+- **Setup 腳本現在告知缺少什麼。** 未安裝 `bun` 就執行 `./setup` 現在會顯示清晰的錯誤訊息與安裝說明，而非令人費解的「command not found」。（修復 #147）
+- **`/debug` 更名為 `/investigate`。** Claude Code 有內建的 `/debug` 命令遮蔽了 gstack 技能。系統性根因除錯工作流程現在位於 `/investigate`。（修復 #190）
+- **移除 Shell 注入攻擊面。** 所有技能模板現在使用 `source <(gstack-slug)` 而非 `eval $(gstack-slug)`。行為相同，沒有 `eval`。（修復 #133）
+- **25 個新安全測試。** URL 驗證（16 個測試）和路徑遍歷驗證（14 個測試）現在有專用的單元測試套件，涵蓋協定封鎖、中繼資料 IP 封鎖、目錄逃脫和前綴衝突邊緣情況。
 
 ## [0.8.2] - 2026-03-19
 
-### Added
+### 新增
 
-- **Hand off to a real Chrome when the headless browser gets stuck.** Hit a CAPTCHA, auth wall, or MFA prompt? Run `$B handoff "reason"` and a visible Chrome opens at the exact same page with all your cookies and tabs intact. Solve the problem, tell Claude you're done, and `$B resume` picks up right where you left off with a fresh snapshot.
-- **Auto-handoff hint after 3 consecutive failures.** If the browse tool fails 3 times in a row, it suggests using `handoff` — so you don't waste time watching the AI retry a CAPTCHA.
-- **15 new tests for the handoff feature.** Unit tests for state save/restore, failure tracking, edge cases, plus integration tests for the full headless-to-headed flow with cookie and tab preservation.
+- **當無頭瀏覽器卡住時，交接給真實的 Chrome。** 遇到 CAPTCHA、認證牆或 MFA 提示？執行 `$B handoff "reason"`，一個可見的 Chrome 視窗會在完全相同的頁面開啟，並保留所有 Cookie 和分頁。解決問題後，告訴 Claude 您已完成，`$B resume` 會從您離開的地方繼續，並提供全新的快照。
+- **連續 3 次失敗後自動提示交接。** 若瀏覽工具連續失敗 3 次，它會建議使用 `handoff` — 讓您不必浪費時間看著 AI 重試 CAPTCHA。
+- **15 個針對交接功能的新測試。** 涵蓋狀態儲存/還原的單元測試、邊緣情況，以及完整的無頭到有頭流程（含 Cookie 和分頁保存）的整合測試。
 
-### Changed
+### 變更
 
-- `recreateContext()` refactored to use shared `saveState()`/`restoreState()` helpers — same behavior, less code, ready for future state persistence features.
-- `browser.close()` now has a 5-second timeout to prevent hangs when closing headed browsers on macOS.
+- `recreateContext()` 重構為使用共享的 `saveState()`/`restoreState()` 輔助函式 — 行為相同，程式碼更少，為未來的狀態持久化功能做好準備。
+- `browser.close()` 現在有 5 秒逾時，防止在 macOS 上關閉有頭瀏覽器時發生掛起。
 
 ## [0.8.1] - 2026-03-19
 
-### Fixed
+### 修復
 
-- **`/qa` no longer refuses to use the browser on backend-only changes.** Previously, if your branch only changed prompt templates, config files, or service logic, `/qa` would analyze the diff, conclude "no UI to test," and suggest running evals instead. Now it always opens the browser -- falling back to a Quick mode smoke test (homepage + top 5 navigation targets) when no specific pages are identified from the diff.
+- **`/qa` 不再拒絕在僅後端變更時使用瀏覽器。** 以前，若您的分支只更改了提示詞模板、設定檔案或服務邏輯，`/qa` 會分析 diff，得出「沒有 UI 需要測試」的結論，並建議改跑 eval。現在它始終打開瀏覽器 — 當從 diff 中無法識別特定頁面時，退而採用快速模式煙霧測試（首頁 + 前 5 個導航目標）。
 
-## [0.8.0] - 2026-03-19 — Multi-AI Second Opinion
+## [0.8.0] - 2026-03-19 — 多 AI 第二意見
 
-**`/codex` — get an independent second opinion from a completely different AI.**
+**`/codex` — 從完全不同的 AI 獲取獨立的第二意見。**
 
-Three modes. `/codex review` runs OpenAI's Codex CLI against your diff and gives a pass/fail gate — if Codex finds critical issues (`[P1]`), it fails. `/codex challenge` goes adversarial: it tries to find ways your code will fail in production, thinking like an attacker and a chaos engineer. `/codex <anything>` opens a conversation with Codex about your codebase, with session continuity so follow-ups remember context.
+三種模式。`/codex review` 對您的 diff 執行 OpenAI 的 Codex CLI 並給出通過/失敗判定 — 若 Codex 發現嚴重問題（`[P1]`），則失敗。`/codex challenge` 採取對抗性方式：它試圖找出您的程式碼在生產環境中失敗的方式，像攻擊者和混沌工程師那樣思考。`/codex <anything>` 與 Codex 開啟關於您程式碼庫的對話，工作階段連續性讓後續問題能記住上下文。
 
-When both `/review` (Claude) and `/codex review` have run, you get a cross-model analysis showing which findings overlap and which are unique to each AI — building intuition for when to trust which system.
+當 `/review`（Claude）和 `/codex review` 都執行後，您會獲得跨模型分析，顯示哪些發現重疊、哪些是各 AI 獨有的 — 培養您對何時信任哪個系統的直覺。
 
-**Integrated everywhere.** After `/review` finishes, it offers a Codex second opinion. During `/ship`, you can run Codex review as an optional gate before pushing. In `/plan-eng-review`, Codex can independently critique your plan before the engineering review begins. All Codex results show up in the Review Readiness Dashboard.
+**整合至各處。** `/review` 完成後，它提供 Codex 第二意見。在 `/ship` 期間，您可以在推送前執行 Codex 審查作為可選關卡。在 `/plan-eng-review` 中，Codex 可以在工程審查開始前獨立批評您的計劃。所有 Codex 結果都顯示在 Review Readiness Dashboard 中。
 
-**Also in this release:** Proactive skill suggestions — gstack now notices what stage of development you're in and suggests the right skill. Don't like it? Say "stop suggesting" and it remembers across sessions.
+**此版本同時新增：** 主動技能建議 — gstack 現在會注意您所在的開發階段並建議正確的技能。不喜歡？說「stop suggesting」，它會跨工作階段記住。
 
 ## [0.7.4] - 2026-03-18
 
-### Changed
+### 變更
 
-- **`/qa` and `/design-review` now ask what to do with uncommitted changes** instead of refusing to start. When your working tree is dirty, you get an interactive prompt with three options: commit your changes, stash them, or abort. No more cryptic "ERROR: Working tree is dirty" followed by a wall of text.
+- **`/qa` 和 `/design-review` 現在詢問如何處理未提交的變更**，而不是拒絕啟動。當您的工作目錄有未提交內容時，您會獲得三個互動選項：提交變更、暫存或中止。不再有神秘的「ERROR: Working tree is dirty」後跟著大量說明文字。
 
 ## [0.7.3] - 2026-03-18
 
-### Added
+### 新增
 
-- **Safety guardrails you can turn on with one command.** Say "be careful" or "safety mode" and `/careful` will warn you before any destructive command — `rm -rf`, `DROP TABLE`, force-push, `kubectl delete`, and more. You can override every warning. Common build artifact cleanups (`rm -rf node_modules`, `dist`, `.next`) are whitelisted.
-- **Lock edits to one folder with `/freeze`.** Debugging something and don't want Claude to "fix" unrelated code? `/freeze` blocks all file edits outside a directory you choose. Hard block, not just a warning. Run `/unfreeze` to remove the restriction without ending your session.
-- **`/guard` activates both at once.** One command for maximum safety when touching prod or live systems — destructive command warnings plus directory-scoped edit restrictions.
-- **`/debug` now auto-freezes edits to the module being debugged.** After forming a root cause hypothesis, `/debug` locks edits to the narrowest affected directory. No more accidental "fixes" to unrelated code during debugging.
-- **You can now see which skills you use and how often.** Every skill invocation is logged locally to `~/.gstack/analytics/skill-usage.jsonl`. Run `bun run analytics` to see your top skills, per-repo breakdown, and how often safety hooks actually catch something. Data stays on your machine.
-- **Weekly retros now include skill usage.** `/retro` shows which skills you used during the retro window alongside your usual commit analysis and metrics.
+- **一個命令即可開啟安全防護措施。** 說「be careful」或「safety mode」，`/careful` 就會在任何破壞性命令前警告您 — `rm -rf`、`DROP TABLE`、force-push、`kubectl delete` 等。您可以覆蓋每個警告。常見的建構產物清理（`rm -rf node_modules`、`dist`、`.next`）已列入白名單。
+- **用 `/freeze` 將編輯鎖定在一個資料夾。** 正在除錯但不想讓 Claude「修復」無關的程式碼？`/freeze` 封鎖您選擇目錄之外的所有檔案編輯。是硬性封鎖，不只是警告。執行 `/unfreeze` 即可移除限制而無需結束工作階段。
+- **`/guard` 一次啟動兩者。** 當接觸生產環境或即時系統時，一個命令提供最大安全保障 — 破壞性命令警告加上目錄範圍編輯限制。
+- **`/debug` 現在自動凍結正在除錯模組的編輯。** 形成根因假設後，`/debug` 將編輯鎖定在受影響的最窄目錄。除錯期間不再意外「修復」無關的程式碼。
+- **您現在可以查看使用哪些技能及使用頻率。** 每次技能調用都在本機記錄至 `~/.gstack/analytics/skill-usage.jsonl`。執行 `bun run analytics` 查看您的頂級技能、各專案分類，以及安全 Hook 實際攔截的頻率。資料保留在您的機器上。
+- **每週回顧現在包含技能使用情況。** `/retro` 在回顧時間窗口內顯示您使用的技能，與您平常的提交分析和指標並排呈現。
 
 ## [0.7.2] - 2026-03-18
 
-### Fixed
+### 修復
 
-- `/retro` date ranges now align to midnight instead of the current time. Running `/retro` at 9pm no longer silently drops the morning of the start date — you get full calendar days.
-- `/retro` timestamps now use your local timezone instead of hardcoded Pacific time. Users outside the US-West coast get correct local hours in histograms, session detection, and streak tracking.
+- `/retro` 日期範圍現在對齊午夜而非當前時間。下午 9 點執行 `/retro` 不再靜默遺漏開始日期的上午時段 — 您獲得完整的日曆天。
+- `/retro` 時間戳記現在使用您的本地時區而非硬編碼的太平洋時間。美西海岸以外的用戶在直方圖、工作階段偵測和連續記錄中可獲得正確的本地時間。
 
 ## [0.7.1] - 2026-03-19
 
-### Added
+### 新增
 
-- **gstack now suggests skills at natural moments.** You don't need to know slash commands — just talk about what you're doing. Brainstorming an idea? gstack suggests `/office-hours`. Something's broken? It suggests `/debug`. Ready to deploy? It suggests `/ship`. Every workflow skill now has proactive triggers that fire when the moment is right.
-- **Lifecycle map.** gstack's root skill description now includes a developer workflow guide mapping 12 stages (brainstorm → plan → review → code → debug → test → ship → docs → retro) to the right skill. Claude sees this in every session.
-- **Opt-out with natural language.** If proactive suggestions feel too aggressive, just say "stop suggesting things" — gstack remembers across sessions. Say "be proactive again" to re-enable.
-- **11 journey-stage E2E tests.** Each test simulates a real moment in the developer lifecycle with realistic project context (plan.md, error logs, git history, code) and verifies the right skill fires from natural language alone. 11/11 pass.
-- **Trigger phrase validation.** Static tests verify every workflow skill has "Use when" and "Proactively suggest" phrases — catches regressions for free.
+- **gstack 現在在自然時機建議技能。** 您不需要知道斜線命令 — 只需談論您在做什麼。腦力激盪一個想法？gstack 建議 `/office-hours`。有東西壞了？它建議 `/debug`。準備部署？它建議 `/ship`。每個工作流程技能現在都有主動觸發器，在時機成熟時啟動。
+- **生命週期地圖。** gstack 的根技能描述現在包含一個開發者工作流程指南，將 12 個階段（腦力激盪 → 計劃 → 審查 → 程式碼 → 除錯 → 測試 → 出貨 → 文件 → 回顧）對應到正確的技能。Claude 在每次工作階段中都能看到這個。
+- **用自然語言退出。** 若主動建議感覺太積極，只需說「stop suggesting things」 — gstack 跨工作階段記住。說「be proactive again」重新啟用。
+- **11 個旅程階段 E2E 測試。** 每個測試模擬開發者生命週期中的真實時刻，包含實際的專案上下文（plan.md、錯誤日誌、git 歷史、程式碼），並驗證正確的技能僅從自然語言就能觸發。11/11 通過。
+- **觸發短語驗證。** 靜態測試驗證每個工作流程技能都有「Use when」和「Proactively suggest」短語 — 免費攔截退化。
 
-### Fixed
+### 修復
 
-- `/debug` and `/office-hours` were completely invisible to natural language — no trigger phrases at all. Now both have full reactive + proactive triggers.
+- `/debug` 和 `/office-hours` 對自然語言完全不可見 — 根本沒有觸發短語。現在兩者都有完整的被動 + 主動觸發器。
 
 ## [0.7.0] - 2026-03-18 — YC Office Hours
 
-**`/office-hours` — sit down with a YC partner before you write a line of code.**
+**`/office-hours` — 在寫第一行程式碼之前，與 YC 合夥人坐下來談。**
 
-Two modes. If you're building a startup, you get six forcing questions distilled from how YC evaluates products: demand reality, status quo, desperate specificity, narrowest wedge, observation & surprise, and future-fit. If you're hacking on a side project, learning to code, or at a hackathon, you get an enthusiastic brainstorming partner who helps you find the coolest version of your idea.
+兩種模式。若您在建立新創公司，您會獲得六個從 YC 評估產品方式提煉出的強制性問題：需求現實、現狀、迫切的具體性、最窄的切入點、觀察與驚喜，以及未來適配性。若您在黑客馬拉松、學習寫程式或開發副業專案，您會獲得一個熱情的腦力激盪夥伴，幫助您找到想法最酷的版本。
 
-Both modes write a design doc that feeds directly into `/plan-ceo-review` and `/plan-eng-review`. After the session, the skill reflects back what it noticed about how you think — specific observations, not generic praise.
+兩種模式都會撰寫一份設計文件，直接供 `/plan-ceo-review` 和 `/plan-eng-review` 使用。工作階段結束後，技能會反映它對您思考方式的觀察 — 具體的觀察，而非泛泛的稱讚。
 
-**`/debug` — find the root cause, not the symptom.**
+**`/debug` — 找到根本原因，而非症狀。**
 
-When something is broken and you don't know why, `/debug` is your systematic debugger. It follows the Iron Law: no fixes without root cause investigation first. Traces data flow, matches against known bug patterns (race conditions, nil propagation, stale cache, config drift), and tests hypotheses one at a time. If 3 fixes fail, it stops and questions the architecture instead of thrashing.
+當有東西壞了而您不知道原因時，`/debug` 是您的系統性除錯工具。它遵循鐵律：在根因調查之前不進行修復。追蹤資料流，與已知的錯誤模式（競態條件、nil 傳播、過時快取、設定漂移）比對，並逐一測試假設。若 3 次修復失敗，它會停下來質疑架構，而不是繼續嘗試。
 
 ## [0.6.4.1] - 2026-03-18
 
-### Added
+### 新增
 
-- **Skills now discoverable via natural language.** All 12 skills that were missing explicit trigger phrases now have them — say "deploy this" and Claude finds `/ship`, say "check my diff" and it finds `/review`. Following Anthropic's best practice: "the description field is not a summary — it's when to trigger."
+- **技能現在可透過自然語言探索。** 所有 12 個缺少明確觸發短語的技能現在都已補充 — 說「deploy this」Claude 就能找到 `/ship`，說「check my diff」它就能找到 `/review`。遵循 Anthropic 的最佳實踐：「description 欄位不是摘要 — 而是觸發時機。」
 
 ## [0.6.4.0] - 2026-03-17
 
-### Added
+### 新增
 
-- **`/plan-design-review` is now interactive — rates 0-10, fixes the plan.** Instead of producing a report with letter grades, the designer now works like CEO and Eng review: rates each design dimension 0-10, explains what a 10 looks like, then edits the plan to get there. One AskUserQuestion per design choice. The output is a better plan, not a document about the plan.
-- **CEO review now calls in the designer.** When `/plan-ceo-review` detects UI scope in a plan, it activates a Design & UX section (Section 11) covering information architecture, interaction state coverage, AI slop risk, and responsive intention. For deep design work, it recommends `/plan-design-review`.
-- **14 of 15 skills now have full test coverage (E2E + LLM-judge + validation).** Added LLM-judge quality evals for 10 skills that were missing them: ship, retro, qa-only, plan-ceo-review, plan-eng-review, plan-design-review, design-review, design-consultation, document-release, gstack-upgrade. Added real E2E test for gstack-upgrade (was a `.todo`). Added design-consultation to command validation.
-- **Bisect commit style.** CLAUDE.md now requires every commit to be a single logical change — renames separate from rewrites, test infrastructure separate from test implementations.
+- **`/plan-design-review` 現在是互動式的 — 評分 0-10，並修復計劃。** 設計師不再產生帶有字母評級的報告，而是像 CEO 和工程審查一樣運作：對每個設計維度評分 0-10，說明 10 分是什麼樣子，然後編輯計劃以達到該分數。每個設計選擇一個 AskUserQuestion。輸出是一個更好的計劃，而不是關於計劃的文件。
+- **CEO 審查現在會召喚設計師。** 當 `/plan-ceo-review` 在計劃中偵測到 UI 範疇時，它會啟動設計與 UX 章節（第 11 節），涵蓋資訊架構、互動狀態覆蓋率、AI 陳腔濫調風險和響應式設計意圖。對於深度設計工作，它建議使用 `/plan-design-review`。
+- **15 個技能中有 14 個現在有完整測試覆蓋率（E2E + LLM 評判 + 驗證）。** 為 10 個缺少它們的技能新增了 LLM 評判品質評估：ship、retro、qa-only、plan-ceo-review、plan-eng-review、plan-design-review、design-review、design-consultation、document-release、gstack-upgrade。為 gstack-upgrade 新增了真實的 E2E 測試（原為 `.todo`）。將 design-consultation 加入命令驗證。
+- **Bisect 提交風格。** CLAUDE.md 現在要求每次提交都是單一邏輯變更 — 重新命名與改寫分開，測試基礎設施與測試實作分開。
 
-### Changed
+### 變更
 
-- `/qa-design-review` renamed to `/design-review` — the "qa-" prefix was confusing now that `/plan-design-review` is plan-mode. Updated across all 22 files.
+- `/qa-design-review` 重命名為 `/design-review` — 「qa-」前綴在 `/plan-design-review` 是計劃模式的情況下令人困惑。已在所有 22 個檔案中更新。
 
 ## [0.6.3.0] - 2026-03-17
 
-### Added
+### 新增
 
-- **Every PR touching frontend code now gets a design review automatically.** `/review` and `/ship` apply a 20-item design checklist against changed CSS, HTML, JSX, and view files. Catches AI slop patterns (purple gradients, 3-column icon grids, generic hero copy), typography issues (body text < 16px, blacklisted fonts), accessibility gaps (`outline: none`), and `!important` abuse. Mechanical CSS fixes are auto-applied; design judgment calls ask you first.
-- **`gstack-diff-scope` categorizes what changed in your branch.** Run `source <(gstack-diff-scope main)` and get `SCOPE_FRONTEND=true/false`, `SCOPE_BACKEND`, `SCOPE_PROMPTS`, `SCOPE_TESTS`, `SCOPE_DOCS`, `SCOPE_CONFIG`. Design review uses it to skip silently on backend-only PRs. Ship pre-flight uses it to recommend design review when frontend files are touched.
-- **Design review shows up in the Review Readiness Dashboard.** The dashboard now distinguishes between "LITE" (code-level, runs automatically in /review and /ship) and "FULL" (visual audit via /plan-design-review with browse binary). Both show up as Design Review entries.
-- **E2E eval for design review detection.** Planted CSS/HTML fixtures with 7 known anti-patterns (Papyrus font, 14px body text, `outline: none`, `!important`, purple gradient, generic hero copy, 3-column feature grid). The eval verifies `/review` catches at least 4 of 7.
+- **每個觸及前端程式碼的 PR 現在都自動獲得設計審查。** `/review` 和 `/ship` 針對已變更的 CSS、HTML、JSX 和視圖檔案應用 20 項設計清單。攔截 AI 陳腔濫調模式（紫色漸層、三欄圖示網格、泛泛的 hero 文案）、排版問題（body 文字 < 16px、黑名單字型）、無障礙設計缺口（`outline: none`）和 `!important` 濫用。機械性 CSS 修復自動應用；設計判斷呼叫會先詢問您。
+- **`gstack-diff-scope` 分類您分支中的變更內容。** 執行 `source <(gstack-diff-scope main)` 並獲得 `SCOPE_FRONTEND=true/false`、`SCOPE_BACKEND`、`SCOPE_PROMPTS`、`SCOPE_TESTS`、`SCOPE_DOCS`、`SCOPE_CONFIG`。設計審查使用它在後端專屬 PR 上靜默跳過。出貨前檢查使用它在觸及前端檔案時建議設計審查。
+- **設計審查顯示在 Review Readiness Dashboard 中。** 儀表板現在區分「LITE」（程式碼層級，在 /review 和 /ship 中自動執行）和「FULL」（透過 /plan-design-review 與 browse binary 的視覺審核）。兩者都以設計審查條目顯示。
+- **設計審查偵測的 E2E eval。** 包含 7 個已知反模式的 CSS/HTML 測試固件（Papyrus 字型、14px body 文字、`outline: none`、`!important`、紫色漸層、泛泛的 hero 文案、三欄功能網格）。eval 驗證 `/review` 至少攔截 7 個中的 4 個。
 
 ## [0.6.2.0] - 2026-03-17
 
-### Added
+### 新增
 
-- **Plan reviews now think like the best in the world.** `/plan-ceo-review` applies 14 cognitive patterns from Bezos (one-way doors, Day 1 proxy skepticism), Grove (paranoid scanning), Munger (inversion), Horowitz (wartime awareness), Chesky/Graham (founder mode), and Altman (leverage obsession). `/plan-eng-review` applies 15 patterns from Larson (team state diagnosis), McKinley (boring by default), Brooks (essential vs accidental complexity), Beck (make the change easy), Majors (own your code in production), and Google SRE (error budgets). `/plan-design-review` applies 12 patterns from Rams (subtraction default), Norman (time-horizon design), Zhuo (principled taste), Gebbia (design for trust, storyboard the journey), and Ive (care is visible).
-- **Latent space activation, not checklists.** The cognitive patterns name-drop frameworks and people so the LLM draws on its deep knowledge of how they actually think. The instruction is "internalize these, don't enumerate them" — making each review a genuine perspective shift, not a longer checklist.
+- **計劃審查現在像世界頂尖人士那樣思考。** `/plan-ceo-review` 應用來自 Bezos（單行道門、第一天代理人懷疑論）、Grove（偏執掃描）、Munger（反轉）、Horowitz（戰時意識）、Chesky/Graham（創辦人模式）和 Altman（槓桿迷戀）的 14 種認知模式。`/plan-eng-review` 應用來自 Larson（團隊狀態診斷）、McKinley（預設無趣）、Brooks（本質 vs 偶然複雜性）、Beck（讓變更變得容易）、Majors（在生產中擁有您的程式碼）和 Google SRE（錯誤預算）的 15 種模式。`/plan-design-review` 應用來自 Rams（減法預設）、Norman（時間跨度設計）、Zhuo（有原則的品味）、Gebbia（為信任而設計、故事板旅程）和 Ive（關懷是可見的）的 12 種模式。
+- **潛在空間啟動，而非清單。** 認知模式透過提及框架和人物，讓 LLM 能汲取其對他們實際思維方式的深刻知識。指令是「內化這些，不要列舉它們」— 使每次審查都成為真正的視角轉換，而非更長的清單。
 
 ## [0.6.1.0] - 2026-03-17
 
-### Added
+### 新增
 
-- **E2E and LLM-judge tests now only run what you changed.** Each test declares which source files it depends on. When you run `bun run test:e2e`, it checks your diff and skips tests whose dependencies weren't touched. A branch that only changes `/retro` now runs 2 tests instead of 31. Use `bun run test:e2e:all` to force everything.
-- **`bun run eval:select` previews which tests would run.** See exactly which tests your diff triggers before spending API credits. Supports `--json` for scripting and `--base <branch>` to override the base branch.
-- **Completeness guardrail catches forgotten test entries.** A free unit test validates that every `testName` in the E2E and LLM-judge test files has a corresponding entry in the TOUCHFILES map. New tests without entries fail `bun test` immediately — no silent always-run degradation.
+- **E2E 和 LLM 評判測試現在只執行您變更的部分。** 每個測試聲明其依賴的來源檔案。當您執行 `bun run test:e2e` 時，它會檢查您的 diff 並跳過依賴項未被觸及的測試。只更改 `/retro` 的分支現在執行 2 個測試而非 31 個。使用 `bun run test:e2e:all` 強制執行所有測試。
+- **`bun run eval:select` 預覽哪些測試會執行。** 在花費 API 額度之前，查看您的 diff 會觸發哪些測試。支援 `--json` 進行腳本編寫，以及 `--base <branch>` 覆蓋基礎分支。
+- **完整性防護措施攔截遺忘的測試條目。** 一個免費的單元測試驗證 E2E 和 LLM 評判測試檔案中的每個 `testName` 在 TOUCHFILES 映射中都有對應條目。沒有條目的新測試立即使 `bun test` 失敗 — 沒有靜默的始終執行退化。
 
-### Changed
+### 變更
 
-- `test:evals` and `test:e2e` now auto-select based on diff (was: all-or-nothing)
-- New `test:evals:all` and `test:e2e:all` scripts for explicit full runs
+- `test:evals` 和 `test:e2e` 現在根據 diff 自動選擇（原為：全部或全不）
+- 新增 `test:evals:all` 和 `test:e2e:all` 腳本以明確執行完整測試
 
-## 0.6.1 — 2026-03-17 — Boil the Lake
+## 0.6.1 — 2026-03-17 — 煮沸整個湖
 
-Every gstack skill now follows the **Completeness Principle**: always recommend the
-full implementation when AI makes the marginal cost near-zero. No more "Choose B
-because it's 90% of the value" when option A is 70 lines more code.
+每個 gstack 技能現在都遵循**完整性原則**：當 AI 使邊際成本接近零時，始終建議完整實作。當選項 A 只多 70 行程式碼時，不再建議「選 B，因為它有 90% 的價值」。
 
-Read the philosophy: https://garryslist.org/posts/boil-the-ocean
+閱讀哲學理念：https://garryslist.org/posts/boil-the-ocean
 
-- **Completeness scoring**: every AskUserQuestion option now shows a completeness
-  score (1-10), biasing toward the complete solution
-- **Dual time estimates**: effort estimates show both human-team and CC+gstack time
-  (e.g., "human: ~2 weeks / CC: ~1 hour") with a task-type compression reference table
-- **Anti-pattern examples**: concrete "don't do this" gallery in the preamble so the
-  principle isn't abstract
-- **First-time onboarding**: new users see a one-time introduction linking to the
-  essay, with option to open in browser
-- **Review completeness gaps**: `/review` now flags shortcut implementations where the
-  complete version costs <30 min CC time
-- **Lake Score**: CEO and Eng review completion summaries show how many recommendations
-  chose the complete option vs shortcuts
-- **CEO + Eng review dual-time**: temporal interrogation, effort estimates, and delight
-  opportunities all show both human and CC time scales
+- **完整性評分**：每個 AskUserQuestion 選項現在顯示完整性評分（1-10），偏向完整解決方案
+- **雙時間估算**：工作量估算同時顯示人類團隊和 CC+gstack 時間（例如：「人類：約 2 週 / CC：約 1 小時」），附帶任務類型壓縮參考表
+- **反模式範例**：前言中具體的「不要這樣做」示例庫，使原則不再抽象
+- **首次使用者導覽**：新用戶看到一次性介紹，連結到文章，可選擇在瀏覽器中開啟
+- **審查完整性缺口**：`/review` 現在標記捷徑實作，其中完整版本的 CC 時間成本不到 30 分鐘
+- **Lake Score**：CEO 和工程審查完成摘要顯示有多少建議選擇了完整選項 vs 捷徑
+- **CEO + 工程審查雙重時間**：時間審訊、工作量估算和令人愉悅的機會均顯示人類和 CC 兩種時間尺度
 
 ## 0.6.0.1 — 2026-03-17
 
-- **`/gstack-upgrade` now catches stale vendored copies automatically.** If your global gstack is up to date but the vendored copy in your project is behind, `/gstack-upgrade` detects the mismatch and syncs it. No more manually asking "did we vendor it?" — it just tells you and offers to update.
-- **Upgrade sync is safer.** If `./setup` fails while syncing a vendored copy, gstack restores the previous version from backup instead of leaving a broken install.
+- **`/gstack-upgrade` 現在自動攔截過時的供應商副本。** 若您的全域 gstack 是最新的，但專案中的供應商副本已落後，`/gstack-upgrade` 會偵測不一致並同步。不再需要手動詢問「我們有供應商化嗎？」— 它直接告訴您並提供更新。
+- **升級同步更安全。** 若在同步供應商副本時 `./setup` 失敗，gstack 會從備份還原之前的版本，而不是留下損壞的安裝。
 
-### For contributors
+### 貢獻者須知
 
-- Standalone usage section in `gstack-upgrade/SKILL.md.tmpl` now references Steps 2 and 4.5 (DRY) instead of duplicating detection/sync bash blocks. Added one new version-comparison bash block.
-- Update check fallback in standalone mode now matches the preamble pattern (global path → local path → `|| true`).
+- `gstack-upgrade/SKILL.md.tmpl` 中的獨立使用章節現在參照步驟 2 和 4.5（DRY），而非複製偵測/同步 bash 區塊。新增了一個版本比較 bash 區塊。
+- 獨立模式中的更新檢查回退現在與前言模式（全域路徑 → 本地路徑 → `|| true`）匹配。
 
 ## 0.6.0 — 2026-03-17
 
-- **100% test coverage is the key to great vibe coding.** gstack now bootstraps test frameworks from scratch when your project doesn't have one. Detects your runtime, researches the best framework, asks you to pick, installs it, writes 3-5 real tests for your actual code, sets up CI/CD (GitHub Actions), creates TESTING.md, and adds test culture instructions to CLAUDE.md. Every Claude Code session after that writes tests naturally.
-- **Every bug fix now gets a regression test.** When `/qa` fixes a bug and verifies it, Phase 8e.5 automatically generates a regression test that catches the exact scenario that broke. Tests include full attribution tracing back to the QA report. Auto-incrementing filenames prevent collisions across sessions.
-- **Ship with confidence — coverage audit shows what's tested and what's not.** `/ship` Step 3.4 builds a code path map from your diff, searches for corresponding tests, and produces an ASCII coverage diagram with quality stars (★★★ = edge cases + errors, ★★ = happy path, ★ = smoke test). Gaps get tests auto-generated. PR body shows "Tests: 42 → 47 (+5 new)".
-- **Your retro tracks test health.** `/retro` now shows total test files, tests added this period, regression test commits, and trend deltas. If test ratio drops below 20%, it flags it as a growth area.
-- **Design reviews generate regression tests too.** `/qa-design-review` Phase 8e.5 skips CSS-only fixes (those are caught by re-running the design audit) but writes tests for JavaScript behavior changes like broken dropdowns or animation failures.
+- **100% 測試覆蓋率是優質 vibe coding 的關鍵。** gstack 現在在您的專案沒有測試框架時從頭建立。偵測您的執行環境、研究最佳框架、請您選擇、安裝它、為您的實際程式碼撰寫 3-5 個真實測試、設定 CI/CD（GitHub Actions）、建立 TESTING.md，並在 CLAUDE.md 中加入測試文化指令。之後每個 Claude Code 工作階段都會自然地撰寫測試。
+- **每個錯誤修復現在都獲得一個迴歸測試。** 當 `/qa` 修復一個錯誤並驗證後，步驟 8e.5 自動產生一個捕獲確切損壞場景的迴歸測試。測試包含完整的追蹤歸因，連結回 QA 報告。自動遞增的檔案名稱防止工作階段間的衝突。
+- **有信心地出貨 — 覆蓋率審計顯示什麼已測試、什麼未測試。** `/ship` 步驟 3.4 從您的 diff 建立程式碼路徑映射，搜尋對應的測試，並產生帶有品質星級的 ASCII 覆蓋率圖（★★★ = 邊緣情況 + 錯誤，★★ = 快樂路徑，★ = 煙霧測試）。缺口自動產生測試。PR 說明顯示「Tests: 42 → 47 (+5 new)」。
+- **您的回顧追蹤測試健康狀況。** `/retro` 現在顯示測試檔案總數、本期新增的測試、迴歸測試提交和趨勢差異。若測試比例降至 20% 以下，它將其標記為成長領域。
+- **設計審查也產生迴歸測試。** `/qa-design-review` 步驟 8e.5 跳過僅 CSS 的修復（這些由重新執行設計審計捕獲），但為 JavaScript 行為變更（如損壞的下拉選單或動畫失敗）撰寫測試。
 
-### For contributors
+### 貢獻者須知
 
-- Added `generateTestBootstrap()` resolver to `gen-skill-docs.ts` (~155 lines). Registered as `{{TEST_BOOTSTRAP}}` in the RESOLVERS map. Inserted into qa, ship (Step 2.5), and qa-design-review templates.
-- Phase 8e.5 regression test generation added to `qa/SKILL.md.tmpl` (46 lines) and CSS-aware variant to `qa-design-review/SKILL.md.tmpl` (12 lines). Rule 13 amended to allow creating new test files.
-- Step 3.4 test coverage audit added to `ship/SKILL.md.tmpl` (88 lines) with quality scoring rubric and ASCII diagram format.
-- Test health tracking added to `retro/SKILL.md.tmpl`: 3 new data gathering commands, metrics row, narrative section, JSON schema field.
-- `qa-only/SKILL.md.tmpl` gets recommendation note when no test framework detected.
-- `qa-report-template.md` gains Regression Tests section with deferred test specs.
-- ARCHITECTURE.md placeholder table updated with `{{TEST_BOOTSTRAP}}` and `{{REVIEW_DASHBOARD}}`.
-- WebSearch added to allowed-tools for qa, ship, qa-design-review.
-- 26 new validation tests, 2 new E2E evals (bootstrap + coverage audit).
-- 2 new P3 TODOs: CI/CD for non-GitHub providers, auto-upgrade weak tests.
+- 在 `gen-skill-docs.ts` 中新增 `generateTestBootstrap()` 解析器（約 155 行）。在 RESOLVERS 映射中註冊為 `{{TEST_BOOTSTRAP}}`。插入 qa、ship（步驟 2.5）和 qa-design-review 模板中。
+- 步驟 8e.5 迴歸測試產生新增至 `qa/SKILL.md.tmpl`（46 行）和 `qa-design-review/SKILL.md.tmpl` 的 CSS 感知變體（12 行）。規則 13 修訂為允許建立新的測試檔案。
+- 步驟 3.4 測試覆蓋率審計新增至 `ship/SKILL.md.tmpl`（88 行），附帶品質評分標準和 ASCII 圖表格式。
+- 測試健康追蹤新增至 `retro/SKILL.md.tmpl`：3 個新的資料收集命令、指標列、敘述章節、JSON 結構描述欄位。
+- `qa-only/SKILL.md.tmpl` 在未偵測到測試框架時獲得建議備注。
+- `qa-report-template.md` 新增含延遲測試規格的迴歸測試章節。
+- ARCHITECTURE.md 佔位符表格以 `{{TEST_BOOTSTRAP}}` 和 `{{REVIEW_DASHBOARD}}` 更新。
+- WebSearch 新增至 qa、ship、qa-design-review 的 allowed-tools。
+- 26 個新驗證測試，2 個新 E2E eval（bootstrap + 覆蓋率審計）。
+- 2 個新 P3 TODO：非 GitHub 提供商的 CI/CD、自動升級弱測試。
 
 ## 0.5.4 — 2026-03-17
 
-- **Engineering review is always the full review now.** `/plan-eng-review` no longer asks you to choose between "big change" and "small change" modes. Every plan gets the full interactive walkthrough (architecture, code quality, tests, performance). Scope reduction is only suggested when the complexity check actually triggers — not as a standing menu option.
-- **Ship stops asking about reviews once you've answered.** When `/ship` asks about missing reviews and you say "ship anyway" or "not relevant," that decision is saved for the branch. No more getting re-asked every time you re-run `/ship` after a pre-landing fix.
+- **工程審查現在始終是完整審查。** `/plan-eng-review` 不再要求您在「大型變更」和「小型變更」模式之間選擇。每個計劃都獲得完整的互動式逐步審查（架構、程式碼品質、測試、效能）。只有當複雜度檢查實際觸發時才建議縮減範疇 — 而非作為固定的選單選項。
+- **出貨停止在您回答後詢問審查事宜。** 當 `/ship` 詢問缺失的審查而您說「ship anyway」或「not relevant」時，該決定會為該分支儲存。不再在預登陸修復後重新執行 `/ship` 時被再次詢問。
 
-### For contributors
+### 貢獻者須知
 
-- Removed SMALL_CHANGE / BIG_CHANGE / SCOPE_REDUCTION menu from `plan-eng-review/SKILL.md.tmpl`. Scope reduction is now proactive (triggered by complexity check) rather than a menu item.
-- Added review gate override persistence to `ship/SKILL.md.tmpl` — writes `ship-review-override` entries to `$BRANCH-reviews.jsonl` so subsequent `/ship` runs skip the gate.
-- Updated 2 E2E test prompts to match new flow.
+- 從 `plan-eng-review/SKILL.md.tmpl` 中移除 SMALL_CHANGE / BIG_CHANGE / SCOPE_REDUCTION 選單。範疇縮減現在是主動性的（由複雜度檢查觸發），而非選單項目。
+- 在 `ship/SKILL.md.tmpl` 中新增 review gate 覆蓋持久性 — 將 `ship-review-override` 條目寫入 `$BRANCH-reviews.jsonl`，讓後續 `/ship` 執行跳過該關卡。
+- 更新 2 個 E2E 測試提示以符合新流程。
 
 ## 0.5.3 — 2026-03-17
 
-- **You're always in control — even when dreaming big.** `/plan-ceo-review` now presents every scope expansion as an individual decision you opt into. EXPANSION mode recommends enthusiastically, but you say yes or no to each idea. No more "the agent went wild and added 5 features I didn't ask for."
-- **New mode: SELECTIVE EXPANSION.** Hold your current scope as the baseline, but see what else is possible. The agent surfaces expansion opportunities one by one with neutral recommendations — you cherry-pick the ones worth doing. Perfect for iterating on existing features where you want rigor but also want to be tempted by adjacent improvements.
-- **Your CEO review visions are saved, not lost.** Expansion ideas, cherry-pick decisions, and 10x visions are now persisted to `~/.gstack/projects/{repo}/ceo-plans/` as structured design documents. Stale plans get archived automatically. If a vision is exceptional, you can promote it to `docs/designs/` in your repo for the team.
+- **您始終在掌控中 — 即使在大膽構想時。** `/plan-ceo-review` 現在將每個範疇擴展作為您選擇加入的個別決定呈現。EXPANSION 模式熱情地建議，但您對每個想法說是或否。不再有「代理瘋狂地添加了我沒有要求的 5 個功能」。
+- **新模式：SELECTIVE EXPANSION。** 將您目前的範疇作為基準，但看看還有什麼可能。代理逐一提出擴展機會並給予中性建議 — 您挑選值得做的那些。非常適合在現有功能上迭代，您希望嚴格把關但也想被相鄰改進所吸引的情況。
+- **您的 CEO 審查願景被儲存，而非遺失。** 擴展想法、挑選決定和 10 倍願景現在以結構化設計文件的形式持久保存至 `~/.gstack/projects/{repo}/ceo-plans/`。過時的計劃會自動歸檔。若某個願景特別出色，您可以將其推廣至您的專案中的 `docs/designs/` 供團隊參考。
 
-- **Smarter ship gates.** `/ship` no longer nags you about CEO and Design reviews when they're not relevant. Eng Review is the only required gate (and you can disable even that with `gstack-config set skip_eng_review true`). CEO Review is recommended for big product changes; Design Review for UI work. The dashboard still shows all three — it just won't block you for the optional ones.
+- **更智慧的出貨關卡。** `/ship` 不再在 CEO 和設計審查不相關時煩擾您。工程審查是唯一必要的關卡（甚至可以用 `gstack-config set skip_eng_review true` 停用）。CEO 審查建議用於大型產品變更；設計審查用於 UI 工作。儀表板仍然顯示所有三個 — 只是不會因為可選項目而阻擋您。
 
-### For contributors
+### 貢獻者須知
 
-- Added SELECTIVE EXPANSION mode to `plan-ceo-review/SKILL.md.tmpl` with cherry-pick ceremony, neutral recommendation posture, and HOLD SCOPE baseline.
-- Rewrote EXPANSION mode's Step 0D to include opt-in ceremony — distill vision into discrete proposals, present each as AskUserQuestion.
-- Added CEO plan persistence (0D-POST step): structured markdown with YAML frontmatter (`status: ACTIVE/ARCHIVED/PROMOTED`), scope decisions table, archival flow.
-- Added `docs/designs` promotion step after Review Log.
-- Mode Quick Reference table expanded to 4 columns.
-- Review Readiness Dashboard: Eng Review required (overridable via `skip_eng_review` config), CEO/Design optional with agent judgment.
-- New tests: CEO review mode validation (4 modes, persistence, promotion), SELECTIVE EXPANSION E2E test.
+- 在 `plan-ceo-review/SKILL.md.tmpl` 中新增 SELECTIVE EXPANSION 模式，包含挑選儀式、中性建議姿態和 HOLD SCOPE 基準。
+- 改寫 EXPANSION 模式的步驟 0D，加入選擇加入儀式 — 將願景提煉為離散提案，每個作為 AskUserQuestion 呈現。
+- 新增 CEO 計劃持久性（0D-POST 步驟）：帶有 YAML frontmatter 的結構化 Markdown（`status: ACTIVE/ARCHIVED/PROMOTED`）、範疇決定表、歸檔流程。
+- 在 Review Log 後新增 `docs/designs` 推廣步驟。
+- 模式快速參考表擴展為 4 欄。
+- Review Readiness Dashboard：工程審查為必要（可透過 `skip_eng_review` 設定覆蓋），CEO/設計為可選，由代理判斷。
+- 新測試：CEO 審查模式驗證（4 種模式、持久性、推廣）、SELECTIVE EXPANSION E2E 測試。
 
 ## 0.5.2 — 2026-03-17
 
-- **Your design consultant now takes creative risks.** `/design-consultation` doesn't just propose a safe, coherent system — it explicitly breaks down SAFE CHOICES (category baseline) vs. RISKS (where your product stands out). You pick which rules to break. Every risk comes with a rationale for why it works and what it costs.
-- **See the landscape before you choose.** When you opt into research, the agent browses real sites in your space with screenshots and accessibility tree analysis — not just web search results. You see what's out there before making design decisions.
-- **Preview pages that look like your product.** The preview page now renders realistic product mockups — dashboards with sidebar nav and data tables, marketing pages with hero sections, settings pages with forms — not just font swatches and color palettes.
+- **您的設計顧問現在承擔創意風險。** `/design-consultation` 不只是提出安全、連貫的系統 — 它明確列出安全選擇（類別基準）與風險（您的產品如何脫穎而出）。您選擇要打破哪些規則。每個風險都附帶為何有效的理由和代價。
+- **在選擇之前看清全貌。** 當您選擇研究時，代理會瀏覽您所在領域的真實網站並提供截圖和無障礙樹狀分析 — 而非僅靠網路搜尋結果。在做設計決定之前，您能看到外面有什麼。
+- **預覽看起來像您產品的頁面。** 預覽頁面現在呈現逼真的產品模型 — 帶有側邊欄導航和資料表格的儀表板、帶有 hero 區段的行銷頁面、帶有表單的設定頁面 — 而非只是字型樣本和色板。
 
 ## 0.5.1 — 2026-03-17
-- **Know where you stand before you ship.** Every `/plan-ceo-review`, `/plan-eng-review`, and `/plan-design-review` now logs its result to a review tracker. At the end of each review, you see a **Review Readiness Dashboard** showing which reviews are done, when they ran, and whether they're clean — with a clear CLEARED TO SHIP or NOT READY verdict.
-- **`/ship` checks your reviews before creating the PR.** Pre-flight now reads the dashboard and asks if you want to continue when reviews are missing. Informational only — it won't block you, but you'll know what you skipped.
-- **One less thing to copy-paste.** The SLUG computation (that opaque sed pipeline for computing `owner-repo` from git remote) is now a shared `bin/gstack-slug` helper. All 14 inline copies across templates replaced with `source <(gstack-slug)`. If the format ever changes, fix it once.
-- **Screenshots are now visible during QA and browse sessions.** When gstack takes screenshots, they now show up as clickable image elements in your output — no more invisible `/tmp/browse-screenshot.png` paths you can't see. Works in `/qa`, `/qa-only`, `/plan-design-review`, `/qa-design-review`, `/browse`, and `/gstack`.
+- **出貨前掌握您的進度。** 每個 `/plan-ceo-review`、`/plan-eng-review` 和 `/plan-design-review` 現在都將結果記錄到審查追蹤器。每次審查結束時，您會看到一個**Review Readiness Dashboard**，顯示哪些審查已完成、何時執行，以及是否通過 — 附有清晰的「已準備好出貨」或「尚未準備好」判定。
+- **`/ship` 在建立 PR 之前檢查您的審查。** 起飛前檢查現在讀取儀表板，並在審查缺失時詢問您是否要繼續。僅供參考 — 它不會阻擋您，但您會知道跳過了什麼。
+- **少一件需要複製貼上的事。** SLUG 計算（那個用於從 git remote 計算 `owner-repo` 的神秘 sed pipeline）現在是一個共享的 `bin/gstack-slug` 輔助工具。所有 14 個跨模板的內嵌副本替換為 `source <(gstack-slug)`。如果格式改變，只需修復一處。
+- **截圖現在在 QA 和瀏覽工作階段中可見。** 當 gstack 截圖時，它們現在以可點擊的圖片元素顯示在您的輸出中 — 不再有看不到的 `/tmp/browse-screenshot.png` 路徑。適用於 `/qa`、`/qa-only`、`/plan-design-review`、`/qa-design-review`、`/browse` 和 `/gstack`。
 
-### For contributors
+### 貢獻者須知
 
-- Added `{{REVIEW_DASHBOARD}}` resolver to `gen-skill-docs.ts` — shared dashboard reader injected into 4 templates (3 review skills + ship).
-- Added `bin/gstack-slug` helper (5-line bash) with unit tests. Outputs `SLUG=` and `BRANCH=` lines, sanitizes `/` to `-`.
-- New TODOs: smart review relevance detection (P3), `/merge` skill for review-gated PR merge (P2).
+- 在 `gen-skill-docs.ts` 中新增 `{{REVIEW_DASHBOARD}}` 解析器 — 共享儀表板讀取器注入 4 個模板（3 個審查技能 + ship）。
+- 新增 `bin/gstack-slug` 輔助工具（5 行 bash），附帶單元測試。輸出 `SLUG=` 和 `BRANCH=` 行，將 `/` 替換為 `-`。
+- 新 TODO：智慧審查相關性偵測（P3）、`/merge` 技能用於審查門控的 PR 合併（P2）。
 
 ## 0.5.0 — 2026-03-16
 
-- **Your site just got a design review.** `/plan-design-review` opens your site and reviews it like a senior product designer — typography, spacing, hierarchy, color, responsive, interactions, and AI slop detection. Get letter grades (A-F) per category, a dual headline "Design Score" + "AI Slop Score", and a structured first impression that doesn't pull punches.
-- **It can fix what it finds, too.** `/qa-design-review` runs the same designer's eye audit, then iteratively fixes design issues in your source code with atomic `style(design):` commits and before/after screenshots. CSS-safe by default, with a stricter self-regulation heuristic tuned for styling changes.
-- **Know your actual design system.** Both skills extract your live site's fonts, colors, heading scale, and spacing patterns via JS — then offer to save the inferred system as a `DESIGN.md` baseline. Finally know how many fonts you're actually using.
-- **AI Slop detection is a headline metric.** Every report opens with two scores: Design Score and AI Slop Score. The AI slop checklist catches the 10 most recognizable AI-generated patterns — the 3-column feature grid, purple gradients, decorative blobs, emoji bullets, generic hero copy.
-- **Design regression tracking.** Reports write a `design-baseline.json`. Next run auto-compares: per-category grade deltas, new findings, resolved findings. Watch your design score improve over time.
-- **80-item design audit checklist** across 10 categories: visual hierarchy, typography, color/contrast, spacing/layout, interaction states, responsive, motion, content/microcopy, AI slop, and performance-as-design. Distilled from Vercel's 100+ rules, Anthropic's frontend design skill, and 6 other design frameworks.
+- **您的網站剛剛獲得了設計審查。** `/plan-design-review` 打開您的網站，像資深產品設計師一樣審查它 — 排版、間距、層次結構、色彩、響應式、互動設計和 AI 陳腔濫調偵測。按類別獲得字母評級（A-F）、「Design Score」+「AI Slop Score」雙重標題，以及不拐彎抹角的結構化第一印象。
+- **它也能修復發現的問題。** `/qa-design-review` 執行相同的設計師視角審計，然後在您的原始碼中以原子式 `style(design):` 提交和前後截圖迭代修復設計問題。預設 CSS 安全，附帶針對樣式變更調整的更嚴格自我調節啟發式。
+- **了解您實際的設計系統。** 兩個技能都通過 JS 提取您即時網站的字型、顏色、標題比例和間距模式 — 然後提供將推斷的系統儲存為 `DESIGN.md` 基準的選項。終於知道您實際使用了多少字型。
+- **AI 陳腔濫調偵測是標題指標。** 每份報告都以兩個分數開頭：設計分數和 AI 陳腔濫調分數。AI 陳腔濫調清單攔截 10 個最容易辨識的 AI 生成模式 — 三欄功能網格、紫色漸層、裝飾性 blob、表情符號項目符號、泛泛的 hero 文案。
+- **設計迴歸追蹤。** 報告寫入 `design-baseline.json`。下次執行自動比較：各類別評級差異、新發現、已解決的發現。隨時間觀察您的設計分數提升。
+- **80 項設計審計清單**，涵蓋 10 個類別：視覺層次結構、排版、色彩/對比度、間距/佈局、互動狀態、響應式、動態效果、內容/文案、AI 陳腔濫調和效能即設計。提煉自 Vercel 的 100+ 條規則、Anthropic 的前端設計技能和其他 6 個設計框架。
 
-### For contributors
+### 貢獻者須知
 
-- Added `{{DESIGN_METHODOLOGY}}` resolver to `gen-skill-docs.ts` — shared design audit methodology injected into both `/plan-design-review` and `/qa-design-review` templates, following the `{{QA_METHODOLOGY}}` pattern.
-- Added `~/.gstack-dev/plans/` as a local plans directory for long-range vision docs (not checked in). CLAUDE.md and TODOS.md updated.
-- Added `/setup-design-md` to TODOS.md (P2) for interactive DESIGN.md creation from scratch.
+- 在 `gen-skill-docs.ts` 中新增 `{{DESIGN_METHODOLOGY}}` 解析器 — 共享設計審計方法論注入 `/plan-design-review` 和 `/qa-design-review` 兩個模板，遵循 `{{QA_METHODOLOGY}}` 模式。
+- 將 `~/.gstack-dev/plans/` 新增為長期願景文件的本地計劃目錄（不納入版本控制）。CLAUDE.md 和 TODOS.md 已更新。
+- 在 TODOS.md 中新增 `/setup-design-md`（P2），用於從頭開始互動式建立 DESIGN.md。
 
 ## 0.4.5 — 2026-03-16
 
-- **Review findings now actually get fixed, not just listed.** `/review` and `/ship` used to print informational findings (dead code, test gaps, N+1 queries) and then ignore them. Now every finding gets action: obvious mechanical fixes are applied automatically, and genuinely ambiguous issues are batched into a single question instead of 8 separate prompts. You see `[AUTO-FIXED] file:line Problem → what was done` for each auto-fix.
-- **You control the line between "just fix it" and "ask me first."** Dead code, stale comments, N+1 queries get auto-fixed. Security issues, race conditions, design decisions get surfaced for your call. The classification lives in one place (`review/checklist.md`) so both `/review` and `/ship` stay in sync.
+- **Review 發現現在真正被修復，而不只是被列出。** `/review` 和 `/ship` 以前會印出資訊性發現（死程式碼、測試缺口、N+1 查詢），然後忽略它們。現在每個發現都採取行動：明顯的機械性修復自動應用，真正模糊的問題批量成一個問題而非 8 個單獨的提示。您會為每個自動修復看到 `[AUTO-FIXED] file:line Problem → what was done`。
+- **您控制「直接修復」和「先問我」之間的界線。** 死程式碼、過時的注釋、N+1 查詢自動修復。安全問題、競態條件、設計決策則提交給您判斷。分類存在於一個地方（`review/checklist.md`），讓 `/review` 和 `/ship` 保持同步。
 
-### Fixed
+### 修復
 
-- **`$B js "const x = await fetch(...); return x.status"` now works.** The `js` command used to wrap everything as an expression — so `const`, semicolons, and multi-line code all broke. It now detects statements and uses a block wrapper, just like `eval` already did.
-- **Clicking a dropdown option no longer hangs forever.** If an agent sees `@e3 [option] "Admin"` in a snapshot and runs `click @e3`, gstack now auto-selects that option instead of hanging on an impossible Playwright click. The right thing just happens.
-- **When click is the wrong tool, gstack tells you.** Clicking an `<option>` via CSS selector used to time out with a cryptic Playwright error. Now you get: `"Use 'browse select' instead of 'click' for dropdown options."`
+- **`$B js "const x = await fetch(...); return x.status"` 現在可以運作。** `js` 命令以前將所有內容包裝為表達式 — 因此 `const`、分號和多行程式碼都會損壞。現在它偵測語句並使用區塊包裝器，就像 `eval` 已經在做的那樣。
+- **點擊下拉選項不再永久掛起。** 若代理在快照中看到 `@e3 [option] "Admin"` 並執行 `click @e3`，gstack 現在自動選擇該選項而非在不可能的 Playwright 點擊上掛起。正確的事情就這樣發生了。
+- **當點擊是錯誤的工具時，gstack 告訴您。** 通過 CSS 選擇器點擊 `<option>` 以前會以神秘的 Playwright 錯誤超時。現在您獲得：`"Use 'browse select' instead of 'click' for dropdown options."`
 
-### For contributors
+### 貢獻者須知
 
-- Gate Classification → Severity Classification rename (severity determines presentation order, not whether you see a prompt).
-- Fix-First Heuristic section added to `review/checklist.md` — the canonical AUTO-FIX vs ASK classification.
-- New validation test: `Fix-First Heuristic exists in checklist and is referenced by review + ship`.
-- Extracted `needsBlockWrapper()` and `wrapForEvaluate()` helpers in `read-commands.ts` — shared by both `js` and `eval` commands (DRY).
-- Added `getRefRole()` to `BrowserManager` — exposes ARIA role for ref selectors without changing `resolveRef` return type.
-- Click handler auto-routes `[role=option]` refs to `selectOption()` via parent `<select>`, with DOM `tagName` check to avoid blocking custom listbox components.
-- 6 new tests: multi-line js, semicolons, statement keywords, simple expressions, option auto-routing, CSS option error guidance.
+- Gate Classification → Severity Classification 重新命名（嚴重性決定呈現順序，而非是否顯示提示）。
+- 在 `review/checklist.md` 中新增 Fix-First Heuristic 章節 — 典範 AUTO-FIX vs ASK 分類。
+- 新驗證測試：`Fix-First Heuristic 存在於清單中並被 review + ship 參照`。
+- 在 `read-commands.ts` 中提取 `needsBlockWrapper()` 和 `wrapForEvaluate()` 輔助函式 — 由 `js` 和 `eval` 命令共享（DRY）。
+- 在 `BrowserManager` 中新增 `getRefRole()` — 為 ref 選擇器公開 ARIA 角色，而不改變 `resolveRef` 返回類型。
+- 點擊處理器通過父 `<select>` 自動將 `[role=option]` refs 路由至 `selectOption()`，附帶 DOM `tagName` 檢查以避免阻擋自訂 listbox 元件。
+- 6 個新測試：多行 js、分號、語句關鍵字、簡單表達式、選項自動路由、CSS 選項錯誤指導。
 
 ## 0.4.4 — 2026-03-16
 
-- **New releases detected in under an hour, not half a day.** The update check cache was set to 12 hours, which meant you could be stuck on an old version all day while new releases dropped. Now "you're up to date" expires after 60 minutes, so you'll see upgrades within the hour. "Upgrade available" still nags for 12 hours (that's the point).
-- **`/gstack-upgrade` always checks for real.** Running `/gstack-upgrade` directly now bypasses the cache and does a fresh check against GitHub. No more "you're already on the latest" when you're not.
+- **新版本在不到一小時內偵測到，而非半天。** 更新檢查快取設定為 12 小時，這意味著您整天都可能停留在舊版本而新版本已發布。現在「您是最新的」在 60 分鐘後過期，所以您會在一小時內看到升級。「升級可用」仍然持續 12 小時提示（這才是重點）。
+- **`/gstack-upgrade` 始終進行真實檢查。** 直接執行 `/gstack-upgrade` 現在繞過快取並對 GitHub 進行全新檢查。不再有「您已是最新版本」而實際上並不是的情況。
 
-### For contributors
+### 貢獻者須知
 
-- Split `last-update-check` cache TTL: 60 min for `UP_TO_DATE`, 720 min for `UPGRADE_AVAILABLE`.
-- Added `--force` flag to `bin/gstack-update-check` (deletes cache file before checking).
-- 3 new tests: `--force` busts UP_TO_DATE cache, `--force` busts UPGRADE_AVAILABLE cache, 60-min TTL boundary test with `utimesSync`.
+- 分割 `last-update-check` 快取 TTL：`UP_TO_DATE` 為 60 分鐘，`UPGRADE_AVAILABLE` 為 720 分鐘。
+- 為 `bin/gstack-update-check` 新增 `--force` 標記（在檢查前刪除快取檔案）。
+- 3 個新測試：`--force` 清除 UP_TO_DATE 快取、`--force` 清除 UPGRADE_AVAILABLE 快取、使用 `utimesSync` 的 60 分鐘 TTL 邊界測試。
 
 ## 0.4.3 — 2026-03-16
 
-- **New `/document-release` skill.** Run it after `/ship` but before merging — it reads every doc file in your project, cross-references the diff, and updates README, ARCHITECTURE, CONTRIBUTING, CHANGELOG, and TODOS to match what you actually shipped. Risky changes get surfaced as questions; everything else is automatic.
-- **Every question is now crystal clear, every time.** You used to need 3+ sessions running before gstack would give you full context and plain English explanations. Now every question — even in a single session — tells you the project, branch, and what's happening, explained simply enough to understand mid-context-switch. No more "sorry, explain it to me more simply."
-- **Branch name is always correct.** gstack now detects your current branch at runtime instead of relying on the snapshot from when the conversation started. Switch branches mid-session? gstack keeps up.
+- **新的 `/document-release` 技能。** 在 `/ship` 之後、合併之前執行它 — 它讀取您專案中的每個文件檔案，交叉參照 diff，並更新 README、ARCHITECTURE、CONTRIBUTING、CHANGELOG 和 TODOS 以符合您實際出貨的內容。有風險的變更以問題形式提交；其他一切都是自動的。
+- **每個問題現在都清晰明瞭，每次都是。** 您以前需要 3 次以上的工作階段才能讓 gstack 給您完整的上下文和簡單的英文解釋。現在每個問題 — 即使在單一工作階段中 — 都告訴您專案、分支和正在發生的事情，說明簡單到足以在上下文切換中理解。不再有「對不起，請更簡單地解釋給我聽」。
+- **分支名稱始終正確。** gstack 現在在執行時偵測您目前的分支，而非依賴對話開始時的快照。在工作階段中間切換分支？gstack 跟上。
 
-### For contributors
+### 貢獻者須知
 
-- Merged ELI16 rules into base AskUserQuestion format — one format instead of two, no `_SESSIONS >= 3` conditional.
-- Added `_BRANCH` detection to preamble bash block (`git branch --show-current` with fallback).
-- Added regression guard tests for branch detection and simplification rules.
+- 將 ELI16 規則合併到基礎 AskUserQuestion 格式 — 一種格式而非兩種，沒有 `_SESSIONS >= 3` 條件式。
+- 在前言 bash 區塊中新增 `_BRANCH` 偵測（帶有回退的 `git branch --show-current`）。
+- 新增分支偵測和簡化規則的迴歸防護測試。
 
 ## 0.4.2 — 2026-03-16
 
-- **`$B js "await fetch(...)"` now just works.** Any `await` expression in `$B js` or `$B eval` is automatically wrapped in an async context. No more `SyntaxError: await is only valid in async functions`. Single-line eval files return values directly; multi-line files use explicit `return`.
-- **Contributor mode now reflects, not just reacts.** Instead of only filing reports when something breaks, contributor mode now prompts periodic reflection: "Rate your gstack experience 0-10. Not a 10? Think about why." Catches quality-of-life issues and friction that passive detection misses. Reports now include a 0-10 rating and "What would make this a 10" to focus on actionable improvements.
-- **Skills now respect your branch target.** `/ship`, `/review`, `/qa`, and `/plan-ceo-review` detect which branch your PR actually targets instead of assuming `main`. Stacked branches, Conductor workspaces targeting feature branches, and repos using `master` all just work now.
-- **`/retro` works on any default branch.** Repos using `master`, `develop`, or other default branch names are detected automatically — no more empty retros because the branch name was wrong.
-- **New `{{BASE_BRANCH_DETECT}}` placeholder** for skill authors — drop it into any template and get 3-step branch detection (PR base → repo default → fallback) for free.
-- **3 new E2E smoke tests** validate base branch detection works end-to-end across ship, review, and retro skills.
+- **`$B js "await fetch(...)"` 現在可以直接運作。** `$B js` 或 `$B eval` 中的任何 `await` 表達式都會自動包裝在非同步上下文中。不再有 `SyntaxError: await is only valid in async functions`。單行 eval 檔案直接返回值；多行檔案使用明確的 `return`。
+- **貢獻者模式現在反思，而不只是反應。** 不只是在出問題時提交報告，貢獻者模式現在提示定期反思：「給您的 gstack 體驗評分 0-10。不是 10 分？想想為什麼。」攔截被動偵測遺漏的生活品質問題和摩擦。報告現在包含 0-10 評分和「什麼能讓這個成為 10 分」以聚焦於可行的改進。
+- **技能現在尊重您的分支目標。** `/ship`、`/review`、`/qa` 和 `/plan-ceo-review` 偵測您的 PR 實際目標的分支，而非假設是 `main`。堆疊分支、Conductor 工作區指向功能分支，以及使用 `master` 的儲存庫現在都可以正常運作。
+- **`/retro` 在任何預設分支上都能運作。** 使用 `master`、`develop` 或其他預設分支名稱的儲存庫被自動偵測 — 不再因分支名稱錯誤而有空白的回顧。
+- **新的 `{{BASE_BRANCH_DETECT}}` 佔位符**，供技能作者使用 — 將其放入任何模板，免費獲得 3 步驟分支偵測（PR base → repo default → fallback）。
+- **3 個新的 E2E 煙霧測試**，驗證 base branch 偵測在 ship、review 和 retro 技能中端到端正確運作。
 
-### For contributors
+### 貢獻者須知
 
-- Added `hasAwait()` helper with comment-stripping to avoid false positives on `// await` in eval files.
-- Smart eval wrapping: single-line → expression `(...)`, multi-line → block `{...}` with explicit `return`.
-- 6 new async wrapping unit tests, 40 new contributor mode preamble validation tests.
-- Calibration example framed as historical ("used to fail") to avoid implying a live bug post-fix.
-- Added "Writing SKILL templates" section to CLAUDE.md — rules for natural language over bash-isms, dynamic branch detection, self-contained code blocks.
-- Hardcoded-main regression test scans all `.tmpl` files for git commands with hardcoded `main`.
-- QA template cleaned up: removed `REPORT_DIR` shell variable, simplified port detection to prose.
-- gstack-upgrade template: explicit cross-step prose for variable references between bash blocks.
+- 新增帶有注釋去除的 `hasAwait()` 輔助函式，以避免 `// await` 中的誤判。
+- 智慧 eval 包裝：單行 → 表達式 `(...)`，多行 → 區塊 `{...}` 含明確 `return`。
+- 6 個新非同步包裝單元測試，40 個新貢獻者模式前言驗證測試。
+- 校準範例框架為歷史（「以前失敗」）以避免在修復後暗示存在即時錯誤。
+- 在 CLAUDE.md 中新增「撰寫 SKILL 模板」章節 — 自然語言優先於 bash-ism、動態分支偵測、自含式程式碼區塊的規則。
+- 硬編碼 main 迴歸測試掃描所有 `.tmpl` 檔案中帶有硬編碼 `main` 的 git 命令。
+- QA 模板清理：移除 `REPORT_DIR` shell 變數，將端口偵測簡化為文字說明。
+- gstack-upgrade 模板：bash 區塊之間變數引用的明確跨步驟文字說明。
 
 ## 0.4.1 — 2026-03-16
 
-- **gstack now notices when it screws up.** Turn on contributor mode (`gstack-config set gstack_contributor true`) and gstack automatically writes up what went wrong — what you were doing, what broke, repro steps. Next time something annoys you, the bug report is already written. Fork gstack and fix it yourself.
-- **Juggling multiple sessions? gstack keeps up.** When you have 3+ gstack windows open, every question now tells you which project, which branch, and what you were working on. No more staring at a question thinking "wait, which window is this?"
-- **Every question now comes with a recommendation.** Instead of dumping options on you and making you think, gstack tells you what it would pick and why. Same clear format across every skill.
-- **/review now catches forgotten enum handlers.** Add a new status, tier, or type constant? /review traces it through every switch statement, allowlist, and filter in your codebase — not just the files you changed. Catches the "added the value but forgot to handle it" class of bugs before they ship.
+- **gstack 現在注意到自己出錯。** 開啟貢獻者模式（`gstack-config set gstack_contributor true`），gstack 自動記錄發生了什麼問題 — 您在做什麼、什麼損壞了、重現步驟。下次有什麼讓您惱火的，錯誤報告已經寫好了。Fork gstack 自己修復它。
+- **同時處理多個工作階段？gstack 跟上。** 當您有 3 個以上的 gstack 視窗開啟時，每個問題現在都告訴您是哪個專案、哪個分支，以及您在做什麼。不再盯著問題想「等等，這是哪個視窗？」
+- **每個問題現在都帶有建議。** gstack 不再把選項傾倒在您身上讓您思考，而是告訴您它會選什麼以及為什麼。在所有技能中使用相同的清晰格式。
+- **/review 現在攔截遺忘的 enum 處理器。** 新增一個新的狀態、層級或類型常數？/review 通過您程式碼庫中的每個 switch 語句、白名單和過濾器追蹤它 — 不只是您變更的檔案。在出貨之前攔截「新增了值但忘記處理它」這類錯誤。
 
-### For contributors
+### 貢獻者須知
 
-- Renamed `{{UPDATE_CHECK}}` to `{{PREAMBLE}}` across all 11 skill templates — one startup block now handles update check, session tracking, contributor mode, and question formatting.
-- DRY'd plan-ceo-review and plan-eng-review question formatting to reference the preamble baseline instead of duplicating rules.
-- Added CHANGELOG style guide and vendored symlink awareness docs to CLAUDE.md.
+- 在所有 11 個技能模板中將 `{{UPDATE_CHECK}}` 重命名為 `{{PREAMBLE}}` — 現在一個啟動區塊處理更新檢查、工作階段追蹤、貢獻者模式和問題格式化。
+- 將 plan-ceo-review 和 plan-eng-review 問題格式化進行 DRY 處理，參照前言基準而非複製規則。
+- 在 CLAUDE.md 中新增 CHANGELOG 風格指南和供應商符號連結意識文件。
 
 ## 0.4.0 — 2026-03-16
 
-### Added
-- **QA-only skill** (`/qa-only`) — report-only QA mode that finds and documents bugs without making fixes. Hand off a clean bug report to your team without the agent touching your code.
-- **QA fix loop** — `/qa` now runs a find-fix-verify cycle: discover bugs, fix them, commit, re-navigate to confirm the fix took. One command to go from broken to shipped.
-- **Plan-to-QA artifact flow** — `/plan-eng-review` writes test-plan artifacts that `/qa` picks up automatically. Your engineering review now feeds directly into QA testing with no manual copy-paste.
-- **`{{QA_METHODOLOGY}}` DRY placeholder** — shared QA methodology block injected into both `/qa` and `/qa-only` templates. Keeps both skills in sync when you update testing standards.
-- **Eval efficiency metrics** — turns, duration, and cost now displayed across all eval surfaces with natural-language **Takeaway** commentary. See at a glance whether your prompt changes made the agent faster or slower.
-- **`generateCommentary()` engine** — interprets comparison deltas so you don't have to: flags regressions, notes improvements, and produces an overall efficiency summary.
-- **Eval list columns** — `bun run eval:list` now shows Turns and Duration per run. Spot expensive or slow runs instantly.
-- **Eval summary per-test efficiency** — `bun run eval:summary` shows average turns/duration/cost per test across runs. Identify which tests are costing you the most over time.
-- **`judgePassed()` unit tests** — extracted and tested the pass/fail judgment logic.
-- **3 new E2E tests** — qa-only no-fix guardrail, qa fix loop with commit verification, plan-eng-review test-plan artifact.
-- **Browser ref staleness detection** — `resolveRef()` now checks element count to detect stale refs after page mutations. SPA navigation no longer causes 30-second timeouts on missing elements.
-- 3 new snapshot tests for ref staleness.
+### 新增
+- **QA-only 技能**（`/qa-only`）— 僅報告 QA 模式，找到並記錄錯誤而不進行修復。將乾淨的錯誤報告交給您的團隊，代理不會碰您的程式碼。
+- **QA 修復循環** — `/qa` 現在執行發現-修復-驗證循環：發現錯誤、修復它們、提交、重新導航以確認修復已生效。一個命令從損壞到出貨。
+- **計劃到 QA 的構件流** — `/plan-eng-review` 寫入測試計劃構件，`/qa` 自動取用。您的工程審查現在直接供 QA 測試使用，無需手動複製貼上。
+- **`{{QA_METHODOLOGY}}` DRY 佔位符** — 共享 QA 方法論區塊注入 `/qa` 和 `/qa-only` 兩個模板。當您更新測試標準時，兩個技能保持同步。
+- **Eval 效率指標** — 迴合次數、持續時間和成本現在顯示在所有 eval 介面中，附帶自然語言**Takeaway**評論。一眼看出您的提示詞變更是否讓代理更快或更慢。
+- **`generateCommentary()` 引擎** — 解讀比較差異，讓您不必：標記退化、記錄改進，並產生整體效率摘要。
+- **Eval 清單欄位** — `bun run eval:list` 現在顯示每次執行的迴合次數和持續時間。立即發現昂貴或緩慢的執行。
+- **Eval 摘要每測試效率** — `bun run eval:summary` 顯示各執行中每個測試的平均迴合次數/持續時間/成本。識別哪些測試長期花費您最多。
+- **`judgePassed()` 單元測試** — 提取並測試通過/失敗判斷邏輯。
+- **3 個新 E2E 測試** — qa-only 無修復防護措施、qa 修復循環含提交驗證、plan-eng-review 測試計劃構件。
+- **瀏覽器 ref 過時偵測** — `resolveRef()` 現在檢查元素計數以偵測頁面突變後的過時 ref。SPA 導航不再在缺失元素上導致 30 秒逾時。
+- ref 過時的 3 個新快照測試。
 
-### Changed
-- QA skill prompt restructured with explicit two-cycle workflow (find → fix → verify).
-- `formatComparison()` now shows per-test turns and duration deltas alongside cost.
-- `printSummary()` shows turns and duration columns.
-- `eval-store.test.ts` fixed pre-existing `_partial` file assertion bug.
+### 變更
+- QA 技能提示詞重構，包含明確的兩階段工作流程（發現 → 修復 → 驗證）。
+- `formatComparison()` 現在顯示每個測試的迴合次數和持續時間差異以及成本。
+- `printSummary()` 顯示迴合次數和持續時間欄位。
+- `eval-store.test.ts` 修復了預先存在的 `_partial` 檔案斷言錯誤。
 
-### Fixed
-- Browser ref staleness — refs collected before page mutation (e.g. SPA navigation) are now detected and re-collected. Eliminates a class of flaky QA failures on dynamic sites.
+### 修復
+- 瀏覽器 ref 過時 — 在頁面突變（如 SPA 導航）之前收集的 ref 現在被偵測並重新收集。消除動態網站上一類不穩定的 QA 失敗。
 
 ## 0.3.9 — 2026-03-15
 
-### Added
-- **`bin/gstack-config` CLI** — simple get/set/list interface for `~/.gstack/config.yaml`. Used by update-check and upgrade skill for persistent settings (auto_upgrade, update_check).
-- **Smart update check** — 12h cache TTL (was 24h), exponential snooze backoff (24h → 48h → 1 week) when user declines upgrades, `update_check: false` config option to disable checks entirely. Snooze resets when a new version is released.
-- **Auto-upgrade mode** — set `auto_upgrade: true` in config or `GSTACK_AUTO_UPGRADE=1` env var to skip the upgrade prompt and update automatically.
-- **4-option upgrade prompt** — "Yes, upgrade now", "Always keep me up to date", "Not now" (snooze), "Never ask again" (disable).
-- **Vendored copy sync** — `/gstack-upgrade` now detects and updates local vendored copies in the current project after upgrading the primary install.
-- 25 new tests: 11 for gstack-config CLI, 14 for snooze/config paths in update-check.
+### 新增
+- **`bin/gstack-config` CLI** — 用於 `~/.gstack/config.yaml` 的簡單 get/set/list 介面。被更新檢查和升級技能用於持久設定（auto_upgrade、update_check）。
+- **智慧更新檢查** — 12 小時快取 TTL（原為 24 小時），當用戶拒絕升級時指數級暫停退避（24 小時 → 48 小時 → 1 週），`update_check: false` 設定選項可完全停用檢查。發布新版本時暫停重置。
+- **自動升級模式** — 在設定中設定 `auto_upgrade: true` 或設定 `GSTACK_AUTO_UPGRADE=1` 環境變數，以跳過升級提示並自動更新。
+- **4 選項升級提示** — 「是，立即升級」、「始終保持最新」、「現在不要」（暫停）、「不再詢問」（停用）。
+- **供應商副本同步** — `/gstack-upgrade` 現在在升級主要安裝後偵測並更新當前專案中的本地供應商副本。
+- 25 個新測試：11 個用於 gstack-config CLI，14 個用於更新檢查中的暫停/設定路徑。
 
-### Changed
-- README upgrade/troubleshooting sections simplified to reference `/gstack-upgrade` instead of long paste commands.
-- Upgrade skill template bumped to v1.1.0 with `Write` tool permission for config editing.
-- All SKILL.md preambles updated with new upgrade flow description.
+### 變更
+- README 升級/疑難排解章節簡化，改為參照 `/gstack-upgrade` 而非長段貼上命令。
+- 升級技能模板升級至 v1.1.0，附帶 `Write` 工具權限用於設定編輯。
+- 所有 SKILL.md 前言以新的升級流程描述更新。
 
 ## 0.3.8 — 2026-03-14
 
-### Added
-- **TODOS.md as single source of truth** — merged `TODO.md` (roadmap) and `TODOS.md` (near-term) into one file organized by skill/component with P0-P4 priority ordering and a Completed section.
-- **`/ship` Step 5.5: TODOS.md management** — auto-detects completed items from the diff, marks them done with version annotations, offers to create/reorganize TODOS.md if missing or unstructured.
-- **Cross-skill TODOS awareness** — `/plan-ceo-review`, `/plan-eng-review`, `/retro`, `/review`, and `/qa` now read TODOS.md for project context. `/retro` adds Backlog Health metric (open counts, P0/P1 items, churn).
-- **Shared `review/TODOS-format.md`** — canonical TODO item format referenced by `/ship` and `/plan-ceo-review` to prevent format drift (DRY).
-- **Greptile 2-tier reply system** — Tier 1 (friendly, inline diff + explanation) for first responses; Tier 2 (firm, full evidence chain + re-rank request) when Greptile re-flags after a prior reply.
-- **Greptile reply templates** — structured templates in `greptile-triage.md` for fixes (inline diff), already-fixed (what was done), and false positives (evidence + suggested re-rank). Replaces vague one-line replies.
-- **Greptile escalation detection** — explicit algorithm to detect prior GStack replies on comment threads and auto-escalate to Tier 2.
-- **Greptile severity re-ranking** — replies now include `**Suggested re-rank:**` when Greptile miscategorizes issue severity.
-- Static validation tests for `TODOS-format.md` references across skills.
+### 新增
+- **TODOS.md 作為單一真實來源** — 將 `TODO.md`（路線圖）和 `TODOS.md`（近期）合併為一個按技能/元件組織的檔案，附帶 P0-P4 優先級排序和已完成章節。
+- **`/ship` 步驟 5.5：TODOS.md 管理** — 從 diff 自動偵測已完成的項目，用版本標注標記為完成，若 TODOS.md 缺失或未結構化則提供建立/重組。
+- **跨技能 TODOS 意識** — `/plan-ceo-review`、`/plan-eng-review`、`/retro`、`/review` 和 `/qa` 現在讀取 TODOS.md 作為專案上下文。`/retro` 新增 Backlog Health 指標（開放計數、P0/P1 項目、流失率）。
+- **共享 `review/TODOS-format.md`** — 被 `/ship` 和 `/plan-ceo-review` 參照的典範 TODO 項目格式，防止格式漂移（DRY）。
+- **Greptile 2 層回覆系統** — 第 1 層（友好、內嵌 diff + 解釋）用於首次回覆；第 2 層（堅定、完整證據鏈 + 重新排序請求）當 Greptile 在之前回覆後重新標記時。
+- **Greptile 回覆模板** — `greptile-triage.md` 中用於修復（內嵌 diff）、已修復（所做的事情）和誤報（證據 + 建議重新排序）的結構化模板。取代模糊的單行回覆。
+- **Greptile 升級偵測** — 明確算法偵測評論串上的先前 GStack 回覆並自動升級至第 2 層。
+- **Greptile 嚴重性重新排序** — 回覆現在在 Greptile 錯誤分類問題嚴重性時包含 `**Suggested re-rank:**`。
+- 跨技能的 `TODOS-format.md` 參照靜態驗證測試。
 
-### Fixed
-- **`.gitignore` append failures silently swallowed** — `ensureStateDir()` bare `catch {}` replaced with ENOENT-only silence; non-ENOENT errors (EACCES, ENOSPC) logged to `.gstack/browse-server.log`.
+### 修復
+- **`.gitignore` 附加失敗被靜默吞噬** — `ensureStateDir()` 的裸 `catch {}` 替換為僅 ENOENT 靜默；非 ENOENT 錯誤（EACCES、ENOSPC）記錄至 `.gstack/browse-server.log`。
 
-### Changed
-- `TODO.md` deleted — all items merged into `TODOS.md`.
-- `/ship` Step 3.75 and `/review` Step 5 now reference reply templates and escalation detection from `greptile-triage.md`.
-- `/ship` Step 6 commit ordering includes TODOS.md in the final commit alongside VERSION + CHANGELOG.
-- `/ship` Step 8 PR body includes TODOS section.
+### 變更
+- `TODO.md` 刪除 — 所有項目合併至 `TODOS.md`。
+- `/ship` 步驟 3.75 和 `/review` 步驟 5 現在參照 `greptile-triage.md` 中的回覆模板和升級偵測。
+- `/ship` 步驟 6 提交順序在最終提交中包含 TODOS.md，與 VERSION + CHANGELOG 並列。
+- `/ship` 步驟 8 PR 說明包含 TODOS 章節。
 
 ## 0.3.7 — 2026-03-14
 
-### Added
-- **Screenshot element/region clipping** — `screenshot` command now supports element crop via CSS selector or @ref (`screenshot "#hero" out.png`, `screenshot @e3 out.png`), region clip (`screenshot --clip x,y,w,h out.png`), and viewport-only mode (`screenshot --viewport out.png`). Uses Playwright's native `locator.screenshot()` and `page.screenshot({ clip })`. Full page remains the default.
-- 10 new tests covering all screenshot modes (viewport, CSS, @ref, clip) and error paths (unknown flag, mutual exclusion, invalid coords, path validation, nonexistent selector).
+### 新增
+- **截圖元素/區域裁剪** — `screenshot` 命令現在支援通過 CSS 選擇器或 @ref 進行元素裁剪（`screenshot "#hero" out.png`、`screenshot @e3 out.png`）、區域裁剪（`screenshot --clip x,y,w,h out.png`）和僅視口模式（`screenshot --viewport out.png`）。使用 Playwright 原生的 `locator.screenshot()` 和 `page.screenshot({ clip })`。全頁面仍為預設值。
+- 10 個新測試，涵蓋所有截圖模式（視口、CSS、@ref、裁剪）和錯誤路徑（未知標記、互斥、無效座標、路徑驗證、不存在的選擇器）。
 
 ## 0.3.6 — 2026-03-14
 
-### Added
-- **E2E observability** — heartbeat file (`~/.gstack-dev/e2e-live.json`), per-run log directory (`~/.gstack-dev/e2e-runs/{runId}/`), progress.log, per-test NDJSON transcripts, persistent failure transcripts. All I/O non-fatal.
-- **`bun run eval:watch`** — live terminal dashboard reads heartbeat + partial eval file every 1s. Shows completed tests, current test with turn/tool info, stale detection (>10min), `--tail` for progress.log.
-- **Incremental eval saves** — `savePartial()` writes `_partial-e2e.json` after each test completes. Crash-resilient: partial results survive killed runs. Never cleaned up.
-- **Machine-readable diagnostics** — `exit_reason`, `timeout_at_turn`, `last_tool_call` fields in eval JSON. Enables `jq` queries for automated fix loops.
-- **API connectivity pre-check** — E2E suite throws immediately on ConnectionRefused before burning test budget.
-- **`is_error` detection** — `claude -p` can return `subtype: "success"` with `is_error: true` on API failures. Now correctly classified as `error_api`.
-- **Stream-json NDJSON parser** — `parseNDJSON()` pure function for real-time E2E progress from `claude -p --output-format stream-json --verbose`.
-- **Eval persistence** — results saved to `~/.gstack-dev/evals/` with auto-comparison against previous run.
-- **Eval CLI tools** — `eval:list`, `eval:compare`, `eval:summary` for inspecting eval history.
-- **All 9 skills converted to `.tmpl` templates** — plan-ceo-review, plan-eng-review, retro, review, ship now use `{{UPDATE_CHECK}}` placeholder. Single source of truth for update check preamble.
-- **3-tier eval suite** — Tier 1: static validation (free), Tier 2: E2E via `claude -p` (~$3.85/run), Tier 3: LLM-as-judge (~$0.15/run). Gated by `EVALS=1`.
-- **Planted-bug outcome testing** — eval fixtures with known bugs, LLM judge scores detection.
-- 15 observability unit tests covering heartbeat schema, progress.log format, NDJSON naming, savePartial, finalize, watcher rendering, stale detection, non-fatal I/O.
-- E2E tests for plan-ceo-review, plan-eng-review, retro skills.
-- Update-check exit code regression tests.
-- `test/helpers/skill-parser.ts` — `getRemoteSlug()` for git remote detection.
+### 新增
+- **E2E 可觀測性** — 心跳檔案（`~/.gstack-dev/e2e-live.json`）、每次執行的日誌目錄（`~/.gstack-dev/e2e-runs/{runId}/`）、progress.log、每測試 NDJSON 記錄、持久性失敗記錄。所有 I/O 非致命性。
+- **`bun run eval:watch`** — 即時終端儀表板每 1 秒讀取心跳 + 部分 eval 檔案。顯示已完成的測試、帶有迴合/工具資訊的當前測試、過時偵測（>10 分鐘）、progress.log 的 `--tail`。
+- **增量 eval 儲存** — `savePartial()` 在每個測試完成後寫入 `_partial-e2e.json`。抵抗崩潰：部分結果在執行被殺死後仍存在。永不清理。
+- **機器可讀診斷** — eval JSON 中的 `exit_reason`、`timeout_at_turn`、`last_tool_call` 欄位。啟用 `jq` 查詢用於自動化修復循環。
+- **API 連通性預檢** — E2E 套件在燒掉測試預算之前立即在 ConnectionRefused 時拋出。
+- **`is_error` 偵測** — `claude -p` 在 API 失敗時可能回傳 `subtype: "success"` 帶 `is_error: true`。現在正確分類為 `error_api`。
+- **Stream-json NDJSON 解析器** — 用於 `claude -p --output-format stream-json --verbose` 即時 E2E 進度的 `parseNDJSON()` 純函式。
+- **Eval 持久性** — 結果儲存至 `~/.gstack-dev/evals/`，與上次執行自動比較。
+- **Eval CLI 工具** — `eval:list`、`eval:compare`、`eval:summary` 用於檢查 eval 歷史。
+- **所有 9 個技能轉換為 `.tmpl` 模板** — plan-ceo-review、plan-eng-review、retro、review、ship 現在使用 `{{UPDATE_CHECK}}` 佔位符。更新檢查前言的單一真實來源。
+- **3 層 eval 套件** — 第 1 層：靜態驗證（免費），第 2 層：通過 `claude -p` 的 E2E（約 $3.85/次），第 3 層：LLM 評判（約 $0.15/次）。由 `EVALS=1` 控制。
+- **植入錯誤的結果測試** — 包含已知錯誤的 eval 固件，LLM 評判分數偵測。
+- 15 個可觀測性單元測試，涵蓋心跳結構、progress.log 格式、NDJSON 命名、savePartial、finalize、watcher 渲染、過時偵測、非致命性 I/O。
+- plan-ceo-review、plan-eng-review、retro 技能的 E2E 測試。
+- 更新檢查退出碼迴歸測試。
+- `test/helpers/skill-parser.ts` — 用於 git remote 偵測的 `getRemoteSlug()`。
 
-### Fixed
-- **Browse binary discovery broken for agents** — replaced `find-browse` indirection with explicit `browse/dist/browse` path in SKILL.md setup blocks.
-- **Update check exit code 1 misleading agents** — added `|| true` to prevent non-zero exit when no update available.
-- **browse/SKILL.md missing setup block** — added `{{BROWSE_SETUP}}` placeholder.
-- **plan-ceo-review timeout** — init git repo in test dir, skip codebase exploration, bump timeout to 420s.
-- Planted-bug eval reliability — simplified prompts, lowered detection baselines, resilient to max_turns flakes.
+### 修復
+- **代理的瀏覽器二進位發現損壞** — 以明確的 `browse/dist/browse` 路徑取代 SKILL.md 設定區塊中的 `find-browse` 間接層。
+- **更新檢查退出碼 1 誤導代理** — 新增 `|| true` 以防止在無更新可用時退出代碼非零。
+- **browse/SKILL.md 缺少設定區塊** — 新增 `{{BROWSE_SETUP}}` 佔位符。
+- **plan-ceo-review 逾時** — 在測試目錄中初始化 git 儲存庫、跳過程式碼庫探索、將逾時增加至 420 秒。
+- 植入錯誤的 eval 可靠性 — 簡化提示詞、降低偵測基準、對 max_turns 閃爍有韌性。
 
-### Changed
-- **Template system expanded** — `{{UPDATE_CHECK}}` and `{{BROWSE_SETUP}}` placeholders in `gen-skill-docs.ts`. All browse-using skills generate from single source of truth.
-- Enriched 14 command descriptions with specific arg formats, valid values, error behavior, and return types.
-- Setup block checks workspace-local path first (for development), falls back to global install.
-- LLM eval judge upgraded from Haiku to Sonnet 4.6.
-- `generateHelpText()` auto-generated from COMMAND_DESCRIPTIONS (replaces hand-maintained help text).
+### 變更
+- **模板系統擴展** — `gen-skill-docs.ts` 中的 `{{UPDATE_CHECK}}` 和 `{{BROWSE_SETUP}}` 佔位符。所有使用瀏覽器的技能從單一真實來源生成。
+- 以特定的參數格式、有效值、錯誤行為和返回類型豐富了 14 個命令描述。
+- 設定區塊先檢查工作區本地路徑（用於開發），回退至全域安裝。
+- LLM eval 評判從 Haiku 升級至 Sonnet 4.6。
+- `generateHelpText()` 從 COMMAND_DESCRIPTIONS 自動生成（取代手動維護的說明文字）。
 
 ## 0.3.3 — 2026-03-13
 
-### Added
-- **SKILL.md template system** — `.tmpl` files with `{{COMMAND_REFERENCE}}` and `{{SNAPSHOT_FLAGS}}` placeholders, auto-generated from source code at build time. Structurally prevents command drift between docs and code.
-- **Command registry** (`browse/src/commands.ts`) — single source of truth for all browse commands with categories and enriched descriptions. Zero side effects, safe to import from build scripts and tests.
-- **Snapshot flags metadata** (`SNAPSHOT_FLAGS` array in `browse/src/snapshot.ts`) — metadata-driven parser replaces hand-coded switch/case. Adding a flag in one place updates the parser, docs, and tests.
-- **Tier 1 static validation** — 43 tests: parses `$B` commands from SKILL.md code blocks, validates against command registry and snapshot flag metadata
-- **Tier 2 E2E tests** via Agent SDK — spawns real Claude sessions, runs skills, scans for browse errors. Gated by `SKILL_E2E=1` env var (~$0.50/run)
-- **Tier 3 LLM-as-judge evals** — Haiku scores generated docs on clarity/completeness/actionability (threshold ≥4/5), plus regression test vs hand-maintained baseline. Gated by `ANTHROPIC_API_KEY`
-- **`bun run skill:check`** — health dashboard showing all skills, command counts, validation status, template freshness
-- **`bun run dev:skill`** — watch mode that regenerates and validates SKILL.md on every template or source file change
-- **CI workflow** (`.github/workflows/skill-docs.yml`) — runs `gen:skill-docs` on push/PR, fails if generated output differs from committed files
-- `bun run gen:skill-docs` script for manual regeneration
-- `bun run test:eval` for LLM-as-judge evals
-- `test/helpers/skill-parser.ts` — extracts and validates `$B` commands from Markdown
-- `test/helpers/session-runner.ts` — Agent SDK wrapper with error pattern scanning and transcript saving
-- **ARCHITECTURE.md** — design decisions document covering daemon model, security, ref system, logging, crash recovery
-- **Conductor integration** (`conductor.json`) — lifecycle hooks for workspace setup/teardown
-- **`.env` propagation** — `bin/dev-setup` copies `.env` from main worktree into Conductor workspaces automatically
-- `.env.example` template for API key configuration
+### 新增
+- **SKILL.md 模板系統** — 帶有 `{{COMMAND_REFERENCE}}` 和 `{{SNAPSHOT_FLAGS}}` 佔位符的 `.tmpl` 檔案，在建置時從原始碼自動生成。結構性防止文件和程式碼之間的命令漂移。
+- **命令登錄檔**（`browse/src/commands.ts`）— 所有 browse 命令的單一真實來源，附帶類別和豐富描述。無副作用，可從建置腳本和測試安全導入。
+- **快照標記元數據**（`browse/src/snapshot.ts` 中的 `SNAPSHOT_FLAGS` 陣列）— 元數據驅動的解析器取代手工編碼的 switch/case。在一處新增標記更新解析器、文件和測試。
+- **第 1 層靜態驗證** — 43 個測試：從 SKILL.md 程式碼區塊解析 `$B` 命令，對命令登錄檔和快照標記元數據進行驗證
+- **第 2 層 E2E 測試**，通過 Agent SDK — 生成真實的 Claude 工作階段、執行技能、掃描 browse 錯誤。由 `SKILL_E2E=1` 環境變數控制（約 $0.50/次）
+- **第 3 層 LLM 評判 eval** — Haiku 在清晰度/完整性/可行性上為生成的文件評分（閾值 ≥4/5），加上對手動維護基準的迴歸測試。由 `ANTHROPIC_API_KEY` 控制
+- **`bun run skill:check`** — 顯示所有技能、命令計數、驗證狀態、模板新鮮度的健康儀表板
+- **`bun run dev:skill`** — 監視模式，在每次模板或原始碼檔案變更時重新生成並驗證 SKILL.md
+- **CI 工作流程**（`.github/workflows/skill-docs.yml`）— 在 push/PR 時執行 `gen:skill-docs`，若生成輸出與已提交檔案不同則失敗
+- `bun run gen:skill-docs` 腳本用於手動重新生成
+- `bun run test:eval` 用於 LLM 評判 eval
+- `test/helpers/skill-parser.ts` — 從 Markdown 提取並驗證 `$B` 命令
+- `test/helpers/session-runner.ts` — 帶有錯誤模式掃描和記錄儲存的 Agent SDK 包裝器
+- **ARCHITECTURE.md** — 設計決策文件，涵蓋 daemon 模型、安全性、ref 系統、日誌、崩潰恢復
+- **Conductor 整合**（`conductor.json`）— 工作區設定/拆除的生命週期 Hook
+- **`.env` 傳播** — `bin/dev-setup` 自動從主工作樹複製 `.env` 到 Conductor 工作區
+- 用於 API 金鑰設定的 `.env.example` 模板
 
-### Changed
-- Build now runs `gen:skill-docs` before compiling binaries
-- `parseSnapshotArgs` is metadata-driven (iterates `SNAPSHOT_FLAGS` instead of switch/case)
-- `server.ts` imports command sets from `commands.ts` instead of declaring inline
-- SKILL.md and browse/SKILL.md are now generated files (edit the `.tmpl` instead)
+### 變更
+- 建置現在在編譯二進位之前執行 `gen:skill-docs`
+- `parseSnapshotArgs` 由元數據驅動（迭代 `SNAPSHOT_FLAGS` 而非 switch/case）
+- `server.ts` 從 `commands.ts` 導入命令集，而非內聯聲明
+- SKILL.md 和 browse/SKILL.md 現在是生成的檔案（請編輯 `.tmpl` 而非直接編輯）
 
 ## 0.3.2 — 2026-03-13
 
-### Fixed
-- Cookie import picker now returns JSON instead of HTML — `jsonResponse()` referenced `url` out of scope, crashing every API call
-- `help` command routed correctly (was unreachable due to META_COMMANDS dispatch ordering)
-- Stale servers from global install no longer shadow local changes — removed legacy `~/.claude/skills/gstack` fallback from `resolveServerScript()`
-- Crash log path references updated from `/tmp/` to `.gstack/`
+### 修復
+- Cookie 導入選擇器現在返回 JSON 而非 HTML — `jsonResponse()` 引用了超出範圍的 `url`，導致每個 API 呼叫崩潰
+- `help` 命令正確路由（由於 META_COMMANDS 分派排序而無法到達）
+- 來自全域安裝的過時伺服器不再遮蔽本地變更 — 從 `resolveServerScript()` 中移除了舊的 `~/.claude/skills/gstack` 回退
+- 崩潰日誌路徑參照從 `/tmp/` 更新至 `.gstack/`
 
-### Added
-- **Diff-aware QA mode** — `/qa` on a feature branch auto-analyzes `git diff`, identifies affected pages/routes, detects the running app on localhost, and tests only what changed. No URL needed.
-- **Project-local browse state** — state file, logs, and all server state now live in `.gstack/` inside the project root (detected via `git rev-parse --show-toplevel`). No more `/tmp` state files.
-- **Shared config module** (`browse/src/config.ts`) — centralizes path resolution for CLI and server, eliminates duplicated port/state logic
-- **Random port selection** — server picks a random port 10000-60000 instead of scanning 9400-9409. No more CONDUCTOR_PORT magic offset. No more port collisions across workspaces.
-- **Binary version tracking** — state file includes `binaryVersion` SHA; CLI auto-restarts the server when the binary is rebuilt
-- **Legacy /tmp cleanup** — CLI scans for and removes old `/tmp/browse-server*.json` files, verifying PID ownership before sending signals
-- **Greptile integration** — `/review` and `/ship` fetch and triage Greptile bot comments; `/retro` tracks Greptile batting average across weeks
-- **Local dev mode** — `bin/dev-setup` symlinks skills from the repo for in-place development; `bin/dev-teardown` restores global install
-- `help` command — agents can self-discover all commands and snapshot flags
-- Version-aware `find-browse` with META signal protocol — detects stale binaries and prompts agents to update
-- `browse/dist/find-browse` compiled binary with git SHA comparison against origin/main (4hr cached)
-- `.version` file written at build time for binary version tracking
-- Route-level tests for cookie picker (13 tests) and find-browse version check (10 tests)
-- Config resolution tests (14 tests) covering git root detection, BROWSE_STATE_FILE override, ensureStateDir, readVersionHash, resolveServerScript, and version mismatch detection
-- Browser interaction guidance in CLAUDE.md — prevents Claude from using mcp\_\_claude-in-chrome\_\_\* tools
-- CONTRIBUTING.md with quick start, dev mode explanation, and instructions for testing branches in other repos
+### 新增
+- **差異感知 QA 模式** — 功能分支上的 `/qa` 自動分析 `git diff`、識別受影響的頁面/路由、偵測 localhost 上的執行中應用程式，並只測試變更的內容。不需要 URL。
+- **專案本地 browse 狀態** — 狀態檔案、日誌和所有伺服器狀態現在存在於專案根目錄的 `.gstack/` 中（通過 `git rev-parse --show-toplevel` 偵測）。不再有 `/tmp` 狀態檔案。
+- **共享設定模組**（`browse/src/config.ts`）— 集中 CLI 和伺服器的路徑解析，消除重複的端口/狀態邏輯
+- **隨機端口選擇** — 伺服器選取 10000-60000 的隨機端口，而非掃描 9400-9409。不再有 CONDUCTOR_PORT 魔術偏移量。不再有跨工作區的端口衝突。
+- **二進位版本追蹤** — 狀態檔案包含 `binaryVersion` SHA；CLI 在二進位重建時自動重啟伺服器
+- **舊版 /tmp 清理** — CLI 掃描並移除舊的 `/tmp/browse-server*.json` 檔案，在發送信號前驗證 PID 所有權
+- **Greptile 整合** — `/review` 和 `/ship` 獲取並分類 Greptile bot 評論；`/retro` 跨週追蹤 Greptile 打擊率
+- **本地開發模式** — `bin/dev-setup` 從儲存庫符號連結技能用於就地開發；`bin/dev-teardown` 還原全域安裝
+- `help` 命令 — 代理可自我探索所有命令和快照標記
+- 帶有 META 信號協議的版本感知 `find-browse` — 偵測過時的二進位並提示代理更新
+- `browse/dist/find-browse` 編譯二進位，帶有 git SHA 與 origin/main 的比較（4 小時快取）
+- 建置時寫入的 `.version` 檔案，用於二進位版本追蹤
+- cookie 選擇器（13 個測試）和 find-browse 版本檢查（10 個測試）的路由層級測試
+- 設定解析測試（14 個測試），涵蓋 git root 偵測、BROWSE_STATE_FILE 覆蓋、ensureStateDir、readVersionHash、resolveServerScript 和版本不符偵測
+- CLAUDE.md 中的瀏覽器互動指南 — 防止 Claude 使用 mcp\_\_claude-in-chrome\_\_\* 工具
+- CONTRIBUTING.md，附帶快速開始、開發模式說明以及在其他儲存庫中測試分支的指令
 
-### Changed
-- State file location: `.gstack/browse.json` (was `/tmp/browse-server.json`)
-- Log files location: `.gstack/browse-{console,network,dialog}.log` (was `/tmp/browse-*.log`)
-- Atomic state file writes: `.json.tmp` → rename (prevents partial reads)
-- CLI passes `BROWSE_STATE_FILE` to spawned server (server derives all paths from it)
-- SKILL.md setup checks parse META signals and handle `META:UPDATE_AVAILABLE`
-- `/qa` SKILL.md now describes four modes (diff-aware, full, quick, regression) with diff-aware as the default on feature branches
-- `jsonResponse`/`errorResponse` use options objects to prevent positional parameter confusion
-- Build script compiles both `browse` and `find-browse` binaries, cleans up `.bun-build` temp files
-- README updated with Greptile setup instructions, diff-aware QA examples, and revised demo transcript
+### 變更
+- 狀態檔案位置：`.gstack/browse.json`（原為 `/tmp/browse-server.json`）
+- 日誌檔案位置：`.gstack/browse-{console,network,dialog}.log`（原為 `/tmp/browse-*.log`）
+- 原子性狀態檔案寫入：`.json.tmp` → 重命名（防止部分讀取）
+- CLI 將 `BROWSE_STATE_FILE` 傳遞給生成的伺服器（伺服器從中衍生所有路徑）
+- SKILL.md 設定檢查解析 META 信號並處理 `META:UPDATE_AVAILABLE`
+- `/qa` SKILL.md 現在描述四種模式（差異感知、完整、快速、迴歸），以差異感知作為功能分支的預設值
+- `jsonResponse`/`errorResponse` 使用選項物件以防止位置參數混淆
+- 建置腳本編譯 `browse` 和 `find-browse` 兩個二進位，清理 `.bun-build` 臨時檔案
+- README 以 Greptile 設定說明、差異感知 QA 範例和修訂的演示記錄更新
 
-### Removed
-- `CONDUCTOR_PORT` magic offset (`browse_port = CONDUCTOR_PORT - 45600`)
-- Port scan range 9400-9409
-- Legacy fallback to `~/.claude/skills/gstack/browse/src/server.ts`
-- `DEVELOPING_GSTACK.md` (renamed to CONTRIBUTING.md)
+### 移除
+- `CONDUCTOR_PORT` 魔術偏移量（`browse_port = CONDUCTOR_PORT - 45600`）
+- 端口掃描範圍 9400-9409
+- 舊版回退至 `~/.claude/skills/gstack/browse/src/server.ts`
+- `DEVELOPING_GSTACK.md`（重命名為 CONTRIBUTING.md）
 
 ## 0.3.1 — 2026-03-12
 
-### Phase 3.5: Browser cookie import
+### 第 3.5 階段：瀏覽器 Cookie 導入
 
-- `cookie-import-browser` command — decrypt and import cookies from real Chromium browsers (Comet, Chrome, Arc, Brave, Edge)
-- Interactive cookie picker web UI served from the browse server (dark theme, two-panel layout, domain search, import/remove)
-- Direct CLI import with `--domain` flag for non-interactive use
-- `/setup-browser-cookies` skill for Claude Code integration
-- macOS Keychain access with async 10s timeout (no event loop blocking)
-- Per-browser AES key caching (one Keychain prompt per browser per session)
-- DB lock fallback: copies locked cookie DB to /tmp for safe reads
-- 18 unit tests with encrypted cookie fixtures
+- `cookie-import-browser` 命令 — 解密並從真實 Chromium 瀏覽器（Comet、Chrome、Arc、Brave、Edge）導入 Cookie
+- 從 browse 伺服器提供的互動式 Cookie 選擇器 Web UI（深色主題、兩欄佈局、域名搜尋、導入/移除）
+- 使用 `--domain` 標記的直接 CLI 導入，用於非互動式使用
+- Claude Code 整合的 `/setup-browser-cookies` 技能
+- macOS 鑰匙圈存取，附帶 10 秒非同步逾時（無事件循環阻塞）
+- 每個瀏覽器的 AES 金鑰快取（每個工作階段每個瀏覽器一次鑰匙圈提示）
+- 資料庫鎖定回退：複製已鎖定的 Cookie 資料庫至 /tmp 以安全讀取
+- 18 個帶有加密 Cookie 固件的單元測試
 
 ## 0.3.0 — 2026-03-12
 
-### Phase 3: /qa skill — systematic QA testing
+### 第 3 階段：/qa 技能 — 系統性 QA 測試
 
-- New `/qa` skill with 6-phase workflow (Initialize, Authenticate, Orient, Explore, Document, Wrap up)
-- Three modes: full (systematic, 5-10 issues), quick (30-second smoke test), regression (compare against baseline)
-- Issue taxonomy: 7 categories, 4 severity levels, per-page exploration checklist
-- Structured report template with health score (0-100, weighted across 7 categories)
-- Framework detection guidance for Next.js, Rails, WordPress, and SPAs
-- `browse/bin/find-browse` — DRY binary discovery using `git rev-parse --show-toplevel`
+- 新的 `/qa` 技能，帶有 6 階段工作流程（初始化、認證、定向、探索、記錄、收尾）
+- 三種模式：完整（系統性，5-10 個問題）、快速（30 秒煙霧測試）、迴歸（與基準比較）
+- 問題分類：7 個類別、4 個嚴重性級別、每頁探索清單
+- 帶有健康分數的結構化報告模板（0-100，跨 7 個類別加權）
+- Next.js、Rails、WordPress 和 SPA 的框架偵測指南
+- `browse/bin/find-browse` — 使用 `git rev-parse --show-toplevel` 的 DRY 二進位探索
 
-### Phase 2: Enhanced browser
+### 第 2 階段：增強型瀏覽器
 
-- Dialog handling: auto-accept/dismiss, dialog buffer, prompt text support
-- File upload: `upload <sel> <file1> [file2...]`
-- Element state checks: `is visible|hidden|enabled|disabled|checked|editable|focused <sel>`
-- Annotated screenshots with ref labels overlaid (`snapshot -a`)
-- Snapshot diffing against previous snapshot (`snapshot -D`)
-- Cursor-interactive element scan for non-ARIA clickables (`snapshot -C`)
-- `wait --networkidle` / `--load` / `--domcontentloaded` flags
-- `console --errors` filter (error + warning only)
-- `cookie-import <json-file>` with auto-fill domain from page URL
-- CircularBuffer O(1) ring buffer for console/network/dialog buffers
-- Async buffer flush with Bun.write()
-- Health check with page.evaluate + 2s timeout
-- Playwright error wrapping — actionable messages for AI agents
-- Context recreation preserves cookies/storage/URLs (useragent fix)
-- SKILL.md rewritten as QA-oriented playbook with 10 workflow patterns
-- 166 integration tests (was ~63)
+- 對話框處理：自動接受/關閉、對話框緩衝區、提示文字支援
+- 檔案上傳：`upload <sel> <file1> [file2...]`
+- 元素狀態檢查：`is visible|hidden|enabled|disabled|checked|editable|focused <sel>`
+- 帶有 ref 標籤覆蓋的標注截圖（`snapshot -a`）
+- 與前一個快照的快照差異比較（`snapshot -D`）
+- 游標互動元素掃描，用於非 ARIA 可點擊元素（`snapshot -C`）
+- `wait --networkidle` / `--load` / `--domcontentloaded` 標記
+- `console --errors` 過濾器（僅錯誤 + 警告）
+- `cookie-import <json-file>`，帶有從頁面 URL 自動填入域名
+- CircularBuffer O(1) 環形緩衝區，用於控制台/網路/對話框緩衝區
+- 使用 Bun.write() 的非同步緩衝區刷新
+- 帶有 page.evaluate + 2 秒逾時的健康檢查
+- Playwright 錯誤包裝 — 為 AI 代理提供可行的訊息
+- 上下文重建保留 Cookie/儲存/URL（使用者代理修復）
+- SKILL.md 改寫為以 QA 為導向的操作手冊，包含 10 個工作流程模式
+- 166 個整合測試（原為約 63 個）
 
 ## 0.0.2 — 2026-03-12
 
-- Fix project-local `/browse` installs — compiled binary now resolves `server.ts` from its own directory instead of assuming a global install exists
-- `setup` rebuilds stale binaries (not just missing ones) and exits non-zero if the build fails
-- Fix `chain` command swallowing real errors from write commands (e.g. navigation timeout reported as "Unknown meta command")
-- Fix unbounded restart loop in CLI when server crashes repeatedly on the same command
-- Cap console/network buffers at 50k entries (ring buffer) instead of growing without bound
-- Fix disk flush stopping silently after buffer hits the 50k cap
-- Fix `ln -snf` in setup to avoid creating nested symlinks on upgrade
-- Use `git fetch && git reset --hard` instead of `git pull` for upgrades (handles force-pushes)
-- Simplify install: global-first with optional project copy (replaces submodule approach)
-- Restructured README: hero, before/after, demo transcript, troubleshooting section
-- Six skills (added `/retro`)
+- 修復專案本地 `/browse` 安裝 — 編譯後的二進位現在從其自身目錄解析 `server.ts`，而非假設存在全域安裝
+- `setup` 重建過時的二進位（不只是缺失的）並在建置失敗時以非零退出
+- 修復 `chain` 命令吞噬寫入命令的真實錯誤（例如：導航逾時被報告為「Unknown meta command」）
+- 修復 CLI 在同一命令上伺服器反覆崩潰時的無界重啟循環
+- 將控制台/網路緩衝區上限設為 50k 條目（環形緩衝區），而非無限增長
+- 修復在緩衝區達到 50k 上限後磁碟刷新靜默停止的問題
+- 修復設定中的 `ln -snf` 以避免在升級時建立巢狀符號連結
+- 使用 `git fetch && git reset --hard` 而非 `git pull` 進行升級（處理 force-push）
+- 簡化安裝：全域優先，附帶可選的專案副本（取代 submodule 方法）
+- 重構 README：hero、前後對比、演示記錄、疑難排解章節
+- 六個技能（新增 `/retro`）
 
 ## 0.0.1 — 2026-03-11
 
-Initial release.
+初始版本。
 
-- Five skills: `/plan-ceo-review`, `/plan-eng-review`, `/review`, `/ship`, `/browse`
-- Headless browser CLI with 40+ commands, ref-based interaction, persistent Chromium daemon
-- One-command install as Claude Code skills (submodule or global clone)
-- `setup` script for binary compilation and skill symlinking
+- 五個技能：`/plan-ceo-review`、`/plan-eng-review`、`/review`、`/ship`、`/browse`
+- 無頭瀏覽器 CLI，帶有 40+ 命令、基於 ref 的互動、持久性 Chromium daemon
+- 以 Claude Code 技能形式一鍵安裝（submodule 或全域 clone）
+- 用於二進位編譯和技能符號連結的 `setup` 腳本

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,69 +1,59 @@
-# Contributing to gstack
+# 貢獻 gstack
 
-Thanks for wanting to make gstack better. Whether you're fixing a typo in a skill prompt or building an entirely new workflow, this guide will get you up and running fast.
+感謝你想讓 gstack 變得更好。無論你是在修復技能提示詞中的錯字，還是在打造全新的工作流程，這份指南都能讓你快速上手。
 
-## Quick start
+## 快速開始
 
-gstack skills are Markdown files that Claude Code discovers from a `skills/` directory. Normally they live at `~/.claude/skills/gstack/` (your global install). But when you're developing gstack itself, you want Claude Code to use the skills *in your working tree* — so edits take effect instantly without copying or deploying anything.
+gstack 技能是 Claude Code 從 `skills/` 目錄發現的 Markdown 檔案。通常它們位於 `~/.claude/skills/gstack/`（你的全域安裝）。但當你在開發 gstack 本身時，你希望 Claude Code 使用*你工作樹中的*技能——這樣編輯就能立即生效，無需複製或部署任何東西。
 
-That's what dev mode does. It symlinks your repo into the local `.claude/skills/` directory so Claude Code reads skills straight from your checkout.
+這就是開發模式的功用。它將你的 repo 符號連結到本地 `.claude/skills/` 目錄，讓 Claude Code 直接從你的 checkout 讀取技能。
 
 ```bash
 git clone <repo> && cd gstack
-bun install                    # install dependencies
-bin/dev-setup                  # activate dev mode
+bun install                    # 安裝依賴
+bin/dev-setup                  # 啟用開發模式
 ```
 
-Now edit any `SKILL.md`, invoke it in Claude Code (e.g. `/review`), and see your changes live. When you're done developing:
+現在編輯任何 `SKILL.md`，在 Claude Code 中呼叫它（例如 `/review`），就能即時看到你的變更。完成開發後：
 
 ```bash
-bin/dev-teardown               # deactivate — back to your global install
+bin/dev-teardown               # 停用——回到你的全域安裝
 ```
 
-## Contributor mode
+## 貢獻者模式
 
-Contributor mode turns gstack into a self-improving tool. Enable it and Claude Code
-will periodically reflect on its gstack experience — rating it 0-10 at the end of
-each major workflow step. When something isn't a 10, it thinks about why and files
-a report to `~/.gstack/contributor-logs/` with what happened, repro steps, and what
-would make it better.
+貢獻者模式將 gstack 變成一個自我改進的工具。啟用它後，Claude Code 會定期在每個主要工作流程步驟結束時反思其 gstack 體驗——對其評分 0-10。當某事不是 10 分時，它會思考原因，並向 `~/.gstack/contributor-logs/` 提交一份報告，記錄發生了什麼、重現步驟，以及什麼能讓它變得更好。
 
 ```bash
 ~/.claude/skills/gstack/bin/gstack-config set gstack_contributor true
 ```
 
-The logs are for **you**. When something bugs you enough to fix, the report is
-already written. Fork gstack, symlink your fork into the project where you hit
-the issue, fix it, and open a PR.
+日誌是**給你的**。當某事困擾你到足以修復的程度時，報告已經寫好了。Fork gstack，將你的 fork 符號連結到你遇到問題的專案中，修復它，然後開一個 PR。
 
-### The contributor workflow
+### 貢獻者工作流程
 
-1. **Use gstack normally** — contributor mode reflects and logs issues automatically
-2. **Check your logs:** `ls ~/.gstack/contributor-logs/`
-3. **Fork and clone gstack** (if you haven't already)
-4. **Symlink your fork into the project where you hit the bug:**
+1. **正常使用 gstack**——貢獻者模式自動反思並記錄問題
+2. **查看你的日誌：** `ls ~/.gstack/contributor-logs/`
+3. **Fork 並 clone gstack**（如果你還沒有的話）
+4. **將你的 fork 符號連結到你遇到 bug 的專案中：**
    ```bash
-   # In your core project (the one where gstack annoyed you)
+   # 在你的核心專案中（遇到 gstack 讓你惱火的地方）
    ln -sfn /path/to/your/gstack-fork .claude/skills/gstack
    cd .claude/skills/gstack && bun install && bun run build
    ```
-5. **Fix the issue** — your changes are live immediately in this project
-6. **Test by actually using gstack** — do the thing that annoyed you, verify it's fixed
-7. **Open a PR from your fork**
+5. **修復問題**——你的變更立即在這個專案中生效
+6. **透過實際使用 gstack 來測試**——做那個讓你惱火的事，驗證它已修復
+7. **從你的 fork 開啟一個 PR**
 
-This is the best way to contribute: fix gstack while doing your real work, in the
-project where you actually felt the pain.
+這是最好的貢獻方式：在做你真正的工作時修復 gstack，在你真正感受到痛點的專案中修復。
 
-### Session awareness
+### 工作階段意識
 
-When you have 3+ gstack sessions open simultaneously, every question tells you which project, which branch, and what's happening. No more staring at a question thinking "wait, which window is this?" The format is consistent across all 15 skills.
+當你同時有 3+ 個 gstack 工作階段開啟時，每個問題都會告訴你是哪個專案、哪個分支，以及正在發生什麼。不再盯著一個問題思考「等等，這是哪個視窗？」格式在所有 15 個技能中保持一致。
 
-## Working on gstack inside the gstack repo
+## 在 gstack repo 內部開發 gstack
 
-When you're editing gstack skills and want to test them by actually using gstack
-in the same repo, `bin/dev-setup` wires this up. It creates `.claude/skills/`
-symlinks (gitignored) pointing back to your working tree, so Claude Code uses
-your local edits instead of the global install.
+當你在編輯 gstack 技能並想透過在同一個 repo 中實際使用 gstack 來測試它們時，`bin/dev-setup` 會設定好這一切。它建立 `.claude/skills/` 符號連結（gitignored），指回你的工作樹，這樣 Claude Code 就會使用你的本地編輯，而不是全域安裝。
 
 ```
 gstack/                          <- your working tree
@@ -82,256 +72,252 @@ gstack/                          <- your working tree
 └── ...
 ```
 
-## Day-to-day workflow
+## 日常工作流程
 
 ```bash
-# 1. Enter dev mode
+# 1. 進入開發模式
 bin/dev-setup
 
-# 2. Edit a skill
+# 2. 編輯技能
 vim review/SKILL.md
 
-# 3. Test it in Claude Code — changes are live
+# 3. 在 Claude Code 中測試——變更立即生效
 #    > /review
 
-# 4. Editing browse source? Rebuild the binary
+# 4. 編輯 browse 原始碼？重新建置二進位檔
 bun run build
 
-# 5. Done for the day? Tear down
+# 5. 今天完成了？拆除
 bin/dev-teardown
 ```
 
-## Testing & evals
+## 測試與評估
 
-### Setup
+### 設定
 
 ```bash
-# 1. Copy .env.example and add your API key
+# 1. 複製 .env.example 並新增你的 API 金鑰
 cp .env.example .env
-# Edit .env → set ANTHROPIC_API_KEY=sk-ant-...
+# 編輯 .env → 設定 ANTHROPIC_API_KEY=sk-ant-...
 
-# 2. Install deps (if you haven't already)
+# 2. 安裝依賴（如果你還沒有的話）
 bun install
 ```
 
-Bun auto-loads `.env` — no extra config. Conductor workspaces inherit `.env` from the main worktree automatically (see "Conductor workspaces" below).
+Bun 自動載入 `.env`——不需要額外設定。Conductor 工作空間自動從主要工作樹繼承 `.env`（見下方「Conductor 工作空間」）。
 
-### Test tiers
+### 測試層級
 
-| Tier | Command | Cost | What it tests |
+| 層級 | 指令 | 費用 | 測試內容 |
 |------|---------|------|---------------|
-| 1 — Static | `bun test` | Free | Command validation, snapshot flags, SKILL.md correctness, TODOS-format.md refs, observability unit tests |
-| 2 — E2E | `bun run test:e2e` | ~$3.85 | Full skill execution via `claude -p` subprocess |
-| 3 — LLM eval | `bun run test:evals` | ~$0.15 standalone | LLM-as-judge scoring of generated SKILL.md docs |
-| 2+3 | `bun run test:evals` | ~$4 combined | E2E + LLM-as-judge (runs both) |
+| 1 — 靜態 | `bun test` | 免費 | 指令驗證、快照旗標、SKILL.md 正確性、TODOS-format.md 參考、可觀察性單元測試 |
+| 2 — E2E | `bun run test:e2e` | ~$3.85 | 透過 `claude -p` 子程序完整技能執行 |
+| 3 — LLM 評估 | `bun run test:evals` | ~$0.15 獨立 | LLM 評審對生成的 SKILL.md 文件評分 |
+| 2+3 | `bun run test:evals` | ~$4 合計 | E2E + LLM 評審（兩者都執行） |
 
 ```bash
-bun test                     # Tier 1 only (runs on every commit, <5s)
-bun run test:e2e             # Tier 2: E2E only (needs EVALS=1, can't run inside Claude Code)
-bun run test:evals           # Tier 2 + 3 combined (~$4/run)
+bun test                     # 僅第 1 層（每次提交都執行，<5 秒）
+bun run test:e2e             # 第 2 層：僅 E2E（需要 EVALS=1，無法在 Claude Code 內執行）
+bun run test:evals           # 第 2 + 3 層合計（~$4/次執行）
 ```
 
-### Tier 1: Static validation (free)
+### 第 1 層：靜態驗證（免費）
 
-Runs automatically with `bun test`. No API keys needed.
+透過 `bun test` 自動執行。不需要 API 金鑰。
 
-- **Skill parser tests** (`test/skill-parser.test.ts`) — Extracts every `$B` command from SKILL.md bash code blocks and validates against the command registry in `browse/src/commands.ts`. Catches typos, removed commands, and invalid snapshot flags.
-- **Skill validation tests** (`test/skill-validation.test.ts`) — Validates that SKILL.md files reference only real commands and flags, and that command descriptions meet quality thresholds.
-- **Generator tests** (`test/gen-skill-docs.test.ts`) — Tests the template system: verifies placeholders resolve correctly, output includes value hints for flags (e.g. `-d <N>` not just `-d`), enriched descriptions for key commands (e.g. `is` lists valid states, `press` lists key examples).
+- **技能解析器測試**（`test/skill-parser.test.ts`）——從 SKILL.md bash 程式碼區塊提取每個 `$B` 指令，並對照 `browse/src/commands.ts` 中的指令登錄檔驗證。捕捉錯字、已移除的指令和無效的快照旗標。
+- **技能驗證測試**（`test/skill-validation.test.ts`）——驗證 SKILL.md 檔案只參考真實的指令和旗標，以及指令描述符合品質閾值。
+- **生成器測試**（`test/gen-skill-docs.test.ts`）——測試模板系統：驗證佔位符正確解析，輸出包含旗標的值提示（例如 `-d <N>` 而不只是 `-d`），以及關鍵指令的豐富描述（例如 `is` 列出有效狀態，`press` 列出按鍵範例）。
 
-### Tier 2: E2E via `claude -p` (~$3.85/run)
+### 第 2 層：透過 `claude -p` 的 E2E（~$3.85/次執行）
 
-Spawns `claude -p` as a subprocess with `--output-format stream-json --verbose`, streams NDJSON for real-time progress, and scans for browse errors. This is the closest thing to "does this skill actually work end-to-end?"
+以子程序形式產生 `claude -p`，搭配 `--output-format stream-json --verbose`，串流 NDJSON 以獲得實時進度，並掃描 browse 錯誤。這是最接近「這個技能真的能端到端運作嗎？」的方式。
 
 ```bash
-# Must run from a plain terminal — can't nest inside Claude Code or Conductor
+# 必須從普通終端機執行——無法在 Claude Code 或 Conductor 內部巢套
 EVALS=1 bun test test/skill-e2e.test.ts
 ```
 
-- Gated by `EVALS=1` env var (prevents accidental expensive runs)
-- Auto-skips if running inside Claude Code (`claude -p` can't nest)
-- API connectivity pre-check — fails fast on ConnectionRefused before burning budget
-- Real-time progress to stderr: `[Ns] turn T tool #C: Name(...)`
-- Saves full NDJSON transcripts and failure JSON for debugging
-- Tests live in `test/skill-e2e.test.ts`, runner logic in `test/helpers/session-runner.ts`
+- 由 `EVALS=1` 環境變數管控（防止意外的昂貴執行）
+- 如果在 Claude Code 內執行則自動跳過（`claude -p` 無法巢套）
+- API 連線預檢——在燒掉預算之前，在 ConnectionRefused 時快速失敗
+- 到 stderr 的實時進度：`[Ns] turn T tool #C: Name(...)`
+- 保存完整 NDJSON 記錄和失敗 JSON 以供除錯
+- 測試在 `test/skill-e2e.test.ts` 中，執行器邏輯在 `test/helpers/session-runner.ts` 中
 
-### E2E observability
+### E2E 可觀察性
 
-When E2E tests run, they produce machine-readable artifacts in `~/.gstack-dev/`:
+E2E 測試執行時，它們在 `~/.gstack-dev/` 中產生機器可讀的工件：
 
-| Artifact | Path | Purpose |
+| 工件 | 路徑 | 用途 |
 |----------|------|---------|
-| Heartbeat | `e2e-live.json` | Current test status (updated per tool call) |
-| Partial results | `evals/_partial-e2e.json` | Completed tests (survives kills) |
-| Progress log | `e2e-runs/{runId}/progress.log` | Append-only text log |
-| NDJSON transcripts | `e2e-runs/{runId}/{test}.ndjson` | Raw `claude -p` output per test |
-| Failure JSON | `e2e-runs/{runId}/{test}-failure.json` | Diagnostic data on failure |
+| 心跳 | `e2e-live.json` | 當前測試狀態（每次工具呼叫更新） |
+| 部分結果 | `evals/_partial-e2e.json` | 已完成的測試（在被終止後存活） |
+| 進度日誌 | `e2e-runs/{runId}/progress.log` | 僅附加的文字日誌 |
+| NDJSON 記錄 | `e2e-runs/{runId}/{test}.ndjson` | 每個測試的原始 `claude -p` 輸出 |
+| 失敗 JSON | `e2e-runs/{runId}/{test}-failure.json` | 失敗時的診斷資料 |
 
-**Live dashboard:** Run `bun run eval:watch` in a second terminal to see a live dashboard showing completed tests, the currently running test, and cost. Use `--tail` to also show the last 10 lines of progress.log.
+**即時儀表板：** 在第二個終端機中執行 `bun run eval:watch` 以查看顯示已完成測試、當前執行中的測試和費用的即時儀表板。使用 `--tail` 也顯示 progress.log 的最後 10 行。
 
-**Eval history tools:**
-
-```bash
-bun run eval:list            # list all eval runs (turns, duration, cost per run)
-bun run eval:compare         # compare two runs — shows per-test deltas + Takeaway commentary
-bun run eval:summary         # aggregate stats + per-test efficiency averages across runs
-```
-
-**Eval comparison commentary:** `eval:compare` generates natural-language Takeaway sections interpreting what changed between runs — flagging regressions, noting improvements, calling out efficiency gains (fewer turns, faster, cheaper), and producing an overall summary. This is driven by `generateCommentary()` in `eval-store.ts`.
-
-Artifacts are never cleaned up — they accumulate in `~/.gstack-dev/` for post-mortem debugging and trend analysis.
-
-### Tier 3: LLM-as-judge (~$0.15/run)
-
-Uses Claude Sonnet to score generated SKILL.md docs on three dimensions:
-
-- **Clarity** — Can an AI agent understand the instructions without ambiguity?
-- **Completeness** — Are all commands, flags, and usage patterns documented?
-- **Actionability** — Can the agent execute tasks using only the information in the doc?
-
-Each dimension is scored 1-5. Threshold: every dimension must score **≥ 4**. There's also a regression test that compares generated docs against the hand-maintained baseline from `origin/main` — generated must score equal or higher.
+**Eval 歷史工具：**
 
 ```bash
-# Needs ANTHROPIC_API_KEY in .env — included in bun run test:evals
+bun run eval:list            # 列出所有 eval 執行（每次執行的回合、時間、費用）
+bun run eval:compare         # 比較兩次執行——顯示每個測試的差異 + Takeaway 評論
+bun run eval:summary         # 跨所有執行的彙總統計 + 每個測試的效率平均值
 ```
 
-- Uses `claude-sonnet-4-6` for scoring stability
-- Tests live in `test/skill-llm-eval.test.ts`
-- Calls the Anthropic API directly (not `claude -p`), so it works from anywhere including inside Claude Code
+**Eval 比較評論：** `eval:compare` 生成自然語言 Takeaway 段落，解釋執行之間的變化——標記退步、注意改進、指出效率提升（更少回合、更快、更便宜），並產生整體摘要。這由 `eval-store.ts` 中的 `generateCommentary()` 驅動。
+
+工件從不被清理——它們在 `~/.gstack-dev/` 中累積，用於事後除錯和趨勢分析。
+
+### 第 3 層：LLM 評審（~$0.15/次執行）
+
+使用 Claude Sonnet 在三個維度上對生成的 SKILL.md 文件評分：
+
+- **清晰度**——AI 代理人能否無歧義地理解說明？
+- **完整性**——所有指令、旗標和使用模式是否都已記錄？
+- **可操作性**——代理人能否只使用文件中的資訊執行任務？
+
+每個維度評分 1-5。閾值：每個維度必須評分 **≥ 4**。還有一個回歸測試，將生成的文件與從 `origin/main` 手動維護的基準進行比較——生成的必須評分相等或更高。
+
+```bash
+# 需要 .env 中的 ANTHROPIC_API_KEY——包含在 bun run test:evals 中
+```
+
+- 使用 `claude-sonnet-4-6` 以保持評分穩定性
+- 測試在 `test/skill-llm-eval.test.ts` 中
+- 直接呼叫 Anthropic API（不是 `claude -p`），因此可以在任何地方運作，包括在 Claude Code 內部
 
 ### CI
 
-A GitHub Action (`.github/workflows/skill-docs.yml`) runs `bun run gen:skill-docs --dry-run` on every push and PR. If the generated SKILL.md files differ from what's committed, CI fails. This catches stale docs before they merge.
+GitHub Action（`.github/workflows/skill-docs.yml`）在每次推送和 PR 上執行 `bun run gen:skill-docs --dry-run`。如果生成的 SKILL.md 檔案與已提交的不同，CI 就會失敗。這在合併前捕捉過時的文件。
 
-Tests run against the browse binary directly — they don't require dev mode.
+測試直接針對 browse 二進位檔執行——它們不需要開發模式。
 
-## Editing SKILL.md files
+## 編輯 SKILL.md 檔案
 
-SKILL.md files are **generated** from `.tmpl` templates. Don't edit the `.md` directly — your changes will be overwritten on the next build.
+SKILL.md 檔案是從 `.tmpl` 模板**生成的**。不要直接編輯 `.md`——你的變更在下次建置時會被覆蓋。
 
 ```bash
-# 1. Edit the template
-vim SKILL.md.tmpl              # or browse/SKILL.md.tmpl
+# 1. 編輯模板
+vim SKILL.md.tmpl              # 或 browse/SKILL.md.tmpl
 
-# 2. Regenerate for both hosts
+# 2. 為兩個主機重新生成
 bun run gen:skill-docs
 bun run gen:skill-docs --host codex
 
-# 3. Check health (reports both Claude and Codex)
+# 3. 檢查健康狀況（報告 Claude 和 Codex 兩者）
 bun run skill:check
 
-# Or use watch mode — auto-regenerates on save
+# 或使用監視模式——在儲存時自動重新生成
 bun run dev:skill
 ```
 
-For template authoring best practices (natural language over bash-isms, dynamic branch detection, `{{BASE_BRANCH_DETECT}}` usage), see CLAUDE.md's "Writing SKILL templates" section.
+關於模板撰寫最佳實踐（自然語言優先於 bash 慣用語、動態分支偵測、`{{BASE_BRANCH_DETECT}}` 用法），請參閱 CLAUDE.md 的「撰寫 SKILL 模板」段落。
 
-To add a browse command, add it to `browse/src/commands.ts`. To add a snapshot flag, add it to `SNAPSHOT_FLAGS` in `browse/src/snapshot.ts`. Then rebuild.
+要新增 browse 指令，請將其新增到 `browse/src/commands.ts`。要新增快照旗標，請將其新增到 `browse/src/snapshot.ts` 中的 `SNAPSHOT_FLAGS`。然後重新建置。
 
-## Dual-host development (Claude + Codex)
+## 雙主機開發（Claude + Codex）
 
-gstack generates SKILL.md files for two hosts: **Claude** (`.claude/skills/`) and **Codex** (`.agents/skills/`). Every template change needs to be generated for both.
+gstack 為兩個主機生成 SKILL.md 檔案：**Claude**（`.claude/skills/`）和 **Codex**（`.agents/skills/`）。每次模板變更都需要為兩者生成。
 
-### Generating for both hosts
+### 為兩個主機生成
 
 ```bash
-# Generate Claude output (default)
+# 生成 Claude 輸出（預設）
 bun run gen:skill-docs
 
-# Generate Codex output
+# 生成 Codex 輸出
 bun run gen:skill-docs --host codex
-# --host agents is an alias for --host codex
+# --host agents 是 --host codex 的別名
 
-# Or use build, which does both + compiles binaries
+# 或使用 build，它會做兩者 + 編譯二進位檔
 bun run build
 ```
 
-### What changes between hosts
+### 主機之間的差異
 
-| Aspect | Claude | Codex |
+| 面向 | Claude | Codex |
 |--------|--------|-------|
-| Output directory | `{skill}/SKILL.md` | `.agents/skills/gstack-{skill}/SKILL.md` |
-| Frontmatter | Full (name, description, allowed-tools, hooks, version) | Minimal (name + description only) |
-| Paths | `~/.claude/skills/gstack` | `~/.codex/skills/gstack` |
-| Hook skills | `hooks:` frontmatter (enforced by Claude) | Inline safety advisory prose (advisory only) |
-| `/codex` skill | Included (Claude wraps codex exec) | Excluded (self-referential) |
+| 輸出目錄 | `{skill}/SKILL.md` | `.agents/skills/gstack-{skill}/SKILL.md` |
+| Frontmatter | 完整（name、description、allowed-tools、hooks、version） | 最小（僅 name + description） |
+| 路徑 | `~/.claude/skills/gstack` | `~/.codex/skills/gstack` |
+| Hook 技能 | `hooks:` frontmatter（由 Claude 強制執行） | 內嵌安全建議說明（僅供建議） |
+| `/codex` 技能 | 包含（Claude 包裝 codex exec） | 排除（自我參照） |
 
-### Testing Codex output
+### 測試 Codex 輸出
 
 ```bash
-# Run all static tests (includes Codex validation)
+# 執行所有靜態測試（包含 Codex 驗證）
 bun test
 
-# Check freshness for both hosts
+# 檢查兩個主機的新鮮度
 bun run gen:skill-docs --dry-run
 bun run gen:skill-docs --host codex --dry-run
 
-# Health dashboard covers both hosts
+# 健康儀表板涵蓋兩個主機
 bun run skill:check
 ```
 
-### Dev setup for .agents/
+### .agents/ 的開發設定
 
-When you run `bin/dev-setup`, it creates symlinks in both `.claude/skills/` and `.agents/skills/` (if applicable), so Codex-compatible agents can discover your dev skills too.
+當你執行 `bin/dev-setup` 時，它會在 `.claude/skills/` 和 `.agents/skills/`（如果適用）中建立符號連結，讓相容 Codex 的代理人也能發現你的開發技能。
 
-### Adding a new skill
+### 新增新技能
 
-When you add a new skill template, both hosts get it automatically:
-1. Create `{skill}/SKILL.md.tmpl`
-2. Run `bun run gen:skill-docs` (Claude output) and `bun run gen:skill-docs --host codex` (Codex output)
-3. The dynamic template discovery picks it up — no static list to update
-4. Commit both `{skill}/SKILL.md` and `.agents/skills/gstack-{skill}/SKILL.md`
+當你新增一個新的技能模板時，兩個主機都會自動獲得它：
+1. 建立 `{skill}/SKILL.md.tmpl`
+2. 執行 `bun run gen:skill-docs`（Claude 輸出）和 `bun run gen:skill-docs --host codex`（Codex 輸出）
+3. 動態模板發現會自動找到它——不需要更新靜態清單
+4. 提交 `{skill}/SKILL.md` 和 `.agents/skills/gstack-{skill}/SKILL.md` 兩者
 
-## Conductor workspaces
+## Conductor 工作空間
 
-If you're using [Conductor](https://conductor.build) to run multiple Claude Code sessions in parallel, `conductor.json` wires up workspace lifecycle automatically:
+如果你使用 [Conductor](https://conductor.build) 並行執行多個 Claude Code 工作階段，`conductor.json` 會自動連接工作空間生命週期：
 
-| Hook | Script | What it does |
+| Hook | 腳本 | 功能說明 |
 |------|--------|-------------|
-| `setup` | `bin/dev-setup` | Copies `.env` from main worktree, installs deps, symlinks skills |
-| `archive` | `bin/dev-teardown` | Removes skill symlinks, cleans up `.claude/` directory |
+| `setup` | `bin/dev-setup` | 從主要工作樹複製 `.env`，安裝依賴，符號連結技能 |
+| `archive` | `bin/dev-teardown` | 移除技能符號連結，清理 `.claude/` 目錄 |
 
-When Conductor creates a new workspace, `bin/dev-setup` runs automatically. It detects the main worktree (via `git worktree list`), copies your `.env` so API keys carry over, and sets up dev mode — no manual steps needed.
+當 Conductor 建立新工作空間時，`bin/dev-setup` 會自動執行。它偵測主要工作樹（透過 `git worktree list`），複製你的 `.env` 以攜帶 API 金鑰，並設定開發模式——不需要手動步驟。
 
-**First-time setup:** Put your `ANTHROPIC_API_KEY` in `.env` in the main repo (see `.env.example`). Every Conductor workspace inherits it automatically.
+**首次設定：** 將你的 `ANTHROPIC_API_KEY` 放在主要 repo 的 `.env` 中（見 `.env.example`）。每個 Conductor 工作空間都會自動繼承它。
 
-## Things to know
+## 注意事項
 
-- **SKILL.md files are generated.** Edit the `.tmpl` template, not the `.md`. Run `bun run gen:skill-docs` to regenerate.
-- **TODOS.md is the unified backlog.** Organized by skill/component with P0-P4 priorities. `/ship` auto-detects completed items. All planning/review/retro skills read it for context.
-- **Browse source changes need a rebuild.** If you touch `browse/src/*.ts`, run `bun run build`.
-- **Dev mode shadows your global install.** Project-local skills take priority over `~/.claude/skills/gstack`. `bin/dev-teardown` restores the global one.
-- **Conductor workspaces are independent.** Each workspace is its own git worktree. `bin/dev-setup` runs automatically via `conductor.json`.
-- **`.env` propagates across worktrees.** Set it once in the main repo, all Conductor workspaces get it.
-- **`.claude/skills/` is gitignored.** The symlinks never get committed.
+- **SKILL.md 檔案是生成的。** 編輯 `.tmpl` 模板，不要編輯 `.md`。執行 `bun run gen:skill-docs` 以重新生成。
+- **TODOS.md 是統一的待辦清單。** 按技能/元件組織，優先級為 P0-P4。`/ship` 自動偵測已完成的項目。所有規劃/審查/回顧技能都讀取它以獲得上下文。
+- **Browse 原始碼變更需要重新建置。** 如果你觸碰 `browse/src/*.ts`，請執行 `bun run build`。
+- **開發模式會遮蔽你的全域安裝。** 專案本地技能優先於 `~/.claude/skills/gstack`。`bin/dev-teardown` 還原全域安裝。
+- **Conductor 工作空間是獨立的。** 每個工作空間都是自己的 git worktree。`bin/dev-setup` 透過 `conductor.json` 自動執行。
+- **`.env` 在工作樹間傳播。** 在主要 repo 中設定一次，所有 Conductor 工作空間都能獲得它。
+- **`.claude/skills/` 在 gitignore 中。** 符號連結永遠不會被提交。
 
-## Testing your changes in a real project
+## 在真實專案中測試你的變更
 
-**This is the recommended way to develop gstack.** Symlink your gstack checkout
-into the project where you actually use it, so your changes are live while you
-do real work:
+**這是開發 gstack 的推薦方式。** 將你的 gstack checkout 符號連結到你實際使用它的專案中，這樣你的變更在你做真實工作時就是即時的：
 
 ```bash
-# In your core project
+# 在你的核心專案中
 ln -sfn /path/to/your/gstack-checkout .claude/skills/gstack
 cd .claude/skills/gstack && bun install && bun run build
 ```
 
-Now every gstack skill invocation in this project uses your working tree. Edit a
-template, run `bun run gen:skill-docs`, and the next `/review` or `/qa` call picks
-it up immediately.
+現在這個專案中每個 gstack 技能呼叫都使用你的工作樹。編輯模板，執行 `bun run gen:skill-docs`，下一個 `/review` 或 `/qa` 呼叫就立即使用它。
 
-**To go back to the stable global install**, just remove the symlink:
+**要回到穩定的全域安裝**，只需移除符號連結：
 
 ```bash
 rm .claude/skills/gstack
 ```
 
-Claude Code falls back to `~/.claude/skills/gstack/` automatically.
+Claude Code 會自動回退到 `~/.claude/skills/gstack/`。
 
-### Alternative: point your global install at a branch
+### 替代方案：將你的全域安裝指向一個分支
 
-If you don't want per-project symlinks, you can switch the global install:
+如果你不想要每個專案的符號連結，你可以切換全域安裝：
 
 ```bash
 cd ~/.claude/skills/gstack
@@ -340,14 +326,14 @@ git checkout origin/<branch>
 bun install && bun run build
 ```
 
-This affects all projects. To revert: `git checkout main && git pull && bun run build`.
+這會影響所有專案。要恢復：`git checkout main && git pull && bun run build`。
 
-## Shipping your changes
+## 出貨你的變更
 
-When you're happy with your skill edits:
+當你對你的技能編輯感到滿意時：
 
 ```bash
 /ship
 ```
 
-This runs tests, reviews the diff, triages Greptile comments (with 2-tier escalation), manages TODOS.md, bumps the version, and opens a PR. See `ship/SKILL.md` for the full workflow.
+這會執行測試、審查 diff、分類 Greptile 評論（2 層升級）、管理 TODOS.md、升級版本，並開啟 PR。完整工作流程見 `ship/SKILL.md`。

--- a/README.md
+++ b/README.md
@@ -1,244 +1,243 @@
 # gstack
 
-Hi, I'm [Garry Tan](https://x.com/garrytan). I'm President & CEO of [Y Combinator](https://www.ycombinator.com/), where I've worked with thousands of startups including Coinbase, Instacart, and Rippling when the founders were just one or two people in a garage — companies now worth tens of billions of dollars. Before YC, I designed the Palantir logo and was one of the first eng manager/PM/designers there. I cofounded Posterous, a blog platform we sold to Twitter. I built Bookface, YC's internal social network, back in 2013. I've been building products as a designer, PM, and eng manager for a long time.
+嗨，我是 [Garry Tan](https://x.com/garrytan)。我是 [Y Combinator](https://www.ycombinator.com/) 的總裁暨 CEO，在這裡我與數千家新創公司共事過，包括 Coinbase、Instacart 和 Rippling——當時這些公司的創辦人都只是一兩個人在車庫裡打拼，如今卻已成為市值數百億美元的企業。在 YC 之前，我設計了 Palantir 的 logo，並在那裡擔任首批工程主管/PM/設計師之一。我共同創立了 Posterous（一個部落格平台，後來賣給了 Twitter）。我在 2013 年建立了 Bookface，也就是 YC 的內部社群網絡。作為設計師、PM 和工程主管，我建立產品已有很長一段時間了。
 
-And right now I am in the middle of something that feels like a new era entirely.
+而現在，我正身處一個感覺像全新時代的時刻中。
 
-In the last 60 days I have written **over 600,000 lines of production code** — 35% tests — and I am doing **10,000 to 20,000 usable lines of code per day** as a part-time part of my day while doing all my duties as CEO of YC. That is not a typo. My last `/retro` (developer stats from the last 7 days) across 3 projects: **140,751 lines added, 362 commits, ~115k net LOC**. The models are getting dramatically better every week. We are at the dawn of something real — one person shipping at a scale that used to require a team of twenty.
+**過去 60 天，我撰寫了超過 600,000 行正式產品程式碼**——其中 35% 是測試——同時每天在身兼 YC CEO 所有職責的情況下，還能產出 **10,000 到 20,000 行可用程式碼**。這不是筆誤。我上次 `/retro`（過去 7 天的開發者統計，橫跨 3 個專案）：**新增 140,751 行、362 次提交、約 115k 淨程式碼行**。模型每週都在大幅進步。我們正處於某件真實之事的黎明——一個人的產能規模，已能媲美過去需要二十人團隊的水準。
 
-**2026 — 1,237 contributions and counting:**
+**2026 年——1,237 次貢獻，持續增加中：**
 
 ![GitHub contributions 2026 — 1,237 contributions, massive acceleration in Jan-Mar](docs/images/github-2026.png)
 
-**2013 — when I built Bookface at YC (772 contributions):**
+**2013 年——我在 YC 建立 Bookface 時（772 次貢獻）：**
 
 ![GitHub contributions 2013 — 772 contributions building Bookface at YC](docs/images/github-2013.png)
 
-Same person. Different era. The difference is the tooling.
+同一個人。不同的時代。差別在於工具。
 
-**gstack is how I do it.** It is my open source software factory. It turns Claude Code into a virtual engineering team you actually manage — a CEO who rethinks the product, an eng manager who locks the architecture, a designer who catches AI slop, a paranoid reviewer who finds production bugs, a QA lead who opens a real browser and clicks through your app, and a release engineer who ships the PR. Fifteen specialists and six power tools, all as slash commands, all Markdown, **all free, MIT license, available right now.**
+**gstack 是我的做法。** 這是我的開源軟體工廠。它將 Claude Code 轉化為一個你真正能管理的虛擬工程團隊——一位重新思考產品的 CEO、一位鎖定架構的工程主管、一位抓出 AI 濫竽充數的設計師、一位找出正式環境 bug 的偏執審查者、一位開啟真實瀏覽器點選你 app 的 QA 主管，以及一位負責送出 PR 的發布工程師。十五位專家加六種強力工具，全部都是斜線指令，全部都是 Markdown，**全部免費，MIT 授權，現在就可用。**
 
-I am learning how to get to the edge of what agentic systems can do as of March 2026, and this is my live experiment. I am sharing it because I want the whole world on this journey with me.
+我正在學習如何在 2026 年 3 月觸及代理人系統所能做到的邊界，而這就是我的實況實驗。我分享它，是因為我希望全世界都能與我一同踏上這段旅程。
 
-Fork it. Improve it. Make it yours. Don't player hate, appreciate.
+Fork 它。改進它。讓它成為你的工具。不要心存嫉妒，要心懷感激。
 
-**Who this is for:**
-- **Founders and CEOs** — especially technical ones who still want to ship. This is how you build like a team of twenty.
-- **First-time Claude Code users** — gstack is the best way to start. Structured roles instead of a blank prompt.
-- **Tech leads and staff engineers** — bring rigorous review, QA, and release automation to every PR
+**適合哪些人：**
+- **創辦人和 CEO**——尤其是仍想親自出貨的技術型創辦人。這就是你如何以二十人團隊的規模建造產品。
+- **第一次使用 Claude Code 的人**——gstack 是最好的起點。有結構化角色，而不是空白提示詞。
+- **技術主管和資深工程師**——為每個 PR 帶入嚴格的審查、QA 和發布自動化
 
-## Quick start: your first 10 minutes
+## 快速開始：你的前 10 分鐘
 
-1. Install gstack (30 seconds — see below)
-2. Run `/office-hours` — describe what you're building. It will reframe the problem before you write a line of code.
-3. Run `/plan-ceo-review` on any feature idea
-4. Run `/review` on any branch with changes
-5. Run `/qa` on your staging URL
-6. Stop there. You'll know if this is for you.
+1. 安裝 gstack（30 秒——見下方）
+2. 執行 `/office-hours`——描述你在打造什麼。它會在你寫任何程式碼前重新框架這個問題。
+3. 對任何功能想法執行 `/plan-ceo-review`
+4. 對任何有變更的分支執行 `/review`
+5. 對你的 staging URL 執行 `/qa`
+6. 就停在這裡。你會知道這是不是適合你的工具。
 
-Expect first useful run in under 5 minutes on any repo with tests already set up.
+在任何已有測試的 repo 上，預期在 5 分鐘內完成第一次有用的執行。
 
-**If you only read one more section, read this one.**
+**如果你只再讀一個段落，請讀這個。**
 
-## Install — takes 30 seconds
+## 安裝——只需 30 秒
 
-**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+
+**需求：** [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Git](https://git-scm.com/)、[Bun](https://bun.sh/) v1.0+
 
-### Step 1: Install on your machine
+### 第一步：安裝到你的機器
 
-Open Claude Code and paste this. Claude does the rest.
+開啟 Claude Code 並貼上這段指令。Claude 會完成剩下的事。
 
 > Install gstack: run **`git clone https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /retro, /investigate, /document-release, /codex, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade. Then ask the user if they also want to add gstack to the current project so teammates get it.
 
-### Step 2: Add to your repo so teammates get it (optional)
+### 第二步：加入你的 repo，讓隊友也能使用（選用）
 
 > Add gstack to this project: run **`cp -Rf ~/.claude/skills/gstack .claude/skills/gstack && rm -rf .claude/skills/gstack/.git && cd .claude/skills/gstack && ./setup`** then add a "gstack" section to this project's CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /retro, /investigate, /document-release, /codex, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, and tells Claude that if gstack skills aren't working, run `cd .claude/skills/gstack && ./setup` to build the binary and register skills.
 
-Real files get committed to your repo (not a submodule), so `git clone` just works. Everything lives inside `.claude/`. Nothing touches your PATH or runs in the background.
+真實檔案會提交到你的 repo（不是子模組），所以 `git clone` 就可以直接運作。所有東西都在 `.claude/` 裡面。不會碰到你的 PATH，也不會在背景執行。
 
-### Codex, Gemini CLI, or Cursor
+### Codex、Gemini CLI 或 Cursor
 
-gstack works on any agent that supports the [SKILL.md standard](https://github.com/anthropics/claude-code). Skills live in `.agents/skills/` and are discovered automatically.
+gstack 可在任何支援 [SKILL.md 標準](https://github.com/anthropics/claude-code) 的代理人上運作。技能存放在 `.agents/skills/` 並且會自動被發現。
 
 ```bash
 git clone https://github.com/garrytan/gstack.git ~/.codex/skills/gstack
 cd ~/.codex/skills/gstack && ./setup --host codex
 ```
 
-Or let setup auto-detect which agents you have installed:
+或讓 setup 自動偵測你安裝了哪些代理人：
 
 ```bash
 git clone https://github.com/garrytan/gstack.git ~/gstack
 cd ~/gstack && ./setup --host auto
 ```
 
-This installs to `~/.claude/skills/gstack` and/or `~/.codex/skills/gstack` depending on what's available. All 21 skills work across all supported agents. Hook-based safety skills (careful, freeze, guard) use inline safety advisory prose on non-Claude hosts.
+這會根據可用的代理人安裝到 `~/.claude/skills/gstack` 和/或 `~/.codex/skills/gstack`。全部 21 個技能在所有支援的代理人上均可運作。基於 hook 的安全技能（careful、freeze、guard）在非 Claude 主機上使用內嵌安全建議說明。
 
-## See it work
+## 實際效果展示
 
 ```
-You:    I want to build a daily briefing app for my calendar.
-You:    /office-hours
-Claude: [asks about the pain — specific examples, not hypotheticals]
+你:    我想打造一個行事曆的每日摘要 app。
+你:    /office-hours
+Claude: [詢問真實的痛點——具體例子，不是假設]
 
-You:    Multiple Google calendars, events with stale info, wrong locations.
-        Prep takes forever and the results aren't good enough...
+你:    多個 Google 日曆，活動資訊過時、地點錯誤。
+        準備工作花時間但結果不夠好...
 
-Claude: I'm going to push back on the framing. You said "daily briefing
-        app." But what you actually described is a personal chief of
-        staff AI.
-        [extracts 5 capabilities you didn't realize you were describing]
-        [challenges 4 premises — you agree, disagree, or adjust]
-        [generates 3 implementation approaches with effort estimates]
-        RECOMMENDATION: Ship the narrowest wedge tomorrow, learn from
-        real usage. The full vision is a 3-month project — start with
-        the daily briefing that actually works.
-        [writes design doc → feeds into downstream skills automatically]
+Claude: 我要挑戰這個框架。你說「每日摘要 app」。
+        但你實際描述的是一個個人 AI 幕僚長。
+        [提取出 5 個你沒有意識到自己在描述的能力]
+        [挑戰 4 個前提——你同意、不同意或調整]
+        [產生 3 種實作方案及工作量估算]
+        建議：明天先出貨最小化版本，從真實使用中學習。
+        完整願景是 3 個月的專案——先從真正有效的
+        每日摘要開始。
+        [撰寫設計文件 → 自動傳入下游技能]
 
-You:    /plan-ceo-review
-        [reads the design doc, challenges scope, runs 10-section review]
+你:    /plan-ceo-review
+        [讀取設計文件，挑戰範疇，執行 10 區段審查]
 
-You:    /plan-eng-review
-        [ASCII diagrams for data flow, state machines, error paths]
-        [test matrix, failure modes, security concerns]
+你:    /plan-eng-review
+        [資料流、狀態機、錯誤路徑的 ASCII 圖表]
+        [測試矩陣、失效模式、安全疑慮]
 
-You:    Approve plan. Exit plan mode.
-        [writes 2,400 lines across 11 files. ~8 minutes.]
+你:    Approve plan. Exit plan mode.
+        [在 11 個檔案中撰寫 2,400 行。約 8 分鐘。]
 
-You:    /review
-        [AUTO-FIXED] 2 issues. [ASK] Race condition → you approve fix.
+你:    /review
+        [自動修復] 2 個問題。[需確認] 競爭條件 → 你批准修復。
 
-You:    /qa https://staging.myapp.com
-        [opens real browser, clicks through flows, finds and fixes a bug]
+你:    /qa https://staging.myapp.com
+        [開啟真實瀏覽器，點選流程，找到並修復一個 bug]
 
-You:    /ship
-        Tests: 42 → 51 (+9 new). PR: github.com/you/app/pull/42
+你:    /ship
+        測試：42 → 51（+9 個新增）。PR：github.com/you/app/pull/42
 ```
 
-You said "daily briefing app." The agent said "you're building a chief of staff AI" — because it listened to your pain, not your feature request. Then it challenged your premises, generated three approaches, recommended the narrowest wedge, and wrote a design doc that fed into every downstream skill. Eight commands. That is not a copilot. That is a team.
+你說「每日摘要 app」。代理人說「你在打造一個 AI 幕僚長」——因為它聆聽你的痛點，而不是你的功能需求。接著它挑戰你的前提，產生三種方案，建議最小化切入點，並撰寫了一份設計文件，直接傳入每個下游技能。八個指令。這不是副駕駛。這是一個團隊。
 
-## The sprint
+## 衝刺流程
 
-gstack is a process, not a collection of tools. The skills are ordered the way a sprint runs:
+gstack 是一個流程，不只是工具的集合。技能的排序方式就像一個衝刺的運作方式：
 
-**Think → Plan → Build → Review → Test → Ship → Reflect**
+**思考 → 計畫 → 建造 → 審查 → 測試 → 出貨 → 反思**
 
-Each skill feeds into the next. `/office-hours` writes a design doc that `/plan-ceo-review` reads. `/plan-eng-review` writes a test plan that `/qa` picks up. `/review` catches bugs that `/ship` verifies are fixed. Nothing falls through the cracks because every step knows what came before it.
+每個技能都傳入下一個。`/office-hours` 寫的設計文件由 `/plan-ceo-review` 讀取。`/plan-eng-review` 寫的測試計畫由 `/qa` 接手。`/review` 發現的 bug 由 `/ship` 驗證已修復。沒有任何事情會漏掉，因為每個步驟都知道前一個步驟發生了什麼。
 
-One sprint, one person, one feature — that takes about 30 minutes with gstack. But here's what changes everything: you can run 10-15 of these sprints in parallel. Different features, different branches, different agents — all at the same time. That is how I ship 10,000+ lines of production code per day while doing my actual job.
+一個衝刺，一個人，一個功能——使用 gstack 大約需要 30 分鐘。但真正改變一切的是：你可以同時執行 10-15 個這樣的衝刺。不同功能、不同分支、不同代理人——全部同時進行。這就是我每天在做自己本職工作的同時，出貨超過 10,000 行正式產品程式碼的方式。
 
-| Skill | Your specialist | What they do |
+| 技能 | 你的專家 | 他們做什麼 |
 |-------|----------------|--------------|
-| `/office-hours` | **YC Office Hours** | Start here. Six forcing questions that reframe your product before you write code. Pushes back on your framing, challenges premises, generates implementation alternatives. Design doc feeds into every downstream skill. |
-| `/plan-ceo-review` | **CEO / Founder** | Rethink the problem. Find the 10-star product hiding inside the request. Four modes: Expansion, Selective Expansion, Hold Scope, Reduction. |
-| `/plan-eng-review` | **Eng Manager** | Lock in architecture, data flow, diagrams, edge cases, and tests. Forces hidden assumptions into the open. |
-| `/plan-design-review` | **Senior Designer** | Rates each design dimension 0-10, explains what a 10 looks like, then edits the plan to get there. AI Slop detection. Interactive — one AskUserQuestion per design choice. |
-| `/design-consultation` | **Design Partner** | Build a complete design system from scratch. Knows the landscape, proposes creative risks, generates realistic product mockups. Design at the heart of all other phases. |
-| `/review` | **Staff Engineer** | Find the bugs that pass CI but blow up in production. Auto-fixes the obvious ones. Flags completeness gaps. |
-| `/investigate` | **Debugger** | Systematic root-cause debugging. Iron Law: no fixes without investigation. Traces data flow, tests hypotheses, stops after 3 failed fixes. |
-| `/design-review` | **Designer Who Codes** | Same audit as /plan-design-review, then fixes what it finds. Atomic commits, before/after screenshots. |
-| `/qa` | **QA Lead** | Test your app, find bugs, fix them with atomic commits, re-verify. Auto-generates regression tests for every fix. |
-| `/qa-only` | **QA Reporter** | Same methodology as /qa but report only. Use when you want a pure bug report without code changes. |
-| `/ship` | **Release Engineer** | Sync main, run tests, audit coverage, push, open PR. Bootstraps test frameworks if you don't have one. One command. |
-| `/document-release` | **Technical Writer** | Update all project docs to match what you just shipped. Catches stale READMEs automatically. |
-| `/retro` | **Eng Manager** | Team-aware weekly retro. Per-person breakdowns, shipping streaks, test health trends, growth opportunities. |
-| `/browse` | **QA Engineer** | Give the agent eyes. Real Chromium browser, real clicks, real screenshots. ~100ms per command. |
-| `/setup-browser-cookies` | **Session Manager** | Import cookies from your real browser (Chrome, Arc, Brave, Edge) into the headless session. Test authenticated pages. |
+| `/office-hours` | **YC 辦公時間** | 從這裡開始。六個強制性問題，在你寫程式前重新框架你的產品。挑戰你的框架，質疑前提，產生實作替代方案。設計文件傳入每個下游技能。 |
+| `/plan-ceo-review` | **CEO / 創辦人** | 重新思考問題。找出需求中藏著的 10 星產品。四種模式：擴展、選擇性擴展、保持範疇、縮減。 |
+| `/plan-eng-review` | **工程主管** | 確立架構、資料流、圖表、邊界案例和測試。將隱藏的假設逼出來。 |
+| `/plan-design-review` | **資深設計師** | 對每個設計維度評分 0-10，說明 10 分是什麼樣子，然後編輯計畫以達到該標準。AI 濫竽充數偵測。互動式——每個設計決策一個 AskUserQuestion。 |
+| `/design-consultation` | **設計夥伴** | 從零建立完整設計系統。了解市場格局，提出創意冒險，產生逼真的產品模型。設計是所有其他階段的核心。 |
+| `/review` | **資深工程師** | 找出通過 CI 卻在正式環境爆掉的 bug。自動修復明顯的問題。標記完整性缺口。 |
+| `/investigate` | **除錯者** | 系統性根本原因除錯。鐵則：沒有調查就沒有修復。追蹤資料流，測試假設，在 3 次修復失敗後停止。 |
+| `/design-review` | **會寫程式的設計師** | 與 /plan-design-review 相同的審查，然後修復所發現的問題。原子提交，前後截圖對比。 |
+| `/qa` | **QA 主管** | 測試你的 app，找到 bug，用原子提交修復，重新驗證。為每次修復自動產生回歸測試。 |
+| `/qa-only` | **QA 報告者** | 與 /qa 相同的方法，但只有報告。當你想要純粹的 bug 報告而不更動程式碼時使用。 |
+| `/ship` | **發布工程師** | 同步 main，執行測試，審查覆蓋率，推送，開 PR。如果你沒有測試框架，會從零建立一個。一個指令。 |
+| `/document-release` | **技術寫作者** | 更新所有專案文件以符合你剛發布的內容。自動抓出過時的 README。 |
+| `/retro` | **工程主管** | 具有團隊意識的每週回顧。每人細分、出貨連勝、測試健康趨勢、成長機會。 |
+| `/browse` | **QA 工程師** | 給代理人眼睛。真實 Chromium 瀏覽器、真實點擊、真實截圖。每個指令約 100ms。 |
+| `/setup-browser-cookies` | **工作階段管理者** | 從你的真實瀏覽器（Chrome、Arc、Brave、Edge）匯入 Cookie 到無頭工作階段。測試已驗證的頁面。 |
 
-### Power tools
+### 強力工具
 
-| Skill | What it does |
+| 技能 | 功能說明 |
 |-------|-------------|
-| `/codex` | **Second Opinion** — independent code review from OpenAI Codex CLI. Three modes: review (pass/fail gate), adversarial challenge, and open consultation. Cross-model analysis when both `/review` and `/codex` have run. |
-| `/careful` | **Safety Guardrails** — warns before destructive commands (rm -rf, DROP TABLE, force-push). Say "be careful" to activate. Override any warning. |
-| `/freeze` | **Edit Lock** — restrict file edits to one directory. Prevents accidental changes outside scope while debugging. |
-| `/guard` | **Full Safety** — `/careful` + `/freeze` in one command. Maximum safety for prod work. |
-| `/unfreeze` | **Unlock** — remove the `/freeze` boundary. |
-| `/gstack-upgrade` | **Self-Updater** — upgrade gstack to latest. Detects global vs vendored install, syncs both, shows what changed. |
+| `/codex` | **第二意見**——來自 OpenAI Codex CLI 的獨立程式碼審查。三種模式：審查（通過/失敗閘門）、對抗性挑戰，以及開放諮詢。當 `/review` 和 `/codex` 都執行過後，提供跨模型分析。 |
+| `/careful` | **安全護欄**——在執行破壞性指令前警告（rm -rf、DROP TABLE、force-push）。可覆蓋任何警告。啟用方式：說「be careful」。 |
+| `/freeze` | **編輯鎖定**——將檔案編輯限制在一個目錄。在除錯時防止意外更動範圍外的檔案。 |
+| `/guard` | **完整安全**——一個指令啟用 `/careful` + `/freeze`。正式環境作業的最高安全模式。 |
+| `/unfreeze` | **解鎖**——移除 `/freeze` 邊界。 |
+| `/gstack-upgrade` | **自我更新**——升級 gstack 到最新版本。偵測全域或本地安裝，同步兩者，顯示變更內容。 |
 
-**[Deep dives with examples and philosophy for every skill →](docs/skills.md)**
+**[每個技能的深度介紹（含範例與理念） →](docs/skills.md)**
 
-## What's new and why it matters
+## 最新功能及其重要性
 
-**`/office-hours` reframes your product before you write code.** You say "daily briefing app." It listens to your actual pain, pushes back on the framing, tells you you're really building a personal chief of staff AI, challenges your premises, and generates three implementation approaches with effort estimates. The design doc it writes feeds directly into `/plan-ceo-review` and `/plan-eng-review` — so every downstream skill starts with real clarity instead of a vague feature request.
+**`/office-hours` 在你寫程式前重新框架你的產品。** 你說「每日摘要 app」。它聆聽你真實的痛點，挑戰框架，告訴你你真正在打造的是個人 AI 幕僚長，質疑你的前提，並產生三種含工作量估算的實作方案。它撰寫的設計文件直接傳入 `/plan-ceo-review` 和 `/plan-eng-review`——讓每個下游技能從真正的清晰認識開始，而不是一個模糊的功能需求。
 
-**Design is at the heart.** `/design-consultation` doesn't just pick fonts. It researches what's out there in your space, proposes safe choices AND creative risks, generates realistic mockups of your actual product, and writes `DESIGN.md` — and then `/design-review` and `/plan-eng-review` read what you chose. Design decisions flow through the whole system.
+**設計是核心。** `/design-consultation` 不只是挑字體。它研究你所在領域已有什麼，提出安全選擇和創意冒險，產生你實際產品的逼真模型，並撰寫 `DESIGN.md`——然後 `/design-review` 和 `/plan-eng-review` 會讀取你的選擇。設計決策流貫整個系統。
 
-**`/qa` was a massive unlock.** It let me go from 6 to 12 parallel workers. Claude Code saying *"I SEE THE ISSUE"* and then actually fixing it, generating a regression test, and verifying the fix — that changed how I work. The agent has eyes now.
+**`/qa` 是重大突破。** 它讓我從 6 個並行工作者增加到 12 個。Claude Code 說「我看到問題了」，然後真正修復它、產生回歸測試並驗證修復——這改變了我的工作方式。代理人現在有眼睛了。
 
-**Smart review routing.** Just like at a well-run startup: CEO doesn't have to look at infra bug fixes, design review isn't needed for backend changes. gstack tracks what reviews are run, figures out what's appropriate, and just does the smart thing. The Review Readiness Dashboard tells you where you stand before you ship.
+**智慧審查路由。** 就像一個運作良好的新創公司：CEO 不需要看基礎設施 bug 修復，設計審查不需要針對後端變更。gstack 追蹤執行了哪些審查，判斷什麼是合適的，然後做出聰明的決定。審查就緒儀表板告訴你在出貨前的狀態。
 
-**Test everything.** `/ship` bootstraps test frameworks from scratch if your project doesn't have one. Every `/ship` run produces a coverage audit. Every `/qa` bug fix generates a regression test. 100% test coverage is the goal — tests make vibe coding safe instead of yolo coding.
+**測試一切。** `/ship` 如果你的專案沒有測試框架，會從零開始建立。每次 `/ship` 執行都會產生覆蓋率審查。每次 `/qa` 的 bug 修復都會產生回歸測試。100% 測試覆蓋率是目標——測試讓有感覺的程式設計變得安全，而不是任性亂搞。
 
-**`/document-release` is the engineer you never had.** It reads every doc file in your project, cross-references the diff, and updates everything that drifted. README, ARCHITECTURE, CONTRIBUTING, CLAUDE.md, TODOS — all kept current automatically. And now `/ship` auto-invokes it — docs stay current without an extra command.
+**`/document-release` 是你從來沒有的工程師。** 它讀取你專案中的每個文件，交叉對照 diff，並更新所有漂移的內容。README、ARCHITECTURE、CONTRIBUTING、CLAUDE.md、TODOS——全部自動保持最新。而且現在 `/ship` 會自動呼叫它——不需要額外指令，文件就能保持最新。
 
-**Browser handoff when the AI gets stuck.** Hit a CAPTCHA, auth wall, or MFA prompt? `$B handoff` opens a visible Chrome at the exact same page with all your cookies and tabs intact. Solve the problem, tell Claude you're done, `$B resume` picks up right where it left off. The agent even suggests it automatically after 3 consecutive failures.
+**AI 卡住時的瀏覽器交接。** 遇到 CAPTCHA、身份驗證牆或 MFA 提示？`$B handoff` 在完全相同的頁面上開啟可見的 Chrome，帶有所有 Cookie 和分頁。解決問題，告訴 Claude 你完成了，`$B resume` 從中斷的地方繼續。代理人甚至會在連續 3 次失敗後自動建議這個方法。
 
-**Multi-AI second opinion.** `/codex` gets an independent review from OpenAI's Codex CLI — a completely different AI looking at the same diff. Three modes: code review with a pass/fail gate, adversarial challenge that actively tries to break your code, and open consultation with session continuity. When both `/review` (Claude) and `/codex` (OpenAI) have reviewed the same branch, you get a cross-model analysis showing which findings overlap and which are unique to each.
+**多 AI 第二意見。** `/codex` 從 OpenAI 的 Codex CLI 獲得獨立審查——一個完全不同的 AI 看著同一個 diff。三種模式：帶通過/失敗閘門的程式碼審查、積極嘗試破壞你程式碼的對抗性挑戰，以及帶工作階段連續性的開放諮詢。當 `/review`（Claude）和 `/codex`（OpenAI）都審查了同一個分支，你會得到跨模型分析，顯示哪些發現重疊，哪些是各自獨有的。
 
-**Safety guardrails on demand.** Say "be careful" and `/careful` warns before any destructive command — rm -rf, DROP TABLE, force-push, git reset --hard. `/freeze` locks edits to one directory while debugging so Claude can't accidentally "fix" unrelated code. `/guard` activates both. `/investigate` auto-freezes to the module being investigated.
+**隨需安全護欄。** 說「be careful」，`/careful` 會在任何破壞性指令前警告——rm -rf、DROP TABLE、force-push、git reset --hard。`/freeze` 在除錯時將編輯鎖定到一個目錄，這樣 Claude 就不會意外「修復」不相關的程式碼。`/guard` 同時啟用兩者。`/investigate` 自動凍結到正在調查的模組。
 
-**Proactive skill suggestions.** gstack notices what stage you're in — brainstorming, reviewing, debugging, testing — and suggests the right skill. Don't like it? Say "stop suggesting" and it remembers across sessions.
+**主動技能建議。** gstack 注意你所在的階段——腦力激盪、審查、除錯、測試——並建議正確的技能。不喜歡？說「stop suggesting」，它會跨工作階段記住。
 
-## 10-15 parallel sprints
+## 10-15 個並行衝刺
 
-gstack is powerful with one sprint. It is transformative with ten running at once.
+gstack 單獨一個衝刺就很強大。十個同時運行，則具有變革性。
 
-[Conductor](https://conductor.build) runs multiple Claude Code sessions in parallel — each in its own isolated workspace. One session running `/office-hours` on a new idea, another doing `/review` on a PR, a third implementing a feature, a fourth running `/qa` on staging, and six more on other branches. All at the same time. I regularly run 10-15 parallel sprints — that's the practical max right now.
+[Conductor](https://conductor.build) 在並行中執行多個 Claude Code 工作階段——每個都在自己的隔離工作空間中。一個工作階段對新想法執行 `/office-hours`，另一個對 PR 執行 `/review`，第三個實作一個功能，第四個對 staging 執行 `/qa`，還有六個在其他分支上。全部同時進行。我經常執行 10-15 個並行衝刺——這是目前的實際上限。
 
-The sprint structure is what makes parallelism work. Without a process, ten agents is ten sources of chaos. With a process — think, plan, build, review, test, ship — each agent knows exactly what to do and when to stop. You manage them the way a CEO manages a team: check in on the decisions that matter, let the rest run.
+衝刺結構是讓並行運作的關鍵。沒有流程，十個代理人就是十個混亂的來源。有了流程——思考、計畫、建造、審查、測試、出貨——每個代理人確切地知道該做什麼以及何時停止。你管理他們的方式就像 CEO 管理團隊：在重要的決策上跟進，讓其他事情自行運作。
 
 ---
 
-## Come ride the wave
+## 加入浪潮
 
-This is **free, MIT licensed, open source, available now.** No premium tier. No waitlist. No strings.
+這是**免費、MIT 授權、開源、現在就可用。** 沒有付費版本。沒有候補名單。沒有附加條件。
 
-I open sourced how I do development and I am actively upgrading my own software factory here. You can fork it and make it your own. That's the whole point. I want everyone on this journey.
+我開源了我的開發方式，並且在這裡積極升級我自己的軟體工廠。你可以 fork 它並讓它成為你自己的工具。這就是整個重點。我希望每個人都能踏上這段旅程。
 
-Same tools, different outcome — because gstack gives you structured roles and review gates, not generic agent chaos. That governance is the difference between shipping fast and shipping reckless.
+相同的工具，不同的結果——因為 gstack 給你結構化角色和審查閘門，而不是通用的代理人混亂。那種治理結構是快速出貨和魯莽出貨之間的差別。
 
-The models are getting better fast. The people who figure out how to work with them now — really work with them, not just dabble — are going to have a massive advantage. This is that window. Let's go.
+模型進步得很快。那些現在就學會如何與它們合作的人——真正合作，不只是嘗試一下——將會擁有巨大的優勢。這就是那個視窗。我們走吧。
 
-Fifteen specialists and six power tools. All slash commands. All Markdown. All free. **[github.com/garrytan/gstack](https://github.com/garrytan/gstack)** — MIT License
+十五位專家加六種強力工具。全部都是斜線指令。全部都是 Markdown。全部免費。**[github.com/garrytan/gstack](https://github.com/garrytan/gstack)** — MIT 授權
 
-> **We're hiring.** Want to ship 10K+ LOC/day and help harden gstack?
-> Come work at YC — [ycombinator.com/software](https://ycombinator.com/software)
-> Extremely competitive salary and equity. San Francisco, Dogpatch District.
+> **我們正在招募。** 想要每天出貨 10K+ 行程式碼並協助強化 gstack？
+> 來 YC 工作——[ycombinator.com/software](https://ycombinator.com/software)
+> 極具競爭力的薪資和股權。舊金山，Dogpatch District。
 
-## Docs
+## 文件
 
-| Doc | What it covers |
+| 文件 | 涵蓋內容 |
 |-----|---------------|
-| [Skill Deep Dives](docs/skills.md) | Philosophy, examples, and workflow for every skill (includes Greptile integration) |
-| [Architecture](ARCHITECTURE.md) | Design decisions and system internals |
-| [Browser Reference](BROWSER.md) | Full command reference for `/browse` |
-| [Contributing](CONTRIBUTING.md) | Dev setup, testing, contributor mode, and dev mode |
-| [Changelog](CHANGELOG.md) | What's new in every version |
+| [技能深度介紹](docs/skills.md) | 每個技能的理念、範例和工作流程（包含 Greptile 整合） |
+| [架構](ARCHITECTURE.md) | 設計決策和系統內部原理 |
+| [瀏覽器參考](BROWSER.md) | `/browse` 的完整指令參考 |
+| [貢獻指南](CONTRIBUTING.md) | 開發設定、測試、貢獻者模式和開發模式 |
+| [更新日誌](CHANGELOG.md) | 每個版本的新功能 |
 
-## Privacy & Telemetry
+## 隱私與遙測
 
-gstack includes **opt-in** usage telemetry to help improve the project. Here's exactly what happens:
+gstack 包含**選擇性**使用遙測，以協助改進專案。以下是確切的運作方式：
 
-- **Default is off.** Nothing is sent anywhere unless you explicitly say yes.
-- **On first run,** gstack asks if you want to share anonymous usage data. You can say no.
-- **What's sent (if you opt in):** skill name, duration, success/fail, gstack version, OS. That's it.
-- **What's never sent:** code, file paths, repo names, branch names, prompts, or any user-generated content.
-- **Change anytime:** `gstack-config set telemetry off` disables everything instantly.
+- **預設為關閉。** 除非你明確同意，否則不會向任何地方傳送任何資料。
+- **首次執行時，** gstack 會詢問你是否願意分享匿名使用資料。你可以說不。
+- **如果你選擇加入，傳送的內容：** 技能名稱、執行時間、成功/失敗、gstack 版本、作業系統。就這些。
+- **永遠不傳送：** 程式碼、檔案路徑、repo 名稱、分支名稱、提示詞或任何使用者產生的內容。
+- **隨時更改：** `gstack-config set telemetry off` 立即停用一切。
 
-Data is stored in [Supabase](https://supabase.com) (open source Firebase alternative). The schema is in [`supabase/migrations/001_telemetry.sql`](supabase/migrations/001_telemetry.sql) — you can verify exactly what's collected. The Supabase publishable key in the repo is a public key (like a Firebase API key) — row-level security policies restrict it to insert-only access.
+資料儲存在 [Supabase](https://supabase.com)（開源的 Firebase 替代品）。結構描述在 [`supabase/migrations/001_telemetry.sql`](supabase/migrations/001_telemetry.sql)——你可以驗證確切收集了什麼。repo 中的 Supabase 可公開金鑰是公開金鑰（就像 Firebase API 金鑰）——資料列級安全政策將其限制為僅限插入存取。
 
-**Local analytics are always available.** Run `gstack-analytics` to see your personal usage dashboard from the local JSONL file — no remote data needed.
+**本地分析始終可用。** 執行 `gstack-analytics` 從本地 JSONL 檔案查看你的個人使用儀表板——不需要遠端資料。
 
-## Troubleshooting
+## 疑難排解
 
-**Skill not showing up?** `cd ~/.claude/skills/gstack && ./setup`
+**技能沒有出現？** `cd ~/.claude/skills/gstack && ./setup`
 
-**`/browse` fails?** `cd ~/.claude/skills/gstack && bun install && bun run build`
+**`/browse` 失敗？** `cd ~/.claude/skills/gstack && bun install && bun run build`
 
-**Stale install?** Run `/gstack-upgrade` — or set `auto_upgrade: true` in `~/.gstack/config.yaml`
+**安裝過時？** 執行 `/gstack-upgrade`——或在 `~/.gstack/config.yaml` 中設定 `auto_upgrade: true`
 
-**Claude says it can't see the skills?** Make sure your project's `CLAUDE.md` has a gstack section. Add this:
+**Claude 說它看不到技能？** 確保你的專案 `CLAUDE.md` 有一個 gstack 段落。加入這個：
 
 ```
 ## gstack
@@ -249,6 +248,6 @@ Available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-desig
 /freeze, /guard, /unfreeze, /gstack-upgrade.
 ```
 
-## License
+## 授權
 
-MIT. Free forever. Go build something.
+MIT。永久免費。去打造些什麼吧。

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,43 +2,43 @@
 name: gstack
 version: 1.1.0
 description: |
-  Fast headless browser for QA testing and site dogfooding. Navigate any URL, interact with
-  elements, verify page state, diff before/after actions, take annotated screenshots, check
-  responsive layouts, test forms and uploads, handle dialogs, and assert element states.
-  ~100ms per command. Use when you need to test a feature, verify a deployment, dogfood a
-  user flow, or file a bug with evidence.
+  快速無頭瀏覽器，用於 QA 測試和網站試用。可導航任何 URL、與元素互動、
+  驗證頁面狀態、比較操作前後差異、拍攝帶標注的截圖、測試響應式版面、
+  測試表單和上傳、處理對話框，以及斷言元素狀態。
+  每個指令約 100ms。當你需要測試功能、驗證部署、試用使用者流程
+  或附上證據提交 bug 時使用。
 
-  gstack also includes development workflow skills. When you notice the user is at
-  these stages, suggest the appropriate skill:
-  - Brainstorming a new idea → suggest /office-hours
-  - Reviewing a plan (strategy) → suggest /plan-ceo-review
-  - Reviewing a plan (architecture) → suggest /plan-eng-review
-  - Reviewing a plan (design) → suggest /plan-design-review
-  - Creating a design system → suggest /design-consultation
-  - Debugging errors → suggest /investigate
-  - Testing the app → suggest /qa
-  - Code review before merge → suggest /review
-  - Visual design audit → suggest /design-review
-  - Ready to deploy / create PR → suggest /ship
-  - Post-ship doc updates → suggest /document-release
-  - Weekly retrospective → suggest /retro
-  - Wanting a second opinion or adversarial code review → suggest /codex
-  - Working with production or live systems → suggest /careful
-  - Want to scope edits to one module/directory → suggest /freeze
-  - Maximum safety mode (destructive warnings + edit restrictions) → suggest /guard
-  - Removing edit restrictions → suggest /unfreeze
-  - Upgrading gstack to latest version → suggest /gstack-upgrade
+  gstack 也包含開發工作流程技能。當你注意到使用者正在這些階段時，
+  建議適合的技能：
+  - 腦力激盪新想法 → 建議 /office-hours
+  - 審查計畫（策略）→ 建議 /plan-ceo-review
+  - 審查計畫（架構）→ 建議 /plan-eng-review
+  - 審查計畫（設計）→ 建議 /plan-design-review
+  - 建立設計系統 → 建議 /design-consultation
+  - 除錯錯誤 → 建議 /investigate
+  - 測試 app → 建議 /qa
+  - 合併前的程式碼審查 → 建議 /review
+  - 視覺設計審查 → 建議 /design-review
+  - 準備部署/建立 PR → 建議 /ship
+  - 出貨後文件更新 → 建議 /document-release
+  - 每週回顧 → 建議 /retro
+  - 想要第二意見或對抗性程式碼審查 → 建議 /codex
+  - 在正式環境或線上系統工作 → 建議 /careful
+  - 想要將編輯範圍限制在一個模組/目錄 → 建議 /freeze
+  - 最高安全模式（破壞性警告 + 編輯限制）→ 建議 /guard
+  - 移除編輯限制 → 建議 /unfreeze
+  - 升級 gstack 到最新版本 → 建議 /gstack-upgrade
 
-  If the user pushes back on skill suggestions ("stop suggesting things",
-  "I don't need suggestions", "too aggressive"):
-  1. Stop suggesting for the rest of this session
-  2. Run: gstack-config set proactive false
-  3. Say: "Got it — I'll stop suggesting skills. Just tell me to be proactive
-     again if you change your mind."
+  如果使用者拒絕技能建議（「stop suggesting things」、
+  「I don't need suggestions」、「too aggressive」）：
+  1. 在本次工作階段停止建議
+  2. 執行：gstack-config set proactive false
+  3. 說：「Got it — I'll stop suggesting skills. Just tell me to be proactive
+     again if you change your mind.」
 
-  If the user says "be proactive again" or "turn on suggestions":
-  1. Run: gstack-config set proactive true
-  2. Say: "Proactive suggestions are back on."
+  如果使用者說「be proactive again」或「turn on suggestions」：
+  1. 執行：gstack-config set proactive true
+  2. 說：「Proactive suggestions are back on.」
 allowed-tools:
   - Bash
   - Read
@@ -233,14 +233,13 @@ success/error/abort, and `USED_BROWSE` with true/false based on whether `$B` was
 If you cannot determine the outcome, use "unknown". This runs in the background and
 never blocks the user.
 
-If `PROACTIVE` is `false`: do NOT proactively suggest other gstack skills during this session.
-Only run skills the user explicitly invokes. This preference persists across sessions via
-`gstack-config`.
+如果 `PROACTIVE` 是 `false`：在本次工作階段中不要主動建議其他 gstack 技能。
+只執行使用者明確呼叫的技能。此偏好透過 `gstack-config` 跨工作階段持續。
 
-# gstack browse: QA Testing & Dogfooding
+# gstack browse：QA 測試與網站試用
 
-Persistent headless Chromium. First call auto-starts (~3s), then ~100-200ms per command.
-Auto-shuts down after 30 min idle. State persists between calls (cookies, tabs, sessions).
+持久無頭 Chromium。第一次呼叫自動啟動（約 3 秒），之後每個指令約 100-200ms。
+閒置 30 分鐘後自動關閉。呼叫之間狀態持續（Cookie、分頁、工作階段）。
 
 ## SETUP (run this check BEFORE any browse command)
 
@@ -261,100 +260,101 @@ If `NEEDS_SETUP`:
 2. Run: `cd <SKILL_DIR> && ./setup`
 3. If `bun` is not installed: `curl -fsSL https://bun.sh/install | bash`
 
-## IMPORTANT
+## 重要事項
 
-- Use the compiled binary via Bash: `$B <command>`
-- NEVER use `mcp__claude-in-chrome__*` tools. They are slow and unreliable.
-- Browser persists between calls — cookies, login sessions, and tabs carry over.
-- Dialogs (alert/confirm/prompt) are auto-accepted by default — no browser lockup.
-- **Show screenshots:** After `$B screenshot`, `$B snapshot -a -o`, or `$B responsive`, always use the Read tool on the output PNG(s) so the user can see them. Without this, screenshots are invisible.
+- 透過 Bash 使用編譯後的二進位檔：`$B <command>`
+- **絕對不要**使用 `mcp__claude-in-chrome__*` 工具。它們緩慢且不可靠。
+- 瀏覽器在呼叫之間持續——Cookie、登入工作階段和分頁都會延續。
+- 對話框（alert/confirm/prompt）預設自動接受——不會發生瀏覽器鎖定。
+- **顯示截圖：** 執行 `$B screenshot`、`$B snapshot -a -o` 或 `$B responsive` 後，
+  務必對輸出的 PNG 使用 Read 工具，讓使用者能看到截圖。沒有這步驟，截圖是看不見的。
 
-## QA Workflows
+## QA 工作流程
 
-### Test a user flow (login, signup, checkout, etc.)
+### 測試使用者流程（登入、註冊、結帳等）
 
 ```bash
-# 1. Go to the page
+# 1. 前往頁面
 $B goto https://app.example.com/login
 
-# 2. See what's interactive
+# 2. 查看有什麼可互動的
 $B snapshot -i
 
-# 3. Fill the form using refs
+# 3. 使用參考填寫表單
 $B fill @e3 "test@example.com"
 $B fill @e4 "password123"
 $B click @e5
 
-# 4. Verify it worked
-$B snapshot -D              # diff shows what changed after clicking
-$B is visible ".dashboard"  # assert the dashboard appeared
+# 4. 驗證是否成功
+$B snapshot -D              # diff 顯示點擊後的變化
+$B is visible ".dashboard"  # 斷言儀表板出現了
 $B screenshot /tmp/after-login.png
 ```
 
-### Verify a deployment / check prod
+### 驗證部署/檢查正式環境
 
 ```bash
 $B goto https://yourapp.com
-$B text                          # read the page — does it load?
-$B console                       # any JS errors?
-$B network                       # any failed requests?
-$B js "document.title"           # correct title?
-$B is visible ".hero-section"    # key elements present?
+$B text                          # 讀取頁面——它有載入嗎？
+$B console                       # 有 JS 錯誤嗎？
+$B network                       # 有失敗的請求嗎？
+$B js "document.title"           # 標題正確嗎？
+$B is visible ".hero-section"    # 關鍵元素存在嗎？
 $B screenshot /tmp/prod-check.png
 ```
 
-### Dogfood a feature end-to-end
+### 端到端試用功能
 
 ```bash
-# Navigate to the feature
+# 導航到功能
 $B goto https://app.example.com/new-feature
 
-# Take annotated screenshot — shows every interactive element with labels
+# 拍攝帶標注的截圖——顯示每個帶標籤的互動元素
 $B snapshot -i -a -o /tmp/feature-annotated.png
 
-# Find ALL clickable things (including divs with cursor:pointer)
+# 找出所有可點擊的東西（包括帶 cursor:pointer 的 div）
 $B snapshot -C
 
-# Walk through the flow
-$B snapshot -i          # baseline
-$B click @e3            # interact
-$B snapshot -D          # what changed? (unified diff)
+# 逐步執行流程
+$B snapshot -i          # 基準線
+$B click @e3            # 互動
+$B snapshot -D          # 發生了什麼變化？（統一差異）
 
-# Check element states
+# 檢查元素狀態
 $B is visible ".success-toast"
 $B is enabled "#next-step-btn"
 $B is checked "#agree-checkbox"
 
-# Check console for errors after interactions
+# 互動後檢查主控台是否有錯誤
 $B console
 ```
 
-### Test responsive layouts
+### 測試響應式版面
 
 ```bash
-# Quick: 3 screenshots at mobile/tablet/desktop
+# 快速：在手機/平板/桌機三種尺寸截圖
 $B goto https://yourapp.com
 $B responsive /tmp/layout
 
-# Manual: specific viewport
+# 手動：特定視窗尺寸
 $B viewport 375x812     # iPhone
 $B screenshot /tmp/mobile.png
-$B viewport 1440x900    # Desktop
+$B viewport 1440x900    # 桌機
 $B screenshot /tmp/desktop.png
 
-# Element screenshot (crop to specific element)
+# 元素截圖（裁切到特定元素）
 $B screenshot "#hero-banner" /tmp/hero.png
 $B snapshot -i
 $B screenshot @e3 /tmp/button.png
 
-# Region crop
+# 區域裁切
 $B screenshot --clip 0,0,800,600 /tmp/above-fold.png
 
-# Viewport only (no scroll)
+# 僅視窗（不捲動）
 $B screenshot --viewport /tmp/viewport.png
 ```
 
-### Test file upload
+### 測試檔案上傳
 
 ```bash
 $B goto https://app.example.com/upload
@@ -364,59 +364,59 @@ $B is visible ".upload-success"
 $B screenshot /tmp/upload-result.png
 ```
 
-### Test forms with validation
+### 測試帶驗證的表單
 
 ```bash
 $B goto https://app.example.com/form
 $B snapshot -i
 
-# Submit empty — check validation errors appear
-$B click @e10                        # submit button
-$B snapshot -D                       # diff shows error messages appeared
+# 空白提交——檢查驗證錯誤是否出現
+$B click @e10                        # 提交按鈕
+$B snapshot -D                       # diff 顯示錯誤訊息出現了
 $B is visible ".error-message"
 
-# Fill and resubmit
+# 填寫並重新提交
 $B fill @e3 "valid input"
 $B click @e10
-$B snapshot -D                       # diff shows errors gone, success state
+$B snapshot -D                       # diff 顯示錯誤消失了，成功狀態
 ```
 
-### Test dialogs (delete confirmations, prompts)
+### 測試對話框（刪除確認、提示）
 
 ```bash
-# Set up dialog handling BEFORE triggering
-$B dialog-accept              # will auto-accept next alert/confirm
-$B click "#delete-button"     # triggers confirmation dialog
-$B dialog                     # see what dialog appeared
-$B snapshot -D                # verify the item was deleted
+# 在觸發之前設定對話框處理
+$B dialog-accept              # 將自動接受下一個 alert/confirm
+$B click "#delete-button"     # 觸發確認對話框
+$B dialog                     # 查看出現了什麼對話框
+$B snapshot -D                # 驗證項目已刪除
 
-# For prompts that need input
-$B dialog-accept "my answer"  # accept with text
-$B click "#rename-button"     # triggers prompt
+# 對需要輸入的 prompt
+$B dialog-accept "my answer"  # 帶文字接受
+$B click "#rename-button"     # 觸發 prompt
 ```
 
-### Test authenticated pages (import real browser cookies)
+### 測試已驗證的頁面（匯入真實瀏覽器 Cookie）
 
 ```bash
-# Import cookies from your real browser (opens interactive picker)
+# 從你的真實瀏覽器匯入 Cookie（開啟互動式選擇器）
 $B cookie-import-browser
 
-# Or import a specific domain directly
+# 或直接匯入特定域名
 $B cookie-import-browser comet --domain .github.com
 
-# Now test authenticated pages
+# 現在測試已驗證的頁面
 $B goto https://github.com/settings/profile
 $B snapshot -i
 $B screenshot /tmp/github-profile.png
 ```
 
-### Compare two pages / environments
+### 比較兩個頁面/環境
 
 ```bash
 $B diff https://staging.app.com https://prod.app.com
 ```
 
-### Multi-step chain (efficient for long flows)
+### 多步驟鏈（適用於長流程的高效方式）
 
 ```bash
 echo '[
@@ -430,39 +430,39 @@ echo '[
 ]' | $B chain
 ```
 
-## Quick Assertion Patterns
+## 快速斷言模式
 
 ```bash
-# Element exists and is visible
+# 元素存在且可見
 $B is visible ".modal"
 
-# Button is enabled/disabled
+# 按鈕已啟用/已停用
 $B is enabled "#submit-btn"
 $B is disabled "#submit-btn"
 
-# Checkbox state
+# 核取方塊狀態
 $B is checked "#agree"
 
-# Input is editable
+# 輸入框可編輯
 $B is editable "#name-field"
 
-# Element has focus
+# 元素已聚焦
 $B is focused "#search-input"
 
-# Page contains text
+# 頁面包含文字
 $B js "document.body.textContent.includes('Success')"
 
-# Element count
+# 元素計數
 $B js "document.querySelectorAll('.list-item').length"
 
-# Specific attribute value
-$B attrs "#logo"    # returns all attributes as JSON
+# 特定屬性值
+$B attrs "#logo"    # 以 JSON 返回所有屬性
 
-# CSS property
+# CSS 屬性
 $B css ".button" "background-color"
 ```
 
-## Snapshot System
+## 快照系統
 
 The snapshot is your primary tool for understanding and interacting with pages.
 
@@ -499,7 +499,7 @@ $B click @c1       # cursor-interactive ref (from -C)
 
 Refs are invalidated on navigation — run `snapshot` again after `goto`.
 
-## Command Reference
+## 指令參考
 
 ### Navigation
 | Command | Description |
@@ -590,13 +590,13 @@ Refs are invalidated on navigation — run `snapshot` again after `goto`.
 | `status` | Health check |
 | `stop` | Shutdown server |
 
-## Tips
+## 技巧
 
-1. **Navigate once, query many times.** `goto` loads the page; then `text`, `js`, `screenshot` all hit the loaded page instantly.
-2. **Use `snapshot -i` first.** See all interactive elements, then click/fill by ref. No CSS selector guessing.
-3. **Use `snapshot -D` to verify.** Baseline → action → diff. See exactly what changed.
-4. **Use `is` for assertions.** `is visible .modal` is faster and more reliable than parsing page text.
-5. **Use `snapshot -a` for evidence.** Annotated screenshots are great for bug reports.
-6. **Use `snapshot -C` for tricky UIs.** Finds clickable divs that the accessibility tree misses.
-7. **Check `console` after actions.** Catch JS errors that don't surface visually.
-8. **Use `chain` for long flows.** Single command, no per-step CLI overhead.
+1. **導航一次，查詢多次。** `goto` 載入頁面；之後 `text`、`js`、`screenshot` 都立即命中已載入的頁面。
+2. **先用 `snapshot -i`。** 查看所有互動元素，然後透過參考點擊/填寫。不需要猜測 CSS 選擇器。
+3. **用 `snapshot -D` 驗證。** 基準線 → 操作 → 差異。精確看到發生了什麼變化。
+4. **用 `is` 進行斷言。** `is visible .modal` 比解析頁面文字更快、更可靠。
+5. **用 `snapshot -a` 作為證據。** 帶標注的截圖非常適合 bug 報告。
+6. **對棘手的 UI 使用 `snapshot -C`。** 找到無障礙樹遺漏的可點擊 div。
+7. **操作後檢查 `console`。** 捕捉視覺上看不出來的 JS 錯誤。
+8. **對長流程使用 `chain`。** 單一指令，沒有每步驟的 CLI 開銷。

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -2,43 +2,43 @@
 name: gstack
 version: 1.1.0
 description: |
-  Fast headless browser for QA testing and site dogfooding. Navigate any URL, interact with
-  elements, verify page state, diff before/after actions, take annotated screenshots, check
-  responsive layouts, test forms and uploads, handle dialogs, and assert element states.
-  ~100ms per command. Use when you need to test a feature, verify a deployment, dogfood a
-  user flow, or file a bug with evidence.
+  快速無頭瀏覽器，用於 QA 測試和網站試用。可導航任何 URL、與元素互動、
+  驗證頁面狀態、比較操作前後差異、拍攝帶標注的截圖、測試響應式版面、
+  測試表單和上傳、處理對話框，以及斷言元素狀態。
+  每個指令約 100ms。當你需要測試功能、驗證部署、試用使用者流程
+  或附上證據提交 bug 時使用。
 
-  gstack also includes development workflow skills. When you notice the user is at
-  these stages, suggest the appropriate skill:
-  - Brainstorming a new idea → suggest /office-hours
-  - Reviewing a plan (strategy) → suggest /plan-ceo-review
-  - Reviewing a plan (architecture) → suggest /plan-eng-review
-  - Reviewing a plan (design) → suggest /plan-design-review
-  - Creating a design system → suggest /design-consultation
-  - Debugging errors → suggest /investigate
-  - Testing the app → suggest /qa
-  - Code review before merge → suggest /review
-  - Visual design audit → suggest /design-review
-  - Ready to deploy / create PR → suggest /ship
-  - Post-ship doc updates → suggest /document-release
-  - Weekly retrospective → suggest /retro
-  - Wanting a second opinion or adversarial code review → suggest /codex
-  - Working with production or live systems → suggest /careful
-  - Want to scope edits to one module/directory → suggest /freeze
-  - Maximum safety mode (destructive warnings + edit restrictions) → suggest /guard
-  - Removing edit restrictions → suggest /unfreeze
-  - Upgrading gstack to latest version → suggest /gstack-upgrade
+  gstack 也包含開發工作流程技能。當你注意到使用者正在這些階段時，
+  建議適合的技能：
+  - 腦力激盪新想法 → 建議 /office-hours
+  - 審查計畫（策略）→ 建議 /plan-ceo-review
+  - 審查計畫（架構）→ 建議 /plan-eng-review
+  - 審查計畫（設計）→ 建議 /plan-design-review
+  - 建立設計系統 → 建議 /design-consultation
+  - 除錯錯誤 → 建議 /investigate
+  - 測試 app → 建議 /qa
+  - 合併前的程式碼審查 → 建議 /review
+  - 視覺設計審查 → 建議 /design-review
+  - 準備部署/建立 PR → 建議 /ship
+  - 出貨後文件更新 → 建議 /document-release
+  - 每週回顧 → 建議 /retro
+  - 想要第二意見或對抗性程式碼審查 → 建議 /codex
+  - 在正式環境或線上系統工作 → 建議 /careful
+  - 想要將編輯範圍限制在一個模組/目錄 → 建議 /freeze
+  - 最高安全模式（破壞性警告 + 編輯限制）→ 建議 /guard
+  - 移除編輯限制 → 建議 /unfreeze
+  - 升級 gstack 到最新版本 → 建議 /gstack-upgrade
 
-  If the user pushes back on skill suggestions ("stop suggesting things",
-  "I don't need suggestions", "too aggressive"):
-  1. Stop suggesting for the rest of this session
-  2. Run: gstack-config set proactive false
-  3. Say: "Got it — I'll stop suggesting skills. Just tell me to be proactive
-     again if you change your mind."
+  如果使用者拒絕技能建議（「stop suggesting things」、
+  「I don't need suggestions」、「too aggressive」）：
+  1. 在本次工作階段停止建議
+  2. 執行：gstack-config set proactive false
+  3. 說：「Got it — I'll stop suggesting skills. Just tell me to be proactive
+     again if you change your mind.」
 
-  If the user says "be proactive again" or "turn on suggestions":
-  1. Run: gstack-config set proactive true
-  2. Say: "Proactive suggestions are back on."
+  如果使用者說「be proactive again」或「turn on suggestions」：
+  1. 執行：gstack-config set proactive true
+  2. 說：「Proactive suggestions are back on.」
 allowed-tools:
   - Bash
   - Read
@@ -48,111 +48,111 @@ allowed-tools:
 
 {{PREAMBLE}}
 
-If `PROACTIVE` is `false`: do NOT proactively suggest other gstack skills during this session.
-Only run skills the user explicitly invokes. This preference persists across sessions via
-`gstack-config`.
+如果 `PROACTIVE` 是 `false`：在本次工作階段中不要主動建議其他 gstack 技能。
+只執行使用者明確呼叫的技能。此偏好透過 `gstack-config` 跨工作階段持續。
 
-# gstack browse: QA Testing & Dogfooding
+# gstack browse：QA 測試與網站試用
 
-Persistent headless Chromium. First call auto-starts (~3s), then ~100-200ms per command.
-Auto-shuts down after 30 min idle. State persists between calls (cookies, tabs, sessions).
+持久無頭 Chromium。第一次呼叫自動啟動（約 3 秒），之後每個指令約 100-200ms。
+閒置 30 分鐘後自動關閉。呼叫之間狀態持續（Cookie、分頁、工作階段）。
 
 {{BROWSE_SETUP}}
 
-## IMPORTANT
+## 重要事項
 
-- Use the compiled binary via Bash: `$B <command>`
-- NEVER use `mcp__claude-in-chrome__*` tools. They are slow and unreliable.
-- Browser persists between calls — cookies, login sessions, and tabs carry over.
-- Dialogs (alert/confirm/prompt) are auto-accepted by default — no browser lockup.
-- **Show screenshots:** After `$B screenshot`, `$B snapshot -a -o`, or `$B responsive`, always use the Read tool on the output PNG(s) so the user can see them. Without this, screenshots are invisible.
+- 透過 Bash 使用編譯後的二進位檔：`$B <command>`
+- **絕對不要**使用 `mcp__claude-in-chrome__*` 工具。它們緩慢且不可靠。
+- 瀏覽器在呼叫之間持續——Cookie、登入工作階段和分頁都會延續。
+- 對話框（alert/confirm/prompt）預設自動接受——不會發生瀏覽器鎖定。
+- **顯示截圖：** 執行 `$B screenshot`、`$B snapshot -a -o` 或 `$B responsive` 後，
+  務必對輸出的 PNG 使用 Read 工具，讓使用者能看到截圖。沒有這步驟，截圖是看不見的。
 
-## QA Workflows
+## QA 工作流程
 
-### Test a user flow (login, signup, checkout, etc.)
+### 測試使用者流程（登入、註冊、結帳等）
 
 ```bash
-# 1. Go to the page
+# 1. 前往頁面
 $B goto https://app.example.com/login
 
-# 2. See what's interactive
+# 2. 查看有什麼可互動的
 $B snapshot -i
 
-# 3. Fill the form using refs
+# 3. 使用參考填寫表單
 $B fill @e3 "test@example.com"
 $B fill @e4 "password123"
 $B click @e5
 
-# 4. Verify it worked
-$B snapshot -D              # diff shows what changed after clicking
-$B is visible ".dashboard"  # assert the dashboard appeared
+# 4. 驗證是否成功
+$B snapshot -D              # diff 顯示點擊後的變化
+$B is visible ".dashboard"  # 斷言儀表板出現了
 $B screenshot /tmp/after-login.png
 ```
 
-### Verify a deployment / check prod
+### 驗證部署/檢查正式環境
 
 ```bash
 $B goto https://yourapp.com
-$B text                          # read the page — does it load?
-$B console                       # any JS errors?
-$B network                       # any failed requests?
-$B js "document.title"           # correct title?
-$B is visible ".hero-section"    # key elements present?
+$B text                          # 讀取頁面——它有載入嗎？
+$B console                       # 有 JS 錯誤嗎？
+$B network                       # 有失敗的請求嗎？
+$B js "document.title"           # 標題正確嗎？
+$B is visible ".hero-section"    # 關鍵元素存在嗎？
 $B screenshot /tmp/prod-check.png
 ```
 
-### Dogfood a feature end-to-end
+### 端到端試用功能
 
 ```bash
-# Navigate to the feature
+# 導航到功能
 $B goto https://app.example.com/new-feature
 
-# Take annotated screenshot — shows every interactive element with labels
+# 拍攝帶標注的截圖——顯示每個帶標籤的互動元素
 $B snapshot -i -a -o /tmp/feature-annotated.png
 
-# Find ALL clickable things (including divs with cursor:pointer)
+# 找出所有可點擊的東西（包括帶 cursor:pointer 的 div）
 $B snapshot -C
 
-# Walk through the flow
-$B snapshot -i          # baseline
-$B click @e3            # interact
-$B snapshot -D          # what changed? (unified diff)
+# 逐步執行流程
+$B snapshot -i          # 基準線
+$B click @e3            # 互動
+$B snapshot -D          # 發生了什麼變化？（統一差異）
 
-# Check element states
+# 檢查元素狀態
 $B is visible ".success-toast"
 $B is enabled "#next-step-btn"
 $B is checked "#agree-checkbox"
 
-# Check console for errors after interactions
+# 互動後檢查主控台是否有錯誤
 $B console
 ```
 
-### Test responsive layouts
+### 測試響應式版面
 
 ```bash
-# Quick: 3 screenshots at mobile/tablet/desktop
+# 快速：在手機/平板/桌機三種尺寸截圖
 $B goto https://yourapp.com
 $B responsive /tmp/layout
 
-# Manual: specific viewport
+# 手動：特定視窗尺寸
 $B viewport 375x812     # iPhone
 $B screenshot /tmp/mobile.png
-$B viewport 1440x900    # Desktop
+$B viewport 1440x900    # 桌機
 $B screenshot /tmp/desktop.png
 
-# Element screenshot (crop to specific element)
+# 元素截圖（裁切到特定元素）
 $B screenshot "#hero-banner" /tmp/hero.png
 $B snapshot -i
 $B screenshot @e3 /tmp/button.png
 
-# Region crop
+# 區域裁切
 $B screenshot --clip 0,0,800,600 /tmp/above-fold.png
 
-# Viewport only (no scroll)
+# 僅視窗（不捲動）
 $B screenshot --viewport /tmp/viewport.png
 ```
 
-### Test file upload
+### 測試檔案上傳
 
 ```bash
 $B goto https://app.example.com/upload
@@ -162,59 +162,59 @@ $B is visible ".upload-success"
 $B screenshot /tmp/upload-result.png
 ```
 
-### Test forms with validation
+### 測試帶驗證的表單
 
 ```bash
 $B goto https://app.example.com/form
 $B snapshot -i
 
-# Submit empty — check validation errors appear
-$B click @e10                        # submit button
-$B snapshot -D                       # diff shows error messages appeared
+# 空白提交——檢查驗證錯誤是否出現
+$B click @e10                        # 提交按鈕
+$B snapshot -D                       # diff 顯示錯誤訊息出現了
 $B is visible ".error-message"
 
-# Fill and resubmit
+# 填寫並重新提交
 $B fill @e3 "valid input"
 $B click @e10
-$B snapshot -D                       # diff shows errors gone, success state
+$B snapshot -D                       # diff 顯示錯誤消失了，成功狀態
 ```
 
-### Test dialogs (delete confirmations, prompts)
+### 測試對話框（刪除確認、提示）
 
 ```bash
-# Set up dialog handling BEFORE triggering
-$B dialog-accept              # will auto-accept next alert/confirm
-$B click "#delete-button"     # triggers confirmation dialog
-$B dialog                     # see what dialog appeared
-$B snapshot -D                # verify the item was deleted
+# 在觸發之前設定對話框處理
+$B dialog-accept              # 將自動接受下一個 alert/confirm
+$B click "#delete-button"     # 觸發確認對話框
+$B dialog                     # 查看出現了什麼對話框
+$B snapshot -D                # 驗證項目已刪除
 
-# For prompts that need input
-$B dialog-accept "my answer"  # accept with text
-$B click "#rename-button"     # triggers prompt
+# 對需要輸入的 prompt
+$B dialog-accept "my answer"  # 帶文字接受
+$B click "#rename-button"     # 觸發 prompt
 ```
 
-### Test authenticated pages (import real browser cookies)
+### 測試已驗證的頁面（匯入真實瀏覽器 Cookie）
 
 ```bash
-# Import cookies from your real browser (opens interactive picker)
+# 從你的真實瀏覽器匯入 Cookie（開啟互動式選擇器）
 $B cookie-import-browser
 
-# Or import a specific domain directly
+# 或直接匯入特定域名
 $B cookie-import-browser comet --domain .github.com
 
-# Now test authenticated pages
+# 現在測試已驗證的頁面
 $B goto https://github.com/settings/profile
 $B snapshot -i
 $B screenshot /tmp/github-profile.png
 ```
 
-### Compare two pages / environments
+### 比較兩個頁面/環境
 
 ```bash
 $B diff https://staging.app.com https://prod.app.com
 ```
 
-### Multi-step chain (efficient for long flows)
+### 多步驟鏈（適用於長流程的高效方式）
 
 ```bash
 echo '[
@@ -228,53 +228,53 @@ echo '[
 ]' | $B chain
 ```
 
-## Quick Assertion Patterns
+## 快速斷言模式
 
 ```bash
-# Element exists and is visible
+# 元素存在且可見
 $B is visible ".modal"
 
-# Button is enabled/disabled
+# 按鈕已啟用/已停用
 $B is enabled "#submit-btn"
 $B is disabled "#submit-btn"
 
-# Checkbox state
+# 核取方塊狀態
 $B is checked "#agree"
 
-# Input is editable
+# 輸入框可編輯
 $B is editable "#name-field"
 
-# Element has focus
+# 元素已聚焦
 $B is focused "#search-input"
 
-# Page contains text
+# 頁面包含文字
 $B js "document.body.textContent.includes('Success')"
 
-# Element count
+# 元素計數
 $B js "document.querySelectorAll('.list-item').length"
 
-# Specific attribute value
-$B attrs "#logo"    # returns all attributes as JSON
+# 特定屬性值
+$B attrs "#logo"    # 以 JSON 返回所有屬性
 
-# CSS property
+# CSS 屬性
 $B css ".button" "background-color"
 ```
 
-## Snapshot System
+## 快照系統
 
 {{SNAPSHOT_FLAGS}}
 
-## Command Reference
+## 指令參考
 
 {{COMMAND_REFERENCE}}
 
-## Tips
+## 技巧
 
-1. **Navigate once, query many times.** `goto` loads the page; then `text`, `js`, `screenshot` all hit the loaded page instantly.
-2. **Use `snapshot -i` first.** See all interactive elements, then click/fill by ref. No CSS selector guessing.
-3. **Use `snapshot -D` to verify.** Baseline → action → diff. See exactly what changed.
-4. **Use `is` for assertions.** `is visible .modal` is faster and more reliable than parsing page text.
-5. **Use `snapshot -a` for evidence.** Annotated screenshots are great for bug reports.
-6. **Use `snapshot -C` for tricky UIs.** Finds clickable divs that the accessibility tree misses.
-7. **Check `console` after actions.** Catch JS errors that don't surface visually.
-8. **Use `chain` for long flows.** Single command, no per-step CLI overhead.
+1. **導航一次，查詢多次。** `goto` 載入頁面；之後 `text`、`js`、`screenshot` 都立即命中已載入的頁面。
+2. **先用 `snapshot -i`。** 查看所有互動元素，然後透過參考點擊/填寫。不需要猜測 CSS 選擇器。
+3. **用 `snapshot -D` 驗證。** 基準線 → 操作 → 差異。精確看到發生了什麼變化。
+4. **用 `is` 進行斷言。** `is visible .modal` 比解析頁面文字更快、更可靠。
+5. **用 `snapshot -a` 作為證據。** 帶標注的截圖非常適合 bug 報告。
+6. **對棘手的 UI 使用 `snapshot -C`。** 找到無障礙樹遺漏的可點擊 div。
+7. **操作後檢查 `console`。** 捕捉視覺上看不出來的 JS 錯誤。
+8. **對長流程使用 `chain`。** 單一指令，沒有每步驟的 CLI 開銷。

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,204 +1,204 @@
-# Skill Deep Dives
+# 技能深入說明
 
-Detailed guides for every gstack skill — philosophy, workflow, and examples.
+每個 gstack 技能的詳細指南——設計理念、工作流程與使用範例。
 
-| Skill | Your specialist | What they do |
+| 技能 | 你的專家 | 他們的職責 |
 |-------|----------------|--------------|
-| [`/office-hours`](#office-hours) | **YC Office Hours** | Start here. Six forcing questions that reframe your product before you write code. Pushes back on your framing, challenges premises, generates implementation alternatives. Design doc feeds into every downstream skill. |
-| [`/plan-ceo-review`](#plan-ceo-review) | **CEO / Founder** | Rethink the problem. Find the 10-star product hiding inside the request. Four modes: Expansion, Selective Expansion, Hold Scope, Reduction. |
-| [`/plan-eng-review`](#plan-eng-review) | **Eng Manager** | Lock in architecture, data flow, diagrams, edge cases, and tests. Forces hidden assumptions into the open. |
-| [`/plan-design-review`](#plan-design-review) | **Senior Designer** | Interactive plan-mode design review. Rates each dimension 0-10, explains what a 10 looks like, fixes the plan. Works in plan mode. |
-| [`/design-consultation`](#design-consultation) | **Design Partner** | Build a complete design system from scratch. Knows the landscape, proposes creative risks, generates realistic product mockups. Design at the heart of all other phases. |
-| [`/review`](#review) | **Staff Engineer** | Find the bugs that pass CI but blow up in production. Auto-fixes the obvious ones. Flags completeness gaps. |
-| [`/investigate`](#investigate) | **Debugger** | Systematic root-cause debugging. Iron Law: no fixes without investigation. Traces data flow, tests hypotheses, stops after 3 failed fixes. |
-| [`/design-review`](#design-review) | **Designer Who Codes** | Live-site visual audit + fix loop. 80-item audit, then fixes what it finds. Atomic commits, before/after screenshots. |
-| [`/qa`](#qa) | **QA Lead** | Test your app, find bugs, fix them with atomic commits, re-verify. Auto-generates regression tests for every fix. |
-| [`/qa-only`](#qa) | **QA Reporter** | Same methodology as /qa but report only. Use when you want a pure bug report without code changes. |
-| [`/ship`](#ship) | **Release Engineer** | Sync main, run tests, audit coverage, push, open PR. Bootstraps test frameworks if you don't have one. One command. |
-| [`/document-release`](#document-release) | **Technical Writer** | Update all project docs to match what you just shipped. Catches stale READMEs automatically. |
-| [`/retro`](#retro) | **Eng Manager** | Team-aware weekly retro. Per-person breakdowns, shipping streaks, test health trends, growth opportunities. |
-| [`/browse`](#browse) | **QA Engineer** | Give the agent eyes. Real Chromium browser, real clicks, real screenshots. ~100ms per command. |
-| [`/setup-browser-cookies`](#setup-browser-cookies) | **Session Manager** | Import cookies from your real browser (Chrome, Arc, Brave, Edge) into the headless session. Test authenticated pages. |
+| [`/office-hours`](#office-hours) | **YC Office Hours** | 從這裡開始。六個逼出真相的問題，在你寫程式碼之前重新框架你的產品。挑戰你的前提假設，質疑思維框架，產生實作替代方案。設計文件直接串接每個下游技能。 |
+| [`/plan-ceo-review`](#plan-ceo-review) | **CEO / 創辦人** | 重新思考問題。找出藏在需求背後的十星級產品。四種模式：擴展、選擇性擴展、維持範疇、縮減。 |
+| [`/plan-eng-review`](#plan-eng-review) | **工程經理** | 確立架構、資料流、流程圖、邊緣情況與測試。把隱藏的假設逼到檯面上。 |
+| [`/plan-design-review`](#plan-design-review) | **資深設計師** | 互動式計畫模式設計審查。對每個維度評分 0-10，說明 10 分長什麼樣，然後修正計畫。在計畫模式下運作。 |
+| [`/design-consultation`](#design-consultation) | **設計夥伴** | 從零開始建立完整的設計系統。了解全貌，提出有創意的冒險，生成逼真的產品原型。讓設計成為所有其他階段的核心。 |
+| [`/review`](#review) | **Staff 工程師** | 找出通過 CI 卻在生產環境爆炸的 bug。自動修復顯而易見的問題。標記完整性缺口。 |
+| [`/investigate`](#investigate) | **除錯專家** | 系統化的根本原因除錯。鐵律：沒有調查就不修復。追蹤資料流，測試假設，三次修復失敗後停手。 |
+| [`/design-review`](#design-review) | **會寫程式的設計師** | 線上網站視覺審計與修復迴圈。80 項審計，然後修復發現的問題。原子提交，附前後對比截圖。 |
+| [`/qa`](#qa) | **QA 負責人** | 測試你的應用程式，找出 bug，用原子提交修復，再驗證。為每個修復自動生成回歸測試。 |
+| [`/qa-only`](#qa) | **QA 報告員** | 方法論與 /qa 相同，但僅輸出報告。當你只想要純粹的 bug 報告而不希望變更程式碼時使用。 |
+| [`/ship`](#ship) | **發佈工程師** | 同步 main、執行測試、審計覆蓋率、推送、開啟 PR。如果你沒有測試框架，它會幫你建立。一個指令搞定。 |
+| [`/document-release`](#document-release) | **技術作家** | 更新所有專案文件，使其符合你剛剛發佈的內容。自動捕捉過時的 README。 |
+| [`/retro`](#retro) | **工程經理** | 具備團隊意識的每週回顧。逐人分析、出貨連勝紀錄、測試健康趨勢、成長機會。 |
+| [`/browse`](#browse) | **QA 工程師** | 給 AI 代理裝上眼睛。真實的 Chromium 瀏覽器、真實的點擊、真實的截圖。每個指令約 100ms。 |
+| [`/setup-browser-cookies`](#setup-browser-cookies) | **Session 管理員** | 從你的真實瀏覽器（Chrome、Arc、Brave、Edge）匯入 cookies 到無頭 session。測試需要登入的頁面。 |
 | | | |
-| **Multi-AI** | | |
-| [`/codex`](#codex) | **Second Opinion** | Independent review from OpenAI Codex CLI. Three modes: code review (pass/fail gate), adversarial challenge, and open consultation with session continuity. Cross-model analysis when both `/review` and `/codex` have run. |
+| **多 AI** | | |
+| [`/codex`](#codex) | **第二意見** | 來自 OpenAI Codex CLI 的獨立審查。三種模式：程式碼審查（通過/失敗關卡）、對抗性挑戰，以及具有 session 連續性的開放諮詢。當 `/review` 與 `/codex` 都執行過後，進行跨模型分析。 |
 | | | |
-| **Safety & Utility** | | |
-| [`/careful`](#safety--guardrails) | **Safety Guardrails** | Warns before destructive commands (rm -rf, DROP TABLE, force-push, git reset --hard). Override any warning. Common build cleanups whitelisted. |
-| [`/freeze`](#safety--guardrails) | **Edit Lock** | Restrict all file edits to a single directory. Blocks Edit and Write outside the boundary. Accident prevention for debugging. |
-| [`/guard`](#safety--guardrails) | **Full Safety** | Combines /careful + /freeze in one command. Maximum safety for prod work. |
-| [`/unfreeze`](#safety--guardrails) | **Unlock** | Remove the /freeze boundary, allowing edits everywhere again. |
-| [`/gstack-upgrade`](#gstack-upgrade) | **Self-Updater** | Upgrade gstack to the latest version. Detects global vs vendored install, syncs both, shows what changed. |
+| **安全性與實用工具** | | |
+| [`/careful`](#safety--guardrails) | **安全護欄** | 在執行破壞性指令前發出警告（rm -rf、DROP TABLE、force-push、git reset --hard）。可覆蓋任何警告。常見的建置清理操作已列入白名單。 |
+| [`/freeze`](#safety--guardrails) | **編輯鎖定** | 將所有檔案編輯限制在單一目錄內。阻止在邊界外執行 Edit 和 Write。用於除錯時防止意外修改。 |
+| [`/guard`](#safety--guardrails) | **完整安全模式** | 一個指令結合 /careful + /freeze。用於生產環境作業的最高安全等級。 |
+| [`/unfreeze`](#safety--guardrails) | **解除鎖定** | 移除 /freeze 邊界，再次允許在任何地方進行編輯。 |
+| [`/gstack-upgrade`](#gstack-upgrade) | **自我更新器** | 將 gstack 升級至最新版本。偵測全域安裝與 vendored 安裝，同步兩者，顯示變更內容。 |
 
 ---
 
 ## `/office-hours`
 
-This is where every project should start.
+這是每個專案應該開始的地方。
 
-Before you plan, before you review, before you write code — sit down with a YC-style partner and think about what you're actually building. Not what you think you're building. What you're *actually* building.
+在你規劃、審查或寫程式碼之前——先坐下來，與 YC 風格的夥伴一起思考你究竟在打造什麼。不是你以為自己在打造的東西。而是你*實際上*在打造的東西。
 
-### The reframe
+### 重新框架
 
-Here's what happened on a real project. The user said: "I want to build a daily briefing app for my calendar." Reasonable request. Then it asked about the pain — specific examples, not hypotheticals. They described an assistant missing things, calendar items across multiple Google accounts with stale info, prep docs that were AI slop, events with wrong locations that took forever to track down.
+以下是一個真實專案的案例。使用者說：「我想建立一個每日行事曆簡報應用程式。」這是個合理的需求。然後它詢問了痛點——具體的例子，而非假設情境。使用者描述了助理遺漏事項的問題、多個 Google 帳號中的行事曆資訊過時、AI 產出的準備文件品質低落、活動地點錯誤導致花了很長時間確認的情況。
 
-It came back with: *"I'm going to push back on the framing, because I think you've outgrown it. You said 'daily briefing app for multi-Google-Calendar management.' But what you actually described is a personal chief of staff AI."*
+它的回應是：*「我要對這個框架提出質疑，因為我認為你已經超越它了。你說的是『多 Google 行事曆管理的每日簡報應用程式』。但你實際描述的是一個個人首席幕僚 AI。」*
 
-Then it extracted five capabilities the user didn't realize they were describing:
+然後它提取了使用者未曾意識到自己在描述的五項能力：
 
-1. **Watches your calendar** across all accounts and detects stale info, missing locations, permission gaps
-2. **Generates real prep work** — not logistics summaries, but *the intellectual work* of preparing for a board meeting, a podcast, a fundraiser
-3. **Manages your CRM** — who are you meeting, what's the relationship, what do they want, what's the history
-4. **Prioritizes your time** — flags when prep needs to start early, blocks time proactively, ranks events by importance
-5. **Trades money for leverage** — actively looks for ways to delegate or automate
+1. **監看你的行事曆**——跨所有帳號，偵測過時資訊、遺漏地點、權限缺口
+2. **產生真正的準備工作**——不是後勤摘要，而是*智識上的工作*——為董事會會議、播客、募資活動做準備
+3. **管理你的 CRM**——你在見誰、關係如何、他們想要什麼、過去的歷史
+4. **優先排序你的時間**——標記何時需要提前準備、主動封鎖時間、按重要性排列活動
+5. **用金錢換取槓桿**——主動尋找委外或自動化的方式
 
-That reframe changed the entire project. They were about to build a calendar app. Now they're building something ten times more valuable — because the skill listened to their pain instead of their feature request.
+這個重新框架改變了整個專案。他們原本要建立一個行事曆應用程式。現在他們在建立一個價值高出十倍的東西——因為這個技能傾聽的是他們的痛點，而非他們的功能需求。
 
-### Premise challenge
+### 前提挑戰
 
-After the reframe, it presents premises for you to validate. Not "does this sound good?" — actual falsifiable claims about the product:
+重新框架之後，它會呈現前提讓你驗證。不是「這聽起來好嗎？」——而是關於產品的可驗證主張：
 
-1. The calendar is the anchor data source, but the value is in the intelligence layer on top
-2. The assistant doesn't get replaced — they get superpowered
-3. The narrowest wedge is a daily briefing that actually works
-4. CRM integration is a must-have, not a nice-to-have
+1. 行事曆是錨定資料來源，但價值在於其上的智慧層
+2. 助理不會被取代——他們會被賦予超能力
+3. 最窄的切入點是一個真正有效的每日簡報
+4. CRM 整合是必備功能，而非錦上添花
 
-You agree, disagree, or adjust. Every premise you accept becomes load-bearing in the design doc.
+你同意、不同意或調整。你接受的每個前提都會成為設計文件的支柱。
 
-### Implementation alternatives
+### 實作替代方案
 
-Then it generates 2-3 concrete implementation approaches with honest effort estimates:
+然後它會生成 2-3 個具體的實作方案，附上誠實的工時估計：
 
-- **Approach A: Daily Briefing First** — narrowest wedge, ships tomorrow, M effort (human: ~3 weeks / CC: ~2 days)
-- **Approach B: CRM-First** — build the relationship graph first, L effort (human: ~6 weeks / CC: ~4 days)
-- **Approach C: Full Vision** — everything at once, XL effort (human: ~3 months / CC: ~1.5 weeks)
+- **方案 A：每日簡報優先**——最窄切入點，明天就能出貨，M 規模（人工團隊：約 3 週 / CC：約 2 天）
+- **方案 B：CRM 優先**——先建立關係圖譜，L 規模（人工團隊：約 6 週 / CC：約 4 天）
+- **方案 C：完整願景**——一次到位，XL 規模（人工團隊：約 3 個月 / CC：約 1.5 週）
 
-Recommends A because you learn from real usage. CRM data comes naturally in week two.
+推薦方案 A，因為你可以從真實使用中學習。CRM 資料在第二週自然呈現。
 
-### Two modes
+### 兩種模式
 
-**Startup mode** — for founders and intrapreneurs building a business. You get six forcing questions distilled from how YC partners evaluate products: demand reality, status quo, desperate specificity, narrowest wedge, observation & surprise, and future-fit. These questions are uncomfortable on purpose. If you can't name a specific human who needs your product, that's the most important thing to learn before writing any code.
+**新創模式**——適合創辦人和內部創業者，正在打造一門生意。你會得到六個逼出真相的問題，這些問題是從 YC 夥伴評估產品的方式中提煉出來的：需求現實、現狀、迫切的具體性、最窄切入點、觀察與意外、以及未來適配性。這些問題刻意讓你感到不舒服。如果你說不出哪個具體的人需要你的產品，那就是你在寫任何程式碼之前最重要的事情。
 
-**Builder mode** — for hackathons, side projects, open source, learning, and having fun. You get an enthusiastic collaborator who helps you find the coolest version of your idea. What would make someone say "whoa"? What's the fastest path to something you can share? The questions are generative, not interrogative.
+**打造者模式**——適合黑客松、側專案、開源、學習和享受樂趣。你會得到一個熱情的協作夥伴，幫你找出想法中最酷的版本。什麼樣的東西會讓人說「哇」？最快能分享出去的路徑是什麼？這些問題是生成式的，而非審問式的。
 
-### The design doc
+### 設計文件
 
-Both modes end with a design doc written to `~/.gstack/projects/` — and that doc feeds directly into `/plan-ceo-review` and `/plan-eng-review`. The full lifecycle is now: `office-hours → plan → implement → review → QA → ship → retro`.
+兩種模式都以寫入 `~/.gstack/projects/` 的設計文件作結——而那份文件會直接串接到 `/plan-ceo-review` 和 `/plan-eng-review`。完整的生命週期現在是：`office-hours → plan → implement → review → QA → ship → retro`。
 
-After the design doc is approved, `/office-hours` reflects on what it noticed about how you think — not generic praise, but specific callbacks to things you said during the session. The observations appear in the design doc too, so you re-encounter them when you re-read later.
+設計文件獲得批准後，`/office-hours` 會反思它注意到的關於你思維方式的觀察——不是空泛的讚美，而是針對你在 session 中說過的話的具體回饋。這些觀察也會出現在設計文件中，讓你日後重新閱讀時再次遇見它們。
 
 ---
 
 ## `/plan-ceo-review`
 
-This is my **founder mode**.
+這是我的**創辦人模式**。
 
-This is where I want the model to think with taste, ambition, user empathy, and a long time horizon. I do not want it taking the request literally. I want it asking a more important question first:
+這是我希望模型以品味、雄心、使用者同理心和長遠視野來思考的地方。我不希望它照字面接受需求。我希望它先問一個更重要的問題：
 
-**What is this product actually for?**
+**這個產品究竟是為了什麼？**
 
-I think of this as **Brian Chesky mode**.
+我把這稱為 **Brian Chesky 模式**。
 
-The point is not to implement the obvious ticket. The point is to rethink the problem from the user's point of view and find the version that feels inevitable, delightful, and maybe even a little magical.
+重點不在於實作顯而易見的任務。重點在於從使用者的角度重新思考問題，找到那個感覺是必然的、令人愉悅的、甚至有點神奇的版本。
 
-### Example
+### 範例
 
-Say I am building a Craigslist-style listing app and I say:
+假設我在建立一個類似 Craigslist 的分類廣告應用程式，我說：
 
-> "Let sellers upload a photo for their item."
+> 「讓賣家上傳商品照片。」
 
-A weak assistant will add a file picker and save an image.
+一個弱的助理會新增一個檔案選擇器並儲存圖片。
 
-That is not the real product.
+這不是真正的產品。
 
-In `/plan-ceo-review`, I want the model to ask whether "photo upload" is even the feature. Maybe the real feature is helping someone create a listing that actually sells.
+在 `/plan-ceo-review` 中，我希望模型質疑「照片上傳」是否真的是這個功能。也許真正的功能是幫助某人建立一個真正能賣出去的商品清單。
 
-If that is the real job, the whole plan changes.
+如果那才是真正的工作，整個計畫就會改變。
 
-Now the model should ask:
+現在模型應該問：
 
-* Can we identify the product from the photo?
-* Can we infer the SKU or model number?
-* Can we search the web and draft the title and description automatically?
-* Can we pull specs, category, and pricing comps?
-* Can we suggest which photo will convert best as the hero image?
-* Can we detect when the uploaded photo is ugly, dark, cluttered, or low-trust?
-* Can we make the experience feel premium instead of like a dead form from 2007?
+* 我們能從照片中辨識商品嗎？
+* 我們能推斷 SKU 或型號嗎？
+* 我們能搜尋網路並自動起草標題和描述嗎？
+* 我們能抓取規格、分類和競品定價嗎？
+* 我們能建議哪張照片最適合作為主圖嗎？
+* 我們能偵測上傳的照片是否醜陋、昏暗、雜亂或缺乏信任感嗎？
+* 我們能讓這個體驗感覺高端，而不是像 2007 年死氣沉沉的表單嗎？
 
-That is what `/plan-ceo-review` does for me.
+這就是 `/plan-ceo-review` 為我做的事。
 
-It does not just ask, "how do I add this feature?"
-It asks, **"what is the 10-star product hiding inside this request?"**
+它不只是問「我如何新增這個功能？」
+它問的是，**「這個需求背後藏著什麼樣的十星級產品？」**
 
-### Four modes
+### 四種模式
 
-- **SCOPE EXPANSION** — dream big. The agent proposes the ambitious version. Every expansion is presented as an individual decision you opt into. Recommends enthusiastically.
-- **SELECTIVE EXPANSION** — hold your current scope as the baseline, but see what else is possible. The agent surfaces opportunities one by one with neutral recommendations — you cherry-pick the ones worth doing.
-- **HOLD SCOPE** — maximum rigor on the existing plan. No expansions surfaced.
-- **SCOPE REDUCTION** — find the minimum viable version. Cut everything else.
+- **範疇擴展**——大膽夢想。AI 代理提出野心勃勃的版本。每個擴展都作為個別決策呈現，讓你選擇是否加入。充滿熱情地推薦。
+- **選擇性擴展**——以你目前的範疇作為基準，但看看還有什麼可能。AI 代理逐一呈現機會，並給出中立建議——你自己挑選值得做的。
+- **維持範疇**——對現有計畫進行最嚴格的審查。不呈現任何擴展。
+- **範疇縮減**——找到最小可行版本。砍掉其他一切。
 
-Visions and decisions are persisted to `~/.gstack/projects/` so they survive beyond the conversation. Exceptional visions can be promoted to `docs/designs/` in your repo for the team.
+願景和決策會持久保存到 `~/.gstack/projects/`，超越對話存活。傑出的願景可以升格到你的 repo 中的 `docs/designs/`，供團隊共用。
 
 ---
 
 ## `/plan-eng-review`
 
-This is my **eng manager mode**.
+這是我的**工程經理模式**。
 
-Once the product direction is right, I want a different kind of intelligence entirely. I do not want more sprawling ideation. I do not want more "wouldn't it be cool if." I want the model to become my best technical lead.
+一旦產品方向正確，我需要一種完全不同的智慧。我不需要更多天馬行空的創意發散。我不需要更多「如果……那就太酷了」。我希望模型成為我最好的技術負責人。
 
-This mode should nail:
+這個模式應該精準處理：
 
-* architecture
-* system boundaries
-* data flow
-* state transitions
-* failure modes
-* edge cases
-* trust boundaries
-* test coverage
+* 架構
+* 系統邊界
+* 資料流
+* 狀態轉換
+* 失敗模式
+* 邊緣情況
+* 信任邊界
+* 測試覆蓋率
 
-And one surprisingly big unlock for me: **diagrams**.
+還有一個對我來說意想不到的重大突破：**流程圖**。
 
-LLMs get way more complete when you force them to draw the system. Sequence diagrams, state diagrams, component diagrams, data-flow diagrams, even test matrices. Diagrams force hidden assumptions into the open. They make hand-wavy planning much harder.
+強迫 LLM 畫出系統時，它們的完整性會大幅提升。時序圖、狀態圖、元件圖、資料流圖，甚至測試矩陣。流程圖把隱藏的假設逼到檯面上。它們讓含糊的規劃更難發生。
 
-So `/plan-eng-review` is where I want the model to build the technical spine that can carry the product vision.
+所以 `/plan-eng-review` 是我希望模型建立技術支柱的地方，能夠承載產品願景。
 
-### Example
+### 範例
 
-Take the same listing app example.
+以同一個分類廣告應用程式為例。
 
-Let's say `/plan-ceo-review` already did its job. We decided the real feature is not just photo upload. It is a smart listing flow that:
+假設 `/plan-ceo-review` 已經完成了它的工作。我們決定真正的功能不只是照片上傳。而是一個智慧商品清單流程，它能：
 
-* uploads photos
-* identifies the product
-* enriches the listing from the web
-* drafts a strong title and description
-* suggests the best hero image
+* 上傳照片
+* 辨識商品
+* 從網路豐富化商品清單
+* 起草強而有力的標題和描述
+* 建議最佳主圖
 
-Now `/plan-eng-review` takes over.
+現在 `/plan-eng-review` 接手。
 
-Now I want the model to answer questions like:
+現在我希望模型回答以下問題：
 
-* What is the architecture for upload, classification, enrichment, and draft generation?
-* Which steps happen synchronously, and which go to background jobs?
-* Where are the boundaries between app server, object storage, vision model, search/enrichment APIs, and the listing database?
-* What happens if upload succeeds but enrichment fails?
-* What happens if product identification is low-confidence?
-* How do retries work?
-* How do we prevent duplicate jobs?
-* What gets persisted when, and what can be safely recomputed?
+* 上傳、分類、豐富化和起草生成的架構是什麼？
+* 哪些步驟同步執行，哪些進入背景工作？
+* 應用伺服器、物件儲存、視覺模型、搜尋/豐富化 API 和商品清單資料庫之間的邊界在哪裡？
+* 如果上傳成功但豐富化失敗，會發生什麼？
+* 如果商品辨識信心度很低，會發生什麼？
+* 重試機制如何運作？
+* 我們如何防止重複工作？
+* 什麼時候持久化什麼，哪些可以安全地重新計算？
 
-And this is where I want diagrams — architecture diagrams, state models, data-flow diagrams, test matrices. Diagrams force hidden assumptions into the open. They make hand-wavy planning much harder.
+這就是我需要流程圖的地方——架構圖、狀態模型、資料流圖、測試矩陣。流程圖把隱藏的假設逼到檯面上。它們讓含糊的規劃更難發生。
 
-That is `/plan-eng-review`.
+這就是 `/plan-eng-review`。
 
-Not "make the idea smaller."
-**Make the idea buildable.**
+不是「讓想法變小」。
+而是**「讓想法變得可以建造」**。
 
-### Review Readiness Dashboard
+### 審查就緒儀表板
 
-Every review (CEO, Eng, Design) logs its result. At the end of each review, you see a dashboard:
+每次審查（CEO、Eng、Design）都會記錄其結果。在每次審查結束時，你會看到一個儀表板：
 
 ```
 +====================================================================+
@@ -214,27 +214,27 @@ Every review (CEO, Eng, Design) logs its result. At the end of each review, you 
 +====================================================================+
 ```
 
-Eng Review is the only required gate (disable with `gstack-config set skip_eng_review true`). CEO and Design are informational — recommended for product and UI changes respectively.
+Eng Review 是唯一的必要關卡（使用 `gstack-config set skip_eng_review true` 停用）。CEO 和 Design 是資訊性的——分別建議用於產品和 UI 變更。
 
-### Plan-to-QA flow
+### 計畫到 QA 的流程
 
-When `/plan-eng-review` finishes the test review section, it writes a test plan artifact to `~/.gstack/projects/`. When you later run `/qa`, it picks up that test plan automatically — your engineering review feeds directly into QA testing with no manual copy-paste.
+當 `/plan-eng-review` 完成測試審查部分後，它會將測試計畫工件寫入 `~/.gstack/projects/`。之後當你執行 `/qa` 時，它會自動取用那個測試計畫——你的工程審查直接串接到 QA 測試，無需手動複製貼上。
 
 ---
 
 ## `/plan-design-review`
 
-This is my **senior designer reviewing your plan** — before you write a single line of code.
+這是我的**資深設計師在你寫任何一行程式碼之前審查你的計畫**的模式。
 
-Most plans describe what the backend does but never specify what the user actually sees. Empty states? Error states? Loading states? Mobile layout? AI slop risk? These decisions get deferred to "figure it out during implementation" — and then an engineer ships "No items found." as the empty state because nobody specified anything better.
+大多數計畫描述了後端要做什麼，卻從未具體說明使用者實際上看到什麼。空白狀態？錯誤狀態？載入狀態？行動版面？AI 濫用風險？這些決策都被推遲到「實作時再想辦法」——然後工程師把「No items found.」當作空白狀態出貨，因為沒有人指定更好的版本。
 
-`/plan-design-review` catches all of this during planning, when it's cheap to fix.
+`/plan-design-review` 在規劃階段就捕捉這一切，這時修正的成本是最低的。
 
-It works like `/plan-ceo-review` and `/plan-eng-review` — interactive, one issue at a time, with the **STOP + AskUserQuestion** pattern. It rates each design dimension 0-10, explains what a 10 looks like, then edits the plan to get there. The rating drives the work: rate low = lots of fixes, rate high = quick pass.
+它的運作方式與 `/plan-ceo-review` 和 `/plan-eng-review` 相同——互動式、一次處理一個問題，採用 **STOP + AskUserQuestion** 模式。它對每個設計維度評分 0-10，說明 10 分長什麼樣，然後編輯計畫使其達標。評分驅動工作量：分數低 = 大量修復，分數高 = 快速通過。
 
-Seven passes over the plan: information architecture, interaction state coverage, user journey, AI slop risk, design system alignment, responsive/accessibility, and unresolved design decisions. For each pass, it finds gaps and either fixes them directly (obvious ones) or asks you to make a design choice (genuine tradeoffs).
+對計畫進行七個輪次的審查：資訊架構、互動狀態覆蓋率、使用者旅程、AI 濫用風險、設計系統一致性、響應式/無障礙性，以及未解決的設計決策。對於每個輪次，它會找出缺口，然後直接修復（明顯的問題）或請你做出設計選擇（真正的取捨）。
 
-### Example
+### 範例
 
 ```
 You:   /plan-design-review
@@ -267,29 +267,29 @@ Claude: Initial Design Rating: 4/10
          implementation for visual QA."
 ```
 
-When you re-run it, sections already at 8+ get a quick pass. Sections below 8 get full treatment. For live-site visual audits post-implementation, use `/design-review`.
+重新執行時，已達 8 分以上的部分會快速通過。低於 8 分的部分會得到完整處理。針對實作後的線上網站視覺審計，請使用 `/design-review`。
 
 ---
 
 ## `/design-consultation`
 
-This is my **design partner mode**.
+這是我的**設計夥伴模式**。
 
-`/plan-design-review` audits a site that already exists. `/design-consultation` is for when you have nothing yet — no design system, no font choices, no color palette. You are starting from zero and you want a senior designer to sit down with you and build the whole visual identity together.
+`/plan-design-review` 審計已經存在的網站。`/design-consultation` 適用於你完全沒有任何東西的時候——沒有設計系統、沒有字型選擇、沒有色彩調色盤。你從零開始，你希望一位資深設計師坐下來與你一起建立整個視覺識別。
 
-It is a conversation, not a form. The agent asks about your product, your users, and your audience. It thinks about what your product needs to communicate — trust, speed, craft, warmth, whatever fits — and works backward from that to concrete choices. Then it proposes a complete, coherent design system: aesthetic direction, typography (3+ fonts with specific roles), color palette with hex values, spacing scale, layout approach, and motion strategy. Every recommendation comes with a rationale. Every choice reinforces every other choice.
+這是一段對話，而非一張表單。AI 代理詢問你的產品、使用者和受眾。它思考你的產品需要傳達什麼——信任、速度、工藝、溫暖，或任何合適的東西——並從中推導出具體的選擇。然後它提出一個完整、連貫的設計系統：美學方向、字型排版（3 種以上字型，各自有明確角色）、附 hex 值的色彩調色盤、間距比例、版面配置方式以及動態策略。每個建議都附有理由。每個選擇都強化其他選擇。
 
-But coherence is table stakes. Every dev tool dashboard looks the same — clean sans-serif, muted grays, a blue accent. They are all coherent. They are all forgettable. The difference between a product that looks "nice" and one that people actually recognize is the **deliberate creative risks**: the unexpected serif for headings, the bold accent nobody else in your category uses, the tighter spacing that makes your data feel authoritative instead of airy.
+但連貫性只是基本要求。每個開發工具儀表板看起來都一樣——乾淨的無襯線字型、柔和的灰色、藍色強調色。它們都是連貫的。它們都令人忘懷。讓產品看起來「不錯」和讓人真正記住的差異在於**刻意的創意冒險**：出人意料的標題襯線字型、你所在類別中沒有人使用的大膽強調色、讓你的資料感覺更有權威而非空曠飄渺的緊湊間距。
 
-That is what `/design-consultation` is really about. It does not just propose a safe system. It proposes safe choices AND risks — and tells you which is which. "Here are the choices that keep you literate in your category. And here is where I think you should break from convention, and why." You pick which risks to take. The agent checks that the whole system still coheres either way.
+這才是 `/design-consultation` 真正關於的事。它不只是提出一個安全的系統。它提出安全選擇與冒險選擇——並告訴你哪個是哪個。「這些是讓你在你的類別中保持可讀性的選擇。這是我認為你應該打破慣例的地方，以及原因。」你挑選要承擔哪些風險。AI 代理確保無論如何整個系統仍然保持連貫。
 
-If you want, the agent will research what's already out there in your space — take screenshots of real sites, analyze their fonts and colors and spacing — so you can see the landscape before you make choices. This is not about copying. It is about getting in the ballpark so you know what the conventions are, and then deciding which ones are worth breaking.
+如果你想要，AI 代理會研究你的領域中已有什麼——截取真實網站的截圖，分析它們的字型、顏色和間距——讓你在做選擇之前能看到全局。這不是為了模仿。而是為了進入那個範圍，讓你知道慣例是什麼，然後決定哪些值得打破。
 
-After you agree on the system, it generates an interactive HTML preview page — not just swatches and font samples, but realistic product pages. If you are building a dashboard, you see a dashboard with a sidebar, data tables, and stat cards. If you are building a marketing site, you see a hero section with real copy and a CTA. Everything rendered in your design system, with your product name, in light and dark mode. You see what your product could feel like before a single line of production code is written.
+你們對設計系統達成共識後，它會生成一個互動式 HTML 預覽頁面——不只是色票和字型樣本，而是逼真的產品頁面。如果你在建立儀表板，你會看到一個有側邊欄、資料表和統計卡的儀表板。如果你在建立行銷網站，你會看到一個有真實文案和 CTA 的英雄區塊。所有內容都以你的設計系統呈現，使用你的產品名稱，並附有淺色和深色模式。你在寫下任何一行生產程式碼之前，就能感受到你的產品的樣貌。
 
-Then it writes `DESIGN.md` to your repo root — your project's design source of truth — and updates `CLAUDE.md` so every future Claude Code session respects the system. From that point on, `/design-review` can audit against it, and any agent working on your frontend knows the rules.
+然後它會將 `DESIGN.md` 寫入你的 repo 根目錄——你的專案設計真相來源——並更新 `CLAUDE.md`，讓每個未來的 Claude Code session 都遵守這個系統。從那時起，`/design-review` 可以對其進行審計，任何處理你前端的 AI 代理都知道規則。
 
-### Example
+### 範例
 
 ```
 You:   /design-consultation
@@ -358,15 +358,15 @@ Claude: Wrote DESIGN.md (typography, color, spacing, layout, motion).
 
 ## `/design-review`
 
-This is my **designer who codes mode**.
+這是我的**會寫程式的設計師模式**。
 
-`/plan-design-review` reviews your plan before implementation. `/design-review` audits and fixes the live site after.
+`/plan-design-review` 在實作前審查你的計畫。`/design-review` 則是在實作後審計和修復線上網站。
 
-It runs an 80-item visual audit on your live site, then enters a fix loop: for each design finding, it locates the source file, makes the minimal CSS/styling change, commits with `style(design): FINDING-NNN`, re-navigates to verify, and takes before/after screenshots. One commit per fix, fully bisectable.
+它對你的線上網站執行 80 項視覺審計，然後進入修復迴圈：對於每個設計發現，它定位源碼檔案，進行最小化的 CSS/樣式變更，以 `style(design): FINDING-NNN` 提交，重新導航以驗證，並拍攝前後對比截圖。每次修復一個提交，完全可二分法。
 
-The self-regulation heuristic is tuned for design work — CSS-only changes get a free pass (they are inherently safe and reversible), but changes to component JSX/TSX files count against the risk budget. Hard cap at 30 fixes. If the risk score exceeds 20%, it stops and asks.
+自我調節啟發法專為設計工作調整——僅 CSS 的變更可以免費通過（它們本質上是安全且可逆的），但對元件 JSX/TSX 檔案的變更會計入風險預算。修復上限為 30 個。如果風險分數超過 20%，它會停下來詢問。
 
-### Example
+### 範例
 
 ```
 You:   /design-review https://myapp.com
@@ -394,90 +394,90 @@ Claude: [Runs full 80-item visual audit on the live site]
         [Report with before/after screenshots saved to .gstack/design-reports/]
 ```
 
-Nine commits, each touching one concern. The AI Slop score went from D to A because the three most recognizable patterns (gradient hero, 3-column grid, uniform radius) are gone.
+九個提交，每個處理一個問題。AI 濫用分數從 D 升到 A，因為三個最易識別的模式（漸層英雄區塊、三欄格線、統一圓角）都消失了。
 
 ---
 
 ## `/review`
 
-This is my **paranoid staff engineer mode**.
+這是我的**偏執 Staff 工程師模式**。
 
-Passing tests do not mean the branch is safe.
+通過測試不代表分支是安全的。
 
-`/review` exists because there is a whole class of bugs that can survive CI and still punch you in the face in production. This mode is not about dreaming bigger. It is not about making the plan prettier. It is about asking:
+`/review` 的存在是因為有一整類 bug 能夠通過 CI 卻仍然在生產環境爆炸。這個模式不是關於夢想更大的事。它不是關於讓計畫更漂亮。它是在問：
 
-**What can still break?**
+**還有什麼會壞掉？**
 
-This is a structural audit, not a style nitpick pass. I want the model to look for things like:
+這是一個結構性審計，而非風格挑剔式的審查。我希望模型尋找以下這類問題：
 
-* N+1 queries
-* stale reads
-* race conditions
-* bad trust boundaries
-* missing indexes
-* escaping bugs
-* broken invariants
-* bad retry logic
-* tests that pass while missing the real failure mode
-* forgotten enum handlers — add a new status or type constant, and `/review` traces it through every switch statement and allowlist in your codebase, not just the files you changed
+* N+1 查詢
+* 過期讀取
+* 競爭條件
+* 不良的信任邊界
+* 缺少索引
+* 跳脫 bug
+* 破壞的不變量
+* 不良的重試邏輯
+* 通過測試卻遺漏真正失敗模式的測試
+* 被遺忘的枚舉處理器——新增一個新的狀態或類型常數，`/review` 會追蹤它通過你程式碼庫中的每個 switch 語句和允許清單，而不只是你變更的檔案
 
-### Fix-First
+### 先修復
 
-Findings get action, not just listed. Obvious mechanical fixes (dead code, stale comments, N+1 queries) are applied automatically — you see `[AUTO-FIXED] file:line Problem → what was done` for each one. Genuinely ambiguous issues (security, race conditions, design decisions) get surfaced for your call.
+發現的問題會採取行動，而非只是列出清單。明顯的機械式修復（死程式碼、過時注解、N+1 查詢）會自動套用——你會看到每個修復的 `[AUTO-FIXED] file:line Problem → what was done`。真正有爭議的問題（安全性、競爭條件、設計決策）會提交給你做決定。
 
-### Completeness gaps
+### 完整性缺口
 
-`/review` now flags shortcut implementations where the complete version costs less than 30 minutes of CC time. If you chose the 80% solution and the 100% solution is a lake, not an ocean, the review will call it out.
+`/review` 現在會標記快捷實作，當完整版本所需的 CC 時間不到 30 分鐘時。如果你選擇了 80% 的解決方案，而 100% 的解決方案是一個湖泊而非海洋，審查會指出來。
 
-### Example
+### 範例
 
-Suppose the smart listing flow is implemented and the tests are green.
+假設智慧商品清單流程已實作，測試都是綠燈。
 
-`/review` should still ask:
+`/review` 還是應該問：
 
-* Did I introduce an N+1 query when rendering listing photos or draft suggestions?
-* Am I trusting client-provided file metadata instead of validating the actual file?
-* Can two tabs race and overwrite cover-photo selection or item details?
-* Do failed uploads leave orphaned files in storage forever?
-* Can the "exactly one hero image" rule break under concurrency?
-* If enrichment APIs partially fail, do I degrade gracefully or save garbage?
-* Did I accidentally create a prompt injection or trust-boundary problem by pulling web data into draft generation?
+* 當渲染商品清單照片或草稿建議時，我有引入 N+1 查詢嗎？
+* 我是在信任客戶端提供的檔案中繼資料，而非驗證實際檔案嗎？
+* 兩個分頁能競爭並覆寫封面照片選擇或商品詳情嗎？
+* 失敗的上傳會永遠在儲存空間留下孤兒檔案嗎？
+* 「恰好一張主圖」的規則在並發情況下會破壞嗎？
+* 如果豐富化 API 部分失敗，我能優雅降級還是保存垃圾資料？
+* 我是否透過將網路資料引入草稿生成，意外製造了提示注入或信任邊界問題？
 
-That is the point of `/review`.
+這就是 `/review` 的意義。
 
-I do not want flattery here.
-I want the model imagining the production incident before it happens.
+我在這裡不需要奉承。
+我希望模型在生產事故發生之前就想像它。
 
 ---
 
 ## `/investigate`
 
-When something is broken and you don't know why, `/investigate` is your systematic debugger. It follows the Iron Law: **no fixes without root cause investigation first.**
+當某些東西壞了而你不知道為什麼，`/investigate` 是你的系統化除錯員。它遵循鐵律：**沒有根本原因調查就不能修復。**
 
-Instead of guessing and patching, it traces data flow, matches against known bug patterns, and tests hypotheses one at a time. If three fix attempts fail, it stops and questions the architecture instead of thrashing. This prevents the "let me try one more thing" spiral that wastes hours.
+它不是猜測和修補，而是追蹤資料流，與已知的 bug 模式比對，一次測試一個假設。如果三次修復嘗試失敗，它會停下來質疑架構，而不是持續亂試。這防止了浪費數小時的「讓我再試一件事」螺旋。
 
 ---
 
 ## `/qa`
 
-This is my **QA lead mode**.
+這是我的 **QA 負責人模式**。
 
-`/browse` gives the agent eyes. `/qa` gives it a testing methodology.
+`/browse` 給了 AI 代理眼睛。`/qa` 給了它一套測試方法論。
 
-The most common use case: you're on a feature branch, you just finished coding, and you want to verify everything works. Just say `/qa` — it reads your git diff, identifies which pages and routes your changes affect, spins up the browser, and tests each one. No URL required. No manual test plan.
+最常見的使用情境：你在功能分支上，剛寫完程式碼，想驗證一切正常。只要說 `/qa`——它會讀取你的 git diff，識別你的變更影響哪些頁面和路由，啟動瀏覽器，然後逐一測試。不需要 URL。不需要手動測試計畫。
 
-Four modes:
+四種模式：
 
-- **Diff-aware** (automatic on feature branches) — reads `git diff main`, identifies affected pages, tests them specifically
-- **Full** — systematic exploration of the entire app. 5-15 minutes. Documents 5-10 well-evidenced issues.
-- **Quick** (`--quick`) — 30-second smoke test. Homepage + top 5 nav targets.
-- **Regression** (`--regression baseline.json`) — run full mode, then diff against a previous baseline.
+- **差異感知**（在功能分支上自動執行）——讀取 `git diff main`，識別受影響的頁面，針對性地測試它們
+- **完整**——系統性地探索整個應用程式。5-15 分鐘。記錄 5-10 個有充分依據的問題。
+- **快速**（`--quick`）——30 秒的冒煙測試。首頁 + 前 5 個導航目標。
+- **回歸**（`--regression baseline.json`）——執行完整模式，然後與之前的基準比對。
 
-### Automatic regression tests
+### 自動回歸測試
 
-When `/qa` fixes a bug and verifies it, it automatically generates a regression test that catches the exact scenario that broke. Tests include full attribution tracing back to the QA report.
+當 `/qa` 修復一個 bug 並驗證後，它會自動生成一個回歸測試，能夠捕捉導致問題的確切情境。測試包含完整的歸因追蹤，指向 QA 報告。
 
-### Example
+### 範例
 
 ```
 You:   /qa https://staging.myapp.com
@@ -494,41 +494,41 @@ Claude: [Explores 12 pages, fills 3 forms, tests 2 flows]
         [Full report with screenshots saved to .gstack/qa-reports/]
 ```
 
-**Testing authenticated pages:** Use `/setup-browser-cookies` first to import your real browser sessions, then `/qa` can test pages behind login.
+**測試需要登入的頁面：** 先使用 `/setup-browser-cookies` 匯入你的真實瀏覽器 session，然後 `/qa` 就能測試登入後的頁面。
 
 ---
 
 ## `/ship`
 
-This is my **release machine mode**.
+這是我的**發佈機器模式**。
 
-Once I have decided what to build, nailed the technical plan, and run a serious review, I do not want more talking. I want execution.
+一旦我決定了要建立什麼、確定了技術計畫、進行了嚴肅的審查，我就不想再多說廢話了。我要執行。
 
-`/ship` is for the final mile. It is for a ready branch, not for deciding what to build.
+`/ship` 是最後一哩路。它適用於已就緒的分支，而非決定要建立什麼。
 
-This is where the model should stop behaving like a brainstorm partner and start behaving like a disciplined release engineer: sync with main, run the right tests, make sure the branch state is sane, update changelog or versioning if the repo expects it, push, and create or update the PR.
+這是模型應該停止表現得像腦力激盪夥伴，開始表現得像紀律嚴明的發佈工程師的地方：與 main 同步、執行正確的測試、確保分支狀態正常、更新 changelog 或 versioning（如果 repo 有需要）、推送並建立或更新 PR。
 
-### Test bootstrap
+### 測試框架自動建立
 
-If your project doesn't have a test framework, `/ship` sets one up — detects your runtime, researches the best framework, installs it, writes 3-5 real tests for your actual code, sets up CI/CD (GitHub Actions), and creates TESTING.md. 100% test coverage is the goal — tests make vibe coding safe instead of yolo coding.
+如果你的專案沒有測試框架，`/ship` 會幫你建立一個——偵測你的執行環境、研究最佳框架、安裝它、為你的實際程式碼編寫 3-5 個真實測試、設置 CI/CD（GitHub Actions），並建立 TESTING.md。100% 測試覆蓋率是目標——測試讓氛圍式撰碼變得安全，而非亂槍打鳥式撰碼。
 
-### Coverage audit
+### 覆蓋率審計
 
-Every `/ship` run builds a code path map from your diff, searches for corresponding tests, and produces an ASCII coverage diagram with quality stars. Gaps get tests auto-generated. Your PR body shows the coverage: `Tests: 42 → 47 (+5 new)`.
+每次 `/ship` 執行都會從你的 diff 建立一個程式碼路徑圖，搜尋對應的測試，並產生附有品質星級的 ASCII 覆蓋率圖。缺口會自動生成測試。你的 PR 主體顯示覆蓋率：`Tests: 42 → 47 (+5 new)`。
 
-### Review gate
+### 審查關卡
 
-`/ship` checks the [Review Readiness Dashboard](#review-readiness-dashboard) before creating the PR. If the Eng Review is missing, it asks — but won't block you. Decisions are saved per-branch so you're never re-asked.
+`/ship` 在建立 PR 之前會檢查[審查就緒儀表板](#review-readiness-dashboard)。如果缺少 Eng Review，它會詢問——但不會阻止你。決策按分支儲存，所以你不會被重複詢問。
 
-A lot of branches die when the interesting work is done and only the boring release work is left. Humans procrastinate that part. AI should not.
+很多分支在有趣的工作完成後就死去了，因為只剩下無聊的發佈工作。人類會拖延那個部分。AI 不應該。
 
 ---
 
 ## `/document-release`
 
-This is my **technical writer mode**.
+這是我的**技術作家模式**。
 
-After `/ship` creates the PR but before it merges, `/document-release` reads every documentation file in the project and cross-references it against the diff. It updates file paths, command lists, project structure trees, and anything else that drifted. Risky or subjective changes get surfaced as questions — everything else is handled automatically.
+在 `/ship` 建立 PR 之後，但在合併之前，`/document-release` 會讀取專案中的每個文件檔案，並與 diff 進行交叉比對。它更新檔案路徑、指令列表、專案結構樹，以及任何其他出現偏差的內容。有風險或主觀的變更會作為問題提出——其他一切都自動處理。
 
 ```
 You:   /document-release
@@ -543,21 +543,21 @@ Claude: Analyzing 21 files changed across 3 commits. Found 8 documentation files
         All docs updated and committed. PR body updated with doc diff.
 ```
 
-It also polishes CHANGELOG voice (without ever overwriting entries), cleans up completed TODOS, checks cross-doc consistency, and asks about VERSION bumps only when appropriate.
+它也會潤色 CHANGELOG 的語氣（從不覆寫現有條目）、清理已完成的 TODOS、檢查跨文件一致性，並在適當時詢問 VERSION 升版的問題。
 
 ---
 
 ## `/retro`
 
-This is my **engineering manager mode**.
+這是我的**工程經理模式**。
 
-At the end of the week I want to know what actually happened. Not vibes — data. `/retro` analyzes commit history, work patterns, and shipping velocity and writes a candid retrospective.
+在週末我想知道實際發生了什麼。不是感覺——是資料。`/retro` 分析提交歷史、工作模式和出貨速度，並撰寫一份坦誠的回顧。
 
-It is team-aware. It identifies who is running the command, gives you the deepest treatment on your own work, then breaks down every contributor with specific praise and growth opportunities. It computes metrics like commits, LOC, test ratio, PR sizes, and fix ratio. It detects coding sessions from commit timestamps, finds hotspot files, tracks shipping streaks, and identifies the biggest ship of the week.
+它具有團隊意識。它識別執行指令的人，對你自己的工作給予最深入的處理，然後對每位貢獻者進行具體的讚美和成長機會分析。它計算提交數、程式碼行數、測試比率、PR 大小和修復比率等指標。它從提交時間戳記偵測撰碼 session，找出熱點檔案，追蹤出貨連勝，並識別當週最大的出貨。
 
-It also tracks test health: total test files, tests added this period, regression test commits, and trend deltas. If test ratio drops below 20%, it flags it as a growth area.
+它也追蹤測試健康狀況：測試檔案總數、本期新增的測試、回歸測試提交以及趨勢增減。如果測試比率低於 20%，它會標記為成長領域。
 
-### Example
+### 範例
 
 ```
 You:   /retro
@@ -583,19 +583,19 @@ Claude: Week of Mar 1: 47 commits (3 contributors), 3.2k LOC, 38% tests, 12 PRs,
         [Top 3 team wins, 3 things to improve, 3 habits for next week]
 ```
 
-It saves a JSON snapshot to `.context/retros/` so the next run can show trends.
+它會將 JSON 快照儲存到 `.context/retros/`，讓下次執行時能顯示趨勢。
 
 ---
 
 ## `/browse`
 
-This is my **QA engineer mode**.
+這是我的 **QA 工程師模式**。
 
-`/browse` is the skill that closes the loop. Before it, the agent could think and code but was still half blind. It had to guess about UI state, auth flows, redirects, console errors, empty states, and broken layouts. Now it can just go look.
+`/browse` 是閉合迴圈的技能。在它出現之前，AI 代理能思考和撰寫程式碼，但仍是半盲的。它必須猜測 UI 狀態、身份驗證流程、重定向、主控台錯誤、空白狀態和破損版面。現在它可以直接去看。
 
-It is a compiled binary that talks to a persistent Chromium daemon — built on [Playwright](https://playwright.dev/) by Microsoft. First call starts the browser (~3s). Every call after that: ~100-200ms. The browser stays running between commands, so cookies, tabs, and localStorage carry over.
+它是一個與持久化 Chromium 常駐程式通訊的編譯二進位——建立在 Microsoft 的 [Playwright](https://playwright.dev/) 之上。第一次呼叫啟動瀏覽器（約 3 秒）。之後每次呼叫：約 100-200ms。瀏覽器在指令之間保持運行，因此 cookies、分頁和 localStorage 會延續。
 
-### Example
+### 範例
 
 ```
 You:   /browse staging.myapp.com — log in, test the signup flow, and check
@@ -624,11 +624,11 @@ Claude: [18 tool calls, ~60 seconds]
         Signup → onboarding → dashboard flow works end to end.
 ```
 
-18 tool calls, about a minute. Full QA pass. No browser opened.
+18 個工具呼叫，約一分鐘。完整的 QA 通過。沒有開啟瀏覽器。
 
-### Browser handoff
+### 瀏覽器交接
 
-When the headless browser gets stuck — CAPTCHA, MFA, complex auth — hand off to the user:
+當無頭瀏覽器卡住時——CAPTCHA、MFA、複雜的身份驗證——交接給使用者：
 
 ```
 Claude: I'm stuck on a CAPTCHA at the login page. Opening a visible
@@ -647,21 +647,21 @@ Claude: > browse resume
         Got a fresh snapshot. Logged in successfully. Continuing QA.
 ```
 
-The browser preserves all state (cookies, localStorage, tabs) across the handoff. After `resume`, the agent gets a fresh snapshot of wherever you left off. If the browse tool fails 3 times in a row, it automatically suggests using `handoff`.
+瀏覽器在交接過程中保留所有狀態（cookies、localStorage、分頁）。`resume` 之後，AI 代理會獲得你離開位置的最新快照。如果 browse 工具連續失敗 3 次，它會自動建議使用 `handoff`。
 
-**Security note:** `/browse` runs a persistent Chromium session. Cookies, localStorage, and session state carry over between commands. Do not use it against sensitive production environments unless you intend to — it is a real browser with real state. The session auto-shuts down after 30 minutes of idle time.
+**安全注意事項：** `/browse` 執行一個持久化的 Chromium session。Cookies、localStorage 和 session 狀態在指令之間會延續。除非你有意這樣做，否則不要針對敏感的生產環境使用它——它是一個有真實狀態的真實瀏覽器。Session 在閒置 30 分鐘後自動關閉。
 
-For the full command reference, see [BROWSER.md](../BROWSER.md).
+完整的指令參考，請參見 [BROWSER.md](../BROWSER.md)。
 
 ---
 
 ## `/setup-browser-cookies`
 
-This is my **session manager mode**.
+這是我的 **Session 管理員模式**。
 
-Before `/qa` or `/browse` can test authenticated pages, they need cookies. Instead of manually logging in through the headless browser every time, `/setup-browser-cookies` imports your real sessions directly from your daily browser.
+在 `/qa` 或 `/browse` 能測試需要登入的頁面之前，它們需要 cookies。`/setup-browser-cookies` 不需要每次都透過無頭瀏覽器手動登入，而是直接從你的日常瀏覽器匯入你的真實 session。
 
-It auto-detects installed Chromium browsers (Comet, Chrome, Arc, Brave, Edge), decrypts cookies via the macOS Keychain, and loads them into the Playwright session. An interactive picker UI lets you choose exactly which domains to import — no cookie values are ever displayed.
+它自動偵測已安裝的 Chromium 瀏覽器（Comet、Chrome、Arc、Brave、Edge），透過 macOS Keychain 解密 cookies，並將它們載入 Playwright session。互動式選擇器 UI 讓你精確選擇要匯入哪些網域——cookie 值永遠不會顯示。
 
 ```
 You:   /setup-browser-cookies
@@ -676,7 +676,7 @@ You:    done
 Claude: Imported 2 domains (47 cookies). Session is ready.
 ```
 
-Or skip the UI entirely:
+或完全跳過 UI：
 
 ```
 You:   /setup-browser-cookies github.com
@@ -688,21 +688,21 @@ Claude: Imported 12 cookies for github.com from Comet.
 
 ## `/codex`
 
-This is my **second opinion mode**.
+這是我的**第二意見模式**。
 
-When `/review` catches bugs from Claude's perspective, `/codex` brings a completely different AI — OpenAI's Codex CLI — to review the same diff. Different training, different blind spots, different strengths. The overlap tells you what's definitely real. The unique findings from each are where you find the bugs neither would catch alone.
+當 `/review` 從 Claude 的角度捕捉 bug 時，`/codex` 帶來一個完全不同的 AI——OpenAI 的 Codex CLI——來審查同一個 diff。不同的訓練、不同的盲點、不同的優勢。兩者的重疊告訴你什麼肯定是真實的。每個獨有的發現是你找到任何一方單獨都抓不到的 bug 的地方。
 
-### Three modes
+### 三種模式
 
-**Review** — run `codex review` against the current diff. Codex reads every changed file, classifies findings by severity (P1 critical, P2 high, P3 medium), and returns a PASS/FAIL verdict. Any P1 finding = FAIL. The review is fully independent — Codex doesn't see Claude's review.
+**審查**——對當前 diff 執行 `codex review`。Codex 讀取每個變更的檔案，按嚴重程度分類發現（P1 嚴重、P2 高、P3 中），並返回 PASS/FAIL 判決。任何 P1 發現 = FAIL。審查完全獨立——Codex 看不到 Claude 的審查。
 
-**Challenge** — adversarial mode. Codex actively tries to break your code. It looks for edge cases, race conditions, security holes, and assumptions that would fail under load. Uses maximum reasoning effort (`xhigh`). Think of it as a penetration test for your logic.
+**挑戰**——對抗模式。Codex 主動嘗試破壞你的程式碼。它尋找邊緣情況、競爭條件、安全漏洞，以及在負載下會失敗的假設。使用最大推理力度（`xhigh`）。把它想成是對你的邏輯進行滲透測試。
 
-**Consult** — open conversation with session continuity. Ask Codex anything about the codebase. Follow-up questions reuse the same session, so context carries over. Great for "am I thinking about this correctly?" moments.
+**諮詢**——具有 session 連續性的開放對話。詢問 Codex 任何關於程式碼庫的問題。後續問題重用同一個 session，因此上下文會延續。非常適合「我這樣想是對的嗎？」的時刻。
 
-### Cross-model analysis
+### 跨模型分析
 
-When both `/review` (Claude) and `/codex` (OpenAI) have reviewed the same branch, you get a cross-model comparison: which findings overlap (high confidence), which are unique to Codex (different perspective), and which are unique to Claude. This is the "two doctors, same patient" approach to code review.
+當 `/review`（Claude）和 `/codex`（OpenAI）都審查了同一個分支後，你會得到一個跨模型比較：哪些發現重疊（高信心度）、哪些是 Codex 獨有的（不同視角），以及哪些是 Claude 獨有的。這是對程式碼審查採取「兩位醫生，同一個病患」的方法。
 
 ```
 You:   /codex review
@@ -723,31 +723,31 @@ Claude: Running independent Codex review...
 
 ---
 
-## Safety & Guardrails
+## 安全性與護欄
 
-Four skills that add safety rails to any Claude Code session. They work via Claude Code's PreToolUse hooks — transparent, session-scoped, no configuration files.
+四個技能，為任何 Claude Code session 添加安全護欄。它們透過 Claude Code 的 PreToolUse hooks 運作——透明、session 範疇、無需配置檔案。
 
 ### `/careful`
 
-Say "be careful" or run `/careful` when you're working near production, running destructive commands, or just want a safety net. Every Bash command gets checked against known-dangerous patterns:
+當你在生產環境附近工作、執行破壞性指令，或只是想要一個安全網時，說「be careful」或執行 `/careful`。每個 Bash 指令都會根據已知的危險模式進行檢查：
 
-- `rm -rf` / `rm -r` — recursive delete
-- `DROP TABLE` / `DROP DATABASE` / `TRUNCATE` — data loss
-- `git push --force` / `git push -f` — history rewrite
-- `git reset --hard` — discard commits
-- `git checkout .` / `git restore .` — discard uncommitted work
-- `kubectl delete` — production resource deletion
-- `docker rm -f` / `docker system prune` — container/image loss
+- `rm -rf` / `rm -r`——遞迴刪除
+- `DROP TABLE` / `DROP DATABASE` / `TRUNCATE`——資料遺失
+- `git push --force` / `git push -f`——歷史覆寫
+- `git reset --hard`——丟棄提交
+- `git checkout .` / `git restore .`——丟棄未提交的工作
+- `kubectl delete`——生產資源刪除
+- `docker rm -f` / `docker system prune`——容器/映像遺失
 
-Common build artifact cleanups (`rm -rf node_modules`, `dist`, `.next`, `__pycache__`, `build`, `coverage`) are whitelisted — no false alarms on routine operations.
+常見的建置工件清理（`rm -rf node_modules`、`dist`、`.next`、`__pycache__`、`build`、`coverage`）已列入白名單——日常操作不會有誤報。
 
-You can override any warning. The guardrails are accident prevention, not access control.
+你可以覆蓋任何警告。護欄是防止意外，而非存取控制。
 
 ### `/freeze`
 
-Restrict all file edits to a single directory. When you're debugging a billing bug, you don't want Claude accidentally "fixing" unrelated code in `src/auth/`. `/freeze src/billing` blocks all Edit and Write operations outside that path.
+將所有檔案編輯限制在單一目錄內。當你在除錯帳單 bug 時，你不希望 Claude 意外地「修復」`src/auth/` 中不相關的程式碼。`/freeze src/billing` 阻止所有在該路徑外的 Edit 和 Write 操作。
 
-`/investigate` activates this automatically — it detects the module being debugged and freezes edits to that directory.
+`/investigate` 會自動啟動這個功能——它偵測被除錯的模組，並將編輯凍結在那個目錄。
 
 ```
 You:   /freeze src/billing
@@ -760,21 +760,21 @@ Claude: BLOCKED — Edit outside freeze boundary (src/billing/).
         Skipping this change.
 ```
 
-Note: this blocks Edit and Write tools only. Bash commands like `sed` can still modify files outside the boundary — it's accident prevention, not a security sandbox.
+注意：這只阻止 Edit 和 Write 工具。像 `sed` 這樣的 Bash 指令仍然可以修改邊界外的檔案——這是防止意外，而非安全沙箱。
 
 ### `/guard`
 
-Full safety mode — combines `/careful` + `/freeze` in one command. Destructive command warnings plus directory-scoped edits. Use when touching prod or debugging live systems.
+完整安全模式——一個指令結合 `/careful` + `/freeze`。破壞性指令警告加上目錄範疇的編輯。在接觸生產環境或除錯線上系統時使用。
 
 ### `/unfreeze`
 
-Remove the `/freeze` boundary, allowing edits everywhere again. The hooks stay registered for the session — they just allow everything. Run `/freeze` again to set a new boundary.
+移除 `/freeze` 邊界，再次允許在任何地方進行編輯。hooks 在 session 中保持已登錄狀態——它們只是允許一切。重新執行 `/freeze` 以設定新的邊界。
 
 ---
 
 ## `/gstack-upgrade`
 
-Keep gstack current with one command. It detects your install type (global at `~/.claude/skills/gstack` vs vendored in your project at `.claude/skills/gstack`), runs the upgrade, syncs both copies if you have dual installs, and shows you what changed.
+一個指令讓 gstack 保持最新。它偵測你的安裝類型（全域在 `~/.claude/skills/gstack` 還是 vendored 在你的專案的 `.claude/skills/gstack`），執行升級，如果你有雙重安裝則同步兩者，並顯示變更內容。
 
 ```
 You:   /gstack-upgrade
@@ -792,35 +792,35 @@ Claude: Current version: 0.7.4
         Upgraded to 0.8.2. Both global and project installs synced.
 ```
 
-Set `auto_upgrade: true` in `~/.gstack/config.yaml` to skip the prompt entirely — gstack upgrades silently at the start of each session when a new version is available.
+在 `~/.gstack/config.yaml` 中設定 `auto_upgrade: true` 可完全跳過提示——當新版本可用時，gstack 會在每個 session 開始時靜默升級。
 
 ---
 
-## Greptile integration
+## Greptile 整合
 
-[Greptile](https://greptile.com) is a YC company that reviews your PRs automatically. It catches real bugs — race conditions, security issues, things that pass CI and blow up in production. It has genuinely saved my ass more than once. I love these guys.
+[Greptile](https://greptile.com) 是一家 YC 公司，能自動審查你的 PR。它捕捉真實的 bug——競爭條件、安全問題、通過 CI 卻在生產環境爆炸的事情。它確實不只一次救了我。我很喜歡這些人。
 
-### Setup
+### 設定
 
-Install Greptile on your GitHub repo at [greptile.com](https://greptile.com) — it takes about 30 seconds. Once it's reviewing your PRs, gstack picks up its comments automatically. No additional configuration.
+在 [greptile.com](https://greptile.com) 將 Greptile 安裝到你的 GitHub repo——大約需要 30 秒。一旦它在審查你的 PR，gstack 會自動取用它的評論。無需額外配置。
 
-### How it works
+### 運作方式
 
-The problem with any automated reviewer is triage. Greptile is good, but not every comment is a real issue. Some are false positives. Some flag things you already fixed three commits ago. Without a triage layer, the comments pile up and you start ignoring them — which defeats the purpose.
+任何自動化審查工具的問題在於分類。Greptile 很好，但不是每條評論都是真實問題。有些是誤報。有些標記了你三個提交前就已經修復的事情。沒有分類層，評論會堆積如山，你開始忽視它們——這違背了目的。
 
-gstack solves this. `/review` and `/ship` are now Greptile-aware. They read Greptile's comments, classify each one, and take action:
+gstack 解決了這個問題。`/review` 和 `/ship` 現在具有 Greptile 意識。它們讀取 Greptile 的評論，分類每一條，並採取行動：
 
-- **Valid issues** get added to the critical findings and fixed before shipping
-- **Already-fixed issues** get an auto-reply acknowledging the catch
-- **False positives** get pushed back — you confirm, and a reply goes out explaining why it's wrong
+- **有效問題**被加入嚴重發現清單，並在出貨前修復
+- **已修復的問題**得到自動回覆，確認捕捉到了
+- **誤報**被推回——你確認，然後一個解釋原因的回覆發出去
 
-The result is a two-layer review: Greptile catches things asynchronously on the PR, then `/review` and `/ship` triage those findings as part of the normal workflow. Nothing falls through the cracks.
+結果是兩層審查：Greptile 在 PR 上非同步捕捉問題，然後 `/review` 和 `/ship` 將這些發現作為正常工作流程的一部分進行分類。沒有任何東西會漏網。
 
-### Learning from history
+### 從歷史中學習
 
-Every false positive you confirm gets saved to `~/.gstack/greptile-history.md`. Future runs auto-skip known FP patterns for your codebase. And `/retro` tracks Greptile's batting average over time — so you can see whether the signal-to-noise ratio is improving.
+你確認的每個誤報都會儲存到 `~/.gstack/greptile-history.md`。未來的執行會自動跳過你程式碼庫的已知誤報模式。`/retro` 也會追蹤 Greptile 隨時間的命中率——讓你能看到信噪比是否在改善。
 
-### Example
+### 範例
 
 ```
 You:   /ship
@@ -852,4 +852,4 @@ Claude: Replied to Greptile. All tests pass.
         PR: github.com/you/app/pull/42
 ```
 
-Three Greptile comments. One real fix. One auto-acknowledged. One false positive pushed back with a reply. Total extra time: about 30 seconds.
+三條 Greptile 評論。一個真實修復。一個自動確認。一個誤報被推回並附上回覆。額外花費的總時間：約 30 秒。


### PR DESCRIPTION
將以下文件翻譯為台灣繁體中文：
- README.md — 主要專案介紹與快速開始指南
- CHANGELOG.md — 版本更新日誌
- CONTRIBUTING.md — 貢獻者指南
- ARCHITECTURE.md — 系統架構說明
- BROWSER.md — 無頭瀏覽器技術參考
- AGENTS.md — AI 代理人支援說明
- docs/skills.md — 每個技能的深度介紹
- SKILL.md.tmpl — 主技能模板（含繁體中文說明）
- SKILL.md — 從模板重新生成

翻譯規則：程式碼區塊、技能名稱、品牌名稱、
檔案路徑與 URL 均保持英文原文不變。