### PR TITLE
Add Codex question gate compatibility

### DIFF
--- a/.agents/skills/gstack-browse/SKILL.md
+++ b/.agents/skills/gstack-browse/SKILL.md
@@ -88,17 +88,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-design-consultation/SKILL.md
+++ b/.agents/skills/gstack-design-consultation/SKILL.md
@@ -89,17 +89,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-design-review/SKILL.md
+++ b/.agents/skills/gstack-design-review/SKILL.md
@@ -89,17 +89,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-document-release/SKILL.md
+++ b/.agents/skills/gstack-document-release/SKILL.md
@@ -87,17 +87,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-investigate/SKILL.md
+++ b/.agents/skills/gstack-investigate/SKILL.md
@@ -90,17 +90,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-office-hours/SKILL.md
+++ b/.agents/skills/gstack-office-hours/SKILL.md
@@ -91,17 +91,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-plan-ceo-review/SKILL.md
+++ b/.agents/skills/gstack-plan-ceo-review/SKILL.md
@@ -90,17 +90,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-plan-design-review/SKILL.md
+++ b/.agents/skills/gstack-plan-design-review/SKILL.md
@@ -89,17 +89,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-plan-eng-review/SKILL.md
+++ b/.agents/skills/gstack-plan-eng-review/SKILL.md
@@ -88,17 +88,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-qa-only/SKILL.md
+++ b/.agents/skills/gstack-qa-only/SKILL.md
@@ -87,17 +87,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-qa/SKILL.md
+++ b/.agents/skills/gstack-qa/SKILL.md
@@ -90,17 +90,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-retro/SKILL.md
+++ b/.agents/skills/gstack-retro/SKILL.md
@@ -87,17 +87,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-review/SKILL.md
+++ b/.agents/skills/gstack-review/SKILL.md
@@ -86,17 +86,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-setup-browser-cookies/SKILL.md
+++ b/.agents/skills/gstack-setup-browser-cookies/SKILL.md
@@ -86,17 +86,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack-ship/SKILL.md
+++ b/.agents/skills/gstack-ship/SKILL.md
@@ -84,17 +84,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/.agents/skills/gstack/SKILL.md
+++ b/.agents/skills/gstack/SKILL.md
@@ -119,17 +119,43 @@ touch ~/.gstack/.telemetry-prompted
 
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
-## AskUserQuestion Format
+## Question Gate Format
 
-**ALWAYS follow this structure for every AskUserQuestion call:**
-1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
-2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
-3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
-4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+`AskUserQuestion` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
 
-Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with `A`, `B`, or `C`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal `RECOMMENDATION:` line before `Options:`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
 
