### PR TITLE
feat: add /design-review-ios with XcodeBuildMCP integration

### DIFF
--- a/.agents/skills/gstack-design-review-ios/SKILL.md
+++ b/.agents/skills/gstack-design-review-ios/SKILL.md
@@ -1,0 +1,1044 @@
+---
+name: design-review-ios
+description: |
+  iOS design QA via simulator: finds visual inconsistency, spacing issues, HIG violations,
+  accessibility gaps, and AI slop patterns — then fixes them. Uses XcodeBuildMCP (MCP server
+  preferred, CLI fallback) to build, screenshot, and interact with the app on iOS Simulator.
+  Iteratively fixes issues in source code, committing each fix atomically and re-verifying
+  with before/after screenshots. Targets iOS 17+. For web design review, use /design-review.
+  Use when asked to "audit the iOS design", "visual QA", "check the app looks good",
+  "HIG review", or "design polish".
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+## Preamble (run first)
+
+```bash
+_UPD=$(~/.codex/skills/gstack/bin/gstack-update-check 2>/dev/null || .agents/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
+[ -n "$_UPD" ] && echo "$_UPD" || true
+mkdir -p ~/.gstack/sessions
+touch ~/.gstack/sessions/"$PPID"
+_SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
+find ~/.gstack/sessions -mmin +120 -type f -delete 2>/dev/null || true
+_CONTRIB=$(~/.codex/skills/gstack/bin/gstack-config get gstack_contributor 2>/dev/null || true)
+_PROACTIVE=$(~/.codex/skills/gstack/bin/gstack-config get proactive 2>/dev/null || echo "true")
+_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+echo "BRANCH: $_BRANCH"
+echo "PROACTIVE: $_PROACTIVE"
+_LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no")
+echo "LAKE_INTRO: $_LAKE_SEEN"
+_TEL=$(~/.codex/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
+_TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
+_TEL_START=$(date +%s)
+_SESSION_ID="$$-$(date +%s)"
+echo "TELEMETRY: ${_TEL:-off}"
+echo "TEL_PROMPTED: $_TEL_PROMPTED"
+mkdir -p ~/.gstack/analytics
+echo '{"skill":"design-review-ios","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+for _PF in ~/.gstack/analytics/.pending-*; do [ -f "$_PF" ] && ~/.codex/skills/gstack/bin/gstack-telemetry-log --event-type skill_run --skill _pending_finalize --outcome unknown --session-id "$_SESSION_ID" 2>/dev/null || true; break; done
+```
+
+If `PROACTIVE` is `"false"`, do not proactively suggest gstack skills — only invoke
+them when the user explicitly asks. The user opted out of proactive suggestions.
+
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.codex/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+
+If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
+Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete
+thing when AI makes the marginal cost near-zero. Read more: https://garryslist.org/posts/boil-the-ocean"
+Then offer to open the essay in their default browser:
+
+```bash
+open https://garryslist.org/posts/boil-the-ocean
+touch ~/.gstack/.completeness-intro-seen
+```
+
+Only run `open` if the user says yes. Always run `touch` to mark as seen. This only happens once.
+
+If `TEL_PROMPTED` is `no` AND `LAKE_INTRO` is `yes`: After the lake intro is handled,
+ask the user about telemetry. Use AskUserQuestion:
+
+> Help gstack get better! Community mode shares usage data (which skills you use, how long
+> they take, crash info) with a stable device ID so we can track trends and fix bugs faster.
+> No code, file paths, or repo names are ever sent.
+> Change anytime with `gstack-config set telemetry off`.
+
+Options:
+- A) Help gstack get better! (recommended)
+- B) No thanks
+
+If A: run `~/.codex/skills/gstack/bin/gstack-config set telemetry community`
+
+If B: ask a follow-up AskUserQuestion:
+
+> How about anonymous mode? We just learn that *someone* used gstack — no unique ID,
+> no way to connect sessions. Just a counter that helps us know if anyone's out there.
+
+Options:
+- A) Sure, anonymous is fine
+- B) No thanks, fully off
+
+If B→A: run `~/.codex/skills/gstack/bin/gstack-config set telemetry anonymous`
+If B→B: run `~/.codex/skills/gstack/bin/gstack-config set telemetry off`
+
+Always run:
+```bash
+touch ~/.gstack/.telemetry-prompted
+```
+
+This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
+
+## AskUserQuestion Format
+
+**ALWAYS follow this structure for every AskUserQuestion call:**
+1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
+2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
+3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
+4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+
+Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+
+Per-skill instructions may add additional formatting rules on top of this baseline.
+
+## Completeness Principle — Boil the Lake
+
+AI-assisted coding makes the marginal cost of completeness near-zero. When you present options:
+
+- If Option A is the complete implementation (full parity, all edge cases, 100% coverage) and Option B is a shortcut that saves modest effort — **always recommend A**. The delta between 80 lines and 150 lines is meaningless with CC+gstack. "Good enough" is the wrong instinct when "complete" costs minutes more.
+- **Lake vs. ocean:** A "lake" is boilable — 100% test coverage for a module, full feature implementation, handling all edge cases, complete error paths. An "ocean" is not — rewriting an entire system from scratch, adding features to dependencies you don't control, multi-quarter platform migrations. Recommend boiling lakes. Flag oceans as out of scope.
+- **When estimating effort**, always show both scales: human team time and CC+gstack time. The compression ratio varies by task type — use this reference:
+
+| Task type | Human team | CC+gstack | Compression |
+|-----------|-----------|-----------|-------------|
+| Boilerplate / scaffolding | 2 days | 15 min | ~100x |
+| Test writing | 1 day | 15 min | ~50x |
+| Feature implementation | 1 week | 30 min | ~30x |
+| Bug fix + regression test | 4 hours | 15 min | ~20x |
+| Architecture / design | 2 days | 4 hours | ~5x |
+| Research / exploration | 1 day | 3 hours | ~3x |
+
+- This principle applies to test coverage, error handling, documentation, edge cases, and feature completeness. Don't skip the last 10% to "save time" — with AI, that 10% costs seconds.
+
+**Anti-patterns — DON'T do this:**
+- BAD: "Choose B — it covers 90% of the value with less code." (If A is only 70 lines more, choose A.)
+- BAD: "We can skip edge case handling to save time." (Edge case handling costs minutes with CC.)
+- BAD: "Let's defer test coverage to a follow-up PR." (Tests are the cheapest lake to boil.)
+- BAD: Quoting only human-team effort: "This would take 2 weeks." (Say: "2 weeks human / ~1 hour CC.")
+
+## Contributor Mode
+
+If `_CONTRIB` is `true`: you are in **contributor mode**. You're a gstack user who also helps make it better.
+
+**At the end of each major workflow step** (not after every single command), reflect on the gstack tooling you used. Rate your experience 0 to 10. If it wasn't a 10, think about why. If there is an obvious, actionable bug OR an insightful, interesting thing that could have been done better by gstack code or skill markdown — file a field report. Maybe our contributor will help make us better!
+
+**Calibration — this is the bar:** For example, `$B js "await fetch(...)"` used to fail with `SyntaxError: await is only valid in async functions` because gstack didn't wrap expressions in async context. Small, but the input was reasonable and gstack should have handled it — that's the kind of thing worth filing. Things less consequential than this, ignore.
+
+**NOT worth filing:** user's app bugs, network errors to user's URL, auth failures on user's site, user's own JS logic bugs.
+
+**To file:** write `~/.gstack/contributor-logs/{slug}.md` with **all sections below** (do not truncate — include every section through the Date/Version footer):
+
+```
+# {Title}
+
+Hey gstack team — ran into this while using /{skill-name}:
+
+**What I was trying to do:** {what the user/agent was attempting}
+**What happened instead:** {what actually happened}
+**My rating:** {0-10} — {one sentence on why it wasn't a 10}
+
+## Steps to reproduce
+1. {step}
+
+## Raw output
+```
+{paste the actual error or unexpected output here}
+```
+
+## What would make this a 10
+{one sentence: what gstack should have done differently}
+
+**Date:** {YYYY-MM-DD} | **Version:** {gstack version} | **Skill:** /{skill}
+```
+
+Slug: lowercase, hyphens, max 60 chars (e.g. `browse-js-no-await`). Skip if file already exists. Max 3 reports per session. File inline and continue — don't stop the workflow. Tell user: "Filed gstack field report: {title}"
+
+## Completion Status Protocol
+
+When completing a skill workflow, report status using one of:
+- **DONE** — All steps completed successfully. Evidence provided for each claim.
+- **DONE_WITH_CONCERNS** — Completed, but with issues the user should know about. List each concern.
+- **BLOCKED** — Cannot proceed. State what is blocking and what was tried.
+- **NEEDS_CONTEXT** — Missing information required to continue. State exactly what you need.
+
+### Escalation
+
+It is always OK to stop and say "this is too hard for me" or "I'm not confident in this result."
+
+Bad work is worse than no work. You will not be penalized for escalating.
+- If you have attempted a task 3 times without success, STOP and escalate.
+- If you are uncertain about a security-sensitive change, STOP and escalate.
+- If the scope of work exceeds what you can verify, STOP and escalate.
+
+Escalation format:
+```
+STATUS: BLOCKED | NEEDS_CONTEXT
+REASON: [1-2 sentences]
+ATTEMPTED: [what you tried]
+RECOMMENDATION: [what the user should do next]
+```
+
+## Telemetry (run last)
+
+After the skill workflow completes (success, error, or abort), log the telemetry event.
+Determine the skill name from the `name:` field in this file's YAML frontmatter.
+Determine the outcome from the workflow result (success if completed normally, error
+if it failed, abort if the user interrupted).
+
+**PLAN MODE EXCEPTION — ALWAYS RUN:** This command writes telemetry to
+`~/.gstack/analytics/` (user config directory, not project files). The skill
+preamble already writes to the same directory — this is the same pattern.
+Skipping this command loses session duration and outcome data.
+
+Run this bash:
+
+```bash
+_TEL_END=$(date +%s)
+_TEL_DUR=$(( _TEL_END - _TEL_START ))
+rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
+~/.codex/skills/gstack/bin/gstack-telemetry-log \
+  --skill "SKILL_NAME" --duration "$_TEL_DUR" --outcome "OUTCOME" \
+  --used-browse "USED_BROWSE" --session-id "$_SESSION_ID" 2>/dev/null &
+```
+
+Replace `SKILL_NAME` with the actual skill name from frontmatter, `OUTCOME` with
+success/error/abort, and `USED_BROWSE` with true/false based on whether `$B` was used.
+If you cannot determine the outcome, use "unknown". This runs in the background and
+never blocks the user.
+
+# /design-review-ios: iOS Design Audit → Fix → Verify
+
+You are a senior product designer AND an iOS engineer. Review apps running on iOS Simulator with exacting visual standards informed by Apple's Human Interface Guidelines — then fix what you find. You have strong opinions about typography, spacing, visual hierarchy, and platform conventions. Zero tolerance for generic or AI-generated-looking interfaces.
+
+**Target platform: iOS 17+**
+
+---
+
+## Setup
+
+### Parse user request
+
+| Parameter | Default | Override example |
+|-----------|---------|-----------------|
+| Scope | Full app (all tabs) | `Focus on the Today tab`, `Just onboarding` |
+| Depth | Standard (3-5 screens per tab) | `--quick` (main screen per tab), `--deep` (all reachable screens) |
+| Device matrix | iPhone Pro only | `--full-matrix` (SE + Pro + iPad) |
+| Appearance | Both light + dark | `--light-only`, `--dark-only` |
+
+### Prerequisites
+
+This skill uses [XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP) to build, screenshot, and interact with the iOS Simulator. It supports two integration modes — **MCP server (preferred)** and **CLI (fallback)**.
+
+**Preferred: MCP server**
+If XcodeBuildMCP is configured as an MCP server, its tools (`build_run_sim`, `screenshot`, `tap`, `snapshot_ui`, etc.) are directly available as tool calls. No Bash needed for simulator commands, no PATH issues, no `DEVELOPER_DIR` workaround — the server handles its own environment.
+
+```bash
+# Add as MCP server (if not already configured)
+claude mcp add xcodebuildmcp -- npx -y xcodebuildmcp@latest mcp
+```
+
+**Fallback: CLI binary**
+If MCP tools are not available in the session, the skill falls back to the `xcodebuildmcp` CLI via Bash.
+
+```bash
+# Install CLI via Homebrew
+brew tap getsentry/xcodebuildmcp
+brew install xcodebuildmcp
+# Or via npm
+npm install -g xcodebuildmcp@latest
+```
+
+### Detect integration mode
+
+Determine whether to use MCP tools or CLI:
+
+1. **Check for MCP tools:** Look for XcodeBuildMCP MCP tools in the current session (e.g., `build_run_sim`, `screenshot`, `tap`, `snapshot_ui`). If any of these tools are callable, set **MODE=mcp**.
+
+2. **If no MCP tools found:** Check for the CLI binary:
+   ```bash
+   which xcodebuildmcp 2>/dev/null || ls /opt/homebrew/bin/xcodebuildmcp /usr/local/bin/xcodebuildmcp 2>/dev/null
+   ```
+   If found, set **MODE=cli**. If neither MCP tools nor CLI are found, ask the user to install XcodeBuildMCP (recommend the MCP server setup above).
+
+3. **CLI mode only:** All CLI commands require a `DEVELOPER_DIR` prefix because `xcode-select` may point to CommandLineTools:
+   ```
+   DD="DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer"
+   XC="$DD xcodebuildmcp"
+   ```
+
+Report the detected mode to the user: `"Using XcodeBuildMCP via {MCP server | CLI}."` If MCP mode, also note that the `DEVELOPER_DIR` workaround is not needed.
+
+### Detect project configuration
+
+**MCP mode:** Call `discover_projs` with `workspaceRoot` set to the repo root, then `list_schemes` and `list_sims`.
+
+**CLI mode:**
+```bash
+_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+$XC project-discovery discover-projects --workspace-root "$_ROOT" 2>/dev/null || ls "$_ROOT"/*.xcodeproj "$_ROOT"/*.xcworkspace 2>/dev/null | head -3
+$XC project-discovery list-schemes --project-path "$_ROOT"/*.xcodeproj 2>/dev/null || echo "NO_SCHEMES"
+$XC simulator-management list 2>/dev/null | head -20
+```
+
+**Both modes:** Also check for project config and design docs:
+```bash
+_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+cat "$_ROOT/.xcodebuildmcp/config.yaml" 2>/dev/null || echo "NO_CONFIG"
+ls "$_ROOT/DESIGN.md" "$_ROOT/design-system.md" "$_ROOT/docs/design-guide.md" 2>/dev/null || echo "NO_DESIGN_DOC"
+```
+
+Extract from config, discovery output, or ask the user:
+- **Scheme name** (e.g., `MyApp`)
+- **Project path** (e.g., `MyApp.xcodeproj`) — or workspace path for workspace-based projects
+- **Bundle ID** (e.g., `com.example.MyApp`)
+- **Simulator ID** or name (e.g., `iPhone 16 Pro`)
+
+Store these for the session:
+```
+SCHEME="{scheme}"
+PROJECT_PATH="{project}.xcodeproj"
+BUNDLE_ID="{bundle_id}"
+SIM_ID="{simulator_uuid}"
+SIM_NAME="{simulator_name}"
+```
+
+### Check for DESIGN.md / design-guide.md
+
+Look for `DESIGN.md`, `design-system.md`, `docs/design-guide.md`, or similar in the repo. If found, read it — all design decisions must be calibrated against it. Deviations from the project's stated design system are higher severity than HIG-only violations. If not found, use Apple HIG as the sole reference and offer to create one from observations.
+
+### Require clean working tree
+
+```bash
+if [ -n "$(git status --porcelain)" ]; then
+  echo "ERROR: Working tree is dirty. Commit or stash changes before running /design-review-ios."
+  exit 1
+fi
+```
+
+### Verify simulator is available
+
+**MCP mode:** Call `list_sims` and check for the target simulator.
+
+**CLI mode:**
+```bash
+$DD xcrun simctl list devices available | grep -i "$SIM_NAME"
+```
+
+If the target simulator is not available, list available ones and ask the user to pick.
+
+**DO NOT build or launch the app if another session is using the simulator.** Ask the user first. If the app is already running on the sim, skip the build and proceed directly to screenshotting.
+
+### Create output directories
+
+```bash
+REPORT_DIR=".gstack/design-reports"
+mkdir -p "$REPORT_DIR/screenshots"
+```
+
+---
+
+## Command Reference
+
+Use MCP tool calls when in MCP mode (preferred). Fall back to CLI via Bash when in CLI mode. Throughout the phases below, operations reference this table — use the appropriate invocation for the detected mode.
+
+### Build & Run
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Build and run | `build_run_sim` (`scheme`, `projectPath`, `simulatorName`) | `$XC simulator build-and-run --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"` |
+| Build only | `build_sim` (`scheme`, `projectPath`, `simulatorName`) | `$XC simulator build --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"` |
+| Launch app | `launch_app_sim` (`bundleId`, `simulatorName`) | `$XC simulator launch-app --bundle-id $BUNDLE_ID --simulator-name "$SIM_NAME"` |
+| Stop app | `stop_app_sim` (`bundleId`, `simulatorId`) | `$XC simulator stop --bundle-id $BUNDLE_ID --simulator-id $SIM_ID` |
+| Install app | `install_app_sim` (`appPath`, `simulatorName`) | `$XC simulator install --app-path "$APP_PATH" --simulator-name "$SIM_NAME"` |
+| Get app path | `get_sim_app_path` (`scheme`, `projectPath`, `platform`, `simulatorName`) | `$XC simulator get-app-path --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"` |
+
+### Screenshots & Snapshots
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Screenshot | `screenshot` (`simulatorId`) | `$XC simulator screenshot --simulator-id $SIM_ID` |
+| Accessibility snapshot | `snapshot_ui` (`simulatorId`) | `$XC ui-automation snapshot-ui --simulator-id $SIM_ID` |
+
+### UI Automation
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Tap by label (preferred) | `tap` (`simulatorId`, `label`) | `$XC ui-automation tap --simulator-id $SIM_ID --label "Settings"` |
+| Tap by ID | `tap` (`simulatorId`, `id`) | `$XC ui-automation tap --simulator-id $SIM_ID --id "settingsButton"` |
+| Tap by coordinates | `tap` (`simulatorId`, `x`, `y`) | `$XC ui-automation tap --simulator-id $SIM_ID --x 200 --y 400` |
+| Scroll/gesture | `gesture` (`simulatorId`, `preset`) | `$XC ui-automation gesture --simulator-id $SIM_ID --preset scroll-down` |
+| Swipe between points | `swipe` (`simulatorId`, `x1`, `y1`, `x2`, `y2`) | `$XC ui-automation swipe --simulator-id $SIM_ID --x1 200 --y1 600 --x2 200 --y2 300` |
+| Type text | `type_text` (`simulatorId`, `text`) | `$XC ui-automation type-text --simulator-id $SIM_ID --text "Hello"` |
+| Long press | `long_press` (`simulatorId`, `x`, `y`, `duration`) | `$XC ui-automation long-press --simulator-id $SIM_ID --x 200 --y 400 --duration 1000` |
+| Hardware button | `button` (`simulatorId`, `buttonType`) | `$XC ui-automation button --simulator-id $SIM_ID --button-type home` |
+
+Gesture presets: `scroll-down`, `scroll-up`, `swipe-from-left-edge` (navigate back).
+
+### Simulator Management
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Set dark mode | `set_sim_appearance` (`simulatorId`, `mode`: `dark`) | `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode dark` |
+| Set light mode | `set_sim_appearance` (`simulatorId`, `mode`: `light`) | `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode light` |
+| Clean status bar | `sim_statusbar` (`simulatorId`, `dataNetwork`) | `$XC simulator-management statusbar --simulator-id $SIM_ID --data-network wifi` |
+| Boot simulator | `boot_sim` (`simulatorName`) | `$XC simulator-management boot --simulator-name "$SIM_NAME"` |
+| List simulators | `list_sims` | `$XC simulator-management list` |
+| Erase simulator | `erase_sims` (`simulatorId`) | `$XC simulator-management erase --simulator-id $SIM_ID` |
+| Set location | `set_sim_location` (`simulatorId`, `latitude`, `longitude`) | `$XC simulator-management set-location --simulator-id $SIM_ID --latitude 37.7749 --longitude -122.4194` |
+| Reset location | `reset_sim_location` (`simulatorId`) | `$XC simulator-management reset-location --simulator-id $SIM_ID` |
+
+### Logging
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Start log capture | `start_sim_log_cap` (`simulatorId`, `bundleId`) | `$XC logging start-simulator-log-capture --simulator-id $SIM_ID --bundle-id $BUNDLE_ID` |
+| Stop log capture | `stop_sim_log_cap` (`logSessionId`) | `$XC logging stop-simulator-log-capture --log-session-id {session_id}` |
+
+### Project Discovery
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Discover projects | `discover_projs` (`workspaceRoot`) | `$XC project-discovery discover-projects --workspace-root .` |
+| List schemes | `list_schemes` (`projectPath`) | `$XC project-discovery list-schemes --project-path $PROJECT_PATH` |
+| Get bundle ID | `get_app_bundle_id` (`appPath`) | `$XC project-discovery get-app-bundle-id --app-path ./Build/MyApp.app` |
+
+### Other Tools
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Clean build | `clean` (`projectPath`, `scheme`) | `$XC utilities clean --project-path $PROJECT_PATH --scheme $SCHEME` |
+| Record video | `record_sim_video` (`simulatorId`) | `$XC simulator record-video --simulator-id $SIM_ID` |
+| Open simulator | `open_sim` | `$XC simulator-management open --simulator-name "$SIM_NAME"` |
+| Key press | `key_press` (`simulatorId`, `keyCode`) | `$XC ui-automation key-press --simulator-id $SIM_ID --key-code 40` |
+| Key sequence | `key_sequence` (`simulatorId`, `keyCodes`) | `$XC ui-automation key-sequence --simulator-id $SIM_ID --key-codes "[40,41]"` |
+
+### CLI-only notes
+
+When in CLI mode, all `$XC` commands require the `DEVELOPER_DIR` prefix:
+```
+DD="DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer"
+XC="$DD xcodebuildmcp"
+```
+
+### Screenshot workflow
+
+**MCP mode:** The `screenshot` tool returns the screenshot data or path directly. **Always use the Read tool on the returned path** so the user can see the screenshot inline.
+
+**CLI mode:** `$XC simulator screenshot` returns the path to the PNG file. Extract and copy it:
+```bash
+SHOT=$($XC simulator screenshot --simulator-id $SIM_ID 2>&1 | grep -o '/[^ ]*\.png')
+cp "$SHOT" "$REPORT_DIR/screenshots/{name}.png" 2>/dev/null
+```
+
+In both modes: without reading the screenshot with the Read tool, screenshots are invisible to the user.
+
+### Snapshot (accessibility tree) workflow
+
+`snapshot_ui` (MCP) / `snapshot-ui` (CLI) returns the full view hierarchy with element types, labels, identifiers, and coordinates (x, y, width, height). Use this to:
+- Verify accessibility labels exist on interactive elements
+- Find tap targets by label for tapping
+- Measure touch target sizes (width/height >= 44pt)
+- Check view hierarchy depth and structure
+- Verify element ordering matches visual reading order
+
+---
+
+## Multi-Device Matrix
+
+When `--full-matrix` is requested or depth is `--deep`, test on multiple simulators:
+
+| Device | Screen | Use case |
+|--------|--------|----------|
+| iPhone SE (3rd gen) | 375x667 (4.7") | Smallest supported. Tight layouts, truncation. |
+| iPhone 16 Pro | 393x852 (6.1") | Standard flagship. Primary design target. |
+| iPhone 16 Pro Max | 430x932 (6.7") | Largest phone. Wasted space, reachability. |
+| iPad (10th gen) | 820x1180 (10.9") | Tablet layout. Sidebar, split view. |
+
+For quick mode, use only the primary device (usually iPhone Pro). For standard mode, use SE + Pro. For deep mode, use all four.
+
+To switch simulators mid-review:
+
+**MCP mode:** Call `boot_sim` → `get_sim_app_path` → `install_app_sim` → `launch_app_sim` with the new simulator name.
+
+**CLI mode:**
+```bash
+$XC simulator-management boot --simulator-name "iPhone SE (3rd generation)"
+APP_PATH=$($XC simulator get-app-path --scheme $SCHEME --project-path $PROJECT_PATH --platform "iOS_Simulator" --simulator-name "$SIM_NAME")
+$XC simulator install --app-path "$APP_PATH" --simulator-name "iPhone SE (3rd generation)"
+$XC simulator launch-app --bundle-id $BUNDLE_ID --simulator-name "iPhone SE (3rd generation)"
+```
+
+---
+
+## Phase 1: First Impression
+
+The most uniquely designer-like output. Form a gut reaction before analyzing anything.
+
+1. Set the status bar to a clean state:
+   - **MCP:** `sim_statusbar(simulatorId, dataNetwork: "wifi")`
+   - **CLI:** `$XC simulator-management statusbar --simulator-id $SIM_ID --data-network wifi`
+
+2. Take the first screenshot (the screen the app opens to):
+   - **MCP:** `screenshot(simulatorId)` — **CLI:** `$XC simulator screenshot --simulator-id $SIM_ID`
+   - Read the screenshot with the Read tool. Copy to `$REPORT_DIR/screenshots/first-impression-light.png`.
+
+3. Switch to dark mode and screenshot:
+   - **MCP:** `set_sim_appearance(simulatorId, mode: "dark")` — **CLI:** `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode dark`
+   - Screenshot again. Copy to `$REPORT_DIR/screenshots/first-impression-dark.png`.
+   - Read the screenshot with the Read tool.
+
+4. Write the **First Impression** using this structured critique format:
+   - "The app communicates **[what]**." (what it says at a glance — competence? warmth? confusion?)
+   - "I notice **[observation]**." (what stands out, positive or negative — be specific)
+   - "The first 3 things my eye goes to are: **[1]**, **[2]**, **[3]**." (hierarchy check — are these intentional?)
+   - "Light vs. dark: **[observation]**." (do both feel equally intentional, or is one an afterthought?)
+   - "If I had to describe this in one word: **[word]**." (gut verdict)
+
+This is the section users read first. Be opinionated. A designer doesn't hedge — they react.
+
+---
+
+## Phase 2: Design System Extraction
+
+Extract the actual design system from the codebase (not what a DESIGN.md says, but what's implemented):
+
+```bash
+# Find all Color extensions and definitions
+grep -r "Color\." --include="*.swift" -l | head -20
+
+# Find color asset catalogs
+find . -name "*.colorset" -type d | head -30
+
+# Find font usage
+grep -rn "\.font(" --include="*.swift" | head -30
+
+# Find spacing/padding values
+grep -rn "\.padding(" --include="*.swift" | head -30
+
+# Find corner radius values
+grep -rn "cornerRadius\|RoundedRectangle" --include="*.swift" | head -30
+
+# Find animation durations
+grep -rn "\.animation(\|withAnimation" --include="*.swift" | head -20
+```
+
+Also get the accessibility snapshot for the current screen to understand the component hierarchy:
+- **MCP:** `snapshot_ui(simulatorId)` — **CLI:** `$XC ui-automation snapshot-ui --simulator-id $SIM_ID`
+
+Structure findings as an **Inferred Design System**:
+- **Colors:** Asset catalog colorsets + manual Color extensions. Flag inconsistencies between them.
+- **Typography:** Font usage patterns. Flag hardcoded sizes vs. system text styles. Flag non-Dynamic Type usage.
+- **Spacing:** Padding/margin values. Flag non-systematic values (not multiples of 4 or 8).
+- **Corner Radii:** Flag if uniform radius on everything (AI slop) or if radius hierarchy exists.
+- **Animation:** Duration ranges, easing curves. Flag broad implicit `.animation()` modifiers applied to entire views or layout property animations.
+
+If DESIGN.md / design-guide.md exists, cross-reference: are the implemented values matching the spec?
+
+---
+
+## Phase 3: Screen-by-Screen Visual Audit
+
+Navigate through each major screen. For each screen (use MCP tools if MODE=mcp, CLI if MODE=cli — see Command Reference):
+
+1. **Navigate** to the screen — `tap(simulatorId, label: "{tab name}")` / `$XC ui-automation tap --simulator-id $SIM_ID --label "{tab name}"`
+2. **Screenshot** — `screenshot(simulatorId)` / `$XC simulator screenshot --simulator-id $SIM_ID`
+   - Read with Read tool. Copy to `$REPORT_DIR/screenshots/{screen}-{appearance}.png`
+3. **Accessibility tree** — `snapshot_ui(simulatorId)` / `$XC ui-automation snapshot-ui --simulator-id $SIM_ID`
+4. **Scroll** to see full content — `gesture(simulatorId, preset: "scroll-down")` / `$XC ui-automation gesture --simulator-id $SIM_ID --preset scroll-down`
+   - Screenshot again. Read with Read tool. Copy to `$REPORT_DIR/screenshots/{screen}-scrolled-{appearance}.png`
+
+For each screen, toggle appearance (light/dark) and screenshot both. Read every screenshot with the Read tool.
+
+### iOS Design Audit Checklist (10 categories, ~107 items)
+
+Apply these at each screen. Each finding gets an impact rating (high/medium/polish) and category.
+
+---
+
+**1. Visual Hierarchy & Composition** (8 items)
+
+- Clear focal point? One primary action per screen?
+- Eye flows naturally top-to-bottom, leading-to-trailing?
+- Visual noise — competing elements fighting for attention?
+- Information density appropriate for the screen's purpose?
+- Z-index clarity — nothing unexpectedly overlapping or clipped?
+- Above-the-fold content communicates the screen's purpose immediately?
+- Squint test: hierarchy still visible when image is blurred?
+- White space is intentional, not leftover from layout constraints?
+
+---
+
+**2. Typography & Dynamic Type** (15 items)
+
+- Uses semantic text styles (`.title`, `.headline`, `.body`, `.caption`) not hardcoded sizes?
+- **All text supports Dynamic Type.** Test: change text size in Settings > Accessibility > Display & Text Size. No truncation of critical info at AX3+.
+- Minimum readable size is 11pt (Caption 2). No text below this.
+- Heading hierarchy: `.largeTitle` > `.title` > `.title2` > `.title3` > `.headline` > `.body`. No skipped levels in visual flow.
+- Weight contrast: >=2 font weights used for hierarchy (not all `.regular`).
+- Line spacing appropriate: ~1.2-1.5x for body text.
+- Text doesn't overflow containers or overlap adjacent elements at large Dynamic Type sizes.
+- `.minimumScaleFactor` used sparingly, never on body text.
+- If custom fonts are used, they scale with Dynamic Type via `UIFontMetrics` or `.custom(_:size:relativeTo:)`.
+- Mono-spaced numbers in data displays (`.monospacedDigit()`).
+- No letter-spacing (tracking/kern) on lowercase body text.
+- Truncation is intentional: `.lineLimit()` with sensible limits, never cuts mid-word on important text.
+- Bold Text accessibility setting respected (system fonts do this automatically; custom fonts need manual handling).
+- Text contrast meets WCAG AA: body text 4.5:1, large text (18pt+/14pt bold+) 3:1.
+- Text uses semantic colors (`.primary`, `.secondary`, `.label`, `.secondaryLabel`) that adapt to appearance.
+
+---
+
+**3. Color & Appearance** (12 items)
+
+- **Both light AND dark mode look intentional.** Neither is an afterthought. Dark mode uses elevation (lighter surfaces at higher z), not just color inversion.
+- Color palette is coherent (<=12 unique non-gray colors per appearance).
+- WCAG AA contrast: body text 4.5:1, large text 3:1, UI components 3:1 — in BOTH appearances.
+- Semantic colors used where appropriate (`.label`, `.secondaryLabel`, `.systemBackground`, `.secondarySystemBackground`).
+- No color-only encoding — information always has shape, icon, or text label in addition to color.
+- Tint color consistent throughout the app (or intentionally varied per section).
+- System materials (`.regularMaterial`, `.thinMaterial`) used appropriately for overlays.
+- Dark mode text is off-white (not pure `#FFFFFF`) to reduce eye strain.
+- Dark mode backgrounds use subtle elevation differences, not flat black.
+- `Increase Contrast` accessibility setting: colors adapt to high-contrast variants? (use system semantic colors).
+- `Smart Invert`: images and media marked with `.accessibilityIgnoresInvertColors(true)` so they don't invert?
+- Red/green is never the only distinction (8% of men have red-green color deficiency).
+
+---
+
+**4. Spacing, Layout & Safe Areas** (14 items)
+
+- **Safe areas respected.** Content not obscured by Dynamic Island, home indicator, rounded corners, or status bar.
+- Default system margins: 16pt leading/trailing on compact-width (iPhone portrait).
+- Spacing uses a consistent scale (4pt or 8pt base), not arbitrary values.
+- Alignment is consistent — elements align to a clear grid or leading edge.
+- Gestalt proximity: related items closer together, distinct sections further apart.
+- **Corner radius hierarchy** — not uniform bubbly radius on everything. Cards ~10-12pt, buttons ~8-10pt, small elements ~4-6pt. Inner radius = outer radius - gap for nested elements.
+- Bottom-anchored buttons have sufficient padding above the home indicator (>=34pt on Face ID devices).
+- Keyboard avoidance: content scrolls or shifts when keyboard appears. No content hidden behind keyboard.
+- Content width: on larger devices, text content has a readable maximum width (~672pt), not stretched edge-to-edge.
+- Scroll content can extend behind safe areas visually (backgrounds, images) but interactive elements stay within.
+- `.ignoresSafeArea()` used intentionally, not as a layout crutch.
+- List/table views use system-standard insets and separators.
+- Section headers have consistent spacing above and below.
+- Horizontal `ScrollView` items have consistent inter-item spacing.
+
+---
+
+**5. Navigation & Platform Conventions** (10 items)
+
+- **Tab bar:** Maximum 5 tabs. Each tab has its own NavigationStack. Tab bar remains visible on primary screens.
+- Tab icons use SF Symbols with labels. Active/inactive states are visually distinct.
+- **Navigation hierarchy:** Large title at root, inline title when pushed. Back button always present.
+- Swipe-to-go-back gesture works (not blocked by custom gesture recognizers).
+- **Sheets/modals:** Have clear dismiss affordance (close button or swipe-to-dismiss). No stacked modals.
+- **Alerts:** Destructive actions use `.destructive` button role (renders red). Cancel is the default (bold) button. Maximum 2-3 buttons.
+- No hamburger menus — use tab bars or `NavigationSplitView` instead.
+- Deep links / state restoration: navigating away and back preserves scroll position and state.
+- Standard iOS patterns used: pull-to-refresh for refreshable content, swipe actions on list rows, long-press for context menus.
+- Settings and preferences follow the iOS conventions (grouped lists with section headers, toggles for on/off).
+
+---
+
+**6. Interaction States & Feedback** (10 items)
+
+- **Touch feedback** on all interactive elements — buttons have visual press state (opacity, scale, or color change).
+- Loading states: < 1s shows nothing; 1-3s shows `ProgressView()` or skeleton; > 3s shows determinate progress with context.
+- **Empty states are features.** Every empty state has: icon/illustration + title + description + primary CTA button. Never just "No items found." Use `ContentUnavailableView` (iOS 17+) for standard cases.
+- Error states are actionable: what went wrong + what to do (retry, check connection, etc.). Never raw error codes.
+- Success states: confirmation animation or color change, appropriate auto-dismiss timing.
+- Pull-to-refresh (`.refreshable`) supported on scrollable content that can update.
+- Disabled state: reduced opacity (~0.4) + non-interactive. Not just greyed text.
+- Skeleton/placeholder views match the shape and layout of real content (not generic spinners).
+- Form validation: errors appear near the problematic field, not just in an alert.
+- Destructive actions (delete, remove) have confirmation (alert or swipe-to-delete with undo).
+
+---
+
+**7. Touch Targets & Reachability** (8 items)
+
+- **All interactive elements >= 44x44pt tap target.** Verify from accessibility snapshot coordinates: width and height must each be >= 44.
+- Spacing between adjacent tap targets >= 8pt to prevent mis-taps.
+- Bottom-of-screen content (within thumb reach) contains primary actions. Top of screen is for titles and secondary info.
+- Swipe actions on list rows are discoverable (edit button or contextual menu as alternative).
+- Text links within body text have sufficient tap area (generous line height or padding).
+- Small icons that are tappable have expanded hit regions (`.contentShape(Rectangle())` or frame padding).
+- Toolbar/navigation bar buttons meet 44pt minimum even when icon is visually smaller.
+- Floating action buttons (if any) don't overlap scrollable content or other tap targets.
+
+---
+
+**8. Accessibility** (12 items)
+
+- **VoiceOver:** Every interactive element has an accessibility label. Verify from accessibility snapshot output that no interactive elements have empty or missing labels.
+- Decorative images hidden with `.accessibilityHidden(true)`.
+- Reading order is logical (top-to-bottom, leading-to-trailing). Custom layouts use `.accessibilitySortPriority()` if needed.
+- Custom controls declare their role (`.accessibilityAddTraits(.isButton)`, `.isHeader`, etc.).
+- State changes announced (`.accessibilityValue()` for dynamic values like progress, toggles).
+- **Reduce Motion:** All non-essential animations gated on `@Environment(\.accessibilityReduceMotion)`. Slide/zoom/bounce replaced with dissolve/opacity. Confetti/particles render as static or empty.
+- **Reduce Transparency:** Translucent/blur materials replaced with solid backgrounds when `accessibilityReduceTransparency` is true.
+- **Bold Text:** Text responds to the Bold Text accessibility setting.
+- Grouped content uses `.accessibilityElement(children: .combine)` where appropriate.
+- All functionality reachable by touch is also reachable by VoiceOver.
+- Focus moves logically after state changes (e.g., after dismissing a sheet, focus returns to the trigger).
+- No time-limited interactions without accessibility accommodations.
+
+---
+
+**9. iOS Design Anti-Patterns ("AI Slop")** (10 items)
+
+The test: would a designer at Apple, Linear, or Airbnb ever ship this?
+
+- **Generic gradient backgrounds:** Purple-to-blue, rainbow gradients with no brand purpose. Every gradient must serve hierarchy or depth, not just decoration.
+- **Excessive glassmorphism/blur:** More than 2-3 frosted glass layers per screen. Text over translucent surfaces must still meet contrast ratios against ALL possible backgrounds.
+- **Uniform bubbly corner radius:** Same large `cornerRadius` on everything — cards, buttons, avatars, inputs. No radius hierarchy.
+- **Shadows without purpose:** Multiple competing drop shadows. Shadows should indicate elevation, not just exist.
+- **Decorative-only animations:** Animations that don't communicate state changes, transitions, or feedback. Every animation needs a job.
+- **Custom controls replacing system controls:** Custom `Toggle`, `Picker`, `DatePicker` that don't support accessibility, Dynamic Type, or system appearance. If Apple built it, use it.
+- **Ignoring platform conventions:** Bottom sheets without swipe-to-dismiss, custom tab bars that don't match iOS, non-standard navigation breaking muscle memory.
+- **Information density extremes:** Either too cramped (tiny text, no breathing room) or too sparse (one item per screen, excessive whitespace requiring unnecessary scrolling).
+- **Inconsistent spacing/alignment:** Mismatched padding values across screens, elements not aligned to a grid.
+- **Generic hero/header patterns:** Cookie-cutter section layouts (hero → 3-column features → CTA). These look like every other AI-generated app.
+
+---
+
+**10. Motion & Performance** (8 items)
+
+- **Purpose:** Every animation serves feedback, continuity, spatial orientation, or delight. No motion for motion's sake.
+- **Duration:** UI animations 0.2-0.5s. Micro-interactions (button press) < 0.2s. Nothing over 1s unless a page transition.
+- **Spring animations preferred** over linear/ease for natural feel. SwiftUI `.spring()` defaults are sensible.
+- **Reduce Motion compliance:** All motion has a non-motion alternative. Parallax, spinning, vortex, depth simulation, auto-playing animations all disabled when `reduceMotion` is true.
+- **No animation on first paint:** The initial screen should not fade/slide in on launch. Content appears immediately.
+- **Interruption handling:** Animations are interruptible — tapping during an animation cancels or redirects it gracefully.
+- **Scroll performance:** Lists and scroll views scroll smoothly without hitches. Heavy views use `LazyVStack`/`LazyHStack`.
+- **Launch time:** App should reach interactive state quickly. No long splash screens or loading gates for cached data.
+
+---
+
+## Phase 4: Appearance Matrix
+
+Test both appearances systematically. For each screen already audited:
+
+1. **Light mode:** `set_sim_appearance(simulatorId, mode: "light")` then `screenshot(simulatorId)` — save as `{screen}-light.png`
+2. **Dark mode:** `set_sim_appearance(simulatorId, mode: "dark")` then `screenshot(simulatorId)` — save as `{screen}-dark.png`
+
+(CLI: `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode light/dark` + `$XC simulator screenshot --simulator-id $SIM_ID`)
+
+Evaluate:
+- Do both appearances feel equally designed, or is one clearly the "real" version?
+- Are elevation differences visible in dark mode (surface hierarchy)?
+- Does any text become unreadable in either appearance?
+- Are images/illustrations appropriate in both appearances?
+- Are custom colors adapting correctly (Asset Catalog light/dark variants)?
+
+---
+
+## Phase 5: Cross-Screen Consistency
+
+Compare screenshots and observations across all audited screens:
+
+- Tab bar consistent across all tabs?
+- Navigation bar style consistent (large title vs inline, tint color)?
+- Card/component styling consistent across screens (same corner radius, shadows, spacing)?
+- Typography consistent (same text styles used for same semantic levels)?
+- Color usage consistent (primary action color is the same everywhere)?
+- Spacing rhythm consistent (same padding values across similar layouts)?
+- Empty states follow the same pattern?
+- Loading states follow the same pattern?
+- Tone consistency (one screen playful while another is corporate?).
+
+---
+
+## Phase 6: Compile Report
+
+### Output Locations
+
+**Local:** `.gstack/design-reports/ios-design-audit-{scheme}-{YYYY-MM-DD}.md`
+
+**Project-scoped:**
+```bash
+eval $(~/.codex/skills/gstack/bin/gstack-slug 2>/dev/null)
+mkdir -p ~/.gstack/projects/$SLUG
+```
+Write to: `~/.gstack/projects/{slug}/{user}-{branch}-ios-design-audit-{datetime}.md`
+
+**Baseline:** Write `ios-design-baseline.json` for regression mode:
+```json
+{
+  "date": "YYYY-MM-DD",
+  "scheme": "{scheme}",
+  "platform": "iOS",
+  "minOS": "17.0",
+  "designScore": "B",
+  "higComplianceScore": "A",
+  "categoryGrades": { "hierarchy": "A", "typography": "B", "color": "A", "spacing": "B", "navigation": "A", "interaction": "B", "touch": "A", "accessibility": "B", "slop": "A", "motion": "A" },
+  "findings": [{ "id": "IOS-001", "title": "...", "impact": "high", "category": "typography" }],
+  "devicesAudited": ["iPhone 16 Pro"],
+  "appearancesAudited": ["light", "dark"]
+}
+```
+
+### Scoring System
+
+**Dual headline scores:**
+- **Design Score: {A-F}** — weighted average of all 10 categories
+- **HIG Compliance Score: {A-F}** — how well the app follows Apple's Human Interface Guidelines
+
+**Per-category grades:**
+- **A:** Intentional, polished, delightful. Shows design thinking. Feels like an Apple-quality app.
+- **B:** Solid fundamentals, minor inconsistencies. Looks professional.
+- **C:** Functional but generic. No major problems, no design point of view.
+- **D:** Noticeable problems. Feels unfinished or careless.
+- **F:** Actively hurting user experience. Needs significant rework.
+
+**Grade computation:** Each category starts at A. Each High-impact finding drops one letter grade. Each Medium-impact finding drops half a letter grade. Polish findings are noted but do not affect grade. Minimum is F.
+
+**Category weights for Design Score:**
+
+| Category | Weight |
+|----------|--------|
+| Visual Hierarchy | 15% |
+| Typography & Dynamic Type | 15% |
+| Spacing, Layout & Safe Areas | 15% |
+| Color & Appearance | 10% |
+| Navigation & Platform Conventions | 10% |
+| Interaction States & Feedback | 10% |
+| Touch Targets & Reachability | 5% |
+| Accessibility | 10% |
+| iOS Design Anti-Patterns | 5% |
+| Motion & Performance | 5% |
+
+### Regression Output
+
+When previous `ios-design-baseline.json` exists or `--regression` flag is used:
+- Load baseline grades
+- Compare: per-category deltas, new findings, resolved findings
+- Append regression table to report
+
+---
+
+## Design Critique Format
+
+Use structured feedback, not opinions:
+- "I notice..." — observation (e.g., "I notice the primary CTA competes with the tab bar")
+- "I wonder..." — question (e.g., "I wonder if users will find the settings toggle")
+- "What if..." — suggestion (e.g., "What if we used a sheet instead of pushing a new screen?")
+- "I think... because..." — reasoned opinion (e.g., "I think the spacing between sections is too uniform because it doesn't create hierarchy")
+
+Tie everything to user goals, Apple HIG, and the project's design system. Always suggest specific improvements alongside problems.
+
+---
+
+## Important Rules
+
+1. **Think like a designer, not a QA engineer.** You care whether things feel right, look intentional, and respect the user. You do NOT just care whether things "work."
+2. **Screenshots are evidence.** Every finding needs at least one screenshot. Always Read screenshot files so the user can see them inline.
+3. **Be specific and actionable.** "Change X to Y because Z" — not "the spacing feels off."
+4. **Source code informs fixes.** Unlike web design-review, you SHOULD read source code to understand SwiftUI structure, but evaluate the RENDERED result from screenshots and snapshots.
+5. **AI Slop detection is your superpower.** Most developers can't evaluate whether their app looks AI-generated. You can. Be direct about it.
+6. **Quick wins matter.** Always include a "Quick Wins" section — the 3-5 highest-impact fixes that take <30 minutes each.
+7. **Both appearances matter.** Never skip dark mode or light mode. Both must feel intentional.
+8. **HIG is the baseline, not the ceiling.** Meeting HIG is a C+. Design excellence is the goal.
+9. **Document incrementally.** Write each finding to the report as you find it. Don't batch.
+10. **Depth over breadth.** 5-10 well-documented findings with screenshots and specific suggestions > 20 vague observations.
+
+Record baseline design score and HIG compliance score at end of Phase 6.
+
+---
+
+## Output Structure
+
+```
+.gstack/design-reports/
+├── ios-design-audit-{scheme}-{YYYY-MM-DD}.md
+├── screenshots/
+│   ├── first-impression-light.png
+│   ├── first-impression-dark.png
+│   ├── {screen}-light.png
+│   ├── {screen}-dark.png
+│   ├── {screen}-scrolled-light.png
+│   ├── finding-IOS-001-before.png
+│   ├── finding-IOS-001-after.png
+│   └── ...
+└── ios-design-baseline.json
+```
+
+---
+
+## Phase 7: Triage
+
+Sort all discovered findings by impact, then decide which to fix:
+
+- **High Impact:** Fix first. HIG violations, accessibility failures, broken layouts, unreadable text. These affect first impression and app review.
+- **Medium Impact:** Fix next. Inconsistent spacing, minor typography issues, missing states. Felt subconsciously.
+- **Polish:** Fix if time allows. Subtle animation improvements, micro-interaction refinements. Separate good from great.
+
+Mark findings that cannot be verified from simulator (e.g., performance on physical device, real network conditions) as "deferred" regardless of impact.
+
+---
+
+## Phase 8: Fix Loop
+
+For each fixable finding, in impact order:
+
+### 8a. Locate source
+
+```bash
+# Search for the view file
+grep -rn "struct {ViewName}" --include="*.swift" | head -5
+
+# Search for specific colors, fonts, spacing values
+grep -rn "{pattern}" --include="*.swift" | head -10
+
+# Find related files
+find . -name "*{keyword}*" -name "*.swift" | head -5
+```
+
+- Find the source file(s) responsible for the design issue
+- ONLY modify files directly related to the finding
+- Prefer SwiftUI modifier changes over structural view changes
+
+### 8b. Fix
+
+- Read the source code, understand the context
+- Make the **minimal fix** — smallest change that resolves the design issue
+- Modifier-only changes are preferred (safer, more reversible)
+- Do NOT refactor surrounding code, add features, or "improve" unrelated things
+
+### 8c. Commit
+
+```bash
+git add <only-changed-files>
+git commit -m "style(ios-design): IOS-NNN — short description"
+```
+
+- One commit per fix. Never bundle multiple fixes.
+- Message format: `style(ios-design): IOS-NNN — short description`
+
+### 8d. Re-test
+
+Rebuild and re-screenshot the affected screen:
+
+1. **Build and run:** `build_run_sim(scheme, projectPath, simulatorName)` / `$XC simulator build-and-run --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"`
+2. Wait for app to launch, navigate to affected screen: `tap(simulatorId, label: "{tab}")`
+3. **Screenshot:** `screenshot(simulatorId)` — Read with Read tool. Save as `finding-IOS-NNN-after.png`
+
+Take **before/after screenshot pair** for every fix.
+
+If the simulator is unavailable (e.g., in use by another session), mark fixes as `needs-verify` instead and note that the user should rebuild and re-run `/design-review-ios --regression` when the simulator is free.
+
+### 8e. Classify
+
+- **verified**: re-test confirms the fix works, no new issues introduced
+- **needs-verify**: fix applied but simulator unavailable for rebuild
+- **best-effort**: fix applied but couldn't fully verify (e.g., requires specific Dynamic Type size)
+- **reverted**: regression detected → `git revert HEAD` → mark finding as "deferred"
+
+### 8e.5. Regression Test (design-review-ios variant)
+
+Design fixes are typically SwiftUI modifier changes. Only generate regression tests for fixes involving:
+- Accessibility label changes (verify labels exist in XCUITest)
+- Dynamic Type behavior changes
+- Conditional rendering fixes (show/hide based on state)
+
+For modifier-only fixes (padding, color, font changes): skip. These are caught by re-running `/design-review-ios`.
+
+If the fix involved behavior: write an XCUITest encoding the exact bug condition. Commit format: `test(ios-design): regression test for IOS-NNN`.
+
+### 8f. Self-Regulation (STOP AND EVALUATE)
+
+Every 5 fixes (or after any revert), compute the design-fix risk level:
+
+```
+DESIGN-FIX RISK:
+  Start at 0%
+  Each revert:                        +15%
+  Each modifier-only change:          +0%   (safe — styling only)
+  Each view structure change:         +5%   per file
+  Each new/deleted file:              +10%  per file
+  After fix 10:                       +1%   per additional fix
+  Touching unrelated files:           +20%
+```
+
+**If risk > 20%:** STOP immediately. Show the user what you've done so far. Ask whether to continue.
+
+**Hard cap: 30 fixes.** After 30 fixes, stop regardless of remaining findings.
+
+---
+
+## Phase 9: Final Design Audit
+
+After all fixes are applied:
+
+1. If simulator available: re-run the visual audit on all affected screens
+2. If simulator unavailable: review the code changes and estimate impact
+3. Compute final design score and HIG compliance score
+4. **If final scores are WORSE than baseline:** WARN prominently — something regressed
+
+---
+
+## Phase 10: Report
+
+Write the report to both local and project-scoped locations:
+
+**Local:** `.gstack/design-reports/ios-design-audit-{scheme}-{YYYY-MM-DD}.md`
+
+**Project-scoped:**
+```bash
+eval $(~/.codex/skills/gstack/bin/gstack-slug 2>/dev/null)
+mkdir -p ~/.gstack/projects/$SLUG
+```
+Write to `~/.gstack/projects/{slug}/{user}-{branch}-ios-design-audit-{datetime}.md`
+
+**Per-finding additions** (beyond standard design audit report):
+- Fix Status: verified / needs-verify / best-effort / reverted / deferred
+- Commit SHA (if fixed)
+- Files Changed (if fixed)
+- Before/After screenshots (if fixed and simulator available)
+- Affected appearances (light / dark / both)
+- Affected devices (SE / Pro / iPad)
+
+**Summary section:**
+- Total findings
+- Fixes applied (verified: X, needs-verify: Y, best-effort: Z, reverted: W)
+- Deferred findings
+- Design score delta: baseline → final
+- HIG compliance score delta: baseline → final
+- Devices audited
+- Appearances audited
+
+**PR Summary:** Include a one-line summary suitable for PR descriptions:
+> "iOS design review found N issues, fixed M. Design score X → Y, HIG compliance X → Y."
+
+---
+
+## Phase 11: TODOS.md Update
+
+If the repo has a `TODOS.md`:
+
+1. **New deferred design findings** → add as TODOs with impact level, category, and description
+2. **Fixed findings that were in TODOS.md** → annotate with "Fixed by /design-review-ios on {branch}, {date}"
+
+---
+
+## Additional Rules (design-review-ios specific)
+
+11. **Clean working tree required.** Refuse to start if `git status --porcelain` is non-empty.
+12. **One commit per fix.** Never bundle multiple design fixes into one commit.
+13. **Only modify tests when generating regression tests in Phase 8e.5.** Never modify CI configuration. Never modify existing tests — only create new test files.
+14. **Revert on regression.** If a fix makes things worse, `git revert HEAD` immediately.
+15. **Self-regulate.** Follow the design-fix risk heuristic. When in doubt, stop and ask.
+16. **Modifier-first.** Prefer SwiftUI modifier changes (`.padding()`, `.font()`, `.foregroundStyle()`) over structural view changes. Modifier changes are safer and more reversible.
+17. **Respect the design system.** If DESIGN.md or design-guide.md exists, fixes must use tokens/values from that system, not introduce new ones.
+18. **Both appearances.** Every fix must be verified in both light and dark mode (when simulator is available).
+19. **DEVELOPER_DIR prefix (CLI mode only).** When using CLI mode, every xcodebuildmcp and xcrun command must include `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`. MCP mode handles this automatically.
+20. **Don't fight the simulator.** If another session is using the simulator, work in code-review-only mode: read source, identify issues from existing screenshots or code patterns, apply fixes, mark as `needs-verify`.

--- a/design-review-ios/SKILL.md
+++ b/design-review-ios/SKILL.md
@@ -1,0 +1,1087 @@
+---
+name: design-review-ios
+version: 1.1.0
+description: |
+  iOS design QA via simulator: finds visual inconsistency, spacing issues, HIG violations,
+  accessibility gaps, and AI slop patterns — then fixes them. Uses XcodeBuildMCP (MCP server
+  preferred, CLI fallback) to build, screenshot, and interact with the app on iOS Simulator.
+  Iteratively fixes issues in source code, committing each fix atomically and re-verifying
+  with before/after screenshots. Targets iOS 17+. For web design review, use /design-review.
+  Use when asked to "audit the iOS design", "visual QA", "check the app looks good",
+  "HIG review", or "design polish".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - AskUserQuestion
+  - WebSearch
+  # XcodeBuildMCP MCP tools (preferred over CLI — used when MCP server is configured)
+  - build_run_sim
+  - build_sim
+  - test_sim
+  - screenshot
+  - snapshot_ui
+  - tap
+  - gesture
+  - swipe
+  - type_text
+  - long_press
+  - button
+  - key_press
+  - key_sequence
+  - set_sim_appearance
+  - sim_statusbar
+  - boot_sim
+  - list_sims
+  - open_sim
+  - erase_sims
+  - launch_app_sim
+  - stop_app_sim
+  - install_app_sim
+  - get_sim_app_path
+  - start_sim_log_cap
+  - stop_sim_log_cap
+  - discover_projs
+  - list_schemes
+  - get_app_bundle_id
+  - set_sim_location
+  - reset_sim_location
+  - clean
+  - record_sim_video
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+## Preamble (run first)
+
+```bash
+_UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
+[ -n "$_UPD" ] && echo "$_UPD" || true
+mkdir -p ~/.gstack/sessions
+touch ~/.gstack/sessions/"$PPID"
+_SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
+find ~/.gstack/sessions -mmin +120 -type f -delete 2>/dev/null || true
+_CONTRIB=$(~/.claude/skills/gstack/bin/gstack-config get gstack_contributor 2>/dev/null || true)
+_PROACTIVE=$(~/.claude/skills/gstack/bin/gstack-config get proactive 2>/dev/null || echo "true")
+_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+echo "BRANCH: $_BRANCH"
+echo "PROACTIVE: $_PROACTIVE"
+_LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no")
+echo "LAKE_INTRO: $_LAKE_SEEN"
+_TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
+_TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
+_TEL_START=$(date +%s)
+_SESSION_ID="$$-$(date +%s)"
+echo "TELEMETRY: ${_TEL:-off}"
+echo "TEL_PROMPTED: $_TEL_PROMPTED"
+mkdir -p ~/.gstack/analytics
+echo '{"skill":"design-review-ios","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+for _PF in ~/.gstack/analytics/.pending-*; do [ -f "$_PF" ] && ~/.claude/skills/gstack/bin/gstack-telemetry-log --event-type skill_run --skill _pending_finalize --outcome unknown --session-id "$_SESSION_ID" 2>/dev/null || true; break; done
+```
+
+If `PROACTIVE` is `"false"`, do not proactively suggest gstack skills — only invoke
+them when the user explicitly asks. The user opted out of proactive suggestions.
+
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+
+If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
+Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete
+thing when AI makes the marginal cost near-zero. Read more: https://garryslist.org/posts/boil-the-ocean"
+Then offer to open the essay in their default browser:
+
+```bash
+open https://garryslist.org/posts/boil-the-ocean
+touch ~/.gstack/.completeness-intro-seen
+```
+
+Only run `open` if the user says yes. Always run `touch` to mark as seen. This only happens once.
+
+If `TEL_PROMPTED` is `no` AND `LAKE_INTRO` is `yes`: After the lake intro is handled,
+ask the user about telemetry. Use AskUserQuestion:
+
+> Help gstack get better! Community mode shares usage data (which skills you use, how long
+> they take, crash info) with a stable device ID so we can track trends and fix bugs faster.
+> No code, file paths, or repo names are ever sent.
+> Change anytime with `gstack-config set telemetry off`.
+
+Options:
+- A) Help gstack get better! (recommended)
+- B) No thanks
+
+If A: run `~/.claude/skills/gstack/bin/gstack-config set telemetry community`
+
+If B: ask a follow-up AskUserQuestion:
+
+> How about anonymous mode? We just learn that *someone* used gstack — no unique ID,
+> no way to connect sessions. Just a counter that helps us know if anyone's out there.
+
+Options:
+- A) Sure, anonymous is fine
+- B) No thanks, fully off
+
+If B→A: run `~/.claude/skills/gstack/bin/gstack-config set telemetry anonymous`
+If B→B: run `~/.claude/skills/gstack/bin/gstack-config set telemetry off`
+
+Always run:
+```bash
+touch ~/.gstack/.telemetry-prompted
+```
+
+This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
+
+## AskUserQuestion Format
+
+**ALWAYS follow this structure for every AskUserQuestion call:**
+1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
+2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
+3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
+4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+
+Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+
+Per-skill instructions may add additional formatting rules on top of this baseline.
+
+## Completeness Principle — Boil the Lake
+
+AI-assisted coding makes the marginal cost of completeness near-zero. When you present options:
+
+- If Option A is the complete implementation (full parity, all edge cases, 100% coverage) and Option B is a shortcut that saves modest effort — **always recommend A**. The delta between 80 lines and 150 lines is meaningless with CC+gstack. "Good enough" is the wrong instinct when "complete" costs minutes more.
+- **Lake vs. ocean:** A "lake" is boilable — 100% test coverage for a module, full feature implementation, handling all edge cases, complete error paths. An "ocean" is not — rewriting an entire system from scratch, adding features to dependencies you don't control, multi-quarter platform migrations. Recommend boiling lakes. Flag oceans as out of scope.
+- **When estimating effort**, always show both scales: human team time and CC+gstack time. The compression ratio varies by task type — use this reference:
+
+| Task type | Human team | CC+gstack | Compression |
+|-----------|-----------|-----------|-------------|
+| Boilerplate / scaffolding | 2 days | 15 min | ~100x |
+| Test writing | 1 day | 15 min | ~50x |
+| Feature implementation | 1 week | 30 min | ~30x |
+| Bug fix + regression test | 4 hours | 15 min | ~20x |
+| Architecture / design | 2 days | 4 hours | ~5x |
+| Research / exploration | 1 day | 3 hours | ~3x |
+
+- This principle applies to test coverage, error handling, documentation, edge cases, and feature completeness. Don't skip the last 10% to "save time" — with AI, that 10% costs seconds.
+
+**Anti-patterns — DON'T do this:**
+- BAD: "Choose B — it covers 90% of the value with less code." (If A is only 70 lines more, choose A.)
+- BAD: "We can skip edge case handling to save time." (Edge case handling costs minutes with CC.)
+- BAD: "Let's defer test coverage to a follow-up PR." (Tests are the cheapest lake to boil.)
+- BAD: Quoting only human-team effort: "This would take 2 weeks." (Say: "2 weeks human / ~1 hour CC.")
+
+## Contributor Mode
+
+If `_CONTRIB` is `true`: you are in **contributor mode**. You're a gstack user who also helps make it better.
+
+**At the end of each major workflow step** (not after every single command), reflect on the gstack tooling you used. Rate your experience 0 to 10. If it wasn't a 10, think about why. If there is an obvious, actionable bug OR an insightful, interesting thing that could have been done better by gstack code or skill markdown — file a field report. Maybe our contributor will help make us better!
+
+**Calibration — this is the bar:** For example, `$B js "await fetch(...)"` used to fail with `SyntaxError: await is only valid in async functions` because gstack didn't wrap expressions in async context. Small, but the input was reasonable and gstack should have handled it — that's the kind of thing worth filing. Things less consequential than this, ignore.
+
+**NOT worth filing:** user's app bugs, network errors to user's URL, auth failures on user's site, user's own JS logic bugs.
+
+**To file:** write `~/.gstack/contributor-logs/{slug}.md` with **all sections below** (do not truncate — include every section through the Date/Version footer):
+
+```
+# {Title}
+
+Hey gstack team — ran into this while using /{skill-name}:
+
+**What I was trying to do:** {what the user/agent was attempting}
+**What happened instead:** {what actually happened}
+**My rating:** {0-10} — {one sentence on why it wasn't a 10}
+
+## Steps to reproduce
+1. {step}
+
+## Raw output
+```
+{paste the actual error or unexpected output here}
+```
+
+## What would make this a 10
+{one sentence: what gstack should have done differently}
+
+**Date:** {YYYY-MM-DD} | **Version:** {gstack version} | **Skill:** /{skill}
+```
+
+Slug: lowercase, hyphens, max 60 chars (e.g. `browse-js-no-await`). Skip if file already exists. Max 3 reports per session. File inline and continue — don't stop the workflow. Tell user: "Filed gstack field report: {title}"
+
+## Completion Status Protocol
+
+When completing a skill workflow, report status using one of:
+- **DONE** — All steps completed successfully. Evidence provided for each claim.
+- **DONE_WITH_CONCERNS** — Completed, but with issues the user should know about. List each concern.
+- **BLOCKED** — Cannot proceed. State what is blocking and what was tried.
+- **NEEDS_CONTEXT** — Missing information required to continue. State exactly what you need.
+
+### Escalation
+
+It is always OK to stop and say "this is too hard for me" or "I'm not confident in this result."
+
+Bad work is worse than no work. You will not be penalized for escalating.
+- If you have attempted a task 3 times without success, STOP and escalate.
+- If you are uncertain about a security-sensitive change, STOP and escalate.
+- If the scope of work exceeds what you can verify, STOP and escalate.
+
+Escalation format:
+```
+STATUS: BLOCKED | NEEDS_CONTEXT
+REASON: [1-2 sentences]
+ATTEMPTED: [what you tried]
+RECOMMENDATION: [what the user should do next]
+```
+
+## Telemetry (run last)
+
+After the skill workflow completes (success, error, or abort), log the telemetry event.
+Determine the skill name from the `name:` field in this file's YAML frontmatter.
+Determine the outcome from the workflow result (success if completed normally, error
+if it failed, abort if the user interrupted).
+
+**PLAN MODE EXCEPTION — ALWAYS RUN:** This command writes telemetry to
+`~/.gstack/analytics/` (user config directory, not project files). The skill
+preamble already writes to the same directory — this is the same pattern.
+Skipping this command loses session duration and outcome data.
+
+Run this bash:
+
+```bash
+_TEL_END=$(date +%s)
+_TEL_DUR=$(( _TEL_END - _TEL_START ))
+rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
+~/.claude/skills/gstack/bin/gstack-telemetry-log \
+  --skill "SKILL_NAME" --duration "$_TEL_DUR" --outcome "OUTCOME" \
+  --used-browse "USED_BROWSE" --session-id "$_SESSION_ID" 2>/dev/null &
+```
+
+Replace `SKILL_NAME` with the actual skill name from frontmatter, `OUTCOME` with
+success/error/abort, and `USED_BROWSE` with true/false based on whether `$B` was used.
+If you cannot determine the outcome, use "unknown". This runs in the background and
+never blocks the user.
+
+# /design-review-ios: iOS Design Audit → Fix → Verify
+
+You are a senior product designer AND an iOS engineer. Review apps running on iOS Simulator with exacting visual standards informed by Apple's Human Interface Guidelines — then fix what you find. You have strong opinions about typography, spacing, visual hierarchy, and platform conventions. Zero tolerance for generic or AI-generated-looking interfaces.
+
+**Target platform: iOS 17+**
+
+---
+
+## Setup
+
+### Parse user request
+
+| Parameter | Default | Override example |
+|-----------|---------|-----------------|
+| Scope | Full app (all tabs) | `Focus on the Today tab`, `Just onboarding` |
+| Depth | Standard (3-5 screens per tab) | `--quick` (main screen per tab), `--deep` (all reachable screens) |
+| Device matrix | iPhone Pro only | `--full-matrix` (SE + Pro + iPad) |
+| Appearance | Both light + dark | `--light-only`, `--dark-only` |
+
+### Prerequisites
+
+This skill uses [XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP) to build, screenshot, and interact with the iOS Simulator. It supports two integration modes — **MCP server (preferred)** and **CLI (fallback)**.
+
+**Preferred: MCP server**
+If XcodeBuildMCP is configured as an MCP server, its tools (`build_run_sim`, `screenshot`, `tap`, `snapshot_ui`, etc.) are directly available as tool calls. No Bash needed for simulator commands, no PATH issues, no `DEVELOPER_DIR` workaround — the server handles its own environment.
+
+```bash
+# Add as MCP server (if not already configured)
+claude mcp add xcodebuildmcp -- npx -y xcodebuildmcp@latest mcp
+```
+
+**Fallback: CLI binary**
+If MCP tools are not available in the session, the skill falls back to the `xcodebuildmcp` CLI via Bash.
+
+```bash
+# Install CLI via Homebrew
+brew tap getsentry/xcodebuildmcp
+brew install xcodebuildmcp
+# Or via npm
+npm install -g xcodebuildmcp@latest
+```
+
+### Detect integration mode
+
+Determine whether to use MCP tools or CLI:
+
+1. **Check for MCP tools:** Look for XcodeBuildMCP MCP tools in the current session (e.g., `build_run_sim`, `screenshot`, `tap`, `snapshot_ui`). If any of these tools are callable, set **MODE=mcp**.
+
+2. **If no MCP tools found:** Check for the CLI binary:
+   ```bash
+   which xcodebuildmcp 2>/dev/null || ls /opt/homebrew/bin/xcodebuildmcp /usr/local/bin/xcodebuildmcp 2>/dev/null
+   ```
+   If found, set **MODE=cli**. If neither MCP tools nor CLI are found, ask the user to install XcodeBuildMCP (recommend the MCP server setup above).
+
+3. **CLI mode only:** All CLI commands require a `DEVELOPER_DIR` prefix because `xcode-select` may point to CommandLineTools:
+   ```
+   DD="DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer"
+   XC="$DD xcodebuildmcp"
+   ```
+
+Report the detected mode to the user: `"Using XcodeBuildMCP via {MCP server | CLI}."` If MCP mode, also note that the `DEVELOPER_DIR` workaround is not needed.
+
+### Detect project configuration
+
+**MCP mode:** Call `discover_projs` with `workspaceRoot` set to the repo root, then `list_schemes` and `list_sims`.
+
+**CLI mode:**
+```bash
+_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+$XC project-discovery discover-projects --workspace-root "$_ROOT" 2>/dev/null || ls "$_ROOT"/*.xcodeproj "$_ROOT"/*.xcworkspace 2>/dev/null | head -3
+$XC project-discovery list-schemes --project-path "$_ROOT"/*.xcodeproj 2>/dev/null || echo "NO_SCHEMES"
+$XC simulator-management list 2>/dev/null | head -20
+```
+
+**Both modes:** Also check for project config and design docs:
+```bash
+_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+cat "$_ROOT/.xcodebuildmcp/config.yaml" 2>/dev/null || echo "NO_CONFIG"
+ls "$_ROOT/DESIGN.md" "$_ROOT/design-system.md" "$_ROOT/docs/design-guide.md" 2>/dev/null || echo "NO_DESIGN_DOC"
+```
+
+Extract from config, discovery output, or ask the user:
+- **Scheme name** (e.g., `MyApp`)
+- **Project path** (e.g., `MyApp.xcodeproj`) — or workspace path for workspace-based projects
+- **Bundle ID** (e.g., `com.example.MyApp`)
+- **Simulator ID** or name (e.g., `iPhone 16 Pro`)
+
+Store these for the session:
+```
+SCHEME="{scheme}"
+PROJECT_PATH="{project}.xcodeproj"
+BUNDLE_ID="{bundle_id}"
+SIM_ID="{simulator_uuid}"
+SIM_NAME="{simulator_name}"
+```
+
+### Check for DESIGN.md / design-guide.md
+
+Look for `DESIGN.md`, `design-system.md`, `docs/design-guide.md`, or similar in the repo. If found, read it — all design decisions must be calibrated against it. Deviations from the project's stated design system are higher severity than HIG-only violations. If not found, use Apple HIG as the sole reference and offer to create one from observations.
+
+### Require clean working tree
+
+```bash
+if [ -n "$(git status --porcelain)" ]; then
+  echo "ERROR: Working tree is dirty. Commit or stash changes before running /design-review-ios."
+  exit 1
+fi
+```
+
+### Verify simulator is available
+
+**MCP mode:** Call `list_sims` and check for the target simulator.
+
+**CLI mode:**
+```bash
+$DD xcrun simctl list devices available | grep -i "$SIM_NAME"
+```
+
+If the target simulator is not available, list available ones and ask the user to pick.
+
+**DO NOT build or launch the app if another session is using the simulator.** Ask the user first. If the app is already running on the sim, skip the build and proceed directly to screenshotting.
+
+### Create output directories
+
+```bash
+REPORT_DIR=".gstack/design-reports"
+mkdir -p "$REPORT_DIR/screenshots"
+```
+
+---
+
+## Command Reference
+
+Use MCP tool calls when in MCP mode (preferred). Fall back to CLI via Bash when in CLI mode. Throughout the phases below, operations reference this table — use the appropriate invocation for the detected mode.
+
+### Build & Run
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Build and run | `build_run_sim` (`scheme`, `projectPath`, `simulatorName`) | `$XC simulator build-and-run --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"` |
+| Build only | `build_sim` (`scheme`, `projectPath`, `simulatorName`) | `$XC simulator build --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"` |
+| Launch app | `launch_app_sim` (`bundleId`, `simulatorName`) | `$XC simulator launch-app --bundle-id $BUNDLE_ID --simulator-name "$SIM_NAME"` |
+| Stop app | `stop_app_sim` (`bundleId`, `simulatorId`) | `$XC simulator stop --bundle-id $BUNDLE_ID --simulator-id $SIM_ID` |
+| Install app | `install_app_sim` (`appPath`, `simulatorName`) | `$XC simulator install --app-path "$APP_PATH" --simulator-name "$SIM_NAME"` |
+| Get app path | `get_sim_app_path` (`scheme`, `projectPath`, `platform`, `simulatorName`) | `$XC simulator get-app-path --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"` |
+
+### Screenshots & Snapshots
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Screenshot | `screenshot` (`simulatorId`) | `$XC simulator screenshot --simulator-id $SIM_ID` |
+| Accessibility snapshot | `snapshot_ui` (`simulatorId`) | `$XC ui-automation snapshot-ui --simulator-id $SIM_ID` |
+
+### UI Automation
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Tap by label (preferred) | `tap` (`simulatorId`, `label`) | `$XC ui-automation tap --simulator-id $SIM_ID --label "Settings"` |
+| Tap by ID | `tap` (`simulatorId`, `id`) | `$XC ui-automation tap --simulator-id $SIM_ID --id "settingsButton"` |
+| Tap by coordinates | `tap` (`simulatorId`, `x`, `y`) | `$XC ui-automation tap --simulator-id $SIM_ID --x 200 --y 400` |
+| Scroll/gesture | `gesture` (`simulatorId`, `preset`) | `$XC ui-automation gesture --simulator-id $SIM_ID --preset scroll-down` |
+| Swipe between points | `swipe` (`simulatorId`, `x1`, `y1`, `x2`, `y2`) | `$XC ui-automation swipe --simulator-id $SIM_ID --x1 200 --y1 600 --x2 200 --y2 300` |
+| Type text | `type_text` (`simulatorId`, `text`) | `$XC ui-automation type-text --simulator-id $SIM_ID --text "Hello"` |
+| Long press | `long_press` (`simulatorId`, `x`, `y`, `duration`) | `$XC ui-automation long-press --simulator-id $SIM_ID --x 200 --y 400 --duration 1000` |
+| Hardware button | `button` (`simulatorId`, `buttonType`) | `$XC ui-automation button --simulator-id $SIM_ID --button-type home` |
+
+Gesture presets: `scroll-down`, `scroll-up`, `swipe-from-left-edge` (navigate back).
+
+### Simulator Management
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Set dark mode | `set_sim_appearance` (`simulatorId`, `mode`: `dark`) | `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode dark` |
+| Set light mode | `set_sim_appearance` (`simulatorId`, `mode`: `light`) | `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode light` |
+| Clean status bar | `sim_statusbar` (`simulatorId`, `dataNetwork`) | `$XC simulator-management statusbar --simulator-id $SIM_ID --data-network wifi` |
+| Boot simulator | `boot_sim` (`simulatorName`) | `$XC simulator-management boot --simulator-name "$SIM_NAME"` |
+| List simulators | `list_sims` | `$XC simulator-management list` |
+| Erase simulator | `erase_sims` (`simulatorId`) | `$XC simulator-management erase --simulator-id $SIM_ID` |
+| Set location | `set_sim_location` (`simulatorId`, `latitude`, `longitude`) | `$XC simulator-management set-location --simulator-id $SIM_ID --latitude 37.7749 --longitude -122.4194` |
+| Reset location | `reset_sim_location` (`simulatorId`) | `$XC simulator-management reset-location --simulator-id $SIM_ID` |
+
+### Logging
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Start log capture | `start_sim_log_cap` (`simulatorId`, `bundleId`) | `$XC logging start-simulator-log-capture --simulator-id $SIM_ID --bundle-id $BUNDLE_ID` |
+| Stop log capture | `stop_sim_log_cap` (`logSessionId`) | `$XC logging stop-simulator-log-capture --log-session-id {session_id}` |
+
+### Project Discovery
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Discover projects | `discover_projs` (`workspaceRoot`) | `$XC project-discovery discover-projects --workspace-root .` |
+| List schemes | `list_schemes` (`projectPath`) | `$XC project-discovery list-schemes --project-path $PROJECT_PATH` |
+| Get bundle ID | `get_app_bundle_id` (`appPath`) | `$XC project-discovery get-app-bundle-id --app-path ./Build/MyApp.app` |
+
+### Other Tools
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Clean build | `clean` (`projectPath`, `scheme`) | `$XC utilities clean --project-path $PROJECT_PATH --scheme $SCHEME` |
+| Record video | `record_sim_video` (`simulatorId`) | `$XC simulator record-video --simulator-id $SIM_ID` |
+| Open simulator | `open_sim` | `$XC simulator-management open --simulator-name "$SIM_NAME"` |
+| Key press | `key_press` (`simulatorId`, `keyCode`) | `$XC ui-automation key-press --simulator-id $SIM_ID --key-code 40` |
+| Key sequence | `key_sequence` (`simulatorId`, `keyCodes`) | `$XC ui-automation key-sequence --simulator-id $SIM_ID --key-codes "[40,41]"` |
+
+### CLI-only notes
+
+When in CLI mode, all `$XC` commands require the `DEVELOPER_DIR` prefix:
+```
+DD="DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer"
+XC="$DD xcodebuildmcp"
+```
+
+### Screenshot workflow
+
+**MCP mode:** The `screenshot` tool returns the screenshot data or path directly. **Always use the Read tool on the returned path** so the user can see the screenshot inline.
+
+**CLI mode:** `$XC simulator screenshot` returns the path to the PNG file. Extract and copy it:
+```bash
+SHOT=$($XC simulator screenshot --simulator-id $SIM_ID 2>&1 | grep -o '/[^ ]*\.png')
+cp "$SHOT" "$REPORT_DIR/screenshots/{name}.png" 2>/dev/null
+```
+
+In both modes: without reading the screenshot with the Read tool, screenshots are invisible to the user.
+
+### Snapshot (accessibility tree) workflow
+
+`snapshot_ui` (MCP) / `snapshot-ui` (CLI) returns the full view hierarchy with element types, labels, identifiers, and coordinates (x, y, width, height). Use this to:
+- Verify accessibility labels exist on interactive elements
+- Find tap targets by label for tapping
+- Measure touch target sizes (width/height >= 44pt)
+- Check view hierarchy depth and structure
+- Verify element ordering matches visual reading order
+
+---
+
+## Multi-Device Matrix
+
+When `--full-matrix` is requested or depth is `--deep`, test on multiple simulators:
+
+| Device | Screen | Use case |
+|--------|--------|----------|
+| iPhone SE (3rd gen) | 375x667 (4.7") | Smallest supported. Tight layouts, truncation. |
+| iPhone 16 Pro | 393x852 (6.1") | Standard flagship. Primary design target. |
+| iPhone 16 Pro Max | 430x932 (6.7") | Largest phone. Wasted space, reachability. |
+| iPad (10th gen) | 820x1180 (10.9") | Tablet layout. Sidebar, split view. |
+
+For quick mode, use only the primary device (usually iPhone Pro). For standard mode, use SE + Pro. For deep mode, use all four.
+
+To switch simulators mid-review:
+
+**MCP mode:** Call `boot_sim` → `get_sim_app_path` → `install_app_sim` → `launch_app_sim` with the new simulator name.
+
+**CLI mode:**
+```bash
+$XC simulator-management boot --simulator-name "iPhone SE (3rd generation)"
+APP_PATH=$($XC simulator get-app-path --scheme $SCHEME --project-path $PROJECT_PATH --platform "iOS_Simulator" --simulator-name "$SIM_NAME")
+$XC simulator install --app-path "$APP_PATH" --simulator-name "iPhone SE (3rd generation)"
+$XC simulator launch-app --bundle-id $BUNDLE_ID --simulator-name "iPhone SE (3rd generation)"
+```
+
+---
+
+## Phase 1: First Impression
+
+The most uniquely designer-like output. Form a gut reaction before analyzing anything.
+
+1. Set the status bar to a clean state:
+   - **MCP:** `sim_statusbar(simulatorId, dataNetwork: "wifi")`
+   - **CLI:** `$XC simulator-management statusbar --simulator-id $SIM_ID --data-network wifi`
+
+2. Take the first screenshot (the screen the app opens to):
+   - **MCP:** `screenshot(simulatorId)` — **CLI:** `$XC simulator screenshot --simulator-id $SIM_ID`
+   - Read the screenshot with the Read tool. Copy to `$REPORT_DIR/screenshots/first-impression-light.png`.
+
+3. Switch to dark mode and screenshot:
+   - **MCP:** `set_sim_appearance(simulatorId, mode: "dark")` — **CLI:** `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode dark`
+   - Screenshot again. Copy to `$REPORT_DIR/screenshots/first-impression-dark.png`.
+   - Read the screenshot with the Read tool.
+
+4. Write the **First Impression** using this structured critique format:
+   - "The app communicates **[what]**." (what it says at a glance — competence? warmth? confusion?)
+   - "I notice **[observation]**." (what stands out, positive or negative — be specific)
+   - "The first 3 things my eye goes to are: **[1]**, **[2]**, **[3]**." (hierarchy check — are these intentional?)
+   - "Light vs. dark: **[observation]**." (do both feel equally intentional, or is one an afterthought?)
+   - "If I had to describe this in one word: **[word]**." (gut verdict)
+
+This is the section users read first. Be opinionated. A designer doesn't hedge — they react.
+
+---
+
+## Phase 2: Design System Extraction
+
+Extract the actual design system from the codebase (not what a DESIGN.md says, but what's implemented):
+
+```bash
+# Find all Color extensions and definitions
+grep -r "Color\." --include="*.swift" -l | head -20
+
+# Find color asset catalogs
+find . -name "*.colorset" -type d | head -30
+
+# Find font usage
+grep -rn "\.font(" --include="*.swift" | head -30
+
+# Find spacing/padding values
+grep -rn "\.padding(" --include="*.swift" | head -30
+
+# Find corner radius values
+grep -rn "cornerRadius\|RoundedRectangle" --include="*.swift" | head -30
+
+# Find animation durations
+grep -rn "\.animation(\|withAnimation" --include="*.swift" | head -20
+```
+
+Also get the accessibility snapshot for the current screen to understand the component hierarchy:
+- **MCP:** `snapshot_ui(simulatorId)` — **CLI:** `$XC ui-automation snapshot-ui --simulator-id $SIM_ID`
+
+Structure findings as an **Inferred Design System**:
+- **Colors:** Asset catalog colorsets + manual Color extensions. Flag inconsistencies between them.
+- **Typography:** Font usage patterns. Flag hardcoded sizes vs. system text styles. Flag non-Dynamic Type usage.
+- **Spacing:** Padding/margin values. Flag non-systematic values (not multiples of 4 or 8).
+- **Corner Radii:** Flag if uniform radius on everything (AI slop) or if radius hierarchy exists.
+- **Animation:** Duration ranges, easing curves. Flag broad implicit `.animation()` modifiers applied to entire views or layout property animations.
+
+If DESIGN.md / design-guide.md exists, cross-reference: are the implemented values matching the spec?
+
+---
+
+## Phase 3: Screen-by-Screen Visual Audit
+
+Navigate through each major screen. For each screen (use MCP tools if MODE=mcp, CLI if MODE=cli — see Command Reference):
+
+1. **Navigate** to the screen — `tap(simulatorId, label: "{tab name}")` / `$XC ui-automation tap --simulator-id $SIM_ID --label "{tab name}"`
+2. **Screenshot** — `screenshot(simulatorId)` / `$XC simulator screenshot --simulator-id $SIM_ID`
+   - Read with Read tool. Copy to `$REPORT_DIR/screenshots/{screen}-{appearance}.png`
+3. **Accessibility tree** — `snapshot_ui(simulatorId)` / `$XC ui-automation snapshot-ui --simulator-id $SIM_ID`
+4. **Scroll** to see full content — `gesture(simulatorId, preset: "scroll-down")` / `$XC ui-automation gesture --simulator-id $SIM_ID --preset scroll-down`
+   - Screenshot again. Read with Read tool. Copy to `$REPORT_DIR/screenshots/{screen}-scrolled-{appearance}.png`
+
+For each screen, toggle appearance (light/dark) and screenshot both. Read every screenshot with the Read tool.
+
+### iOS Design Audit Checklist (10 categories, ~107 items)
+
+Apply these at each screen. Each finding gets an impact rating (high/medium/polish) and category.
+
+---
+
+**1. Visual Hierarchy & Composition** (8 items)
+
+- Clear focal point? One primary action per screen?
+- Eye flows naturally top-to-bottom, leading-to-trailing?
+- Visual noise — competing elements fighting for attention?
+- Information density appropriate for the screen's purpose?
+- Z-index clarity — nothing unexpectedly overlapping or clipped?
+- Above-the-fold content communicates the screen's purpose immediately?
+- Squint test: hierarchy still visible when image is blurred?
+- White space is intentional, not leftover from layout constraints?
+
+---
+
+**2. Typography & Dynamic Type** (15 items)
+
+- Uses semantic text styles (`.title`, `.headline`, `.body`, `.caption`) not hardcoded sizes?
+- **All text supports Dynamic Type.** Test: change text size in Settings > Accessibility > Display & Text Size. No truncation of critical info at AX3+.
+- Minimum readable size is 11pt (Caption 2). No text below this.
+- Heading hierarchy: `.largeTitle` > `.title` > `.title2` > `.title3` > `.headline` > `.body`. No skipped levels in visual flow.
+- Weight contrast: >=2 font weights used for hierarchy (not all `.regular`).
+- Line spacing appropriate: ~1.2-1.5x for body text.
+- Text doesn't overflow containers or overlap adjacent elements at large Dynamic Type sizes.
+- `.minimumScaleFactor` used sparingly, never on body text.
+- If custom fonts are used, they scale with Dynamic Type via `UIFontMetrics` or `.custom(_:size:relativeTo:)`.
+- Mono-spaced numbers in data displays (`.monospacedDigit()`).
+- No letter-spacing (tracking/kern) on lowercase body text.
+- Truncation is intentional: `.lineLimit()` with sensible limits, never cuts mid-word on important text.
+- Bold Text accessibility setting respected (system fonts do this automatically; custom fonts need manual handling).
+- Text contrast meets WCAG AA: body text 4.5:1, large text (18pt+/14pt bold+) 3:1.
+- Text uses semantic colors (`.primary`, `.secondary`, `.label`, `.secondaryLabel`) that adapt to appearance.
+
+---
+
+**3. Color & Appearance** (12 items)
+
+- **Both light AND dark mode look intentional.** Neither is an afterthought. Dark mode uses elevation (lighter surfaces at higher z), not just color inversion.
+- Color palette is coherent (<=12 unique non-gray colors per appearance).
+- WCAG AA contrast: body text 4.5:1, large text 3:1, UI components 3:1 — in BOTH appearances.
+- Semantic colors used where appropriate (`.label`, `.secondaryLabel`, `.systemBackground`, `.secondarySystemBackground`).
+- No color-only encoding — information always has shape, icon, or text label in addition to color.
+- Tint color consistent throughout the app (or intentionally varied per section).
+- System materials (`.regularMaterial`, `.thinMaterial`) used appropriately for overlays.
+- Dark mode text is off-white (not pure `#FFFFFF`) to reduce eye strain.
+- Dark mode backgrounds use subtle elevation differences, not flat black.
+- `Increase Contrast` accessibility setting: colors adapt to high-contrast variants? (use system semantic colors).
+- `Smart Invert`: images and media marked with `.accessibilityIgnoresInvertColors(true)` so they don't invert?
+- Red/green is never the only distinction (8% of men have red-green color deficiency).
+
+---
+
+**4. Spacing, Layout & Safe Areas** (14 items)
+
+- **Safe areas respected.** Content not obscured by Dynamic Island, home indicator, rounded corners, or status bar.
+- Default system margins: 16pt leading/trailing on compact-width (iPhone portrait).
+- Spacing uses a consistent scale (4pt or 8pt base), not arbitrary values.
+- Alignment is consistent — elements align to a clear grid or leading edge.
+- Gestalt proximity: related items closer together, distinct sections further apart.
+- **Corner radius hierarchy** — not uniform bubbly radius on everything. Cards ~10-12pt, buttons ~8-10pt, small elements ~4-6pt. Inner radius = outer radius - gap for nested elements.
+- Bottom-anchored buttons have sufficient padding above the home indicator (>=34pt on Face ID devices).
+- Keyboard avoidance: content scrolls or shifts when keyboard appears. No content hidden behind keyboard.
+- Content width: on larger devices, text content has a readable maximum width (~672pt), not stretched edge-to-edge.
+- Scroll content can extend behind safe areas visually (backgrounds, images) but interactive elements stay within.
+- `.ignoresSafeArea()` used intentionally, not as a layout crutch.
+- List/table views use system-standard insets and separators.
+- Section headers have consistent spacing above and below.
+- Horizontal `ScrollView` items have consistent inter-item spacing.
+
+---
+
+**5. Navigation & Platform Conventions** (10 items)
+
+- **Tab bar:** Maximum 5 tabs. Each tab has its own NavigationStack. Tab bar remains visible on primary screens.
+- Tab icons use SF Symbols with labels. Active/inactive states are visually distinct.
+- **Navigation hierarchy:** Large title at root, inline title when pushed. Back button always present.
+- Swipe-to-go-back gesture works (not blocked by custom gesture recognizers).
+- **Sheets/modals:** Have clear dismiss affordance (close button or swipe-to-dismiss). No stacked modals.
+- **Alerts:** Destructive actions use `.destructive` button role (renders red). Cancel is the default (bold) button. Maximum 2-3 buttons.
+- No hamburger menus — use tab bars or `NavigationSplitView` instead.
+- Deep links / state restoration: navigating away and back preserves scroll position and state.
+- Standard iOS patterns used: pull-to-refresh for refreshable content, swipe actions on list rows, long-press for context menus.
+- Settings and preferences follow the iOS conventions (grouped lists with section headers, toggles for on/off).
+
+---
+
+**6. Interaction States & Feedback** (10 items)
+
+- **Touch feedback** on all interactive elements — buttons have visual press state (opacity, scale, or color change).
+- Loading states: < 1s shows nothing; 1-3s shows `ProgressView()` or skeleton; > 3s shows determinate progress with context.
+- **Empty states are features.** Every empty state has: icon/illustration + title + description + primary CTA button. Never just "No items found." Use `ContentUnavailableView` (iOS 17+) for standard cases.
+- Error states are actionable: what went wrong + what to do (retry, check connection, etc.). Never raw error codes.
+- Success states: confirmation animation or color change, appropriate auto-dismiss timing.
+- Pull-to-refresh (`.refreshable`) supported on scrollable content that can update.
+- Disabled state: reduced opacity (~0.4) + non-interactive. Not just greyed text.
+- Skeleton/placeholder views match the shape and layout of real content (not generic spinners).
+- Form validation: errors appear near the problematic field, not just in an alert.
+- Destructive actions (delete, remove) have confirmation (alert or swipe-to-delete with undo).
+
+---
+
+**7. Touch Targets & Reachability** (8 items)
+
+- **All interactive elements >= 44x44pt tap target.** Verify from accessibility snapshot coordinates: width and height must each be >= 44.
+- Spacing between adjacent tap targets >= 8pt to prevent mis-taps.
+- Bottom-of-screen content (within thumb reach) contains primary actions. Top of screen is for titles and secondary info.
+- Swipe actions on list rows are discoverable (edit button or contextual menu as alternative).
+- Text links within body text have sufficient tap area (generous line height or padding).
+- Small icons that are tappable have expanded hit regions (`.contentShape(Rectangle())` or frame padding).
+- Toolbar/navigation bar buttons meet 44pt minimum even when icon is visually smaller.
+- Floating action buttons (if any) don't overlap scrollable content or other tap targets.
+
+---
+
+**8. Accessibility** (12 items)
+
+- **VoiceOver:** Every interactive element has an accessibility label. Verify from accessibility snapshot output that no interactive elements have empty or missing labels.
+- Decorative images hidden with `.accessibilityHidden(true)`.
+- Reading order is logical (top-to-bottom, leading-to-trailing). Custom layouts use `.accessibilitySortPriority()` if needed.
+- Custom controls declare their role (`.accessibilityAddTraits(.isButton)`, `.isHeader`, etc.).
+- State changes announced (`.accessibilityValue()` for dynamic values like progress, toggles).
+- **Reduce Motion:** All non-essential animations gated on `@Environment(\.accessibilityReduceMotion)`. Slide/zoom/bounce replaced with dissolve/opacity. Confetti/particles render as static or empty.
+- **Reduce Transparency:** Translucent/blur materials replaced with solid backgrounds when `accessibilityReduceTransparency` is true.
+- **Bold Text:** Text responds to the Bold Text accessibility setting.
+- Grouped content uses `.accessibilityElement(children: .combine)` where appropriate.
+- All functionality reachable by touch is also reachable by VoiceOver.
+- Focus moves logically after state changes (e.g., after dismissing a sheet, focus returns to the trigger).
+- No time-limited interactions without accessibility accommodations.
+
+---
+
+**9. iOS Design Anti-Patterns ("AI Slop")** (10 items)
+
+The test: would a designer at Apple, Linear, or Airbnb ever ship this?
+
+- **Generic gradient backgrounds:** Purple-to-blue, rainbow gradients with no brand purpose. Every gradient must serve hierarchy or depth, not just decoration.
+- **Excessive glassmorphism/blur:** More than 2-3 frosted glass layers per screen. Text over translucent surfaces must still meet contrast ratios against ALL possible backgrounds.
+- **Uniform bubbly corner radius:** Same large `cornerRadius` on everything — cards, buttons, avatars, inputs. No radius hierarchy.
+- **Shadows without purpose:** Multiple competing drop shadows. Shadows should indicate elevation, not just exist.
+- **Decorative-only animations:** Animations that don't communicate state changes, transitions, or feedback. Every animation needs a job.
+- **Custom controls replacing system controls:** Custom `Toggle`, `Picker`, `DatePicker` that don't support accessibility, Dynamic Type, or system appearance. If Apple built it, use it.
+- **Ignoring platform conventions:** Bottom sheets without swipe-to-dismiss, custom tab bars that don't match iOS, non-standard navigation breaking muscle memory.
+- **Information density extremes:** Either too cramped (tiny text, no breathing room) or too sparse (one item per screen, excessive whitespace requiring unnecessary scrolling).
+- **Inconsistent spacing/alignment:** Mismatched padding values across screens, elements not aligned to a grid.
+- **Generic hero/header patterns:** Cookie-cutter section layouts (hero → 3-column features → CTA). These look like every other AI-generated app.
+
+---
+
+**10. Motion & Performance** (8 items)
+
+- **Purpose:** Every animation serves feedback, continuity, spatial orientation, or delight. No motion for motion's sake.
+- **Duration:** UI animations 0.2-0.5s. Micro-interactions (button press) < 0.2s. Nothing over 1s unless a page transition.
+- **Spring animations preferred** over linear/ease for natural feel. SwiftUI `.spring()` defaults are sensible.
+- **Reduce Motion compliance:** All motion has a non-motion alternative. Parallax, spinning, vortex, depth simulation, auto-playing animations all disabled when `reduceMotion` is true.
+- **No animation on first paint:** The initial screen should not fade/slide in on launch. Content appears immediately.
+- **Interruption handling:** Animations are interruptible — tapping during an animation cancels or redirects it gracefully.
+- **Scroll performance:** Lists and scroll views scroll smoothly without hitches. Heavy views use `LazyVStack`/`LazyHStack`.
+- **Launch time:** App should reach interactive state quickly. No long splash screens or loading gates for cached data.
+
+---
+
+## Phase 4: Appearance Matrix
+
+Test both appearances systematically. For each screen already audited:
+
+1. **Light mode:** `set_sim_appearance(simulatorId, mode: "light")` then `screenshot(simulatorId)` — save as `{screen}-light.png`
+2. **Dark mode:** `set_sim_appearance(simulatorId, mode: "dark")` then `screenshot(simulatorId)` — save as `{screen}-dark.png`
+
+(CLI: `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode light/dark` + `$XC simulator screenshot --simulator-id $SIM_ID`)
+
+Evaluate:
+- Do both appearances feel equally designed, or is one clearly the "real" version?
+- Are elevation differences visible in dark mode (surface hierarchy)?
+- Does any text become unreadable in either appearance?
+- Are images/illustrations appropriate in both appearances?
+- Are custom colors adapting correctly (Asset Catalog light/dark variants)?
+
+---
+
+## Phase 5: Cross-Screen Consistency
+
+Compare screenshots and observations across all audited screens:
+
+- Tab bar consistent across all tabs?
+- Navigation bar style consistent (large title vs inline, tint color)?
+- Card/component styling consistent across screens (same corner radius, shadows, spacing)?
+- Typography consistent (same text styles used for same semantic levels)?
+- Color usage consistent (primary action color is the same everywhere)?
+- Spacing rhythm consistent (same padding values across similar layouts)?
+- Empty states follow the same pattern?
+- Loading states follow the same pattern?
+- Tone consistency (one screen playful while another is corporate?).
+
+---
+
+## Phase 6: Compile Report
+
+### Output Locations
+
+**Local:** `.gstack/design-reports/ios-design-audit-{scheme}-{YYYY-MM-DD}.md`
+
+**Project-scoped:**
+```bash
+eval $(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)
+mkdir -p ~/.gstack/projects/$SLUG
+```
+Write to: `~/.gstack/projects/{slug}/{user}-{branch}-ios-design-audit-{datetime}.md`
+
+**Baseline:** Write `ios-design-baseline.json` for regression mode:
+```json
+{
+  "date": "YYYY-MM-DD",
+  "scheme": "{scheme}",
+  "platform": "iOS",
+  "minOS": "17.0",
+  "designScore": "B",
+  "higComplianceScore": "A",
+  "categoryGrades": { "hierarchy": "A", "typography": "B", "color": "A", "spacing": "B", "navigation": "A", "interaction": "B", "touch": "A", "accessibility": "B", "slop": "A", "motion": "A" },
+  "findings": [{ "id": "IOS-001", "title": "...", "impact": "high", "category": "typography" }],
+  "devicesAudited": ["iPhone 16 Pro"],
+  "appearancesAudited": ["light", "dark"]
+}
+```
+
+### Scoring System
+
+**Dual headline scores:**
+- **Design Score: {A-F}** — weighted average of all 10 categories
+- **HIG Compliance Score: {A-F}** — how well the app follows Apple's Human Interface Guidelines
+
+**Per-category grades:**
+- **A:** Intentional, polished, delightful. Shows design thinking. Feels like an Apple-quality app.
+- **B:** Solid fundamentals, minor inconsistencies. Looks professional.
+- **C:** Functional but generic. No major problems, no design point of view.
+- **D:** Noticeable problems. Feels unfinished or careless.
+- **F:** Actively hurting user experience. Needs significant rework.
+
+**Grade computation:** Each category starts at A. Each High-impact finding drops one letter grade. Each Medium-impact finding drops half a letter grade. Polish findings are noted but do not affect grade. Minimum is F.
+
+**Category weights for Design Score:**
+
+| Category | Weight |
+|----------|--------|
+| Visual Hierarchy | 15% |
+| Typography & Dynamic Type | 15% |
+| Spacing, Layout & Safe Areas | 15% |
+| Color & Appearance | 10% |
+| Navigation & Platform Conventions | 10% |
+| Interaction States & Feedback | 10% |
+| Touch Targets & Reachability | 5% |
+| Accessibility | 10% |
+| iOS Design Anti-Patterns | 5% |
+| Motion & Performance | 5% |
+
+### Regression Output
+
+When previous `ios-design-baseline.json` exists or `--regression` flag is used:
+- Load baseline grades
+- Compare: per-category deltas, new findings, resolved findings
+- Append regression table to report
+
+---
+
+## Design Critique Format
+
+Use structured feedback, not opinions:
+- "I notice..." — observation (e.g., "I notice the primary CTA competes with the tab bar")
+- "I wonder..." — question (e.g., "I wonder if users will find the settings toggle")
+- "What if..." — suggestion (e.g., "What if we used a sheet instead of pushing a new screen?")
+- "I think... because..." — reasoned opinion (e.g., "I think the spacing between sections is too uniform because it doesn't create hierarchy")
+
+Tie everything to user goals, Apple HIG, and the project's design system. Always suggest specific improvements alongside problems.
+
+---
+
+## Important Rules
+
+1. **Think like a designer, not a QA engineer.** You care whether things feel right, look intentional, and respect the user. You do NOT just care whether things "work."
+2. **Screenshots are evidence.** Every finding needs at least one screenshot. Always Read screenshot files so the user can see them inline.
+3. **Be specific and actionable.** "Change X to Y because Z" — not "the spacing feels off."
+4. **Source code informs fixes.** Unlike web design-review, you SHOULD read source code to understand SwiftUI structure, but evaluate the RENDERED result from screenshots and snapshots.
+5. **AI Slop detection is your superpower.** Most developers can't evaluate whether their app looks AI-generated. You can. Be direct about it.
+6. **Quick wins matter.** Always include a "Quick Wins" section — the 3-5 highest-impact fixes that take <30 minutes each.
+7. **Both appearances matter.** Never skip dark mode or light mode. Both must feel intentional.
+8. **HIG is the baseline, not the ceiling.** Meeting HIG is a C+. Design excellence is the goal.
+9. **Document incrementally.** Write each finding to the report as you find it. Don't batch.
+10. **Depth over breadth.** 5-10 well-documented findings with screenshots and specific suggestions > 20 vague observations.
+
+Record baseline design score and HIG compliance score at end of Phase 6.
+
+---
+
+## Output Structure
+
+```
+.gstack/design-reports/
+├── ios-design-audit-{scheme}-{YYYY-MM-DD}.md
+├── screenshots/
+│   ├── first-impression-light.png
+│   ├── first-impression-dark.png
+│   ├── {screen}-light.png
+│   ├── {screen}-dark.png
+│   ├── {screen}-scrolled-light.png
+│   ├── finding-IOS-001-before.png
+│   ├── finding-IOS-001-after.png
+│   └── ...
+└── ios-design-baseline.json
+```
+
+---
+
+## Phase 7: Triage
+
+Sort all discovered findings by impact, then decide which to fix:
+
+- **High Impact:** Fix first. HIG violations, accessibility failures, broken layouts, unreadable text. These affect first impression and app review.
+- **Medium Impact:** Fix next. Inconsistent spacing, minor typography issues, missing states. Felt subconsciously.
+- **Polish:** Fix if time allows. Subtle animation improvements, micro-interaction refinements. Separate good from great.
+
+Mark findings that cannot be verified from simulator (e.g., performance on physical device, real network conditions) as "deferred" regardless of impact.
+
+---
+
+## Phase 8: Fix Loop
+
+For each fixable finding, in impact order:
+
+### 8a. Locate source
+
+```bash
+# Search for the view file
+grep -rn "struct {ViewName}" --include="*.swift" | head -5
+
+# Search for specific colors, fonts, spacing values
+grep -rn "{pattern}" --include="*.swift" | head -10
+
+# Find related files
+find . -name "*{keyword}*" -name "*.swift" | head -5
+```
+
+- Find the source file(s) responsible for the design issue
+- ONLY modify files directly related to the finding
+- Prefer SwiftUI modifier changes over structural view changes
+
+### 8b. Fix
+
+- Read the source code, understand the context
+- Make the **minimal fix** — smallest change that resolves the design issue
+- Modifier-only changes are preferred (safer, more reversible)
+- Do NOT refactor surrounding code, add features, or "improve" unrelated things
+
+### 8c. Commit
+
+```bash
+git add <only-changed-files>
+git commit -m "style(ios-design): IOS-NNN — short description"
+```
+
+- One commit per fix. Never bundle multiple fixes.
+- Message format: `style(ios-design): IOS-NNN — short description`
+
+### 8d. Re-test
+
+Rebuild and re-screenshot the affected screen:
+
+1. **Build and run:** `build_run_sim(scheme, projectPath, simulatorName)` / `$XC simulator build-and-run --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"`
+2. Wait for app to launch, navigate to affected screen: `tap(simulatorId, label: "{tab}")`
+3. **Screenshot:** `screenshot(simulatorId)` — Read with Read tool. Save as `finding-IOS-NNN-after.png`
+
+Take **before/after screenshot pair** for every fix.
+
+If the simulator is unavailable (e.g., in use by another session), mark fixes as `needs-verify` instead and note that the user should rebuild and re-run `/design-review-ios --regression` when the simulator is free.
+
+### 8e. Classify
+
+- **verified**: re-test confirms the fix works, no new issues introduced
+- **needs-verify**: fix applied but simulator unavailable for rebuild
+- **best-effort**: fix applied but couldn't fully verify (e.g., requires specific Dynamic Type size)
+- **reverted**: regression detected → `git revert HEAD` → mark finding as "deferred"
+
+### 8e.5. Regression Test (design-review-ios variant)
+
+Design fixes are typically SwiftUI modifier changes. Only generate regression tests for fixes involving:
+- Accessibility label changes (verify labels exist in XCUITest)
+- Dynamic Type behavior changes
+- Conditional rendering fixes (show/hide based on state)
+
+For modifier-only fixes (padding, color, font changes): skip. These are caught by re-running `/design-review-ios`.
+
+If the fix involved behavior: write an XCUITest encoding the exact bug condition. Commit format: `test(ios-design): regression test for IOS-NNN`.
+
+### 8f. Self-Regulation (STOP AND EVALUATE)
+
+Every 5 fixes (or after any revert), compute the design-fix risk level:
+
+```
+DESIGN-FIX RISK:
+  Start at 0%
+  Each revert:                        +15%
+  Each modifier-only change:          +0%   (safe — styling only)
+  Each view structure change:         +5%   per file
+  Each new/deleted file:              +10%  per file
+  After fix 10:                       +1%   per additional fix
+  Touching unrelated files:           +20%
+```
+
+**If risk > 20%:** STOP immediately. Show the user what you've done so far. Ask whether to continue.
+
+**Hard cap: 30 fixes.** After 30 fixes, stop regardless of remaining findings.
+
+---
+
+## Phase 9: Final Design Audit
+
+After all fixes are applied:
+
+1. If simulator available: re-run the visual audit on all affected screens
+2. If simulator unavailable: review the code changes and estimate impact
+3. Compute final design score and HIG compliance score
+4. **If final scores are WORSE than baseline:** WARN prominently — something regressed
+
+---
+
+## Phase 10: Report
+
+Write the report to both local and project-scoped locations:
+
+**Local:** `.gstack/design-reports/ios-design-audit-{scheme}-{YYYY-MM-DD}.md`
+
+**Project-scoped:**
+```bash
+eval $(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)
+mkdir -p ~/.gstack/projects/$SLUG
+```
+Write to `~/.gstack/projects/{slug}/{user}-{branch}-ios-design-audit-{datetime}.md`
+
+**Per-finding additions** (beyond standard design audit report):
+- Fix Status: verified / needs-verify / best-effort / reverted / deferred
+- Commit SHA (if fixed)
+- Files Changed (if fixed)
+- Before/After screenshots (if fixed and simulator available)
+- Affected appearances (light / dark / both)
+- Affected devices (SE / Pro / iPad)
+
+**Summary section:**
+- Total findings
+- Fixes applied (verified: X, needs-verify: Y, best-effort: Z, reverted: W)
+- Deferred findings
+- Design score delta: baseline → final
+- HIG compliance score delta: baseline → final
+- Devices audited
+- Appearances audited
+
+**PR Summary:** Include a one-line summary suitable for PR descriptions:
+> "iOS design review found N issues, fixed M. Design score X → Y, HIG compliance X → Y."
+
+---
+
+## Phase 11: TODOS.md Update
+
+If the repo has a `TODOS.md`:
+
+1. **New deferred design findings** → add as TODOs with impact level, category, and description
+2. **Fixed findings that were in TODOS.md** → annotate with "Fixed by /design-review-ios on {branch}, {date}"
+
+---
+
+## Additional Rules (design-review-ios specific)
+
+11. **Clean working tree required.** Refuse to start if `git status --porcelain` is non-empty.
+12. **One commit per fix.** Never bundle multiple design fixes into one commit.
+13. **Only modify tests when generating regression tests in Phase 8e.5.** Never modify CI configuration. Never modify existing tests — only create new test files.
+14. **Revert on regression.** If a fix makes things worse, `git revert HEAD` immediately.
+15. **Self-regulate.** Follow the design-fix risk heuristic. When in doubt, stop and ask.
+16. **Modifier-first.** Prefer SwiftUI modifier changes (`.padding()`, `.font()`, `.foregroundStyle()`) over structural view changes. Modifier changes are safer and more reversible.
+17. **Respect the design system.** If DESIGN.md or design-guide.md exists, fixes must use tokens/values from that system, not introduce new ones.
+18. **Both appearances.** Every fix must be verified in both light and dark mode (when simulator is available).
+19. **DEVELOPER_DIR prefix (CLI mode only).** When using CLI mode, every xcodebuildmcp and xcrun command must include `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`. MCP mode handles this automatically.
+20. **Don't fight the simulator.** If another session is using the simulator, work in code-review-only mode: read source, identify issues from existing screenshots or code patterns, apply fixes, mark as `needs-verify`.

--- a/design-review-ios/SKILL.md.tmpl
+++ b/design-review-ios/SKILL.md.tmpl
@@ -1,0 +1,883 @@
+---
+name: design-review-ios
+version: 1.1.0
+description: |
+  iOS design QA via simulator: finds visual inconsistency, spacing issues, HIG violations,
+  accessibility gaps, and AI slop patterns — then fixes them. Uses XcodeBuildMCP (MCP server
+  preferred, CLI fallback) to build, screenshot, and interact with the app on iOS Simulator.
+  Iteratively fixes issues in source code, committing each fix atomically and re-verifying
+  with before/after screenshots. Targets iOS 17+. For web design review, use /design-review.
+  Use when asked to "audit the iOS design", "visual QA", "check the app looks good",
+  "HIG review", or "design polish".
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - AskUserQuestion
+  - WebSearch
+  # XcodeBuildMCP MCP tools (preferred over CLI — used when MCP server is configured)
+  - build_run_sim
+  - build_sim
+  - test_sim
+  - screenshot
+  - snapshot_ui
+  - tap
+  - gesture
+  - swipe
+  - type_text
+  - long_press
+  - button
+  - key_press
+  - key_sequence
+  - set_sim_appearance
+  - sim_statusbar
+  - boot_sim
+  - list_sims
+  - open_sim
+  - erase_sims
+  - launch_app_sim
+  - stop_app_sim
+  - install_app_sim
+  - get_sim_app_path
+  - start_sim_log_cap
+  - stop_sim_log_cap
+  - discover_projs
+  - list_schemes
+  - get_app_bundle_id
+  - set_sim_location
+  - reset_sim_location
+  - clean
+  - record_sim_video
+---
+
+{{PREAMBLE}}
+
+# /design-review-ios: iOS Design Audit → Fix → Verify
+
+You are a senior product designer AND an iOS engineer. Review apps running on iOS Simulator with exacting visual standards informed by Apple's Human Interface Guidelines — then fix what you find. You have strong opinions about typography, spacing, visual hierarchy, and platform conventions. Zero tolerance for generic or AI-generated-looking interfaces.
+
+**Target platform: iOS 17+**
+
+---
+
+## Setup
+
+### Parse user request
+
+| Parameter | Default | Override example |
+|-----------|---------|-----------------|
+| Scope | Full app (all tabs) | `Focus on the Today tab`, `Just onboarding` |
+| Depth | Standard (3-5 screens per tab) | `--quick` (main screen per tab), `--deep` (all reachable screens) |
+| Device matrix | iPhone Pro only | `--full-matrix` (SE + Pro + iPad) |
+| Appearance | Both light + dark | `--light-only`, `--dark-only` |
+
+### Prerequisites
+
+This skill uses [XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP) to build, screenshot, and interact with the iOS Simulator. It supports two integration modes — **MCP server (preferred)** and **CLI (fallback)**.
+
+**Preferred: MCP server**
+If XcodeBuildMCP is configured as an MCP server, its tools (`build_run_sim`, `screenshot`, `tap`, `snapshot_ui`, etc.) are directly available as tool calls. No Bash needed for simulator commands, no PATH issues, no `DEVELOPER_DIR` workaround — the server handles its own environment.
+
+```bash
+# Add as MCP server (if not already configured)
+claude mcp add xcodebuildmcp -- npx -y xcodebuildmcp@latest mcp
+```
+
+**Fallback: CLI binary**
+If MCP tools are not available in the session, the skill falls back to the `xcodebuildmcp` CLI via Bash.
+
+```bash
+# Install CLI via Homebrew
+brew tap getsentry/xcodebuildmcp
+brew install xcodebuildmcp
+# Or via npm
+npm install -g xcodebuildmcp@latest
+```
+
+### Detect integration mode
+
+Determine whether to use MCP tools or CLI:
+
+1. **Check for MCP tools:** Look for XcodeBuildMCP MCP tools in the current session (e.g., `build_run_sim`, `screenshot`, `tap`, `snapshot_ui`). If any of these tools are callable, set **MODE=mcp**.
+
+2. **If no MCP tools found:** Check for the CLI binary:
+   ```bash
+   which xcodebuildmcp 2>/dev/null || ls /opt/homebrew/bin/xcodebuildmcp /usr/local/bin/xcodebuildmcp 2>/dev/null
+   ```
+   If found, set **MODE=cli**. If neither MCP tools nor CLI are found, ask the user to install XcodeBuildMCP (recommend the MCP server setup above).
+
+3. **CLI mode only:** All CLI commands require a `DEVELOPER_DIR` prefix because `xcode-select` may point to CommandLineTools:
+   ```
+   DD="DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer"
+   XC="$DD xcodebuildmcp"
+   ```
+
+Report the detected mode to the user: `"Using XcodeBuildMCP via {MCP server | CLI}."` If MCP mode, also note that the `DEVELOPER_DIR` workaround is not needed.
+
+### Detect project configuration
+
+**MCP mode:** Call `discover_projs` with `workspaceRoot` set to the repo root, then `list_schemes` and `list_sims`.
+
+**CLI mode:**
+```bash
+_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+$XC project-discovery discover-projects --workspace-root "$_ROOT" 2>/dev/null || ls "$_ROOT"/*.xcodeproj "$_ROOT"/*.xcworkspace 2>/dev/null | head -3
+$XC project-discovery list-schemes --project-path "$_ROOT"/*.xcodeproj 2>/dev/null || echo "NO_SCHEMES"
+$XC simulator-management list 2>/dev/null | head -20
+```
+
+**Both modes:** Also check for project config and design docs:
+```bash
+_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+cat "$_ROOT/.xcodebuildmcp/config.yaml" 2>/dev/null || echo "NO_CONFIG"
+ls "$_ROOT/DESIGN.md" "$_ROOT/design-system.md" "$_ROOT/docs/design-guide.md" 2>/dev/null || echo "NO_DESIGN_DOC"
+```
+
+Extract from config, discovery output, or ask the user:
+- **Scheme name** (e.g., `MyApp`)
+- **Project path** (e.g., `MyApp.xcodeproj`) — or workspace path for workspace-based projects
+- **Bundle ID** (e.g., `com.example.MyApp`)
+- **Simulator ID** or name (e.g., `iPhone 16 Pro`)
+
+Store these for the session:
+```
+SCHEME="{scheme}"
+PROJECT_PATH="{project}.xcodeproj"
+BUNDLE_ID="{bundle_id}"
+SIM_ID="{simulator_uuid}"
+SIM_NAME="{simulator_name}"
+```
+
+### Check for DESIGN.md / design-guide.md
+
+Look for `DESIGN.md`, `design-system.md`, `docs/design-guide.md`, or similar in the repo. If found, read it — all design decisions must be calibrated against it. Deviations from the project's stated design system are higher severity than HIG-only violations. If not found, use Apple HIG as the sole reference and offer to create one from observations.
+
+### Require clean working tree
+
+```bash
+if [ -n "$(git status --porcelain)" ]; then
+  echo "ERROR: Working tree is dirty. Commit or stash changes before running /design-review-ios."
+  exit 1
+fi
+```
+
+### Verify simulator is available
+
+**MCP mode:** Call `list_sims` and check for the target simulator.
+
+**CLI mode:**
+```bash
+$DD xcrun simctl list devices available | grep -i "$SIM_NAME"
+```
+
+If the target simulator is not available, list available ones and ask the user to pick.
+
+**DO NOT build or launch the app if another session is using the simulator.** Ask the user first. If the app is already running on the sim, skip the build and proceed directly to screenshotting.
+
+### Create output directories
+
+```bash
+REPORT_DIR=".gstack/design-reports"
+mkdir -p "$REPORT_DIR/screenshots"
+```
+
+---
+
+## Command Reference
+
+Use MCP tool calls when in MCP mode (preferred). Fall back to CLI via Bash when in CLI mode. Throughout the phases below, operations reference this table — use the appropriate invocation for the detected mode.
+
+### Build & Run
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Build and run | `build_run_sim` (`scheme`, `projectPath`, `simulatorName`) | `$XC simulator build-and-run --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"` |
+| Build only | `build_sim` (`scheme`, `projectPath`, `simulatorName`) | `$XC simulator build --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"` |
+| Launch app | `launch_app_sim` (`bundleId`, `simulatorName`) | `$XC simulator launch-app --bundle-id $BUNDLE_ID --simulator-name "$SIM_NAME"` |
+| Stop app | `stop_app_sim` (`bundleId`, `simulatorId`) | `$XC simulator stop --bundle-id $BUNDLE_ID --simulator-id $SIM_ID` |
+| Install app | `install_app_sim` (`appPath`, `simulatorName`) | `$XC simulator install --app-path "$APP_PATH" --simulator-name "$SIM_NAME"` |
+| Get app path | `get_sim_app_path` (`scheme`, `projectPath`, `platform`, `simulatorName`) | `$XC simulator get-app-path --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"` |
+
+### Screenshots & Snapshots
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Screenshot | `screenshot` (`simulatorId`) | `$XC simulator screenshot --simulator-id $SIM_ID` |
+| Accessibility snapshot | `snapshot_ui` (`simulatorId`) | `$XC ui-automation snapshot-ui --simulator-id $SIM_ID` |
+
+### UI Automation
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Tap by label (preferred) | `tap` (`simulatorId`, `label`) | `$XC ui-automation tap --simulator-id $SIM_ID --label "Settings"` |
+| Tap by ID | `tap` (`simulatorId`, `id`) | `$XC ui-automation tap --simulator-id $SIM_ID --id "settingsButton"` |
+| Tap by coordinates | `tap` (`simulatorId`, `x`, `y`) | `$XC ui-automation tap --simulator-id $SIM_ID --x 200 --y 400` |
+| Scroll/gesture | `gesture` (`simulatorId`, `preset`) | `$XC ui-automation gesture --simulator-id $SIM_ID --preset scroll-down` |
+| Swipe between points | `swipe` (`simulatorId`, `x1`, `y1`, `x2`, `y2`) | `$XC ui-automation swipe --simulator-id $SIM_ID --x1 200 --y1 600 --x2 200 --y2 300` |
+| Type text | `type_text` (`simulatorId`, `text`) | `$XC ui-automation type-text --simulator-id $SIM_ID --text "Hello"` |
+| Long press | `long_press` (`simulatorId`, `x`, `y`, `duration`) | `$XC ui-automation long-press --simulator-id $SIM_ID --x 200 --y 400 --duration 1000` |
+| Hardware button | `button` (`simulatorId`, `buttonType`) | `$XC ui-automation button --simulator-id $SIM_ID --button-type home` |
+
+Gesture presets: `scroll-down`, `scroll-up`, `swipe-from-left-edge` (navigate back).
+
+### Simulator Management
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Set dark mode | `set_sim_appearance` (`simulatorId`, `mode`: `dark`) | `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode dark` |
+| Set light mode | `set_sim_appearance` (`simulatorId`, `mode`: `light`) | `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode light` |
+| Clean status bar | `sim_statusbar` (`simulatorId`, `dataNetwork`) | `$XC simulator-management statusbar --simulator-id $SIM_ID --data-network wifi` |
+| Boot simulator | `boot_sim` (`simulatorName`) | `$XC simulator-management boot --simulator-name "$SIM_NAME"` |
+| List simulators | `list_sims` | `$XC simulator-management list` |
+| Erase simulator | `erase_sims` (`simulatorId`) | `$XC simulator-management erase --simulator-id $SIM_ID` |
+| Set location | `set_sim_location` (`simulatorId`, `latitude`, `longitude`) | `$XC simulator-management set-location --simulator-id $SIM_ID --latitude 37.7749 --longitude -122.4194` |
+| Reset location | `reset_sim_location` (`simulatorId`) | `$XC simulator-management reset-location --simulator-id $SIM_ID` |
+
+### Logging
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Start log capture | `start_sim_log_cap` (`simulatorId`, `bundleId`) | `$XC logging start-simulator-log-capture --simulator-id $SIM_ID --bundle-id $BUNDLE_ID` |
+| Stop log capture | `stop_sim_log_cap` (`logSessionId`) | `$XC logging stop-simulator-log-capture --log-session-id {session_id}` |
+
+### Project Discovery
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Discover projects | `discover_projs` (`workspaceRoot`) | `$XC project-discovery discover-projects --workspace-root .` |
+| List schemes | `list_schemes` (`projectPath`) | `$XC project-discovery list-schemes --project-path $PROJECT_PATH` |
+| Get bundle ID | `get_app_bundle_id` (`appPath`) | `$XC project-discovery get-app-bundle-id --app-path ./Build/MyApp.app` |
+
+### Other Tools
+
+| Operation | MCP tool | CLI equivalent |
+|-----------|----------|----------------|
+| Clean build | `clean` (`projectPath`, `scheme`) | `$XC utilities clean --project-path $PROJECT_PATH --scheme $SCHEME` |
+| Record video | `record_sim_video` (`simulatorId`) | `$XC simulator record-video --simulator-id $SIM_ID` |
+| Open simulator | `open_sim` | `$XC simulator-management open --simulator-name "$SIM_NAME"` |
+| Key press | `key_press` (`simulatorId`, `keyCode`) | `$XC ui-automation key-press --simulator-id $SIM_ID --key-code 40` |
+| Key sequence | `key_sequence` (`simulatorId`, `keyCodes`) | `$XC ui-automation key-sequence --simulator-id $SIM_ID --key-codes "[40,41]"` |
+
+### CLI-only notes
+
+When in CLI mode, all `$XC` commands require the `DEVELOPER_DIR` prefix:
+```
+DD="DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer"
+XC="$DD xcodebuildmcp"
+```
+
+### Screenshot workflow
+
+**MCP mode:** The `screenshot` tool returns the screenshot data or path directly. **Always use the Read tool on the returned path** so the user can see the screenshot inline.
+
+**CLI mode:** `$XC simulator screenshot` returns the path to the PNG file. Extract and copy it:
+```bash
+SHOT=$($XC simulator screenshot --simulator-id $SIM_ID 2>&1 | grep -o '/[^ ]*\.png')
+cp "$SHOT" "$REPORT_DIR/screenshots/{name}.png" 2>/dev/null
+```
+
+In both modes: without reading the screenshot with the Read tool, screenshots are invisible to the user.
+
+### Snapshot (accessibility tree) workflow
+
+`snapshot_ui` (MCP) / `snapshot-ui` (CLI) returns the full view hierarchy with element types, labels, identifiers, and coordinates (x, y, width, height). Use this to:
+- Verify accessibility labels exist on interactive elements
+- Find tap targets by label for tapping
+- Measure touch target sizes (width/height >= 44pt)
+- Check view hierarchy depth and structure
+- Verify element ordering matches visual reading order
+
+---
+
+## Multi-Device Matrix
+
+When `--full-matrix` is requested or depth is `--deep`, test on multiple simulators:
+
+| Device | Screen | Use case |
+|--------|--------|----------|
+| iPhone SE (3rd gen) | 375x667 (4.7") | Smallest supported. Tight layouts, truncation. |
+| iPhone 16 Pro | 393x852 (6.1") | Standard flagship. Primary design target. |
+| iPhone 16 Pro Max | 430x932 (6.7") | Largest phone. Wasted space, reachability. |
+| iPad (10th gen) | 820x1180 (10.9") | Tablet layout. Sidebar, split view. |
+
+For quick mode, use only the primary device (usually iPhone Pro). For standard mode, use SE + Pro. For deep mode, use all four.
+
+To switch simulators mid-review:
+
+**MCP mode:** Call `boot_sim` → `get_sim_app_path` → `install_app_sim` → `launch_app_sim` with the new simulator name.
+
+**CLI mode:**
+```bash
+$XC simulator-management boot --simulator-name "iPhone SE (3rd generation)"
+APP_PATH=$($XC simulator get-app-path --scheme $SCHEME --project-path $PROJECT_PATH --platform "iOS_Simulator" --simulator-name "$SIM_NAME")
+$XC simulator install --app-path "$APP_PATH" --simulator-name "iPhone SE (3rd generation)"
+$XC simulator launch-app --bundle-id $BUNDLE_ID --simulator-name "iPhone SE (3rd generation)"
+```
+
+---
+
+## Phase 1: First Impression
+
+The most uniquely designer-like output. Form a gut reaction before analyzing anything.
+
+1. Set the status bar to a clean state:
+   - **MCP:** `sim_statusbar(simulatorId, dataNetwork: "wifi")`
+   - **CLI:** `$XC simulator-management statusbar --simulator-id $SIM_ID --data-network wifi`
+
+2. Take the first screenshot (the screen the app opens to):
+   - **MCP:** `screenshot(simulatorId)` — **CLI:** `$XC simulator screenshot --simulator-id $SIM_ID`
+   - Read the screenshot with the Read tool. Copy to `$REPORT_DIR/screenshots/first-impression-light.png`.
+
+3. Switch to dark mode and screenshot:
+   - **MCP:** `set_sim_appearance(simulatorId, mode: "dark")` — **CLI:** `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode dark`
+   - Screenshot again. Copy to `$REPORT_DIR/screenshots/first-impression-dark.png`.
+   - Read the screenshot with the Read tool.
+
+4. Write the **First Impression** using this structured critique format:
+   - "The app communicates **[what]**." (what it says at a glance — competence? warmth? confusion?)
+   - "I notice **[observation]**." (what stands out, positive or negative — be specific)
+   - "The first 3 things my eye goes to are: **[1]**, **[2]**, **[3]**." (hierarchy check — are these intentional?)
+   - "Light vs. dark: **[observation]**." (do both feel equally intentional, or is one an afterthought?)
+   - "If I had to describe this in one word: **[word]**." (gut verdict)
+
+This is the section users read first. Be opinionated. A designer doesn't hedge — they react.
+
+---
+
+## Phase 2: Design System Extraction
+
+Extract the actual design system from the codebase (not what a DESIGN.md says, but what's implemented):
+
+```bash
+# Find all Color extensions and definitions
+grep -r "Color\." --include="*.swift" -l | head -20
+
+# Find color asset catalogs
+find . -name "*.colorset" -type d | head -30
+
+# Find font usage
+grep -rn "\.font(" --include="*.swift" | head -30
+
+# Find spacing/padding values
+grep -rn "\.padding(" --include="*.swift" | head -30
+
+# Find corner radius values
+grep -rn "cornerRadius\|RoundedRectangle" --include="*.swift" | head -30
+
+# Find animation durations
+grep -rn "\.animation(\|withAnimation" --include="*.swift" | head -20
+```
+
+Also get the accessibility snapshot for the current screen to understand the component hierarchy:
+- **MCP:** `snapshot_ui(simulatorId)` — **CLI:** `$XC ui-automation snapshot-ui --simulator-id $SIM_ID`
+
+Structure findings as an **Inferred Design System**:
+- **Colors:** Asset catalog colorsets + manual Color extensions. Flag inconsistencies between them.
+- **Typography:** Font usage patterns. Flag hardcoded sizes vs. system text styles. Flag non-Dynamic Type usage.
+- **Spacing:** Padding/margin values. Flag non-systematic values (not multiples of 4 or 8).
+- **Corner Radii:** Flag if uniform radius on everything (AI slop) or if radius hierarchy exists.
+- **Animation:** Duration ranges, easing curves. Flag broad implicit `.animation()` modifiers applied to entire views or layout property animations.
+
+If DESIGN.md / design-guide.md exists, cross-reference: are the implemented values matching the spec?
+
+---
+
+## Phase 3: Screen-by-Screen Visual Audit
+
+Navigate through each major screen. For each screen (use MCP tools if MODE=mcp, CLI if MODE=cli — see Command Reference):
+
+1. **Navigate** to the screen — `tap(simulatorId, label: "{tab name}")` / `$XC ui-automation tap --simulator-id $SIM_ID --label "{tab name}"`
+2. **Screenshot** — `screenshot(simulatorId)` / `$XC simulator screenshot --simulator-id $SIM_ID`
+   - Read with Read tool. Copy to `$REPORT_DIR/screenshots/{screen}-{appearance}.png`
+3. **Accessibility tree** — `snapshot_ui(simulatorId)` / `$XC ui-automation snapshot-ui --simulator-id $SIM_ID`
+4. **Scroll** to see full content — `gesture(simulatorId, preset: "scroll-down")` / `$XC ui-automation gesture --simulator-id $SIM_ID --preset scroll-down`
+   - Screenshot again. Read with Read tool. Copy to `$REPORT_DIR/screenshots/{screen}-scrolled-{appearance}.png`
+
+For each screen, toggle appearance (light/dark) and screenshot both. Read every screenshot with the Read tool.
+
+### iOS Design Audit Checklist (10 categories, ~107 items)
+
+Apply these at each screen. Each finding gets an impact rating (high/medium/polish) and category.
+
+---
+
+**1. Visual Hierarchy & Composition** (8 items)
+
+- Clear focal point? One primary action per screen?
+- Eye flows naturally top-to-bottom, leading-to-trailing?
+- Visual noise — competing elements fighting for attention?
+- Information density appropriate for the screen's purpose?
+- Z-index clarity — nothing unexpectedly overlapping or clipped?
+- Above-the-fold content communicates the screen's purpose immediately?
+- Squint test: hierarchy still visible when image is blurred?
+- White space is intentional, not leftover from layout constraints?
+
+---
+
+**2. Typography & Dynamic Type** (15 items)
+
+- Uses semantic text styles (`.title`, `.headline`, `.body`, `.caption`) not hardcoded sizes?
+- **All text supports Dynamic Type.** Test: change text size in Settings > Accessibility > Display & Text Size. No truncation of critical info at AX3+.
+- Minimum readable size is 11pt (Caption 2). No text below this.
+- Heading hierarchy: `.largeTitle` > `.title` > `.title2` > `.title3` > `.headline` > `.body`. No skipped levels in visual flow.
+- Weight contrast: >=2 font weights used for hierarchy (not all `.regular`).
+- Line spacing appropriate: ~1.2-1.5x for body text.
+- Text doesn't overflow containers or overlap adjacent elements at large Dynamic Type sizes.
+- `.minimumScaleFactor` used sparingly, never on body text.
+- If custom fonts are used, they scale with Dynamic Type via `UIFontMetrics` or `.custom(_:size:relativeTo:)`.
+- Mono-spaced numbers in data displays (`.monospacedDigit()`).
+- No letter-spacing (tracking/kern) on lowercase body text.
+- Truncation is intentional: `.lineLimit()` with sensible limits, never cuts mid-word on important text.
+- Bold Text accessibility setting respected (system fonts do this automatically; custom fonts need manual handling).
+- Text contrast meets WCAG AA: body text 4.5:1, large text (18pt+/14pt bold+) 3:1.
+- Text uses semantic colors (`.primary`, `.secondary`, `.label`, `.secondaryLabel`) that adapt to appearance.
+
+---
+
+**3. Color & Appearance** (12 items)
+
+- **Both light AND dark mode look intentional.** Neither is an afterthought. Dark mode uses elevation (lighter surfaces at higher z), not just color inversion.
+- Color palette is coherent (<=12 unique non-gray colors per appearance).
+- WCAG AA contrast: body text 4.5:1, large text 3:1, UI components 3:1 — in BOTH appearances.
+- Semantic colors used where appropriate (`.label`, `.secondaryLabel`, `.systemBackground`, `.secondarySystemBackground`).
+- No color-only encoding — information always has shape, icon, or text label in addition to color.
+- Tint color consistent throughout the app (or intentionally varied per section).
+- System materials (`.regularMaterial`, `.thinMaterial`) used appropriately for overlays.
+- Dark mode text is off-white (not pure `#FFFFFF`) to reduce eye strain.
+- Dark mode backgrounds use subtle elevation differences, not flat black.
+- `Increase Contrast` accessibility setting: colors adapt to high-contrast variants? (use system semantic colors).
+- `Smart Invert`: images and media marked with `.accessibilityIgnoresInvertColors(true)` so they don't invert?
+- Red/green is never the only distinction (8% of men have red-green color deficiency).
+
+---
+
+**4. Spacing, Layout & Safe Areas** (14 items)
+
+- **Safe areas respected.** Content not obscured by Dynamic Island, home indicator, rounded corners, or status bar.
+- Default system margins: 16pt leading/trailing on compact-width (iPhone portrait).
+- Spacing uses a consistent scale (4pt or 8pt base), not arbitrary values.
+- Alignment is consistent — elements align to a clear grid or leading edge.
+- Gestalt proximity: related items closer together, distinct sections further apart.
+- **Corner radius hierarchy** — not uniform bubbly radius on everything. Cards ~10-12pt, buttons ~8-10pt, small elements ~4-6pt. Inner radius = outer radius - gap for nested elements.
+- Bottom-anchored buttons have sufficient padding above the home indicator (>=34pt on Face ID devices).
+- Keyboard avoidance: content scrolls or shifts when keyboard appears. No content hidden behind keyboard.
+- Content width: on larger devices, text content has a readable maximum width (~672pt), not stretched edge-to-edge.
+- Scroll content can extend behind safe areas visually (backgrounds, images) but interactive elements stay within.
+- `.ignoresSafeArea()` used intentionally, not as a layout crutch.
+- List/table views use system-standard insets and separators.
+- Section headers have consistent spacing above and below.
+- Horizontal `ScrollView` items have consistent inter-item spacing.
+
+---
+
+**5. Navigation & Platform Conventions** (10 items)
+
+- **Tab bar:** Maximum 5 tabs. Each tab has its own NavigationStack. Tab bar remains visible on primary screens.
+- Tab icons use SF Symbols with labels. Active/inactive states are visually distinct.
+- **Navigation hierarchy:** Large title at root, inline title when pushed. Back button always present.
+- Swipe-to-go-back gesture works (not blocked by custom gesture recognizers).
+- **Sheets/modals:** Have clear dismiss affordance (close button or swipe-to-dismiss). No stacked modals.
+- **Alerts:** Destructive actions use `.destructive` button role (renders red). Cancel is the default (bold) button. Maximum 2-3 buttons.
+- No hamburger menus — use tab bars or `NavigationSplitView` instead.
+- Deep links / state restoration: navigating away and back preserves scroll position and state.
+- Standard iOS patterns used: pull-to-refresh for refreshable content, swipe actions on list rows, long-press for context menus.
+- Settings and preferences follow the iOS conventions (grouped lists with section headers, toggles for on/off).
+
+---
+
+**6. Interaction States & Feedback** (10 items)
+
+- **Touch feedback** on all interactive elements — buttons have visual press state (opacity, scale, or color change).
+- Loading states: < 1s shows nothing; 1-3s shows `ProgressView()` or skeleton; > 3s shows determinate progress with context.
+- **Empty states are features.** Every empty state has: icon/illustration + title + description + primary CTA button. Never just "No items found." Use `ContentUnavailableView` (iOS 17+) for standard cases.
+- Error states are actionable: what went wrong + what to do (retry, check connection, etc.). Never raw error codes.
+- Success states: confirmation animation or color change, appropriate auto-dismiss timing.
+- Pull-to-refresh (`.refreshable`) supported on scrollable content that can update.
+- Disabled state: reduced opacity (~0.4) + non-interactive. Not just greyed text.
+- Skeleton/placeholder views match the shape and layout of real content (not generic spinners).
+- Form validation: errors appear near the problematic field, not just in an alert.
+- Destructive actions (delete, remove) have confirmation (alert or swipe-to-delete with undo).
+
+---
+
+**7. Touch Targets & Reachability** (8 items)
+
+- **All interactive elements >= 44x44pt tap target.** Verify from accessibility snapshot coordinates: width and height must each be >= 44.
+- Spacing between adjacent tap targets >= 8pt to prevent mis-taps.
+- Bottom-of-screen content (within thumb reach) contains primary actions. Top of screen is for titles and secondary info.
+- Swipe actions on list rows are discoverable (edit button or contextual menu as alternative).
+- Text links within body text have sufficient tap area (generous line height or padding).
+- Small icons that are tappable have expanded hit regions (`.contentShape(Rectangle())` or frame padding).
+- Toolbar/navigation bar buttons meet 44pt minimum even when icon is visually smaller.
+- Floating action buttons (if any) don't overlap scrollable content or other tap targets.
+
+---
+
+**8. Accessibility** (12 items)
+
+- **VoiceOver:** Every interactive element has an accessibility label. Verify from accessibility snapshot output that no interactive elements have empty or missing labels.
+- Decorative images hidden with `.accessibilityHidden(true)`.
+- Reading order is logical (top-to-bottom, leading-to-trailing). Custom layouts use `.accessibilitySortPriority()` if needed.
+- Custom controls declare their role (`.accessibilityAddTraits(.isButton)`, `.isHeader`, etc.).
+- State changes announced (`.accessibilityValue()` for dynamic values like progress, toggles).
+- **Reduce Motion:** All non-essential animations gated on `@Environment(\.accessibilityReduceMotion)`. Slide/zoom/bounce replaced with dissolve/opacity. Confetti/particles render as static or empty.
+- **Reduce Transparency:** Translucent/blur materials replaced with solid backgrounds when `accessibilityReduceTransparency` is true.
+- **Bold Text:** Text responds to the Bold Text accessibility setting.
+- Grouped content uses `.accessibilityElement(children: .combine)` where appropriate.
+- All functionality reachable by touch is also reachable by VoiceOver.
+- Focus moves logically after state changes (e.g., after dismissing a sheet, focus returns to the trigger).
+- No time-limited interactions without accessibility accommodations.
+
+---
+
+**9. iOS Design Anti-Patterns ("AI Slop")** (10 items)
+
+The test: would a designer at Apple, Linear, or Airbnb ever ship this?
+
+- **Generic gradient backgrounds:** Purple-to-blue, rainbow gradients with no brand purpose. Every gradient must serve hierarchy or depth, not just decoration.
+- **Excessive glassmorphism/blur:** More than 2-3 frosted glass layers per screen. Text over translucent surfaces must still meet contrast ratios against ALL possible backgrounds.
+- **Uniform bubbly corner radius:** Same large `cornerRadius` on everything — cards, buttons, avatars, inputs. No radius hierarchy.
+- **Shadows without purpose:** Multiple competing drop shadows. Shadows should indicate elevation, not just exist.
+- **Decorative-only animations:** Animations that don't communicate state changes, transitions, or feedback. Every animation needs a job.
+- **Custom controls replacing system controls:** Custom `Toggle`, `Picker`, `DatePicker` that don't support accessibility, Dynamic Type, or system appearance. If Apple built it, use it.
+- **Ignoring platform conventions:** Bottom sheets without swipe-to-dismiss, custom tab bars that don't match iOS, non-standard navigation breaking muscle memory.
+- **Information density extremes:** Either too cramped (tiny text, no breathing room) or too sparse (one item per screen, excessive whitespace requiring unnecessary scrolling).
+- **Inconsistent spacing/alignment:** Mismatched padding values across screens, elements not aligned to a grid.
+- **Generic hero/header patterns:** Cookie-cutter section layouts (hero → 3-column features → CTA). These look like every other AI-generated app.
+
+---
+
+**10. Motion & Performance** (8 items)
+
+- **Purpose:** Every animation serves feedback, continuity, spatial orientation, or delight. No motion for motion's sake.
+- **Duration:** UI animations 0.2-0.5s. Micro-interactions (button press) < 0.2s. Nothing over 1s unless a page transition.
+- **Spring animations preferred** over linear/ease for natural feel. SwiftUI `.spring()` defaults are sensible.
+- **Reduce Motion compliance:** All motion has a non-motion alternative. Parallax, spinning, vortex, depth simulation, auto-playing animations all disabled when `reduceMotion` is true.
+- **No animation on first paint:** The initial screen should not fade/slide in on launch. Content appears immediately.
+- **Interruption handling:** Animations are interruptible — tapping during an animation cancels or redirects it gracefully.
+- **Scroll performance:** Lists and scroll views scroll smoothly without hitches. Heavy views use `LazyVStack`/`LazyHStack`.
+- **Launch time:** App should reach interactive state quickly. No long splash screens or loading gates for cached data.
+
+---
+
+## Phase 4: Appearance Matrix
+
+Test both appearances systematically. For each screen already audited:
+
+1. **Light mode:** `set_sim_appearance(simulatorId, mode: "light")` then `screenshot(simulatorId)` — save as `{screen}-light.png`
+2. **Dark mode:** `set_sim_appearance(simulatorId, mode: "dark")` then `screenshot(simulatorId)` — save as `{screen}-dark.png`
+
+(CLI: `$XC simulator-management set-appearance --simulator-id $SIM_ID --mode light/dark` + `$XC simulator screenshot --simulator-id $SIM_ID`)
+
+Evaluate:
+- Do both appearances feel equally designed, or is one clearly the "real" version?
+- Are elevation differences visible in dark mode (surface hierarchy)?
+- Does any text become unreadable in either appearance?
+- Are images/illustrations appropriate in both appearances?
+- Are custom colors adapting correctly (Asset Catalog light/dark variants)?
+
+---
+
+## Phase 5: Cross-Screen Consistency
+
+Compare screenshots and observations across all audited screens:
+
+- Tab bar consistent across all tabs?
+- Navigation bar style consistent (large title vs inline, tint color)?
+- Card/component styling consistent across screens (same corner radius, shadows, spacing)?
+- Typography consistent (same text styles used for same semantic levels)?
+- Color usage consistent (primary action color is the same everywhere)?
+- Spacing rhythm consistent (same padding values across similar layouts)?
+- Empty states follow the same pattern?
+- Loading states follow the same pattern?
+- Tone consistency (one screen playful while another is corporate?).
+
+---
+
+## Phase 6: Compile Report
+
+### Output Locations
+
+**Local:** `.gstack/design-reports/ios-design-audit-{scheme}-{YYYY-MM-DD}.md`
+
+**Project-scoped:**
+```bash
+eval $(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)
+mkdir -p ~/.gstack/projects/$SLUG
+```
+Write to: `~/.gstack/projects/{slug}/{user}-{branch}-ios-design-audit-{datetime}.md`
+
+**Baseline:** Write `ios-design-baseline.json` for regression mode:
+```json
+{
+  "date": "YYYY-MM-DD",
+  "scheme": "{scheme}",
+  "platform": "iOS",
+  "minOS": "17.0",
+  "designScore": "B",
+  "higComplianceScore": "A",
+  "categoryGrades": { "hierarchy": "A", "typography": "B", "color": "A", "spacing": "B", "navigation": "A", "interaction": "B", "touch": "A", "accessibility": "B", "slop": "A", "motion": "A" },
+  "findings": [{ "id": "IOS-001", "title": "...", "impact": "high", "category": "typography" }],
+  "devicesAudited": ["iPhone 16 Pro"],
+  "appearancesAudited": ["light", "dark"]
+}
+```
+
+### Scoring System
+
+**Dual headline scores:**
+- **Design Score: {A-F}** — weighted average of all 10 categories
+- **HIG Compliance Score: {A-F}** — how well the app follows Apple's Human Interface Guidelines
+
+**Per-category grades:**
+- **A:** Intentional, polished, delightful. Shows design thinking. Feels like an Apple-quality app.
+- **B:** Solid fundamentals, minor inconsistencies. Looks professional.
+- **C:** Functional but generic. No major problems, no design point of view.
+- **D:** Noticeable problems. Feels unfinished or careless.
+- **F:** Actively hurting user experience. Needs significant rework.
+
+**Grade computation:** Each category starts at A. Each High-impact finding drops one letter grade. Each Medium-impact finding drops half a letter grade. Polish findings are noted but do not affect grade. Minimum is F.
+
+**Category weights for Design Score:**
+
+| Category | Weight |
+|----------|--------|
+| Visual Hierarchy | 15% |
+| Typography & Dynamic Type | 15% |
+| Spacing, Layout & Safe Areas | 15% |
+| Color & Appearance | 10% |
+| Navigation & Platform Conventions | 10% |
+| Interaction States & Feedback | 10% |
+| Touch Targets & Reachability | 5% |
+| Accessibility | 10% |
+| iOS Design Anti-Patterns | 5% |
+| Motion & Performance | 5% |
+
+### Regression Output
+
+When previous `ios-design-baseline.json` exists or `--regression` flag is used:
+- Load baseline grades
+- Compare: per-category deltas, new findings, resolved findings
+- Append regression table to report
+
+---
+
+## Design Critique Format
+
+Use structured feedback, not opinions:
+- "I notice..." — observation (e.g., "I notice the primary CTA competes with the tab bar")
+- "I wonder..." — question (e.g., "I wonder if users will find the settings toggle")
+- "What if..." — suggestion (e.g., "What if we used a sheet instead of pushing a new screen?")
+- "I think... because..." — reasoned opinion (e.g., "I think the spacing between sections is too uniform because it doesn't create hierarchy")
+
+Tie everything to user goals, Apple HIG, and the project's design system. Always suggest specific improvements alongside problems.
+
+---
+
+## Important Rules
+
+1. **Think like a designer, not a QA engineer.** You care whether things feel right, look intentional, and respect the user. You do NOT just care whether things "work."
+2. **Screenshots are evidence.** Every finding needs at least one screenshot. Always Read screenshot files so the user can see them inline.
+3. **Be specific and actionable.** "Change X to Y because Z" — not "the spacing feels off."
+4. **Source code informs fixes.** Unlike web design-review, you SHOULD read source code to understand SwiftUI structure, but evaluate the RENDERED result from screenshots and snapshots.
+5. **AI Slop detection is your superpower.** Most developers can't evaluate whether their app looks AI-generated. You can. Be direct about it.
+6. **Quick wins matter.** Always include a "Quick Wins" section — the 3-5 highest-impact fixes that take <30 minutes each.
+7. **Both appearances matter.** Never skip dark mode or light mode. Both must feel intentional.
+8. **HIG is the baseline, not the ceiling.** Meeting HIG is a C+. Design excellence is the goal.
+9. **Document incrementally.** Write each finding to the report as you find it. Don't batch.
+10. **Depth over breadth.** 5-10 well-documented findings with screenshots and specific suggestions > 20 vague observations.
+
+Record baseline design score and HIG compliance score at end of Phase 6.
+
+---
+
+## Output Structure
+
+```
+.gstack/design-reports/
+├── ios-design-audit-{scheme}-{YYYY-MM-DD}.md
+├── screenshots/
+│   ├── first-impression-light.png
+│   ├── first-impression-dark.png
+│   ├── {screen}-light.png
+│   ├── {screen}-dark.png
+│   ├── {screen}-scrolled-light.png
+│   ├── finding-IOS-001-before.png
+│   ├── finding-IOS-001-after.png
+│   └── ...
+└── ios-design-baseline.json
+```
+
+---
+
+## Phase 7: Triage
+
+Sort all discovered findings by impact, then decide which to fix:
+
+- **High Impact:** Fix first. HIG violations, accessibility failures, broken layouts, unreadable text. These affect first impression and app review.
+- **Medium Impact:** Fix next. Inconsistent spacing, minor typography issues, missing states. Felt subconsciously.
+- **Polish:** Fix if time allows. Subtle animation improvements, micro-interaction refinements. Separate good from great.
+
+Mark findings that cannot be verified from simulator (e.g., performance on physical device, real network conditions) as "deferred" regardless of impact.
+
+---
+
+## Phase 8: Fix Loop
+
+For each fixable finding, in impact order:
+
+### 8a. Locate source
+
+```bash
+# Search for the view file
+grep -rn "struct {ViewName}" --include="*.swift" | head -5
+
+# Search for specific colors, fonts, spacing values
+grep -rn "{pattern}" --include="*.swift" | head -10
+
+# Find related files
+find . -name "*{keyword}*" -name "*.swift" | head -5
+```
+
+- Find the source file(s) responsible for the design issue
+- ONLY modify files directly related to the finding
+- Prefer SwiftUI modifier changes over structural view changes
+
+### 8b. Fix
+
+- Read the source code, understand the context
+- Make the **minimal fix** — smallest change that resolves the design issue
+- Modifier-only changes are preferred (safer, more reversible)
+- Do NOT refactor surrounding code, add features, or "improve" unrelated things
+
+### 8c. Commit
+
+```bash
+git add <only-changed-files>
+git commit -m "style(ios-design): IOS-NNN — short description"
+```
+
+- One commit per fix. Never bundle multiple fixes.
+- Message format: `style(ios-design): IOS-NNN — short description`
+
+### 8d. Re-test
+
+Rebuild and re-screenshot the affected screen:
+
+1. **Build and run:** `build_run_sim(scheme, projectPath, simulatorName)` / `$XC simulator build-and-run --scheme $SCHEME --project-path $PROJECT_PATH --simulator-name "$SIM_NAME"`
+2. Wait for app to launch, navigate to affected screen: `tap(simulatorId, label: "{tab}")`
+3. **Screenshot:** `screenshot(simulatorId)` — Read with Read tool. Save as `finding-IOS-NNN-after.png`
+
+Take **before/after screenshot pair** for every fix.
+
+If the simulator is unavailable (e.g., in use by another session), mark fixes as `needs-verify` instead and note that the user should rebuild and re-run `/design-review-ios --regression` when the simulator is free.
+
+### 8e. Classify
+
+- **verified**: re-test confirms the fix works, no new issues introduced
+- **needs-verify**: fix applied but simulator unavailable for rebuild
+- **best-effort**: fix applied but couldn't fully verify (e.g., requires specific Dynamic Type size)
+- **reverted**: regression detected → `git revert HEAD` → mark finding as "deferred"
+
+### 8e.5. Regression Test (design-review-ios variant)
+
+Design fixes are typically SwiftUI modifier changes. Only generate regression tests for fixes involving:
+- Accessibility label changes (verify labels exist in XCUITest)
+- Dynamic Type behavior changes
+- Conditional rendering fixes (show/hide based on state)
+
+For modifier-only fixes (padding, color, font changes): skip. These are caught by re-running `/design-review-ios`.
+
+If the fix involved behavior: write an XCUITest encoding the exact bug condition. Commit format: `test(ios-design): regression test for IOS-NNN`.
+
+### 8f. Self-Regulation (STOP AND EVALUATE)
+
+Every 5 fixes (or after any revert), compute the design-fix risk level:
+
+```
+DESIGN-FIX RISK:
+  Start at 0%
+  Each revert:                        +15%
+  Each modifier-only change:          +0%   (safe — styling only)
+  Each view structure change:         +5%   per file
+  Each new/deleted file:              +10%  per file
+  After fix 10:                       +1%   per additional fix
+  Touching unrelated files:           +20%
+```
+
+**If risk > 20%:** STOP immediately. Show the user what you've done so far. Ask whether to continue.
+
+**Hard cap: 30 fixes.** After 30 fixes, stop regardless of remaining findings.
+
+---
+
+## Phase 9: Final Design Audit
+
+After all fixes are applied:
+
+1. If simulator available: re-run the visual audit on all affected screens
+2. If simulator unavailable: review the code changes and estimate impact
+3. Compute final design score and HIG compliance score
+4. **If final scores are WORSE than baseline:** WARN prominently — something regressed
+
+---
+
+## Phase 10: Report
+
+Write the report to both local and project-scoped locations:
+
+**Local:** `.gstack/design-reports/ios-design-audit-{scheme}-{YYYY-MM-DD}.md`
+
+**Project-scoped:**
+```bash
+eval $(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)
+mkdir -p ~/.gstack/projects/$SLUG
+```
+Write to `~/.gstack/projects/{slug}/{user}-{branch}-ios-design-audit-{datetime}.md`
+
+**Per-finding additions** (beyond standard design audit report):
+- Fix Status: verified / needs-verify / best-effort / reverted / deferred
+- Commit SHA (if fixed)
+- Files Changed (if fixed)
+- Before/After screenshots (if fixed and simulator available)
+- Affected appearances (light / dark / both)
+- Affected devices (SE / Pro / iPad)
+
+**Summary section:**
+- Total findings
+- Fixes applied (verified: X, needs-verify: Y, best-effort: Z, reverted: W)
+- Deferred findings
+- Design score delta: baseline → final
+- HIG compliance score delta: baseline → final
+- Devices audited
+- Appearances audited
+
+**PR Summary:** Include a one-line summary suitable for PR descriptions:
+> "iOS design review found N issues, fixed M. Design score X → Y, HIG compliance X → Y."
+
+---
+
+## Phase 11: TODOS.md Update
+
+If the repo has a `TODOS.md`:
+
+1. **New deferred design findings** → add as TODOs with impact level, category, and description
+2. **Fixed findings that were in TODOS.md** → annotate with "Fixed by /design-review-ios on {branch}, {date}"
+
+---
+
+## Additional Rules (design-review-ios specific)
+
+11. **Clean working tree required.** Refuse to start if `git status --porcelain` is non-empty.
+12. **One commit per fix.** Never bundle multiple design fixes into one commit.
+13. **Only modify tests when generating regression tests in Phase 8e.5.** Never modify CI configuration. Never modify existing tests — only create new test files.
+14. **Revert on regression.** If a fix makes things worse, `git revert HEAD` immediately.
+15. **Self-regulate.** Follow the design-fix risk heuristic. When in doubt, stop and ask.
+16. **Modifier-first.** Prefer SwiftUI modifier changes (`.padding()`, `.font()`, `.foregroundStyle()`) over structural view changes. Modifier changes are safer and more reversible.
+17. **Respect the design system.** If DESIGN.md or design-guide.md exists, fixes must use tokens/values from that system, not introduce new ones.
+18. **Both appearances.** Every fix must be verified in both light and dark mode (when simulator is available).
+19. **DEVELOPER_DIR prefix (CLI mode only).** When using CLI mode, every xcodebuildmcp and xcrun command must include `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`. MCP mode handles this automatically.
+20. **Don't fight the simulator.** If another session is using the simulator, work in code-review-only mode: read source, identify issues from existing screenshots or code patterns, apply fixes, mark as `needs-verify`.

--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -29,6 +29,7 @@ const SKILL_FILES = [
   'setup-browser-cookies/SKILL.md',
   'plan-design-review/SKILL.md',
   'design-review/SKILL.md',
+  'design-review-ios/SKILL.md',
   'gstack-upgrade/SKILL.md',
   'document-release/SKILL.md',
 ].filter(f => fs.existsSync(path.join(ROOT, f)));


### PR DESCRIPTION
## Summary

- Adds [XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP) integration to gstack, enabling iOS design QA directly from Claude Code
- New `/design-review-ios` skill builds, screenshots, and interacts with iOS apps on the simulator — **MCP server preferred, CLI fallback**
- Iteratively finds and fixes visual issues with atomic commits and before/after screenshot evidence

## What this enables

gstack can now audit iOS apps the same way `/design-review` audits web apps, using the iOS Simulator via [XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP). The skill covers 10 design categories (~107 checklist items):

- Typography, spacing, and visual hierarchy
- Apple Human Interface Guidelines (HIG) compliance
- Accessibility (touch targets, labels, VoiceOver readiness)
- Light/dark mode parity
- AI slop detection (generic gradients, placeholder copy, stock patterns)
- Multi-device matrix testing (iPhone SE → iPad)

## Integration architecture

The skill auto-detects the best integration mode at startup:

1. **MCP server (preferred):** If XcodeBuildMCP is configured as an MCP server, the skill calls its tools directly (`build_run_sim`, `screenshot`, `tap`, `snapshot_ui`, etc.) — no Bash, no PATH issues, no `DEVELOPER_DIR` workaround
2. **CLI fallback:** If no MCP tools are available, falls back to the `xcodebuildmcp` CLI via Bash

This means zero-config for users who already have XcodeBuildMCP set up as an MCP server (`claude mcp add xcodebuildmcp`).

## How it works

1. Detects the Xcode project, scheme, and simulator via `discover_projs` / `list_schemes` / `list_sims`
2. Builds and launches the app via `build_run_sim`
3. Screenshots and inspects the accessibility tree via `screenshot` and `snapshot_ui`
4. Navigates the app using UI automation tools (`tap`, `gesture`, `swipe`)
5. Audits every reachable screen against HIG + the project's design system
6. Fixes issues in source code, commits atomically, rebuilds, and re-screenshots to verify

## Requirements

- [XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP) — either as an MCP server (recommended: `claude mcp add xcodebuildmcp -- npx -y xcodebuildmcp@latest mcp`) or CLI (`brew install getsentry/xcodebuildmcp/xcodebuildmcp`)
- Xcode + iOS Simulator
- macOS only (iOS Simulator requirement)

## Test plan

- [x] Tested on a live iOS project(s). Full audit cycle with screenshot capture, issue detection, and fix verification in both MCP and CLI modes
- [ ] Reviewer can invoke `/design-review-ios` on any iOS project with XcodeBuildMCP configured (MCP server or CLI)
