### PR TITLE
Fix YAML linter error: nested mapping in compact sequence entries

### DIFF
--- a/.github/workflows/skill-docs.yml
+++ b/.github/workflows/skill-docs.yml
@@ -9,7 +9,9 @@ jobs:
       - run: bun install
       - name: Check Claude host freshness
         run: bun run gen:skill-docs
-      - run: git diff --exit-code || (echo "Generated SKILL.md files are stale. Run: bun run gen:skill-docs" && exit 1)
+      - run: |
+          git diff --exit-code || (echo "Generated SKILL.md files are stale. Run: bun run gen:skill-docs" && exit 1)
       - name: Check Codex host freshness
         run: bun run gen:skill-docs --host codex
-      - run: git diff --exit-code -- .agents/ || (echo "Generated Codex SKILL.md files are stale. Run: bun run gen:skill-docs --host codex" && exit 1)
+      - run: |
+          git diff --exit-code -- .agents/ || (echo "Generated Codex SKILL.md files are stale. Run: bun run gen:skill-docs --host codex" && exit 1)


### PR DESCRIPTION
Having "Run: bun" inside a plain scalar is not allowed per [YAML spec](https://yaml.org/spec/1.2.2/#plain-style) which states: Plain scalars must never contain the “: ” and “ #” character combinations.

This simple fix switches to block scalars (|) to eliminate the ambiguity without changing runtime behavior.