-Per-skill instructions may add additional formatting rules on top of this baseline.
+Use this structure for every Question Gate:
+
+```md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+```
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.
 
 ## Completeness Principle — Boil the Lake
 

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -222,6 +222,46 @@ This only happens once. If \`TEL_PROMPTED\` is \`yes\`, skip this entirely.`;
 }
 
 function generateAskUserFormat(_ctx: TemplateContext): string {
+  if (_ctx.host === 'codex') {
+    return `## Question Gate Format
+
+Codex may not provide a native AskUserQuestion UI. In this host, **every mention of
+\`AskUserQuestion\` anywhere in this skill means: write a single structured question
+to the user in chat, then stop and wait.**
+
+Rules:
+1. **One issue = one Question Gate.** Never combine multiple issues unless the skill explicitly allows batching.
+2. **End your turn immediately after the question.** Do not keep reviewing, editing, or running tools after asking.
+3. **Never silently choose a default** when the skill told you to ask the user.
+4. **If the user replies with \`A\`, \`B\`, or \`C\`,** treat that as the choice. If they reply in freeform, restate the decision you inferred before continuing.
+5. **If there is no real tradeoff and the fix is obvious,** make the fix instead of asking.
+6. **Always include a literal \`RECOMMENDATION:\` line before \`Options:\`.** Do not omit it, even if your recommendation is "no default" or "answer with constraints first".
+
+Use this structure for every Question Gate:
+
+\`\`\`md
+QUESTION
+Project: <project>
+Branch: <branch>
+Task: <current plan/task>
+
+Problem:
+<plain-English explanation a smart 16-year-old could follow>
+
+RECOMMENDATION: Choose A because <one-line reason>
+
+Options:
+A) <option> (Completeness: 10/10, human: ~X / CC: ~Y)
+B) <option> (Completeness: 7/10, human: ~X / CC: ~Y)
+C) <option> (Completeness: 3/10, human: ~X / CC: ~Y)
+
+Reply with A/B/C or answer in your own words.
+STOP here until the user responds.
+\`\`\`
+
+Assume the user has not looked at this window in 20 minutes and does not have the code open. Re-ground them before asking.`;
+  }
+
   return `## AskUserQuestion Format
 
 **ALWAYS follow this structure for every AskUserQuestion call:**

--- a/test/codex-e2e.test.ts
+++ b/test/codex-e2e.test.ts
@@ -55,6 +55,7 @@ if (!evalsEnabled) {
 const CODEX_E2E_TOUCHFILES: Record<string, string[]> = {
   'codex-discover-skill':    ['codex/**', '.agents/skills/**', 'test/helpers/codex-session-runner.ts'],
   'codex-review-findings':   ['review/**', '.agents/skills/gstack-review/**', 'codex/**', 'test/helpers/codex-session-runner.ts'],
+  'codex-question-gate':     ['plan-eng-review/**', '.agents/skills/gstack-plan-eng-review/**', 'codex/**', 'test/helpers/codex-session-runner.ts'],
 };
 
 let selectedTests: string[] | null = null; // null = run all
@@ -182,4 +183,45 @@ describeCodex('Codex E2E', () => {
       outputLower.includes('p2');
     expect(hasReviewContent).toBe(true);
   }, 600_000);
+
+  testIfSelected('codex-question-gate', async () => {
+    const skillDir = path.join(ROOT, '.agents', 'skills', 'gstack-plan-eng-review');
+    const tempRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-question-gate-'));
+
+    try {
+      const run = (args: string[]) => Bun.spawnSync(args, { cwd: tempRepo, stdout: 'pipe', stderr: 'pipe' });
+      run(['git', 'init', '-b', 'main']);
+      run(['git', 'config', 'user.email', 'test@test.com']);
+      run(['git', 'config', 'user.name', 'Test']);
+      run(['git', 'commit', '--allow-empty', '-m', 'init']);
+
+      const result = await runCodexSkill({
+        skillDir,
+        prompt: 'Use the gstack-plan-eng-review skill. You are reviewing a plan to add Stripe payments. The plan does not specify whether to use Stripe Checkout or Stripe Elements. Ask the next decision question and stop. Do not choose a default. Do not continue the review after asking.',
+        timeoutMs: 180_000,
+        cwd: tempRepo,
+        skillName: 'gstack-plan-eng-review',
+      });
+
+      logCodexCost('codex-question-gate', result);
+
+      const output = result.output;
+      const passed =
+        result.exitCode === 0 &&
+        output.includes('QUESTION') &&
+        output.includes('RECOMMENDATION:') &&
+        output.includes('STOP here until the user responds.');
+      recordCodexE2E('codex-question-gate', result, passed);
+
+      expect(result.exitCode).toBe(0);
+      expect(output).toContain('QUESTION');
+      expect(output).toContain('RECOMMENDATION:');
+      expect(output).toContain('Options:');
+      expect(output).toContain('A)');
+      expect(output).toContain('B)');
+      expect(output).toContain('STOP here until the user responds.');
+    } finally {
+      try { fs.rmSync(tempRepo, { recursive: true, force: true }); } catch {}
+    }
+  }, 240_000);
 });

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -564,6 +564,15 @@ describe('Codex generation (--host codex)', () => {
     expect(content).toContain('.agents/skills/gstack');
   });
 
+  test('Codex output includes Question Gate compatibility instructions', () => {
+    const content = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-plan-eng-review', 'SKILL.md'), 'utf-8');
+    expect(content).toContain('## Question Gate Format');
+    expect(content).toContain('every mention of');
+    expect(content).toContain('`AskUserQuestion`');
+    expect(content).toContain('QUESTION');
+    expect(content).toContain('STOP here until the user responds.');
+  });
+
   // ─── Path rewriting regression tests ─────────────────────────
 
   test('sidecar paths point to .agents/skills/gstack/review/ (not gstack-review/)', () => {

--- a/test/helpers/codex-session-runner.ts
+++ b/test/helpers/codex-session-runner.ts
@@ -39,6 +39,37 @@ export interface ParsedCodexJSONL {
   sessionId: string | null;
 }
 
+async function collectStreamText(
+  stream: ReadableStream<Uint8Array>,
+): Promise<{ text: string; done: Promise<void>; cancel: () => Promise<void> }> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+
+  const done = (async () => {
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        text += decoder.decode(value, { stream: true });
+      }
+      text += decoder.decode();
+    } catch {
+      // Ignore stream read/cancel errors; return whatever was collected.
+    }
+  })();
+
+  return {
+    get text() {
+      return text;
+    },
+    done,
+    cancel: async () => {
+      try { await reader.cancel(); } catch { /* non-fatal */ }
+    },
+  };
+}
+
 /**
  * Parse an array of JSONL lines from `codex exec --json` into structured data.
  * Pure function — no I/O, no side effects.
@@ -119,6 +150,25 @@ export function installSkillToTempHome(
   return home;
 }
 
+function copyCodexAuthFiles(realCodexConfig: string, tempCodexDir: string): void {
+  // Copy only the minimum files needed for auth/config. Copying the entire
+  // ~/.codex directory drags in large state DBs, worktrees, and archives,
+  // which makes E2E tests extremely slow and can hang cleanup.
+  const allowlist = [
+    'auth.json',
+    'config.toml',
+    'AGENTS.md',
+    'version.json',
+  ];
+
+  for (const entry of allowlist) {
+    const src = path.join(realCodexConfig, entry);
+    const dst = path.join(tempCodexDir, entry);
+    if (!fs.existsSync(src) || fs.existsSync(dst)) continue;
+    fs.cpSync(src, dst, { recursive: true });
+  }
+}
+
 // --- Main runner ---
 
 /**
@@ -175,17 +225,7 @@ export async function runCodexSkill(opts: {
     const realCodexConfig = path.join(realHome, '.codex');
     const tempCodexDir = path.join(tempHome, '.codex');
     if (fs.existsSync(realCodexConfig)) {
-      // Copy auth-related files from real ~/.codex/ into temp ~/.codex/
-      // (skills/ is already set up by installSkillToTempHome)
-      const entries = fs.readdirSync(realCodexConfig);
-      for (const entry of entries) {
-        if (entry === 'skills') continue; // don't clobber our test skills
-        const src = path.join(realCodexConfig, entry);
-        const dst = path.join(tempCodexDir, entry);
-        if (!fs.existsSync(dst)) {
-          fs.cpSync(src, dst, { recursive: true });
-        }
-      }
+      copyCodexAuthFiles(realCodexConfig, tempCodexDir);
     }
 
     // Build codex exec command
@@ -211,7 +251,7 @@ export async function runCodexSkill(opts: {
 
     // Stream and collect JSONL from stdout
     const collectedLines: string[] = [];
-    const stderrPromise = new Response(proc.stderr).text();
+    const stderrCollector = await collectStreamText(proc.stderr);
 
     const reader = proc.stdout.getReader();
     const decoder = new TextDecoder();
@@ -251,9 +291,15 @@ export async function runCodexSkill(opts: {
       collectedLines.push(buf);
     }
 
-    const stderr = await stderrPromise;
     const exitCode = await proc.exited;
     clearTimeout(timeoutId);
+    // Codex may leave stderr pipes open briefly via child processes (MCP/browser).
+    // Don't hang the entire E2E run waiting forever for stderr to close.
+    await Promise.race([
+      stderrCollector.done,
+      new Promise(resolve => setTimeout(resolve, 500)),
+    ]);
+    await stderrCollector.cancel();
 
     const durationMs = Date.now() - startTime;
 
@@ -261,8 +307,8 @@ export async function runCodexSkill(opts: {
     const parsed = parseCodexJSONL(collectedLines);
 
     // Log stderr if non-empty (may contain auth errors, etc.)
-    if (stderr.trim()) {
-      process.stderr.write(`  [codex stderr] ${stderr.trim().slice(0, 200)}\n`);
+    if (stderrCollector.text.trim()) {
+      process.stderr.write(`  [codex stderr] ${stderrCollector.text.trim().slice(0, 200)}\n`);
     }
 
     return {

--- a/test/helpers/touchfiles.ts
+++ b/test/helpers/touchfiles.ts
@@ -79,6 +79,7 @@ export const E2E_TOUCHFILES: Record<string, string[]> = {
   // Codex E2E (tests skills via Codex CLI)
   'codex-discover-skill':  ['codex/**', '.agents/skills/**', 'test/helpers/codex-session-runner.ts'],
   'codex-review-findings': ['review/**', '.agents/skills/gstack-review/**', 'codex/**', 'test/helpers/codex-session-runner.ts'],
+  'codex-question-gate':   ['plan-eng-review/**', '.agents/skills/gstack-plan-eng-review/**', 'codex/**', 'test/helpers/codex-session-runner.ts'],
 
   // QA bootstrap
   'qa-bootstrap': ['qa/**', 'browse/src/**', 'ship/**'],


### PR DESCRIPTION
## Summary
- add a Codex-specific Question Gate format so AskUserQuestion-style interactions become explicit ask-and-stop behavior
- add Codex E2E coverage for the question-gate flow and update touchfile selection
- slim down the Codex E2E temp HOME copy + stderr handling so the new E2E test runs reliably

## Testing
- bun test test/gen-skill-docs.test.ts
- bun test test/touchfiles.test.ts
- bun run scripts/gen-skill-docs.ts --host codex --dry-run
- EVALS=1 bun test test/codex-e2e.test.ts -t "codex-question-gate"