### PR TITLE
Fix Codex root skill description length

### DIFF
--- a/.agents/skills/gstack/SKILL.md
+++ b/.agents/skills/gstack/SKILL.md
@@ -1,43 +1,7 @@
 ---
 name: gstack
 description: |
-  Fast headless browser for QA testing and site dogfooding. Navigate any URL, interact with
-  elements, verify page state, diff before/after actions, take annotated screenshots, check
-  responsive layouts, test forms and uploads, handle dialogs, and assert element states.
-  ~100ms per command. Use when you need to test a feature, verify a deployment, dogfood a
-  user flow, or file a bug with evidence.
-  
-  gstack also includes development workflow skills. When you notice the user is at
-  these stages, suggest the appropriate skill:
-  - Brainstorming a new idea → suggest /office-hours
-  - Reviewing a plan (strategy) → suggest /plan-ceo-review
-  - Reviewing a plan (architecture) → suggest /plan-eng-review
-  - Reviewing a plan (design) → suggest /plan-design-review
-  - Creating a design system → suggest /design-consultation
-  - Debugging errors → suggest /investigate
-  - Testing the app → suggest /qa
-  - Code review before merge → suggest /review
-  - Visual design audit → suggest /design-review
-  - Ready to deploy / create PR → suggest /ship
-  - Post-ship doc updates → suggest /document-release
-  - Weekly retrospective → suggest /retro
-  - Wanting a second opinion or adversarial code review → suggest /codex
-  - Working with production or live systems → suggest /careful
-  - Want to scope edits to one module/directory → suggest /freeze
-  - Maximum safety mode (destructive warnings + edit restrictions) → suggest /guard
-  - Removing edit restrictions → suggest /unfreeze
-  - Upgrading gstack to latest version → suggest /gstack-upgrade
-  
-  If the user pushes back on skill suggestions ("stop suggesting things",
-  "I don't need suggestions", "too aggressive"):
-  1. Stop suggesting for the rest of this session
-  2. Run: gstack-config set proactive false
-  3. Say: "Got it — I'll stop suggesting skills. Just tell me to be proactive
-     again if you change your mind."
-  
-  If the user says "be proactive again" or "turn on suggestions":
-  1. Run: gstack-config set proactive true
-  2. Say: "Proactive suggestions are back on."
+  Fast headless browser plus workflow skills for Codex. Use it to QA apps, dogfood flows, inspect pages, review code, investigate bugs, ship changes, and run design audits. For focused workflows, use the linked gstack-* skills such as gstack-browse, gstack-review, gstack-qa, gstack-investigate, gstack-design-review, and gstack-ship.
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -20,6 +20,7 @@ const DRY_RUN = process.argv.includes('--dry-run');
 // ─── Template Context ───────────────────────────────────────
 
 type Host = 'claude' | 'codex';
+const CODEX_MAX_DESCRIPTION_LEN = 1024;
 
 const HOST_ARG = process.argv.find(a => a.startsWith('--host'));
 const HOST: Host = (() => {
@@ -1571,6 +1572,19 @@ function codexSkillName(skillDir: string): string {
   return `gstack-${skillDir}`;
 }
 
+function codexDescriptionForSkill(name: string, description: string): string {
+  if (name === 'gstack') {
+    return [
+      'Fast headless browser plus workflow skills for Codex.',
+      'Use it to QA apps, dogfood flows, inspect pages, review code, investigate bugs, ship changes, and run design audits.',
+      'For focused workflows, use the linked gstack-* skills such as gstack-browse, gstack-review, gstack-qa, gstack-investigate, gstack-design-review, and gstack-ship.',
+    ].join(' ');
+  }
+
+  if (description.length <= CODEX_MAX_DESCRIPTION_LEN) return description;
+  return `${description.slice(0, CODEX_MAX_DESCRIPTION_LEN - 3).trimEnd()}...`;
+}
+
 /**
  * Transform frontmatter for Codex: keep only name + description.
  * Strips allowed-tools, hooks, version, and all other fields.
@@ -1621,6 +1635,7 @@ function transformFrontmatter(content: string, host: Host): string {
   if (descLines.length > 0) {
     description = descLines.join('\n').trim();
   }
+  description = codexDescriptionForSkill(name, description);
 
   // Re-emit Codex frontmatter (name + description only)
   const indentedDesc = description.split('\n').map(l => `  ${l}`).join('\n');

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -666,6 +666,38 @@ describe('Codex generation (--host codex)', () => {
     expect(content).toContain('.agents/skills/gstack');
   });
 
+  test('all Codex skill descriptions stay within the 1024-character loader limit', () => {
+    for (const skill of CODEX_SKILLS) {
+      const content = fs.readFileSync(path.join(AGENTS_DIR, skill.codexName, 'SKILL.md'), 'utf-8');
+      const fmEnd = content.indexOf('\n---', 4);
+      const frontmatter = content.slice(4, fmEnd);
+      const lines = frontmatter.split('\n');
+      let inDescription = false;
+      const descLines: string[] = [];
+
+      for (const line of lines) {
+        if (line.match(/^description:\s*\|?\s*$/)) {
+          inDescription = true;
+          continue;
+        }
+        if (line.match(/^description:\s*\S/)) {
+          descLines.push(line.replace(/^description:\s*/, '').trim());
+          break;
+        }
+        if (inDescription) {
+          if (line === '' || line.match(/^\s/)) {
+            descLines.push(line.replace(/^  /, ''));
+          } else {
+            break;
+          }
+        }
+      }
+
+      const description = descLines.join('\n').trim();
+      expect(description.length).toBeLessThanOrEqual(1024);
+    }
+  });
+
   // ─── Path rewriting regression tests ─────────────────────────
 
   test('sidecar paths point to .agents/skills/gstack/review/ (not gstack-review/)', () => {


### PR DESCRIPTION
## Summary
- shorten the generated Codex root `gstack` skill description so it stays within Codex's 1024-character SKILL.md metadata limit
- keep the long Claude-facing description unchanged
- add a regression test that enforces the loader limit across all generated Codex skills

Closes #281

## Testing
- PATH="$HOME/.bun/bin:$PATH" bun run scripts/gen-skill-docs.ts --host codex
- PATH="$HOME/.bun/bin:$PATH" bun test test/gen-skill-docs.test.ts