### PR TITLE
feat: isolated browser sessions with separate cookies/storage

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -587,6 +587,11 @@ Refs are invalidated on navigation — run `snapshot` again after `goto`.
 |---------|-------------|
 | `snapshot [flags]` | Accessibility tree with @e refs for element selection. Flags: -i interactive only, -c compact, -d N depth limit, -s sel scope, -D diff vs previous, -a annotated screenshot, -o path output, -C cursor-interactive @c refs |
 
+### Session
+| Command | Description |
+|---------|-------------|
+| `session <new|switch|list|delete> [name]` | Manage isolated browser sessions with separate cookies/storage |
+
 ### Meta
 | Command | Description |
 |---------|-------------|

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -459,6 +459,11 @@ Refs are invalidated on navigation — run `snapshot` again after `goto`.
 |---------|-------------|
 | `snapshot [flags]` | Accessibility tree with @e refs for element selection. Flags: -i interactive only, -c compact, -d N depth limit, -s sel scope, -D diff vs previous, -a annotated screenshot, -o path output, -C cursor-interactive @c refs |
 
+### Session
+| Command | Description |
+|---------|-------------|
+| `session <new|switch|list|delete> [name]` | Manage isolated browser sessions with separate cookies/storage |
+
 ### Meta
 | Command | Description |
 |---------|-------------|

--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -1,6 +1,11 @@
 /**
  * Browser lifecycle manager
  *
+ * Session isolation:
+ *   Each session has its own BrowserContext with separate cookies, storage,
+ *   and tab set. The "default" session is created on launch.
+ *   Global state (dialog handling, UA, headers) is shared across sessions.
+ *
  * Chromium crash handling:
  *   browser.on('disconnected') → log error → process.exit(1)
  *   CLI detects dead server → auto-restarts on next command
@@ -34,24 +39,25 @@ export interface BrowserState {
   }>;
 }
 
+interface Session {
+  name: string;
+  context: BrowserContext;
+  pages: Map<number, Page>;
+  activeTabId: number;
+  refMap: Map<string, RefEntry>;
+  lastSnapshot: string | null;
+}
+
 export class BrowserManager {
   private browser: Browser | null = null;
-  private context: BrowserContext | null = null;
-  private pages: Map<number, Page> = new Map();
-  private activeTabId: number = 0;
+  private sessions: Map<string, Session> = new Map();
+  private activeSessionName: string = 'default';
   private nextTabId: number = 1;
   private extraHeaders: Record<string, string> = {};
   private customUserAgent: string | null = null;
 
   /** Server port — set after server starts, used by cookie-import-browser command */
   public serverPort: number = 0;
-
-  // ─── Ref Map (snapshot → @e1, @e2, @c1, @c2, ...) ────────
-  private refMap: Map<string, RefEntry> = new Map();
-
-  // ─── Snapshot Diffing ─────────────────────────────────────
-  // NOT cleared on navigation — it's a text baseline for diffing
-  private lastSnapshot: string | null = null;
 
   // ─── Dialog Handling ──────────────────────────────────────
   private dialogAutoAccept: boolean = true;
@@ -60,6 +66,13 @@ export class BrowserManager {
   // ─── Handoff State ─────────────────────────────────────────
   private isHeaded: boolean = false;
   private consecutiveFailures: number = 0;
+
+  // ─── Session Accessor ───────────────────────────────────────
+  private get session(): Session {
+    const s = this.sessions.get(this.activeSessionName);
+    if (!s) throw new Error(`No active session "${this.activeSessionName}" — this is a bug`);
+    return s;
+  }
 
   async launch() {
     this.browser = await chromium.launch({ headless: true });
@@ -77,11 +90,22 @@ export class BrowserManager {
     if (this.customUserAgent) {
       contextOptions.userAgent = this.customUserAgent;
     }
-    this.context = await this.browser.newContext(contextOptions);
+    const context = await this.browser.newContext(contextOptions);
 
     if (Object.keys(this.extraHeaders).length > 0) {
-      await this.context.setExtraHTTPHeaders(this.extraHeaders);
+      await context.setExtraHTTPHeaders(this.extraHeaders);
     }
+
+    const session: Session = {
+      name: 'default',
+      context,
+      pages: new Map(),
+      activeTabId: 0,
+      refMap: new Map(),
+      lastSnapshot: null,
+    };
+    this.sessions.set('default', session);
+    this.activeSessionName = 'default';
 
     // Create first tab
     await this.newTab();
@@ -97,6 +121,7 @@ export class BrowserManager {
         new Promise(resolve => setTimeout(resolve, 5000)),
       ]).catch(() => {});
       this.browser = null;
+      this.sessions.clear();
     }
   }
 
