### PR TITLE
fix(gen-skill-docs): cap Codex skill descriptions at 1024 characters

### DIFF
--- a/.agents/skills/gstack/SKILL.md
+++ b/.agents/skills/gstack/SKILL.md
@@ -19,25 +19,7 @@ description: |
   - Code review before merge → suggest /review
   - Visual design audit → suggest /design-review
   - Ready to deploy / create PR → suggest /ship
-  - Post-ship doc updates → suggest /document-release
-  - Weekly retrospective → suggest /retro
-  - Wanting a second opinion or adversarial code review → suggest /codex
-  - Working with production or live systems → suggest /careful
-  - Want to scope edits to one module/directory → suggest /freeze
-  - Maximum safety mode (destructive warnings + edit restrictions) → suggest /guard
-  - Removing edit restrictions → suggest /unfreeze
-  - Upgrading gstack to latest version → suggest /gstack-upgrade
-  
-  If the user pushes back on skill suggestions ("stop suggesting things",
-  "I don't need suggestions", "too aggressive"):
-  1. Stop suggesting for the rest of this session
-  2. Run: gstack-config set proactive false
-  3. Say: "Got it — I'll stop suggesting skills. Just tell me to be proactive
-     again if you change your mind."
-  
-  If the user says "be proactive again" or "turn on suggestions":
-  1. Run: gstack-config set proactive true
-  2. Say: "Proactive suggestions are back on."
+  -…
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -1276,6 +1276,24 @@ const RESOLVERS: Record<string, (ctx: TemplateContext) => string> = {
 
 // ─── Codex Helpers ───────────────────────────────────────────
 
+/** Codex CLI rejects skill descriptions longer than this (garrytan/gstack#230). */
+const CODEX_DESCRIPTION_MAX_LEN = 1024;
+
+/**
+ * Truncate description so Codex accepts the skill. Prefers a word boundary near the end.
+ */
+function truncateForCodexDescription(description: string): string {
+  if (description.length <= CODEX_DESCRIPTION_MAX_LEN) return description;
+  const ellipsis = '…';
+  const budget = CODEX_DESCRIPTION_MAX_LEN - ellipsis.length;
+  let cut = description.slice(0, budget);
+  const lastSpace = cut.lastIndexOf(' ');
+  if (lastSpace > budget * 0.85) {
+    cut = cut.slice(0, lastSpace);
+  }
+  return cut + ellipsis;
+}
+
 function codexSkillName(skillDir: string): string {
   if (skillDir === '.' || skillDir === '') return 'gstack';
   // Don't double-prefix: gstack-upgrade → gstack-upgrade (not gstack-gstack-upgrade)
@@ -1333,6 +1351,8 @@ function transformFrontmatter(content: string, host: Host): string {
   if (descLines.length > 0) {
     description = descLines.join('\n').trim();
   }
+
+  description = truncateForCodexDescription(description);
 
   // Re-emit Codex frontmatter (name + description only)
   const indentedDesc = description.split('\n').map(l => `  ${l}`).join('\n');

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -473,6 +473,38 @@ describe('Codex generation (--host codex)', () => {
     }
   });
 
+  test('Codex description fits CLI limit (1024 chars)', () => {
+    const MAX = 1024;
+    for (const skill of CODEX_SKILLS) {
+      const content = fs.readFileSync(path.join(AGENTS_DIR, skill.codexName, 'SKILL.md'), 'utf-8');
+      const fmEnd = content.indexOf('\n---', 4);
+      expect(fmEnd).toBeGreaterThan(0);
+      const frontmatter = content.slice(4, fmEnd);
+      const lines = frontmatter.split('\n');
+      let inDescription = false;
+      const descLines: string[] = [];
+      for (const line of lines) {
+        if (line.match(/^description:\s*\|?\s*$/)) {
+          inDescription = true;
+          continue;
+        }
+        if (line.match(/^description:\s*\S/)) {
+          break;
+        }
+        if (inDescription) {
+          if (line === '' || line.match(/^\s/)) {
+            descLines.push(line.replace(/^  /, ''));
+          } else {
+            break;
+          }
+        }
+      }
+      const descText = descLines.length > 0 ? descLines.join('\n').trim() : '';
+      expect(descText.length).toBeGreaterThan(0);
+      expect(descText.length).toBeLessThanOrEqual(MAX);
+    }
+  });
+
   test('no .claude/skills/ in Codex output', () => {
     for (const skill of CODEX_SKILLS) {
       const content = fs.readFileSync(path.join(AGENTS_DIR, skill.codexName, 'SKILL.md'), 'utf-8');


### PR DESCRIPTION
## Summary

OpenAI Codex CLI rejects skill YAML when `description` exceeds **1024 characters** ([issue #230](https://github.com/garrytan/gstack/issues/230)). This change:

- Adds `truncateForCodexDescription()` in `scripts/gen-skill-docs.ts` and applies it in `transformFrontmatter()` for Codex output, preferring a word boundary near the end and appending an ellipsis when truncated.
- Regenerates `.agents/skills/gstack/SKILL.md` so the committed Codex skill stays under the limit.
- Adds a Tier 1 test in `test/gen-skill-docs.test.ts` that asserts every generated `.agents/skills/*/SKILL.md` Codex description is non-empty and ≤ 1024 characters.

## How to test

From the repo root (per [CONTRIBUTING](https://github.com/garrytan/gstack/blob/main/CONTRIBUTING.md) / project docs):

```bash
bun install
bun run test
```

Optional: after template changes, run `bun run gen:skill-docs` (and `bun run gen:skill-docs --host codex` if you touch Codex paths) and confirm a clean working tree so CI doc checks pass.

Fixes #230