### PR TITLE
fix: repair workflow YAML parsing and lint CI

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,8 @@
+name: Workflow Lint
+on: [push, pull_request]
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint@v1

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -5,4 +5,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rhysd/actionlint@v1
+      - uses: rhysd/actionlint@v1.7.11

--- a/.github/workflows/skill-docs.yml
+++ b/.github/workflows/skill-docs.yml
@@ -9,7 +9,17 @@ jobs:
       - run: bun install
       - name: Check Claude host freshness
         run: bun run gen:skill-docs
-      - run: git diff --exit-code || (echo "Generated SKILL.md files are stale. Run: bun run gen:skill-docs" && exit 1)
+      - name: Verify Claude skill docs are fresh
+        run: |
+          git diff --exit-code || {
+            echo "Generated SKILL.md files are stale. Run: bun run gen:skill-docs"
+            exit 1
+          }
       - name: Check Codex host freshness
         run: bun run gen:skill-docs --host codex
-      - run: git diff --exit-code -- .agents/ || (echo "Generated Codex SKILL.md files are stale. Run: bun run gen:skill-docs --host codex" && exit 1)
+      - name: Verify Codex skill docs are fresh
+        run: |
+          git diff --exit-code -- .agents/ || {
+            echo "Generated Codex SKILL.md files are stale. Run: bun run gen:skill-docs --host codex"
+            exit 1
+          }


### PR DESCRIPTION
## Summary
- rewrite the two diff-check workflow steps as block scalars so GitHub can parse the workflow YAML
- preserve the existing skill docs freshness behavior for Claude and Codex generation
- add a lightweight actionlint workflow to catch future workflow syntax regressions

## Verification
- ruby YAML parse for .github/workflows/skill-docs.yml
- ruby YAML parse for .github/workflows/actionlint.yml

## Notes
- left unrelated local changes untouched (`bin/gstack-config`, `pnpm-lock.yaml`)