@@ -104,7 +129,7 @@ export class BrowserManager {
   async isHealthy(): Promise<boolean> {
     if (!this.browser || !this.browser.isConnected()) return false;
     try {
-      const page = this.pages.get(this.activeTabId);
+      const page = this.session.pages.get(this.session.activeTabId);
       if (!page) return true; // connected but no pages — still healthy
       await Promise.race([
         page.evaluate('1'),
@@ -118,20 +143,21 @@ export class BrowserManager {
 
   // ─── Tab Management ────────────────────────────────────────
   async newTab(url?: string): Promise<number> {
-    if (!this.context) throw new Error('Browser not launched');
+    const session = this.session;
+    if (!session.context) throw new Error('Browser not launched');
 
     // Validate URL before allocating page to avoid zombie tabs on rejection
     if (url) {
       validateNavigationUrl(url);
     }
 
-    const page = await this.context.newPage();
+    const page = await session.context.newPage();
     const id = this.nextTabId++;
-    this.pages.set(id, page);
-    this.activeTabId = id;
+    session.pages.set(id, page);
+    session.activeTabId = id;
 
     // Wire up console/network/dialog capture
-    this.wirePageEvents(page);
+    this.wirePageEvents(page, this.activeSessionName);
 
     if (url) {
       await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
@@ -141,18 +167,19 @@ export class BrowserManager {
   }
 
   async closeTab(id?: number): Promise<void> {
-    const tabId = id ?? this.activeTabId;
-    const page = this.pages.get(tabId);
+    const session = this.session;
+    const tabId = id ?? session.activeTabId;
+    const page = session.pages.get(tabId);
     if (!page) throw new Error(`Tab ${tabId} not found`);
 
     await page.close();
-    this.pages.delete(tabId);
+    session.pages.delete(tabId);
 
     // Switch to another tab if we closed the active one
-    if (tabId === this.activeTabId) {
-      const remaining = [...this.pages.keys()];
+    if (tabId === session.activeTabId) {
+      const remaining = [...session.pages.keys()];
       if (remaining.length > 0) {
-        this.activeTabId = remaining[remaining.length - 1];
+        session.activeTabId = remaining[remaining.length - 1];
       } else {
         // No tabs left — create a new blank one
         await this.newTab();
@@ -161,22 +188,23 @@ export class BrowserManager {
   }
 
   switchTab(id: number): void {
-    if (!this.pages.has(id)) throw new Error(`Tab ${id} not found`);
-    this.activeTabId = id;
+    if (!this.session.pages.has(id)) throw new Error(`Tab ${id} not found`);
+    this.session.activeTabId = id;
   }
 
   getTabCount(): number {
-    return this.pages.size;
+    return this.session.pages.size;
   }
 
   async getTabListWithTitles(): Promise<Array<{ id: number; url: string; title: string; active: boolean }>> {
+    const session = this.session;
     const tabs: Array<{ id: number; url: string; title: string; active: boolean }> = [];
-    for (const [id, page] of this.pages) {
+    for (const [id, page] of session.pages) {
       tabs.push({
         id,
         url: page.url(),
         title: await page.title().catch(() => ''),
-        active: id === this.activeTabId,
+        active: id === session.activeTabId,
       });
     }
     return tabs;
@@ -184,7 +212,7 @@ export class BrowserManager {
 
   // ─── Page Access ───────────────────────────────────────────
   getPage(): Page {
-    const page = this.pages.get(this.activeTabId);
+    const page = this.session.pages.get(this.session.activeTabId);
     if (!page) throw new Error('No active page. Use "browse goto <url>" first.');
     return page;
   }
@@ -199,11 +227,11 @@ export class BrowserManager {
 
   // ─── Ref Map ──────────────────────────────────────────────
   setRefMap(refs: Map<string, RefEntry>) {
-    this.refMap = refs;
+    this.session.refMap = refs;
   }
 
   clearRefs() {
-    this.refMap.clear();
+    this.session.refMap.clear();
   }
 
   /**
@@ -213,7 +241,7 @@ export class BrowserManager {
   async resolveRef(selector: string): Promise<{ locator: Locator } | { selector: string }> {
     if (selector.startsWith('@e') || selector.startsWith('@c')) {
       const ref = selector.slice(1); // "e3" or "c1"
-      const entry = this.refMap.get(ref);
+      const entry = this.session.refMap.get(ref);
       if (!entry) {
         throw new Error(
           `Ref ${selector} not found. Run 'snapshot' to get fresh refs.`
@@ -234,23 +262,23 @@ export class BrowserManager {
   /** Get the ARIA role for a ref selector, or null for CSS selectors / unknown refs. */
   getRefRole(selector: string): string | null {
     if (selector.startsWith('@e') || selector.startsWith('@c')) {
-      const entry = this.refMap.get(selector.slice(1));
+      const entry = this.session.refMap.get(selector.slice(1));
       return entry?.role ?? null;
     }
     return null;
   }
 
   getRefCount(): number {
-    return this.refMap.size;
+    return this.session.refMap.size;
   }
 
   // ─── Snapshot Diffing ─────────────────────────────────────
   setLastSnapshot(text: string | null) {
-    this.lastSnapshot = text;
+    this.session.lastSnapshot = text;
   }
 
   getLastSnapshot(): string | null {
-    return this.lastSnapshot;
+    return this.session.lastSnapshot;
   }
 
   // ─── Dialog Control ───────────────────────────────────────
@@ -278,8 +306,9 @@ export class BrowserManager {
   // ─── Extra Headers ─────────────────────────────────────────
   async setExtraHeader(name: string, value: string) {
     this.extraHeaders[name] = value;
-    if (this.context) {
-      await this.context.setExtraHTTPHeaders(this.extraHeaders);
+    const s = this.sessions.get(this.activeSessionName);
+    if (s?.context) {
+      await s.context.setExtraHTTPHeaders(this.extraHeaders);
     }
   }
 
@@ -294,16 +323,17 @@ export class BrowserManager {
 
   // ─── State Save/Restore (shared by recreateContext + handoff) ─
   /**
-   * Capture browser state: cookies, localStorage, sessionStorage, URLs, active tab.
+   * Capture browser state for the active session: cookies, localStorage,
+   * sessionStorage, URLs, active tab.
    * Skips pages that fail storage reads (e.g., already closed).
    */
   async saveState(): Promise<BrowserState> {
-    if (!this.context) throw new Error('Browser not launched');
+    const session = this.session;
 
-    const cookies = await this.context.cookies();
+    const cookies = await session.context.cookies();
     const pages: BrowserState['pages'] = [];
 
-    for (const [id, page] of this.pages) {
+    for (const [id, page] of session.pages) {
       const url = page.url();
       let storage = null;
       try {
@@ -314,7 +344,7 @@ export class BrowserManager {
       } catch {}
       pages.push({
         url: url === 'about:blank' ? '' : url,
-        isActive: id === this.activeTabId,
+        isActive: id === session.activeTabId,
         storage,
       });
     }
@@ -323,25 +353,25 @@ export class BrowserManager {
   }
 
   /**
-   * Restore browser state into the current context: cookies, pages, storage.
+   * Restore browser state into the active session's context: cookies, pages, storage.
    * Navigates to saved URLs, restores storage, wires page events.
    * Failures on individual pages are swallowed — partial restore is better than none.
    */
   async restoreState(state: BrowserState): Promise<void> {
-    if (!this.context) throw new Error('Browser not launched');
+    const session = this.session;
 
     // Restore cookies
     if (state.cookies.length > 0) {
-      await this.context.addCookies(state.cookies);
+      await session.context.addCookies(state.cookies);
     }
 
     // Re-create pages
     let activeId: number | null = null;
     for (const saved of state.pages) {
-      const page = await this.context.newPage();
+      const page = await session.context.newPage();
       const id = this.nextTabId++;
-      this.pages.set(id, page);
-      this.wirePageEvents(page);
+      session.pages.set(id, page);
+      this.wirePageEvents(page, this.activeSessionName);
 
       if (saved.url) {
         await page.goto(saved.url, { waitUntil: 'domcontentloaded', timeout: 15000 }).catch(() => {});
@@ -368,14 +398,14 @@ export class BrowserManager {
     }
 
     // If no pages were saved, create a blank one
-    if (this.pages.size === 0) {
+    if (session.pages.size === 0) {
       await this.newTab();
     } else {
-      this.activeTabId = activeId ?? [...this.pages.keys()][0];
+      session.activeTabId = activeId ?? [...session.pages.keys()][0];
     }
 
     // Clear refs — pages are new, locators are stale
-    this.clearRefs();
+    session.refMap.clear();
   }
 
   /**
@@ -384,7 +414,8 @@ export class BrowserManager {
    * Falls back to a clean slate on any failure.
    */
   async recreateContext(): Promise<string | null> {
-    if (!this.browser || !this.context) {
+    const session = this.session;
+    if (!this.browser || !session.context) {
       throw new Error('Browser not launched');
     }
 
@@ -393,11 +424,11 @@ export class BrowserManager {
       const state = await this.saveState();
 
       // 2. Close old pages and context
-      for (const page of this.pages.values()) {
+      for (const page of session.pages.values()) {
         await page.close().catch(() => {});
       }
-      this.pages.clear();
-      await this.context.close().catch(() => {});
+      session.pages.clear();
+      await session.context.close().catch(() => {});
 
       // 3. Create new context with updated settings
       const contextOptions: BrowserContextOptions = {
@@ -406,10 +437,10 @@ export class BrowserManager {
       if (this.customUserAgent) {
         contextOptions.userAgent = this.customUserAgent;
       }
-      this.context = await this.browser.newContext(contextOptions);
+      session.context = await this.browser.newContext(contextOptions);
 
       if (Object.keys(this.extraHeaders).length > 0) {
-        await this.context.setExtraHTTPHeaders(this.extraHeaders);
+        await session.context.setExtraHTTPHeaders(this.extraHeaders);
       }
 
       // 4. Restore state
@@ -419,8 +450,8 @@ export class BrowserManager {
     } catch (err: unknown) {
       // Fallback: create a clean context + blank tab
       try {
-        this.pages.clear();
-        if (this.context) await this.context.close().catch(() => {});
+        session.pages.clear();
+        if (session.context) await session.context.close().catch(() => {});
 
         const contextOptions: BrowserContextOptions = {
           viewport: { width: 1280, height: 720 },
@@ -428,9 +459,9 @@ export class BrowserManager {
         if (this.customUserAgent) {
           contextOptions.userAgent = this.customUserAgent;
         }
-        this.context = await this.browser!.newContext(contextOptions);
+        session.context = await this.browser!.newContext(contextOptions);
         await this.newTab();
-        this.clearRefs();
+        session.refMap.clear();
       } catch {
         // If even the fallback fails, we're in trouble — but browser is still alive
       }
@@ -441,6 +472,7 @@ export class BrowserManager {
   // ─── Handoff: Headless → Headed ─────────────────────────────
   /**
    * Hand off browser control to the user by relaunching in headed mode.
+   * Saves and restores the active session's state.
    *
    * Flow (launch-first-close-second for safe rollback):
    *   1. Save state from current headless browser
@@ -453,7 +485,8 @@ export class BrowserManager {
     if (this.isHeaded) {
       return `HANDOFF: Already in headed mode at ${this.getCurrentUrl()}`;
     }
-    if (!this.browser || !this.context) {
+    const session = this.session;
+    if (!this.browser || !session.context) {
       throw new Error('Browser not launched');
     }
 
@@ -484,13 +517,12 @@ export class BrowserManager {
         await newContext.setExtraHTTPHeaders(this.extraHeaders);
       }
 
-      // Swap to new browser/context before restoreState (it uses this.context)
+      // Swap to new browser/context before restoreState (it uses this.session)
       const oldBrowser = this.browser;
-      const oldContext = this.context;
 
       this.browser = newBrowser;
-      this.context = newContext;
-      this.pages.clear();
+      session.context = newContext;
+      session.pages.clear();
 
       // Register crash handler on new browser
       this.browser.on('disconnected', () => {
@@ -550,13 +582,74 @@ export class BrowserManager {
     return null;
   }
 
+  // ─── Session Management ─────────────────────────────────────
+  async newSession(name: string): Promise<void> {
+    if (!/^[a-zA-Z0-9_-]{1,32}$/.test(name)) {
+      throw new Error('Session name must be 1-32 alphanumeric characters, dashes, or underscores');
+    }
+    if (this.sessions.has(name)) {
+      throw new Error(`Session "${name}" already exists`);
+    }
+    if (!this.browser) throw new Error('Browser not launched');
+
+    const contextOptions: BrowserContextOptions = { viewport: { width: 1280, height: 720 } };
+    if (this.customUserAgent) contextOptions.userAgent = this.customUserAgent;
+    const context = await this.browser.newContext(contextOptions);
+    if (Object.keys(this.extraHeaders).length > 0) {
+      await context.setExtraHTTPHeaders(this.extraHeaders);
+    }
+
+    const session: Session = {
+      name,
+      context,
+      pages: new Map(),
+      activeTabId: 0,
+      refMap: new Map(),
+      lastSnapshot: null,
+    };
+    this.sessions.set(name, session);
+    this.activeSessionName = name;
+    await this.newTab();
+  }
+
+  async deleteSession(name: string): Promise<void> {
+    if (name === 'default') throw new Error('Cannot delete the default session');
+    if (name === this.activeSessionName) throw new Error('Cannot delete the active session — switch first');
+    const session = this.sessions.get(name);
+    if (!session) throw new Error(`Session "${name}" not found`);
+
+    for (const page of session.pages.values()) {
+      await page.close().catch(() => {});
+    }
+    await session.context.close().catch(() => {});
+    this.sessions.delete(name);
+  }
+
+  switchSession(name: string): void {
+    if (!this.sessions.has(name)) throw new Error(`Session "${name}" not found`);
+    this.activeSessionName = name;
+  }
+
+  getSessionList(): Array<{ name: string; tabCount: number; active: boolean }> {
+    return [...this.sessions.entries()].map(([name, session]) => ({
+      name,
+      tabCount: session.pages.size,
+      active: name === this.activeSessionName,
+    }));
+  }
+
+  getActiveSessionName(): string {
+    return this.activeSessionName;
+  }
+
   // ─── Console/Network/Dialog/Ref Wiring ────────────────────
-  private wirePageEvents(page: Page) {
+  private wirePageEvents(page: Page, sessionName: string) {
     // Clear ref map on navigation — refs point to stale elements after page change
     // (lastSnapshot is NOT cleared — it's a text baseline for diffing)
     page.on('framenavigated', (frame) => {
       if (frame === page.mainFrame()) {
-        this.clearRefs();
+        const session = this.sessions.get(sessionName);
+        if (session) session.refMap.clear();
       }
     });
 

--- a/browse/src/commands.ts
+++ b/browse/src/commands.ts
@@ -31,6 +31,7 @@ export const META_COMMANDS = new Set([
   'chain', 'diff',
   'url', 'snapshot',
   'handoff', 'resume',
+  'session',
 ]);
 
 export const ALL_COMMANDS = new Set([...READ_COMMANDS, ...WRITE_COMMANDS, ...META_COMMANDS]);
@@ -92,6 +93,8 @@ export const COMMAND_DESCRIPTIONS: Record<string, { category: string; descriptio
   'status':  { category: 'Server', description: 'Health check' },
   'stop':    { category: 'Server', description: 'Shutdown server' },
   'restart': { category: 'Server', description: 'Restart server' },
+  // Session
+  'session': { category: 'Session', description: 'Manage isolated browser sessions with separate cookies/storage', usage: 'session <new|switch|list|delete> [name]' },
   // Meta
   'snapshot':{ category: 'Snapshot', description: 'Accessibility tree with @e refs for element selection. Flags: -i interactive only, -c compact, -d N depth limit, -s sel scope, -D diff vs previous, -a annotated screenshot, -o path output, -C cursor-interactive @c refs', usage: 'snapshot [flags]' },
   'chain':   { category: 'Meta', description: 'Run commands from JSON stdin. Format: [["cmd","arg1",...],...]' },

--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -61,10 +61,13 @@ export async function handleMetaCommand(
     case 'status': {
       const page = bm.getPage();
       const tabs = bm.getTabCount();
+      const sessionName = bm.getActiveSessionName();
+      const sessionCount = bm.getSessionList().length;
       return [
         `Status: healthy`,
         `URL: ${page.url()}`,
         `Tabs: ${tabs}`,
+        `Session: ${sessionName} (${sessionCount} total)`,
         `PID: ${process.pid}`,
       ].join('\n');
     }
@@ -261,6 +264,35 @@ export async function handleMetaCommand(
       // Re-snapshot to capture current page state after human interaction
       const snapshot = await handleSnapshot(['-i'], bm);
       return `RESUMED\n${snapshot}`;
+    }
+
+    // ─── Session ─────────────────────────────────────
+    case 'session': {
+      const [sub, name] = args;
+      switch (sub) {
+        case 'new': {
+          if (!name) throw new Error('Usage: session new <name>');
+          await bm.newSession(name);
+          return `Created and switched to session "${name}"`;
+        }
+        case 'switch': {
+          if (!name) throw new Error('Usage: session switch <name>');
+          bm.switchSession(name);
+          return `Switched to session "${name}"`;
+        }
+        case 'delete': {
+          if (!name) throw new Error('Usage: session delete <name>');
+          await bm.deleteSession(name);
+          return `Deleted session "${name}"`;
+        }
+        case 'list':
+        default: {
+          const sessions = bm.getSessionList();
+          return sessions.map(s =>
+            `${s.active ? '→ ' : '  '}${s.name} (${s.tabCount} tab${s.tabCount !== 1 ? 's' : ''})`
+          ).join('\n');
+        }
+      }
     }
 
     default:

--- a/browse/test/session.test.ts
+++ b/browse/test/session.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Session isolation tests for browse
+ *
+ * Verifies that sessions have independent cookies, tabs, refs, and state.
+ * Each test cleans up after itself to ensure no cross-test pollution.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { startTestServer } from './test-server';
+import { BrowserManager } from '../src/browser-manager';
+import { handleReadCommand } from '../src/read-commands';
+import { handleWriteCommand } from '../src/write-commands';
+import { handleMetaCommand } from '../src/meta-commands';
+
+let testServer: ReturnType<typeof startTestServer>;
+let bm: BrowserManager;
+let baseUrl: string;
+const shutdown = async () => {};
+
+beforeAll(async () => {
+  testServer = startTestServer(0);
+  baseUrl = testServer.url;
+
+  bm = new BrowserManager();
+  await bm.launch();
+});
+
+afterAll(() => {
+  try { testServer.server.stop(); } catch {}
+  setTimeout(() => process.exit(0), 500);
+});
+
+// ─── Session Isolation ──────────────────────────────────────────
+
+describe('session isolation', () => {
+  test('session list shows default on startup', () => {
+    const sessions = bm.getSessionList();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].name).toBe('default');
+    expect(sessions[0].active).toBe(true);
+    expect(sessions[0].tabCount).toBeGreaterThanOrEqual(1);
+  });
+
+  test('session new creates isolated context', async () => {
+    await bm.newSession('test-a');
+    const sessions = bm.getSessionList();
+    expect(sessions).toHaveLength(2);
+    expect(bm.getActiveSessionName()).toBe('test-a');
+
+    bm.switchSession('default');
+    await bm.deleteSession('test-a');
+  });
+
+  test('cookies isolated between sessions', async () => {
+    // Set cookie in default session
+    await handleWriteCommand('goto', [baseUrl + '/basic.html'], bm);
+    await handleWriteCommand('cookie', ['test_cookie=default_value'], bm);
+    const defaultCookies = await handleReadCommand('cookies', [], bm);
+    expect(defaultCookies).toContain('test_cookie');
+
+    // Create new session — cookie should NOT be visible
+    await bm.newSession('cookie-test');
+    await handleWriteCommand('goto', [baseUrl + '/basic.html'], bm);
+    const newCookies = await handleReadCommand('cookies', [], bm);
+    expect(newCookies).not.toContain('test_cookie');
+
+    // Switch back — cookie should still be there
+    bm.switchSession('default');
+    const backCookies = await handleReadCommand('cookies', [], bm);
+    expect(backCookies).toContain('test_cookie');
+
+    await bm.deleteSession('cookie-test');
+  });
+
+  test('tabs isolated between sessions', async () => {
+    const defaultTabCount = bm.getTabCount();
+
+    await bm.newSession('tab-test');
+    expect(bm.getTabCount()).toBe(1);
+
+    bm.switchSession('default');
+    expect(bm.getTabCount()).toBe(defaultTabCount);
+
+    await bm.deleteSession('tab-test');
+  });
+
+  test('refs isolated between sessions', async () => {
+    await handleWriteCommand('goto', [baseUrl + '/basic.html'], bm);
+    await handleMetaCommand('snapshot', ['-i'], bm, shutdown);
+    const defaultRefCount = bm.getRefCount();
+    expect(defaultRefCount).toBeGreaterThan(0);
+
+    await bm.newSession('ref-test');
+    expect(bm.getRefCount()).toBe(0);
+
+    bm.switchSession('default');
+    expect(bm.getRefCount()).toBe(defaultRefCount);
+
+    await bm.deleteSession('ref-test');
+  });
+
+  test('session switch preserves state', async () => {
+    await bm.newSession('state-test');
+    await handleWriteCommand('goto', [baseUrl + '/basic.html'], bm);
+    await handleWriteCommand('cookie', ['state_cookie=preserved'], bm);
+
+    bm.switchSession('default');
+    bm.switchSession('state-test');
+
+    const cookies = await handleReadCommand('cookies', [], bm);
+    expect(cookies).toContain('state_cookie');
+    expect(bm.getCurrentUrl()).toContain('basic.html');
+
+    bm.switchSession('default');
+    await bm.deleteSession('state-test');
+  });
+
+  test('session delete removes session', async () => {
+    await bm.newSession('delete-me');
+    expect(bm.getSessionList()).toHaveLength(2);
+
+    bm.switchSession('default');
+    await bm.deleteSession('delete-me');
+    expect(bm.getSessionList()).toHaveLength(1);
+  });
+
+  test('session delete default throws', async () => {
+    await expect(bm.deleteSession('default')).rejects.toThrow('Cannot delete the default session');
+  });
+
+  test('session delete active throws', async () => {
+    await bm.newSession('active-test');
+    await expect(bm.deleteSession('active-test')).rejects.toThrow('Cannot delete the active session');
+
+    bm.switchSession('default');
+    await bm.deleteSession('active-test');
+  });
+
+  test('session new duplicate name throws', async () => {
+    await bm.newSession('dup-test');
+    await expect(bm.newSession('dup-test')).rejects.toThrow('already exists');
+
+    bm.switchSession('default');
+    await bm.deleteSession('dup-test');
+  });
+
+  test('session new with invalid name throws', async () => {
+    await expect(bm.newSession('')).rejects.toThrow();
+    await expect(bm.newSession('has spaces')).rejects.toThrow();
+    await expect(bm.newSession('a'.repeat(33))).rejects.toThrow();
+    await expect(bm.newSession('special!chars')).rejects.toThrow();
+  });
+
+  test('session name reuse after delete works', async () => {
+    await bm.newSession('reuse-me');
+    await handleWriteCommand('goto', [baseUrl + '/basic.html'], bm);
+    await handleWriteCommand('cookie', ['old_cookie=old_value'], bm);
+
+    bm.switchSession('default');
+    await bm.deleteSession('reuse-me');
+
+    await bm.newSession('reuse-me');
+    await handleWriteCommand('goto', [baseUrl + '/basic.html'], bm);
+    const cookies = await handleReadCommand('cookies', [], bm);
+    expect(cookies).not.toContain('old_cookie');
+
+    bm.switchSession('default');
+    await bm.deleteSession('reuse-me');
+  });
+
+  test('navigate in inactive session does not clear active session refs', async () => {
+    await handleWriteCommand('goto', [baseUrl + '/basic.html'], bm);
+    await handleMetaCommand('snapshot', ['-i'], bm, shutdown);
+    const refCount = bm.getRefCount();
+    expect(refCount).toBeGreaterThan(0);
+
+    await bm.newSession('nav-test');
+    await handleWriteCommand('goto', [baseUrl + '/basic.html'], bm);
+
+    bm.switchSession('default');
+    expect(bm.getRefCount()).toBe(refCount);
+
+    await bm.deleteSession('nav-test');
+  });
+
+  test('session list via meta command', async () => {
+    const result = await handleMetaCommand('session', ['list'], bm, shutdown);
+    expect(result).toContain('default');
+    expect(result).toContain('→');
+  });
+
+  test('session new/switch/delete via meta command', async () => {
+    let result = await handleMetaCommand('session', ['new', 'cmd-test'], bm, shutdown);
+    expect(result).toContain('Created');
+
+    result = await handleMetaCommand('session', ['switch', 'default'], bm, shutdown);
+    expect(result).toContain('Switched');
+
+    result = await handleMetaCommand('session', ['delete', 'cmd-test'], bm, shutdown);
+    expect(result).toContain('Deleted');
+  });
+
+  test('status includes session info', async () => {
+    const result = await handleMetaCommand('status', [], bm, shutdown);
+    expect(result).toContain('Session:');
+    expect(result).toContain('default');
+  });
+
+  test('setExtraHeader before launch does not throw', async () => {
+    const fresh = new BrowserManager();
+    // Should not throw — no session exists yet, header is stored globally
+    await fresh.setExtraHeader('X-Test', 'value');
+    // If the getter was used instead of sessions.get(), this would throw:
+    // "No active session "default" — this is a bug"
+  });
+});

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -74,7 +74,7 @@ function generateCommandReference(_ctx: TemplateContext): string {
   // Category display order
   const categoryOrder = [
     'Navigation', 'Reading', 'Interaction', 'Inspection',
-    'Visual', 'Snapshot', 'Meta', 'Tabs', 'Server',
+    'Visual', 'Snapshot', 'Session', 'Meta', 'Tabs', 'Server',
   ];
 
   const sections: string[] = [];


### PR DESCRIPTION
## Summary

- Each session gets its own `BrowserContext` with independent cookies, localStorage, sessionStorage, and tab set
- The "default" session is created on launch; global state (dialog handling, UA, headers) is shared
- New `session` command: `new`, `switch`, `list`, `delete` subcommands
- Adapted to work alongside existing `handoff`/`resume`, `saveState`/`restoreState`, `RefEntry`, and URL validation

## New commands

| Command | Description |
|---------|-------------|
| `session new <name>` | Create and switch to a new isolated session |
| `session switch <name>` | Switch to an existing session |
| `session list` | List all sessions with tab counts |
| `session delete <name>` | Delete a non-active session |

## Test plan

- [x] Type-checks pass (`tsc --noEmit`)
- [x] Existing tests pass (2 Codex failures are pre-existing on main)
- [x] Session isolation test suite included (`browse/test/session.test.ts`)
- [ ] Manual verification: create sessions, verify cookies don't leak between them