### PR TITLE
fix: Windows+Bun compatibility for gstack browse

### DIFF
--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -13,10 +13,16 @@ import * as path from 'path';
 
 // Security: Path validation to prevent path traversal attacks
 const SAFE_DIRECTORIES = ['/tmp', process.cwd()];
+// Normalize path separators to forward slashes for cross-platform comparison (Windows uses backslashes)
+const normSep = (p: string) => p.replace(/\\/g, '/');
 
 export function validateOutputPath(filePath: string): void {
   const resolved = path.resolve(filePath);
-  const isSafe = SAFE_DIRECTORIES.some(dir => resolved === dir || resolved.startsWith(dir + '/'));
+  const resolvedNorm = normSep(resolved);
+  const isSafe = SAFE_DIRECTORIES.some(dir => {
+    const dirNorm = normSep(dir);
+    return resolvedNorm === dirNorm || resolvedNorm.startsWith(dirNorm + '/');
+  });
   if (!isSafe) {
     throw new Error(`Path must be within: ${SAFE_DIRECTORIES.join(', ')}`);
   }

--- a/browse/src/read-commands.ts
+++ b/browse/src/read-commands.ts
@@ -37,11 +37,17 @@ function wrapForEvaluate(code: string): string {
 
 // Security: Path validation to prevent path traversal attacks
 const SAFE_DIRECTORIES = ['/tmp', process.cwd()];
+// Normalize path separators to forward slashes for cross-platform comparison (Windows uses backslashes)
+const normSep = (p: string) => p.replace(/\\/g, '/');
 
 export function validateReadPath(filePath: string): void {
   if (path.isAbsolute(filePath)) {
     const resolved = path.resolve(filePath);
-    const isSafe = SAFE_DIRECTORIES.some(dir => resolved === dir || resolved.startsWith(dir + '/'));
+    const resolvedNorm = normSep(resolved);
+    const isSafe = SAFE_DIRECTORIES.some(dir => {
+      const dirNorm = normSep(dir);
+      return resolvedNorm === dirNorm || resolvedNorm.startsWith(dirNorm + '/');
+    });
     if (!isSafe) {
       throw new Error(`Absolute path must be within: ${SAFE_DIRECTORIES.join(', ')}`);
     }

--- a/browse/src/snapshot.ts
+++ b/browse/src/snapshot.ts
@@ -312,7 +312,9 @@ export async function handleSnapshot(
     // Validate output path (consistent with screenshot/pdf/responsive)
     const resolvedPath = require('path').resolve(screenshotPath);
     const safeDirs = ['/tmp', process.cwd()];
-    if (!safeDirs.some((dir: string) => resolvedPath === dir || resolvedPath.startsWith(dir + '/'))) {
+    const normSep = (p: string) => p.replace(/\\/g, '/');
+    const resolvedPathNorm = normSep(resolvedPath);
+    if (!safeDirs.some((dir: string) => { const d = normSep(dir); return resolvedPathNorm === d || resolvedPathNorm.startsWith(d + '/'); })) {
       throw new Error(`Path must be within: ${safeDirs.join(', ')}`);
     }
     try {

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -279,7 +279,9 @@ export async function handleWriteCommand(
       if (path.isAbsolute(filePath)) {
         const safeDirs = ['/tmp', process.cwd()];
         const resolved = path.resolve(filePath);
-        if (!safeDirs.some(dir => resolved === dir || resolved.startsWith(dir + '/'))) {
+        const normSep = (p: string) => p.replace(/\\/g, '/');
+        const resolvedNorm = normSep(resolved);
+        if (!safeDirs.some(dir => { const d = normSep(dir); return resolvedNorm === d || resolvedNorm.startsWith(d + '/'); })) {
           throw new Error(`Path must be within: ${safeDirs.join(', ')}`);
         }
       }

--- a/patches/browserType.patch
+++ b/patches/browserType.patch
@@ -1,0 +1,17 @@
+--- a/lib/server/browserType.js	1985-10-26 16:15:00.000000000 +0800
++++ b/lib/server/browserType.js	2026-03-20 16:02:38.280613900 +0800
+@@ -193,6 +193,14 @@
+       handleSIGHUP = true
+     } = options;
+     const env = options.env ? (0, import_processLauncher.envArrayToObject)(options.env) : process.env;
++    // On Windows under Bun: pre-allocate a specific CDP port before Chrome launches.
++    // We use HTTP polling to detect Chrome readiness, avoiding the buffered-stderr timing issue.
++    if (process.platform === "win32" && typeof Bun !== "undefined" && options.cdpPort === void 0) {
++      options.cdpPort = await new Promise((resolve) => {
++        const srv = require('net').createServer();
++        srv.listen(0, '127.0.0.1', () => { const p = srv.address().port; srv.close(() => resolve(p)); });
++      });
++    }
+     const prepared = await progress.race(this._prepareToLaunch(options, isPersistent, userDataDir));
+     let transport = void 0;
+     let browserProcess = void 0;

--- a/patches/chromium.patch
+++ b/patches/chromium.patch
@@ -1,0 +1,50 @@
+--- a/lib/server/chromium/chromium.js	1985-10-26 16:15:00.000000000 +0800
++++ b/lib/server/chromium/chromium.js	2026-03-20 16:17:17.807119900 +0800
+@@ -257,6 +257,11 @@
+   async defaultArgs(options, isPersistent, userDataDir) {
+     const chromeArguments = this._innerDefaultArgs(options);
+     chromeArguments.push(`--user-data-dir=${userDataDir}`);
++    // On Windows under Bun, use CDP-over-WebSocket (port) instead of pipe transport.
++    // Bun cannot correctly pass fd 3/4 pipe handles to child processes on Windows.
++    const isBunWindows = process.platform === "win32" && typeof Bun !== "undefined";
++    if (isBunWindows && options.cdpPort === void 0)
++      options.cdpPort = 0;  // Force WebSocket transport; also signals waitForReadyState to wait for WS URL
+     if (options.cdpPort !== void 0)
+       chromeArguments.push(`--remote-debugging-port=${options.cdpPort}`);
+     else
+@@ -327,6 +332,35 @@
+ async function waitForReadyState(options, browserLogsCollector) {
+   if (options.cdpPort === void 0 && !options.args?.some((a) => a.startsWith("--remote-debugging-port")))
+     return {};
++  // On Windows under Bun: Chrome's stderr is block-buffered, so log messages arrive late.
++  // Poll the HTTP CDP endpoint directly instead of waiting for the log message.
++  const isBunWindows = process.platform === "win32" && typeof Bun !== "undefined";
++  if (isBunWindows && options.cdpPort !== void 0 && options.cdpPort > 0) {
++    const port = options.cdpPort;
++    const result = new import_manualPromise.ManualPromise();
++    // Also watch for profile-lock errors in logs
++    browserLogsCollector.onMessage((message) => {
++      if (message.includes("Failed to create a ProcessSingleton for your profile directory.")) {
++        result.reject(new Error("Failed to create a ProcessSingleton for your profile directory. This usually means that the profile is already in use by another instance of Chromium."));
++      }
++    });
++    (async () => {
++      while (!result.isDone()) {
++        try {
++          const resp = await fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(500) });
++          if (resp.ok) {
++            const data = await resp.json();
++            if (data && data.webSocketDebuggerUrl) {
++              result.resolve({ wsEndpoint: data.webSocketDebuggerUrl });
++              return;
++            }
++          }
++        } catch {}
++        await new Promise(resolve => setTimeout(resolve, 100));
++      }
++    })();
++    return result;
++  }
+   const result = new import_manualPromise.ManualPromise();
+   browserLogsCollector.onMessage((message) => {
+     if (message.includes("Failed to create a ProcessSingleton for your profile directory.")) {

--- a/patches/processLauncher.patch
+++ b/patches/processLauncher.patch
@@ -1,0 +1,14 @@
+--- a/lib/server/utils/processLauncher.js	1985-10-26 16:15:00.000000000 +0800
++++ b/lib/server/utils/processLauncher.js	2026-03-20 15:43:03.110644000 +0800
+@@ -102,7 +102,10 @@
+   installedHandlers.clear();
+ }
+ async function launchProcess(options) {
+-  const stdio = options.stdio === "pipe" ? ["ignore", "pipe", "pipe", "pipe", "pipe"] : ["pipe", "pipe", "pipe"];
++  // On Windows under Bun, 5-element stdio arrays are not correctly handled (fd 3/4 pipes fail).
++  // Fall back to 3-element stdio and use CDP-over-WebSocket transport instead.
++  const isBunWindows = process.platform === "win32" && typeof Bun !== "undefined";
++  const stdio = options.stdio === "pipe" && !isBunWindows ? ["ignore", "pipe", "pipe", "pipe", "pipe"] : ["pipe", "pipe", "pipe"];
+   options.log(`<launching> ${options.command} ${options.args ? options.args.join(" ") : ""}`);
+   const spawnOptions = {
+     // On non-windows platforms, `detached: true` makes child process a leader of a new

--- a/patches/transport.patch
+++ b/patches/transport.patch
@@ -1,0 +1,55 @@
+--- a/lib/server/transport.js	1985-10-26 16:15:00.000000000 +0800
++++ b/lib/server/transport.js	2026-03-20 16:14:30.067142000 +0800
+@@ -35,12 +35,41 @@
+   },
+   threshold: 10 * 1024
+ };
++// On Windows under Bun: the bundled ws npm library's WebSocket upgrade via http.request()
++// fails with "Unexpected server response: 101". Use Bun's native WebSocket instead,
++// wrapped in an adapter that mimics the ws EventEmitter + addEventListener API.
++function createBunNativeWsAdapter(url) {
++  const nativeWs = new WebSocket(url);
++  const listeners = {};
++  function emit(event, ...args) {
++    if (listeners[event]) listeners[event].slice().forEach(fn => fn(...args));
++  }
++  const adapter = {
++    get readyState() { return nativeWs.readyState; },
++    on(event, fn) { (listeners[event] = listeners[event] || []).push(fn); return adapter; },
++    once(event, fn) {
++      const wrapper = (...args) => { fn(...args); adapter.off(event, wrapper); };
++      return adapter.on(event, wrapper);
++    },
++    off(event, fn) { if (listeners[event]) listeners[event] = listeners[event].filter(f => f !== fn); return adapter; },
++    addEventListener(event, fn) { adapter.on(event, fn); },
++    removeEventListener(event, fn) { adapter.off(event, fn); },
++    send(data) { nativeWs.send(data); },
++    close() { nativeWs.close(); },
++  };
++  nativeWs.onopen = () => emit('open');
++  nativeWs.onmessage = (e) => emit('message', { data: e.data });
++  nativeWs.onclose = (e) => emit('close', { code: e.code, reason: e.reason });
++  nativeWs.onerror = (e) => emit('error', Object.assign(new Error('WebSocket error'), { type: 'error' }));
++  return adapter;
++}
++const isBunWindows = process.platform === "win32" && typeof Bun !== "undefined";
+ class WebSocketTransport {
+   constructor(progress, url, logUrl, options) {
+     this.headers = [];
+     this.wsEndpoint = url;
+     this._logUrl = logUrl;
+-    this._ws = new import_utilsBundle.ws(url, [], {
++    this._ws = isBunWindows ? createBunNativeWsAdapter(url) : new import_utilsBundle.ws(url, [], {
+       maxPayload: 256 * 1024 * 1024,
+       // 256Mb,
+       headers: options.headers,
+@@ -157,7 +186,8 @@
+     this._ws.close();
+   }
+   async closeAndWait() {
+-    if (this._ws.readyState === import_utilsBundle.ws.CLOSED)
++    const CLOSED = 3; // WebSocket.CLOSED — same value in both ws npm library and native WebSocket
++    if (this._ws.readyState === CLOSED)
+       return;
+     const promise = new Promise((f) => this._ws.once("close", f));
+     this.close();

--- a/scripts/apply-windows-patches.sh
+++ b/scripts/apply-windows-patches.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# apply-windows-patches.sh
+# Apply Windows+Bun compatibility patches to playwright-core node_modules.
+# Run this after `bun install` whenever node_modules is refreshed.
+#
+# Usage:
+#   bash scripts/apply-windows-patches.sh
+#
+# What it patches (playwright-core@1.58.x):
+#   - processLauncher.js  : use 3-element stdio on Bun+Windows (fd 3/4 broken)
+#   - chromium.js         : force CDP-over-port + HTTP polling for readiness
+#   - browserType.js      : pre-allocate free TCP port before Chrome launch
+#   - transport.js        : use Bun native WebSocket instead of ws npm library
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PATCHES_DIR="$REPO_DIR/patches"
+PW_DIR="$REPO_DIR/node_modules/playwright-core/lib/server"
+
+echo "==> Applying Windows+Bun playwright-core patches..."
+
+if [ ! -d "$PW_DIR" ]; then
+  echo "ERROR: node_modules/playwright-core not found. Run 'bun install' first."
+  exit 1
+fi
+
+apply_patch() {
+  local patch_file="$PATCHES_DIR/$1"
+  local target_dir="$PW_DIR"
+  echo "  Applying $1..."
+  if patch -d "$target_dir" -p3 --forward --dry-run < "$patch_file" >/dev/null 2>&1; then
+    patch -d "$target_dir" -p3 --forward < "$patch_file"
+  elif patch -d "$target_dir" -p3 --forward --dry-run -R < "$patch_file" >/dev/null 2>&1; then
+    echo "  (already applied, skipping)"
+  else
+    echo "  WARNING: $1 failed to apply cleanly — may need updating for this playwright-core version"
+  fi
+}
+
+apply_patch processLauncher.patch
+apply_patch chromium.patch
+apply_patch browserType.patch
+apply_patch transport.patch
+
+echo "==> Done. Rebuild browse binary: bun run build"


### PR DESCRIPTION
gstack browse uses Playwright internally, but the bundled playwright-core has several incompatibilities with Bun on Windows 10+:

1. **processLauncher.js**: Bun cannot pass fd 3/4 pipe handles to child processes on Windows. Detect `isBunWindows` and use 3-element stdio instead of the default 5-element array.

2. **chromium.js** (two hunks):
   - Force `cdpPort=0` on Bun+Windows to use WebSocket-over-port transport instead of `--remote-debugging-pipe` (which requires fd 3/4).
   - Replace stderr log-message readiness detection with an HTTP polling loop against `/json/version`, because Chrome's stderr is block-buffered on Windows and the log arrives after Playwright already times out.

3. **browserType.js**: Pre-allocate a free TCP port via `net.createServer()` before Chrome launches, eliminating the race between port assignment and the HTTP poller.

4. **transport.js**: The bundled `ws` npm library fails with "Unexpected server response: 101" in Bun on Windows because Bun's `http.request()` handles WebSocket upgrade differently. Replace with a Bun native `WebSocket` adapter that mimics the ws EventEmitter API.

Also fixes path-separator validation in browse/src (was using `dir + '/'` which breaks on Windows `\` separators) — affects meta-commands.ts, read-commands.ts, snapshot.ts, write-commands.ts.

**How to apply after `bun install`:**
  bash scripts/apply-windows-patches.sh

Patch files in patches/ target playwright-core@1.58.2.