### PR TITLE
fix(browse): kill old server before restart to prevent orphaned chromium processes

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -234,7 +234,10 @@ async function ensureServer(): Promise<ServerState> {
     }
   }
 
-  // Need to (re)start
+  // Need to (re)start — kill the old server first to avoid orphaned chromium processes
+  if (state && state.pid) {
+    await killServer(state.pid);
+  }
   console.error('[browse] Starting server...');
   return startServer();
 }
@@ -289,6 +292,11 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
     if (err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET' || err.message?.includes('fetch failed')) {
       if (retries >= 1) throw new Error('[browse] Server crashed twice in a row — aborting');
       console.error('[browse] Server connection lost. Restarting...');
+      // Kill the old server to avoid orphaned chromium processes
+      const oldState = readState();
+      if (oldState && oldState.pid) {
+        await killServer(oldState.pid);
+      }
       const newState = await startServer();
       return sendCommand(newState, command, args, retries + 1);
     }


### PR DESCRIPTION
## Problem

When the browse server's health check fails or the connection drops (e.g. pages that crash during hydration or trigger hard navigations via `window.location.href`), `ensureServer()` and `sendCommand()` call `startServer()` **without killing the previous server process first**.

This leaves orphaned `chrome-headless-shell` renderer processes running at ~120% CPU each. After several reconnect cycles, dozens of zombie chromium processes accumulate and exhaust system resources — in my case, 7 processes at ~840% CPU total, which crashed my dev server.

## Fix

Call `killServer()` on the stale PID before spawning a new server in both restart paths:
- `ensureServer()` — when the health check fails
- `sendCommand()` — when the connection is lost (ECONNREFUSED/ECONNRESET)

## Testing

Simulated a frozen server via `kill -STOP` (health check timeout path):
- **Before fix:** old chromium processes survive, new ones spawn → process count doubles each cycle
- **After fix:** old server + its chromium children are killed before new server starts → process count stays constant

Fixes #294