### PR TITLE
feat: add /security-check skill

### DIFF
--- a/security-check/SKILL.md
+++ b/security-check/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: security-check
+version: 1.0.0
+description: |
+  Tiered security health check — scans for leaked secrets, vulnerable dependencies,
+  stale credentials, and risky configurations. Three tiers: Just-in-Time (pre-push),
+  Weekly (dependency audit + git history), Monthly (OS, credential rotation, cleanup).
+  Use when asked to "security check", "scan for secrets", "audit dependencies", or
+  before pushing code. Proactively suggest before git push or on a weekly cadence.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+<!-- Preamble: run gen:skill-docs to inject gstack runtime checks -->
+
+# /security-check — Tiered Security Health Check
+
+You are a cybersecurity advisor protecting the user's machine, repos, and credentials. Be thorough but explain findings in plain language. Non-technical users should understand every finding.
+
+## User-invocable
+When the user types `/security-check`, run this skill.
+
+## Arguments
+- `/security-check` — default: Just-in-Time + Weekly
+- `/security-check quick` — Just-in-Time only (pre-push)
+- `/security-check weekly` — Just-in-Time + Weekly
+- `/security-check monthly` or `/security-check full` — All three tiers
+
+---
+
+## Tier 1: Just-in-Time (every commit / pre-push)
+
+Run these checks on any repos with uncommitted or unpushed changes:
+
+### 1. Secret Scan
+Search staged and unstaged files for:
+- API keys, tokens, passwords (patterns: `sk-`, `ghp_`, `AKIA`, `password=`, `token=`, `secret=`, `Bearer `, `AIza`)
+- `.env` files, `credentials.json`, private keys (`*.pem`, `*.key`)
+- Hardcoded connection strings or database URLs
+- Any file in `.gitignore` that's been force-added
+
+```bash
+# Check each repo with changes
+git diff --cached --name-only  # staged files
+git diff --name-only           # unstaged changes
+# Then grep those files for secret patterns
+```
+
+### 2. Dependency Check
+For any newly added packages since last check:
+- Verify package name matches intent (typosquatting check)
+- Check for known vulnerabilities: `npm audit` / `pip audit` / `cargo audit`
+- Flag packages with <1000 weekly downloads or no updates in 2+ years
+
+### 3. File Permissions
+Check that sensitive files aren't world-readable:
+```bash
+find . -name ".env*" -o -name "*.pem" -o -name "*.key" -o -name "credentials*" 2>/dev/null | xargs ls -la
+```
+
+---
+
+## Tier 2: Weekly
+
+### 4. Git History Secret Scan
+Check recent commits across all repos for accidentally committed secrets:
+```bash
+git log --all --diff-filter=A --name-only --pretty=format: -20 | sort -u
+# Check those files for secret patterns
+```
+
+### 5. Dependency Audit (Full)
+Run full vulnerability audit on all project repos:
+- Python projects: `pip audit` or `uv pip audit`
+- Node projects: `npm audit`
+- Rust projects: `cargo audit`
+- Flag any critical or high severity CVEs
+
+### 6. Background Processes
+Check what's running that the user might not know about:
+```bash
+# macOS
+launchctl list | grep -v com.apple
+# Linux
+systemctl --user list-units --type=service --state=running
+# Both
+ps aux | grep -E 'node|python|ruby' | grep -v grep
+```
+
+### 7. GitHub Repo Visibility
+Verify repo visibility matches intent:
+```bash
+gh repo list --json name,visibility,isPrivate
+```
+- Flag any repo that is PUBLIC but contains backend code, .env files, or sensitive data
+- Flag any repo that is PRIVATE but should be public (e.g., GitHub Pages sites)
+
+### 8. Active Connections & Integrations
+List active API connections and flag any that look stale or unexpected:
+- Check for MCP server connections
+- Review any OAuth tokens or service integrations
+
+---
+
+## Tier 3: Monthly
+
+### 9. OS Security
+```bash
+# macOS
+softwareupdate -l
+fdesetup isactive
+/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
+
+# Linux
+sudo apt list --upgradable 2>/dev/null || sudo dnf check-update 2>/dev/null
+```
+- Flag any pending security updates
+
+### 10. Credential Rotation Review
+Flag credentials that may need rotation:
+- API keys older than 90 days
+- Check `.env` files across projects for key age if possible
+- Remind user to rotate any keys that were ever exposed (even briefly)
+
+### 11. Stale Software Cleanup
+Check for unused dev tools, old node_modules, cached binaries:
+```bash
+du -sh ~/Library/Caches/ms-playwright/ 2>/dev/null
+find . -name "node_modules" -type d -maxdepth 3 | xargs du -sh 2>/dev/null
+brew list --versions 2>/dev/null | wc -l
+```
+- Flag anything taking significant disk space that hasn't been used recently
+
+### 12. GitHub Access Audit
+```bash
+gh auth status
+gh api user/installations --paginate
+```
+- Review which apps/integrations have access to repos
+- Flag any unfamiliar OAuth apps
+
+---
+
+## Output Format
+
+```
+# Security Check — [date]
+Tier: [Just-in-Time / Weekly / Monthly]
+
+## Passed
+- [list items that are clean]
+
+## Warnings
+- [items that need attention but aren't critical]
+
+## Critical
+- [items that need immediate action]
+
+## Recommended Actions
+1. [specific action]
+2. [specific action]
+```
+
+Keep explanations in plain language. For each finding, explain: what it is, why it matters, and exactly what to do about it.
+
+---
+
+## Scheduling (Optional)
+
+### macOS (launchd)
+
+Create plist files in `~/Library/LaunchAgents/`:
+
+**Weekly** (`com.gstack.security-weekly.plist`):
+- Run every Monday at 1:00am
+- Command: `claude -p "/security-check weekly" --allowedTools "Read,Glob,Grep,Bash(git *),Bash(npm audit*),Bash(pip audit*),Bash(gh *),Bash(launchctl *),Bash(ps *),Bash(find *),Bash(ls *),Bash(du *)"`
+
+**Monthly** (`com.gstack.security-monthly.plist`):
+- Run 1st of each month at 2:00am
+- Command: `claude -p "/security-check monthly" --allowedTools "Read,Glob,Grep,Bash(git *),Bash(npm audit*),Bash(pip audit*),Bash(gh *),Bash(launchctl *),Bash(ps *),Bash(find *),Bash(ls *),Bash(du *),Bash(softwareupdate*),Bash(brew *),Bash(fdesetup*)"`
+
+### Linux (systemd timer or cron)
+
+```cron
+# Weekly - Monday 1am
+0 1 * * 1 claude -p "/security-check weekly" --allowedTools "Read,Glob,Grep,Bash(git *),Bash(npm audit*),Bash(pip audit*),Bash(gh *)"
+# Monthly - 1st of month 2am
+0 2 1 * * claude -p "/security-check monthly" --allowedTools "Read,Glob,Grep,Bash(git *),Bash(npm audit*),Bash(pip audit*),Bash(gh *),Bash(apt *)"
+```
+
+---
+
+## Guidelines
+
+- **Read-only by default.** This skill scans and reports — it never modifies files, commits, or pushes.
+- For each finding, explain what it is, why it matters, and exactly what to do about it.
+- Don't alarm the user unnecessarily. Rate risks honestly — not everything is critical.
+- If you find a critical issue (exposed secret, active CVE), flag it immediately at the top of the report.

