### PR TITLE
fix: skip sidecar dir in Codex skill linking to preserve root symlink

### DIFF
--- a/setup
+++ b/setup
@@ -173,6 +173,10 @@ link_codex_skill_dirs() {
   for skill_dir in "$agents_dir"/gstack*/; do
     if [ -f "$skill_dir/SKILL.md" ]; then
       skill_name="$(basename "$skill_dir")"
+      # Skip the sidecar directory — it contains runtime asset symlinks (bin/,
+      # browse/), not a skill. Linking it would overwrite the root gstack
+      # symlink that Step 5 already pointed at the repo root.
+      [ "$skill_name" = "gstack" ] && continue
       target="$skills_dir/$skill_name"
       # Create or update symlink
       if [ -L "$target" ] || [ ! -e "$target" ]; then


### PR DESCRIPTION
## Summary

`link_codex_skill_dirs()` in `setup` uses a `gstack*/` glob that matches both individual skill dirs (`gstack-browse/`, `gstack-qa/`) and the sidecar dir (`gstack/`). When the sidecar matches, it overwrites the root `~/.codex/skills/gstack` symlink that Step 5 already pointed at the repo root, breaking runtime paths like `bin/gstack-update-check`.

One-line guard: skip `gstack/` in the loop since it contains runtime asset symlinks, not a skill.

## Changes

- `setup:link_codex_skill_dirs()` - skip `$skill_name = "gstack"` to avoid overwriting the root symlink with the sidecar directory

## Testing

Manual verification:
1. `./setup --host codex`
2. `readlink ~/.codex/skills/gstack` - should point to repo root, not `.agents/skills/gstack/`
3. `ls ~/.codex/skills/gstack/bin/` - should list gstack binaries

`bun test` passes (2 pre-existing Codex generation test failures unrelated to this change).

This contribution was developed with AI assistance (Claude Code).

Fixes #261