### PR TITLE
feat: add --host kiro support to setup script

### DIFF
--- a/setup
+++ b/setup
@@ -28,24 +28,28 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|auto) ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, or auto)" >&2; exit 1 ;;
+  claude|codex|kiro|auto) ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, or auto)" >&2; exit 1 ;;
 esac
 
 # For auto: detect which agents are installed
 INSTALL_CLAUDE=0
 INSTALL_CODEX=0
+INSTALL_KIRO=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
-  # If neither found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ]; then
+  command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
+  # If none found, default to claude
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
   INSTALL_CLAUDE=1
 elif [ "$HOST" = "codex" ]; then
   INSTALL_CODEX=1
+elif [ "$HOST" = "kiro" ]; then
+  INSTALL_KIRO=1
 fi
 
 ensure_playwright_browser() {
@@ -250,7 +254,47 @@ if [ "$INSTALL_CODEX" -eq 1 ]; then
   echo "  codex skills: $CODEX_SKILLS"
 fi
 
-# 6. Create .agents/ sidecar symlinks (useful for Codex/Gemini/Cursor workspace-local)
+# 6. Install for Kiro CLI (copy from .agents/skills, rewrite paths)
+if [ "$INSTALL_KIRO" -eq 1 ]; then
+  KIRO_SKILLS="$HOME/.kiro/skills"
+  AGENTS_DIR="$GSTACK_DIR/.agents/skills"
+  mkdir -p "$KIRO_SKILLS"
+
+  # Create gstack dir with symlinks for runtime assets, copy+sed for SKILL.md
+  KIRO_GSTACK="$KIRO_SKILLS/gstack"
+  # Remove old whole-dir symlink from previous installs
+  [ -L "$KIRO_GSTACK" ] && rm -f "$KIRO_GSTACK"
+  mkdir -p "$KIRO_GSTACK"
+  ln -snf "$GSTACK_DIR/bin" "$KIRO_GSTACK/bin"
+  ln -snf "$GSTACK_DIR/browse" "$KIRO_GSTACK/browse"
+
+  # Rewrite root SKILL.md paths for Kiro
+  sed -e "s|~/.claude/skills/gstack|~/.kiro/skills/gstack|g" \
+      -e "s|\.claude/skills/gstack|.kiro/skills/gstack|g" \
+      -e "s|\.claude/skills|.kiro/skills|g" \
+      "$GSTACK_DIR/SKILL.md" > "$KIRO_GSTACK/SKILL.md"
+
+  if [ ! -d "$AGENTS_DIR" ]; then
+    echo "  warning: no .agents/skills/ directory found — run 'bun run build' first" >&2
+  else
+    for skill_dir in "$AGENTS_DIR"/gstack*/; do
+      [ -f "$skill_dir/SKILL.md" ] || continue
+      skill_name="$(basename "$skill_dir")"
+      target_dir="$KIRO_SKILLS/$skill_name"
+      mkdir -p "$target_dir"
+      sed -e "s|~/.codex/skills/gstack|~/.kiro/skills/gstack|g" \
+          -e "s|~/.claude/skills/gstack|~/.kiro/skills/gstack|g" \
+          -e "s|\.agents/skills/gstack|.kiro/skills/gstack|g" \
+          -e "s|\.agents/skills|.kiro/skills|g" \
+          "$skill_dir/SKILL.md" > "$target_dir/SKILL.md"
+    done
+    echo "gstack ready (kiro)."
+    echo "  browse: $BROWSE_BIN"
+    echo "  kiro skills: $KIRO_SKILLS"
+  fi
+fi
+
+# 7. Create .agents/ sidecar symlinks (useful for Codex/Gemini/Cursor workspace-local)
 if [ "$INSTALL_CODEX" -eq 1 ]; then
   # Detect repo root: if we're inside a skills directory, go up two levels
   if [ "$SKILLS_BASENAME" = "skills" ]; then
@@ -261,7 +305,7 @@ if [ "$INSTALL_CODEX" -eq 1 ]; then
   create_agents_sidecar "$REPO_ROOT"
 fi
 
-# 7. First-time welcome + legacy cleanup
+# 8. First-time welcome + legacy cleanup
 if [ ! -d "$HOME/.gstack" ]; then
   mkdir -p "$HOME/.gstack"
   echo "  Welcome! Run /gstack-upgrade anytime to stay current."


### PR DESCRIPTION
Add Kiro CLI as a new host option alongside Claude and Codex.

## Changes

- Add `--host kiro` and auto-detection of `kiro-cli` in `--host auto` mode
- Install to `~/.kiro/skills/` with selective symlinks (`bin/`, `browse/`) and copy+sed for SKILL.md path rewrites
- Handle stale whole-dir symlinks from previous installs
- Per-skill SKILL.md files rewritten from both `.claude` and `.codex` paths
- No changes to root SKILL.md — Claude/Codex installs unaffected

## Usage

```bash
git clone https://github.com/garrytan/gstack.git ~/gstack
cd ~/gstack && ./setup --host kiro
```

Or auto-detect:
```bash
./setup --host auto  # detects kiro-cli alongside claude/codex
```