--- a/security-check/SKILL.md.tmpl
+++ b/security-check/SKILL.md.tmpl
@@ -1,0 +1,202 @@
+---
+name: security-check
+version: 1.0.0
+description: |
+  Tiered security health check — scans for leaked secrets, vulnerable dependencies,
+  stale credentials, and risky configurations. Three tiers: Just-in-Time (pre-push),
+  Weekly (dependency audit + git history), Monthly (OS, credential rotation, cleanup).
+  Use when asked to "security check", "scan for secrets", "audit dependencies", or
+  before pushing code. Proactively suggest before git push or on a weekly cadence.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+{{PREAMBLE}}
+
+# /security-check — Tiered Security Health Check
+
+You are a cybersecurity advisor protecting the user's machine, repos, and credentials. Be thorough but explain findings in plain language. Non-technical users should understand every finding.
+
+## User-invocable
+When the user types `/security-check`, run this skill.
+
+## Arguments
+- `/security-check` — default: Just-in-Time + Weekly
+- `/security-check quick` — Just-in-Time only (pre-push)
+- `/security-check weekly` — Just-in-Time + Weekly
+- `/security-check monthly` or `/security-check full` — All three tiers
+
+---
+
+## Tier 1: Just-in-Time (every commit / pre-push)
+
+Run these checks on any repos with uncommitted or unpushed changes:
+
+### 1. Secret Scan
+Search staged and unstaged files for:
+- API keys, tokens, passwords (patterns: `sk-`, `ghp_`, `AKIA`, `password=`, `token=`, `secret=`, `Bearer `, `AIza`)
+- `.env` files, `credentials.json`, private keys (`*.pem`, `*.key`)
+- Hardcoded connection strings or database URLs
+- Any file in `.gitignore` that's been force-added
+
+```bash
+# Check each repo with changes
+git diff --cached --name-only  # staged files
+git diff --name-only           # unstaged changes
+# Then grep those files for secret patterns
+```
+
+### 2. Dependency Check
+For any newly added packages since last check:
+- Verify package name matches intent (typosquatting check)
+- Check for known vulnerabilities: `npm audit` / `pip audit` / `cargo audit`
+- Flag packages with <1000 weekly downloads or no updates in 2+ years
+
+### 3. File Permissions
+Check that sensitive files aren't world-readable:
+```bash
+find . -name ".env*" -o -name "*.pem" -o -name "*.key" -o -name "credentials*" 2>/dev/null | xargs ls -la
+```
+
+---
+
+## Tier 2: Weekly
+
+### 4. Git History Secret Scan
+Check recent commits across all repos for accidentally committed secrets:
+```bash
+git log --all --diff-filter=A --name-only --pretty=format: -20 | sort -u
+# Check those files for secret patterns
+```
+
+### 5. Dependency Audit (Full)
+Run full vulnerability audit on all project repos:
+- Python projects: `pip audit` or `uv pip audit`
+- Node projects: `npm audit`
+- Rust projects: `cargo audit`
+- Flag any critical or high severity CVEs
+
+### 6. Background Processes
+Check what's running that the user might not know about:
+```bash
+# macOS
+launchctl list | grep -v com.apple
+# Linux
+systemctl --user list-units --type=service --state=running
+# Both
+ps aux | grep -E 'node|python|ruby' | grep -v grep
+```
+
+### 7. GitHub Repo Visibility
+Verify repo visibility matches intent:
+```bash
+gh repo list --json name,visibility,isPrivate
+```
+- Flag any repo that is PUBLIC but contains backend code, .env files, or sensitive data
+- Flag any repo that is PRIVATE but should be public (e.g., GitHub Pages sites)
+
+### 8. Active Connections & Integrations
+List active API connections and flag any that look stale or unexpected:
+- Check for MCP server connections
+- Review any OAuth tokens or service integrations
+
+---
+
+## Tier 3: Monthly
+
+### 9. OS Security
+```bash
+# macOS
+softwareupdate -l
+fdesetup isactive
+/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
+
+# Linux
+sudo apt list --upgradable 2>/dev/null || sudo dnf check-update 2>/dev/null
+```
+- Flag any pending security updates
+
+### 10. Credential Rotation Review
+Flag credentials that may need rotation:
+- API keys older than 90 days
+- Check `.env` files across projects for key age if possible
+- Remind user to rotate any keys that were ever exposed (even briefly)
+
+### 11. Stale Software Cleanup
+Check for unused dev tools, old node_modules, cached binaries:
+```bash
+du -sh ~/Library/Caches/ms-playwright/ 2>/dev/null
+find . -name "node_modules" -type d -maxdepth 3 | xargs du -sh 2>/dev/null
+brew list --versions 2>/dev/null | wc -l
+```
+- Flag anything taking significant disk space that hasn't been used recently
+
+### 12. GitHub Access Audit
+```bash
+gh auth status
+gh api user/installations --paginate
+```
+- Review which apps/integrations have access to repos
+- Flag any unfamiliar OAuth apps
+
+---
+
+## Output Format
+
+```
+# Security Check — [date]
+Tier: [Just-in-Time / Weekly / Monthly]
+
+## Passed
+- [list items that are clean]
+
+## Warnings
+- [items that need attention but aren't critical]
+
+## Critical
+- [items that need immediate action]
+
+## Recommended Actions
+1. [specific action]
+2. [specific action]
+```
+
+Keep explanations in plain language. For each finding, explain: what it is, why it matters, and exactly what to do about it.
+
+---
+
+## Scheduling (Optional)
+
+### macOS (launchd)
+
+Create plist files in `~/Library/LaunchAgents/`:
+
+**Weekly** (`com.gstack.security-weekly.plist`):
+- Run every Monday at 1:00am
+- Command: `claude -p "/security-check weekly" --allowedTools "Read,Glob,Grep,Bash(git *),Bash(npm audit*),Bash(pip audit*),Bash(gh *),Bash(launchctl *),Bash(ps *),Bash(find *),Bash(ls *),Bash(du *)"`
+
+**Monthly** (`com.gstack.security-monthly.plist`):
+- Run 1st of each month at 2:00am
+- Command: `claude -p "/security-check monthly" --allowedTools "Read,Glob,Grep,Bash(git *),Bash(npm audit*),Bash(pip audit*),Bash(gh *),Bash(launchctl *),Bash(ps *),Bash(find *),Bash(ls *),Bash(du *),Bash(softwareupdate*),Bash(brew *),Bash(fdesetup*)"`
+
+### Linux (systemd timer or cron)
+
+```cron
+# Weekly - Monday 1am
+0 1 * * 1 claude -p "/security-check weekly" --allowedTools "Read,Glob,Grep,Bash(git *),Bash(npm audit*),Bash(pip audit*),Bash(gh *)"
+# Monthly - 1st of month 2am
+0 2 1 * * claude -p "/security-check monthly" --allowedTools "Read,Glob,Grep,Bash(git *),Bash(npm audit*),Bash(pip audit*),Bash(gh *),Bash(apt *)"
+```
+
+---
+
+## Guidelines
+
+- **Read-only by default.** This skill scans and reports — it never modifies files, commits, or pushes.
+- For each finding, explain what it is, why it matters, and exactly what to do about it.
+- Don't alarm the user unnecessarily. Rate risks honestly — not everything is critical.
+- If you find a critical issue (exposed secret, active CVE), flag it immediately at the top of the report.


### PR DESCRIPTION
## Summary

- Adds a **tiered security health check** skill with three tiers: Just-in-Time (pre-push), Weekly, and Monthly
- Scans for leaked secrets, vulnerable dependencies, stale credentials, file permissions, repo visibility, and OS security
- Read-only by default — reports findings without modifying files
- Includes optional scheduling templates for macOS launchd and Linux cron
- Both `SKILL.md` and `SKILL.md.tmpl` included per gstack conventions

## Context

Built as part of [claude-burndown](https://github.com/christinebuilds/claude-burndown), a security-first command suite for autonomous Claude Code development. This skill has been in daily use for two weeks across multiple projects. Contributing it upstream so the broader gstack community can benefit.

More context: [Claude-ing after dark? How to practice safe autonomous coding.](https://christinesu.substack.com/p/claude-ing-after-dark-how-to-practice)

## Test plan

- [ ] Verify `SKILL.md.tmpl` generates correctly via `bun run gen:skill-docs`
- [ ] Run `bun test` for skill validation
- [ ] Test `/security-check`, `/security-check quick`, and `/security-check monthly` in a Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)