### PR TITLE
fix: add --local flag for project-scoped gstack install

### DIFF
--- a/setup
+++ b/setup
@@ -17,12 +17,14 @@ case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*|Windows_NT) IS_WINDOWS=1 ;;
 esac
 
-# ─── Parse --host flag ─────────────────────────────────────────
+# ─── Parse flags ──────────────────────────────────────────────
 HOST="claude"
+LOCAL_INSTALL=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --host) HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
+    --local) LOCAL_INSTALL=1; shift ;;
     *) shift ;;
   esac
 done
@@ -31,6 +33,18 @@ case "$HOST" in
   claude|codex|auto) ;;
   *) echo "Unknown --host value: $HOST (expected claude, codex, or auto)" >&2; exit 1 ;;
 esac
+
+# --local: install to .claude/skills/ in the current working directory
+if [ "$LOCAL_INSTALL" -eq 1 ]; then
+  if [ "$HOST" = "codex" ]; then
+    echo "Error: --local is only supported for Claude Code (not Codex)." >&2
+    exit 1
+  fi
+  SKILLS_DIR="$(pwd)/.claude/skills"
+  mkdir -p "$SKILLS_DIR"
+  HOST="claude"
+  INSTALL_CODEX=0
+fi
 
 # For auto: detect which agents are installed
 INSTALL_CLAUDE=0
@@ -212,7 +226,12 @@ SKILLS_BASENAME="$(basename "$SKILLS_DIR")"
 if [ "$INSTALL_CLAUDE" -eq 1 ]; then
   if [ "$SKILLS_BASENAME" = "skills" ]; then
     link_claude_skill_dirs "$GSTACK_DIR" "$SKILLS_DIR"
-    echo "gstack ready (claude)."
+    if [ "$LOCAL_INSTALL" -eq 1 ]; then
+      echo "gstack ready (project-local)."
+      echo "  skills: $SKILLS_DIR"
+    else
+      echo "gstack ready (claude)."
+    fi
     echo "  browse: $BROWSE_BIN"
   else
     echo "gstack ready (claude)."


### PR DESCRIPTION
## Summary

Users evaluating gstack in a project fork have no way to avoid installing skills globally to `~/.claude/skills/`. The `--local` flag installs to `./.claude/skills/` in the current working directory so Claude Code picks them up for that project only.

## Changes

- `setup` - add `--local` flag to argument parser
- When `--local` is set, override `SKILLS_DIR` to `$(pwd)/.claude/skills/` and create the directory
- Error if `--local` is combined with `--host codex` (Codex doesn't read project-local skills)
- Show `gstack ready (project-local).` with the install path in output

Default behavior (`./setup` without `--local`) is unchanged.

## Usage

```bash
cd my-project
git clone https://github.com/garrytan/gstack .claude/skills/gstack
cd .claude/skills/gstack
./setup --local
```

## Testing

`bun test` passes (2 pre-existing Codex generation failures unrelated to this change).

This contribution was developed with AI assistance (Claude Code).

Fixes #229