### PR TITLE
feat(browse): support Chrome extensions via BROWSE_EXTENSIONS_DIR

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -62,7 +62,28 @@ export class BrowserManager {
   private consecutiveFailures: number = 0;
 
   async launch() {
-    this.browser = await chromium.launch({ headless: true });
+    // ─── Extension Support ────────────────────────────────────
+    // BROWSE_EXTENSIONS_DIR points to an unpacked Chrome extension directory.
+    // Extensions only work in headed mode, so we use an off-screen window.
+    const extensionsDir = process.env.BROWSE_EXTENSIONS_DIR;
+    const launchArgs: string[] = [];
+    let useHeadless = true;
+
+    if (extensionsDir) {
+      launchArgs.push(
+        `--disable-extensions-except=${extensionsDir}`,
+        `--load-extension=${extensionsDir}`,
+        '--window-position=-9999,-9999',
+        '--window-size=1,1',
+      );
+      useHeadless = false; // extensions require headed mode; off-screen window simulates headless
+      console.log(`[browse] Extensions loaded from: ${extensionsDir}`);
+    }
+
+    this.browser = await chromium.launch({
+      headless: useHeadless,
+      ...(launchArgs.length > 0 ? { args: launchArgs } : {}),
+    });
 
     // Chromium crash → exit with clear message
     this.browser.on('disconnected', () => {


### PR DESCRIPTION
## Summary

- Add `BROWSE_EXTENSIONS_DIR` environment variable to load unpacked Chrome extensions into browse's Chromium instance
- When set, browse launches in headed mode with the window off-screen (`--window-position=-9999,-9999`) since Chrome extensions require a headed browser
- When unset, behavior is identical to current — pure headless, zero side effects

## Why

Browse users often have Chrome extensions that improve their browsing workflow — ad blockers (fewer tokens wasted on ad-heavy pages), accessibility tools, custom header managers, etc. Currently there's no way to bring these into browse's Chromium.

This is a single env var, zero config files, fully opt-in. One line in `.zshrc` and it just works.

## Change

One file, 22 lines added: `browse/src/browser-manager.ts`

```typescript
const extensionsDir = process.env.BROWSE_EXTENSIONS_DIR;
if (extensionsDir) {
  // headed + off-screen window (extensions don't work in headless)
  // --load-extension + --disable-extensions-except
}
```

## Test plan

- [ ] `BROWSE_EXTENSIONS_DIR` unset → headless as before, no regression
- [ ] `BROWSE_EXTENSIONS_DIR` set to valid unpacked extension → extension loads, pages render correctly
- [ ] `BROWSE_EXTENSIONS_DIR` set to invalid path → Chromium launches normally (extensions silently ignored)
- [ ] Handoff (headless → headed) still works with extensions loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)