### PR TITLE
feat: add iframe support via `frame` command

### DIFF
--- a/.agents/skills/gstack-browse/SKILL.md
+++ b/.agents/skills/gstack-browse/SKILL.md
@@ -492,6 +492,7 @@ Refs are invalidated on navigation — run `snapshot` again after `goto`.
 | Command | Description |
 |---------|-------------|
 | `chain` | Run commands from JSON stdin. Format: [["cmd","arg1",...],...] |
+| `frame <list|main|selector>` | Switch to iframe context for cross-frame interaction. list: show all iframes. main: return to main frame |
 
 ### Tabs
 | Command | Description |

--- a/.agents/skills/gstack/SKILL.md
+++ b/.agents/skills/gstack/SKILL.md
@@ -621,6 +621,7 @@ Refs are invalidated on navigation — run `snapshot` again after `goto`.
 | Command | Description |
 |---------|-------------|
 | `chain` | Run commands from JSON stdin. Format: [["cmd","arg1",...],...] |
+| `frame <list|main|selector>` | Switch to iframe context for cross-frame interaction. list: show all iframes. main: return to main frame |
 
 ### Tabs
 | Command | Description |

--- a/SKILL.md
+++ b/SKILL.md
@@ -627,6 +627,7 @@ Refs are invalidated on navigation — run `snapshot` again after `goto`.
 | Command | Description |
 |---------|-------------|
 | `chain` | Run commands from JSON stdin. Format: [["cmd","arg1",...],...] |
+| `frame <list|main|selector>` | Switch to iframe context for cross-frame interaction. list: show all iframes. main: return to main frame |
 
 ### Tabs
 | Command | Description |

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -498,6 +498,7 @@ Refs are invalidated on navigation — run `snapshot` again after `goto`.
 | Command | Description |
 |---------|-------------|
 | `chain` | Run commands from JSON stdin. Format: [["cmd","arg1",...],...] |
+| `frame <list|main|selector>` | Switch to iframe context for cross-frame interaction. list: show all iframes. main: return to main frame |
 
 ### Tabs
 | Command | Description |

--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -15,7 +15,7 @@
  *   restores state. Falls back to clean slate on any failure.
  */
 
-import { chromium, type Browser, type BrowserContext, type BrowserContextOptions, type Page, type Locator, type Cookie } from 'playwright';
+import { chromium, type Browser, type BrowserContext, type BrowserContextOptions, type Page, type Locator, type Cookie, type FrameLocator } from 'playwright';
 import { addConsoleEntry, addNetworkEntry, addDialogEntry, networkBuffer, type DialogEntry } from './buffers';
 import { validateNavigationUrl } from './url-validation';
 
@@ -59,6 +59,7 @@ export class BrowserManager {
 
   // ─── Handoff State ─────────────────────────────────────────
   private isHeaded: boolean = false;
+  private frameSelector: string | null = null;
   private consecutiveFailures: number = 0;
 
   async launch() {
@@ -242,6 +243,54 @@ export class BrowserManager {
 
   getRefCount(): number {
     return this.refMap.size;
+  }
+
+
+  // ─── Frame Support ──────────────────────────────────────
+  /**
+   * Set the active iframe selector. When set, snapshot and ref-based
+   * commands scope to this frame. Pass null to return to main frame.
+   */
+  setFrameSelector(selector: string | null) {
+    this.frameSelector = selector;
+    this.clearRefs(); // refs are scoped to frame context
+  }
+
+  getFrameSelector(): string | null {
+    return this.frameSelector;
+  }
+
+  /**
+   * Get a FrameLocator for the active iframe, or null if on the main frame.
+   * Used by snapshot to scope the accessibility tree to the iframe.
+   */
+  getFrameLocator(): FrameLocator | null {
+    if (!this.frameSelector) return null;
+    const page = this.getPage();
+    return page.frameLocator(this.frameSelector);
+  }
+
+  /**
+   * List all iframes on the current page with their URLs and selectors.
+   */
+  async listFrames(): Promise<Array<{ index: number; url: string; name: string; selector: string }>> {
+    const page = this.getPage();
+    const frames = page.frames().filter(f => f !== page.mainFrame() && f.parentFrame() === page.mainFrame());
+    const results: Array<{ index: number; url: string; name: string; selector: string }> = [];
+    for (let i = 0; i < frames.length; i++) {
+      const frame = frames[i];
+      const name = frame.name() || "";
+      const url = frame.url();
+      // Build a selector that can be used with frameLocator()
+      let selector: string;
+      if (name) {
+        selector = `iframe[name="${name}"]`;
+      } else {
+        selector = `iframe >> nth=${i}`;
+      }
+      results.push({ index: i, url, name, selector });
+    }
+    return results;
   }
 
   // ─── Snapshot Diffing ─────────────────────────────────────
@@ -557,6 +606,7 @@ export class BrowserManager {
     page.on('framenavigated', (frame) => {
       if (frame === page.mainFrame()) {
         this.clearRefs();
+        this.frameSelector = null; // iframe context is stale after main frame navigation
       }
     });
 

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -325,6 +325,7 @@ Snapshot:       snapshot [-i] [-c] [-d N] [-s sel] [-D] [-a] [-o path] [-C]
                 -C/--cursor-interactive: find non-ARIA clickable elements
 Compare:        diff <url1> <url2>
 Multi-step:     chain (reads JSON from stdin)
+Frames:         frame <list|main|selector>
 Tabs:           tabs | tab <id> | newtab [url] | closetab [id]
 Server:         status | cookie <n>=<v> | header <n>:<v>
                 useragent <str> | stop | restart

--- a/browse/src/commands.ts
+++ b/browse/src/commands.ts
@@ -30,7 +30,7 @@ export const META_COMMANDS = new Set([
   'screenshot', 'pdf', 'responsive',
   'chain', 'diff',
   'url', 'snapshot',
-  'handoff', 'resume',
+  'handoff', 'resume', 'frame',
 ]);
 
 export const ALL_COMMANDS = new Set([...READ_COMMANDS, ...WRITE_COMMANDS, ...META_COMMANDS]);
@@ -98,6 +98,7 @@ export const COMMAND_DESCRIPTIONS: Record<string, { category: string; descriptio
   // Handoff
   'handoff': { category: 'Server', description: 'Open visible Chrome at current page for user takeover', usage: 'handoff [message]' },
   'resume':  { category: 'Server', description: 'Re-snapshot after user takeover, return control to AI', usage: 'resume' },
+  'frame':   { category: 'Meta', description: 'Switch to iframe context for cross-frame interaction. list: show all iframes. main: return to main frame', usage: 'frame <list|main|selector>' },
 };
 
 // Load-time validation: descriptions must cover exactly the command sets

--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -250,6 +250,43 @@ export async function handleMetaCommand(
       return await handleSnapshot(args, bm);
     }
 
+    // ─── Frame (iframe support) ───────────────────────
+    case 'frame': {
+      const subcommand = args[0];
+      if (!subcommand) throw new Error('Usage: browse frame <list|main|selector>');
+
+      if (subcommand === 'list') {
+        const frames = await bm.listFrames();
+        if (frames.length === 0) return '(no iframes found on this page)';
+        const current = bm.getFrameSelector();
+        return frames.map(f => {
+          const active = current === f.selector ? '→ ' : '  ';
+          const name = f.name ? ` name="${f.name}"` : '';
+          return `${active}[${f.index}]${name} ${f.url} — ${f.selector}`;
+        }).join('\n');
+      }
+
+      if (subcommand === 'main') {
+        bm.setFrameSelector(null);
+        return 'Switched to main frame. Run snapshot to get fresh refs.';
+      }
+
+      // Treat as selector — validate that the frame exists
+      const page = bm.getPage();
+      try {
+        const fl = page.frameLocator(subcommand);
+        // Verify the frame exists by trying to locate an element
+        const count = await fl.locator('body').count();
+        if (count === 0) throw new Error('Frame body not found');
+      } catch {
+        throw new Error(
+          `Iframe not found: ${subcommand}. Run 'frame list' to see available iframes.`
+        );
+      }
+      bm.setFrameSelector(subcommand);
+      return `Switched to iframe: ${subcommand}. Run snapshot to get fresh refs.`;
+    }
+
     // ─── Handoff ────────────────────────────────────
     case 'handoff': {
       const message = args.join(' ') || 'User takeover requested';

--- a/browse/src/snapshot.ts
+++ b/browse/src/snapshot.ts
@@ -138,8 +138,14 @@ export async function handleSnapshot(
   const page = bm.getPage();
 
   // Get accessibility tree via ariaSnapshot
+  // When a frame is active, scope to the iframe content
+  const frameLocator = bm.getFrameLocator();
   let rootLocator: Locator;
-  if (opts.selector) {
+  if (frameLocator) {
+    rootLocator = opts.selector
+      ? frameLocator.locator(opts.selector)
+      : frameLocator.locator('body');
+  } else if (opts.selector) {
     rootLocator = page.locator(opts.selector);
     const count = await rootLocator.count();
     if (count === 0) throw new Error(`Selector not found: ${opts.selector}`);
@@ -204,7 +210,18 @@ export async function handleSnapshot(
     const totalCount = roleNameCounts.get(key) || 1;
 
     let locator: Locator;
-    if (opts.selector) {
+    if (frameLocator) {
+      // Frame-scoped locator
+      if (opts.selector) {
+        locator = frameLocator.locator(opts.selector).getByRole(node.role as any, {
+          name: node.name || undefined,
+        });
+      } else {
+        locator = frameLocator.getByRole(node.role as any, {
+          name: node.name || undefined,
+        });
+      }
+    } else if (opts.selector) {
       locator = page.locator(opts.selector).getByRole(node.role as any, {
         name: node.name || undefined,
       });


### PR DESCRIPTION
## Summary

Implements the **most-requested missing feature** per [ARCHITECTURE.md](https://github.com/garrytan/gstack/blob/main/ARCHITECTURE.md#whats-intentionally-not-here) and [TODOS.md](https://github.com/garrytan/gstack/blob/main/TODOS.md#iframe-support):

> No iframe support. Playwright can handle iframes but the ref system doesn't cross frame boundaries yet. **This is the most-requested missing feature.**

Adds `frame <list|main|selector>` — three subcommands that let AI agents interact with elements inside iframes (payment forms, OAuth flows, embedded widgets, ads).

## How it works

```
$B frame list                         # enumerate iframes with URLs + selectors
$B frame 'iframe[name="payment"]'     # switch context to iframe
$B snapshot -i                        # refs now scope to iframe content
$B fill @e3 "4242424242424242"        # interact with elements inside iframe
$B frame main                         # return to main frame
```

### Design decisions

- **Frame context stored as selector** on BrowserManager → `page.frameLocator(selector)` builds frame-scoped Locators at snapshot time
- **Zero changes to read/write command handlers** — Playwright Locators built from `FrameLocator.getByRole()` are automatically frame-aware, so `click @e3`, `fill @e4`, etc. just work
- **Refs cleared on frame switch** (same safety principle as tab switch — stale locators fail loudly)
- **Frame selector cleared on main frame navigation** (iframe context is stale after the parent page navigates)
- **No ref namespace changes** — `@e1`/`@c1` refs work identically within frames, keeping the mental model simple

### Files changed

| File | What |
|------|------|
| `browser-manager.ts` | Frame tracking: `setFrameSelector()`, `getFrameLocator()`, `listFrames()`, navigation cleanup |
| `snapshot.ts` | Frame-scoped `ariaSnapshot()` + frame-scoped Locator building |
| `commands.ts` | Register `frame` in `META_COMMANDS` + `COMMAND_DESCRIPTIONS` |
| `meta-commands.ts` | `frame list/main/<selector>` handler with validation |
| `cli.ts` | Help text |
| `SKILL.md` (4 files) | Auto-regenerated via `gen:skill-docs` |

## Test plan

- [x] All 173 command tests pass (`bun test browse/test/commands.test.ts`)
- [x] All 38 snapshot tests pass (`bun test browse/test/snapshot.test.ts`)
- [x] All 379 skill validation tests pass (`bun test test/skill-validation.test.ts`)
- [x] All 125 gen-skill-docs tests pass
- [x] `bun run gen:skill-docs` and `--host codex` regenerate cleanly
- [ ] Manual: `frame list` on a page with iframes shows correct entries
- [ ] Manual: `frame <sel>` → `snapshot -i` → `click @e3` works cross-frame
- [ ] Manual: `frame main` returns context and clears refs