### PR TITLE
fix: keep root gstack skill loadable in codex

### DIFF
--- a/.agents/skills/gstack/SKILL.md
+++ b/.agents/skills/gstack/SKILL.md
@@ -7,38 +7,10 @@ description: |
   ~100ms per command. Use when you need to test a feature, verify a deployment, dogfood a
   user flow, or file a bug with evidence.
   
-  gstack also includes development workflow skills. When you notice the user is at
-  these stages, suggest the appropriate skill:
-  - Brainstorming a new idea → suggest /office-hours
-  - Reviewing a plan (strategy) → suggest /plan-ceo-review
-  - Reviewing a plan (architecture) → suggest /plan-eng-review
-  - Reviewing a plan (design) → suggest /plan-design-review
-  - Auto-reviewing a plan (all reviews at once) → suggest /autoplan
-  - Creating a design system → suggest /design-consultation
-  - Debugging errors → suggest /investigate
-  - Testing the app → suggest /qa
-  - Code review before merge → suggest /review
-  - Visual design audit → suggest /design-review
-  - Ready to deploy / create PR → suggest /ship
-  - Post-ship doc updates → suggest /document-release
-  - Weekly retrospective → suggest /retro
-  - Wanting a second opinion or adversarial code review → suggest /codex
-  - Working with production or live systems → suggest /careful
-  - Want to scope edits to one module/directory → suggest /freeze
-  - Maximum safety mode (destructive warnings + edit restrictions) → suggest /guard
-  - Removing edit restrictions → suggest /unfreeze
-  - Upgrading gstack to latest version → suggest /gstack-upgrade
-  
-  If the user pushes back on skill suggestions ("stop suggesting things",
-  "I don't need suggestions", "too aggressive"):
-  1. Stop suggesting for the rest of this session
-  2. Run: gstack-config set proactive false
-  3. Say: "Got it — I'll stop suggesting skills. Just tell me to be proactive
-     again if you change your mind."
-  
-  If the user says "be proactive again" or "turn on suggestions":
-  1. Run: gstack-config set proactive true
-  2. Say: "Proactive suggestions are back on."
+  gstack also bundles development workflow skills such as /office-hours, /plan-ceo-review,
+  /plan-eng-review, /plan-design-review, /autoplan, /design-consultation, /investigate,
+  /qa, /review, /design-review, /ship, /document-release, /retro, /codex, /careful,
+  /freeze, /guard, /unfreeze, and /gstack-upgrade.
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->

--- a/SKILL.md
+++ b/SKILL.md
@@ -8,38 +8,10 @@ description: |
   ~100ms per command. Use when you need to test a feature, verify a deployment, dogfood a
   user flow, or file a bug with evidence.
 
-  gstack also includes development workflow skills. When you notice the user is at
-  these stages, suggest the appropriate skill:
-  - Brainstorming a new idea → suggest /office-hours
-  - Reviewing a plan (strategy) → suggest /plan-ceo-review
-  - Reviewing a plan (architecture) → suggest /plan-eng-review
-  - Reviewing a plan (design) → suggest /plan-design-review
-  - Auto-reviewing a plan (all reviews at once) → suggest /autoplan
-  - Creating a design system → suggest /design-consultation
-  - Debugging errors → suggest /investigate
-  - Testing the app → suggest /qa
-  - Code review before merge → suggest /review
-  - Visual design audit → suggest /design-review
-  - Ready to deploy / create PR → suggest /ship
-  - Post-ship doc updates → suggest /document-release
-  - Weekly retrospective → suggest /retro
-  - Wanting a second opinion or adversarial code review → suggest /codex
-  - Working with production or live systems → suggest /careful
-  - Want to scope edits to one module/directory → suggest /freeze
-  - Maximum safety mode (destructive warnings + edit restrictions) → suggest /guard
-  - Removing edit restrictions → suggest /unfreeze
-  - Upgrading gstack to latest version → suggest /gstack-upgrade
-
-  If the user pushes back on skill suggestions ("stop suggesting things",
-  "I don't need suggestions", "too aggressive"):
-  1. Stop suggesting for the rest of this session
-  2. Run: gstack-config set proactive false
-  3. Say: "Got it — I'll stop suggesting skills. Just tell me to be proactive
-     again if you change your mind."
-
-  If the user says "be proactive again" or "turn on suggestions":
-  1. Run: gstack-config set proactive true
-  2. Say: "Proactive suggestions are back on."
+  gstack also bundles development workflow skills such as /office-hours, /plan-ceo-review,
+  /plan-eng-review, /plan-design-review, /autoplan, /design-consultation, /investigate,
+  /qa, /review, /design-review, /ship, /document-release, /retro, /codex, /careful,
+  /freeze, /guard, /unfreeze, and /gstack-upgrade.
 allowed-tools:
   - Bash
   - Read

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -8,38 +8,10 @@ description: |
   ~100ms per command. Use when you need to test a feature, verify a deployment, dogfood a
   user flow, or file a bug with evidence.
 
-  gstack also includes development workflow skills. When you notice the user is at
-  these stages, suggest the appropriate skill:
-  - Brainstorming a new idea → suggest /office-hours
-  - Reviewing a plan (strategy) → suggest /plan-ceo-review
-  - Reviewing a plan (architecture) → suggest /plan-eng-review
-  - Reviewing a plan (design) → suggest /plan-design-review
-  - Auto-reviewing a plan (all reviews at once) → suggest /autoplan
-  - Creating a design system → suggest /design-consultation
-  - Debugging errors → suggest /investigate
-  - Testing the app → suggest /qa
-  - Code review before merge → suggest /review
-  - Visual design audit → suggest /design-review
-  - Ready to deploy / create PR → suggest /ship
-  - Post-ship doc updates → suggest /document-release
-  - Weekly retrospective → suggest /retro
-  - Wanting a second opinion or adversarial code review → suggest /codex
-  - Working with production or live systems → suggest /careful
-  - Want to scope edits to one module/directory → suggest /freeze
-  - Maximum safety mode (destructive warnings + edit restrictions) → suggest /guard
-  - Removing edit restrictions → suggest /unfreeze
-  - Upgrading gstack to latest version → suggest /gstack-upgrade
-
-  If the user pushes back on skill suggestions ("stop suggesting things",
-  "I don't need suggestions", "too aggressive"):
-  1. Stop suggesting for the rest of this session
-  2. Run: gstack-config set proactive false
-  3. Say: "Got it — I'll stop suggesting skills. Just tell me to be proactive
-     again if you change your mind."
-
-  If the user says "be proactive again" or "turn on suggestions":
-  1. Run: gstack-config set proactive true
-  2. Say: "Proactive suggestions are back on."
+  gstack also bundles development workflow skills such as /office-hours, /plan-ceo-review,
+  /plan-eng-review, /plan-design-review, /autoplan, /design-consultation, /investigate,
+  /qa, /review, /design-review, /ship, /document-release, /retro, /codex, /careful,
+  /freeze, /guard, /unfreeze, and /gstack-upgrade.
 allowed-tools:
   - Bash
   - Read

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -22,6 +22,29 @@ const ALL_SKILLS = (() => {
   return skills;
 })();
 
+function extractFrontmatter(content: string): string {
+  const fmEnd = content.indexOf('\n---', 4);
+  expect(fmEnd).toBeGreaterThan(0);
+  return content.slice(4, fmEnd);
+}
+
+function extractBlockScalarDescription(frontmatter: string): string {
+  const lines = frontmatter.split('\n');
+  const descStart = lines.findIndex(line => line === 'description: |');
+  expect(descStart).toBeGreaterThanOrEqual(0);
+
+  const descLines: string[] = [];
+  for (const line of lines.slice(descStart + 1)) {
+    if (line === '' || line.startsWith('  ')) {
+      descLines.push(line.replace(/^  /, ''));
+      continue;
+    }
+    break;
+  }
+
+  return descLines.join('\n').trim();
+}
+
 describe('gen-skill-docs', () => {
   test('generated SKILL.md contains all command categories', () => {
     const content = fs.readFileSync(path.join(ROOT, 'SKILL.md'), 'utf-8');
@@ -720,9 +743,7 @@ describe('Codex generation (--host codex)', () => {
     for (const skill of CODEX_SKILLS) {
       const content = fs.readFileSync(path.join(AGENTS_DIR, skill.codexName, 'SKILL.md'), 'utf-8');
       expect(content.startsWith('---\n')).toBe(true);
-      const fmEnd = content.indexOf('\n---', 4);
-      expect(fmEnd).toBeGreaterThan(0);
-      const frontmatter = content.slice(4, fmEnd);
+      const frontmatter = extractFrontmatter(content);
       // Must have name and description
       expect(frontmatter).toContain('name:');
       expect(frontmatter).toContain('description:');
@@ -797,8 +818,7 @@ describe('Codex generation (--host codex)', () => {
   test('multiline descriptions preserved in Codex output', () => {
     // office-hours has a multiline description — verify it survives the frontmatter transform
     const content = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-office-hours', 'SKILL.md'), 'utf-8');
-    const fmEnd = content.indexOf('\n---', 4);
-    const frontmatter = content.slice(4, fmEnd);
+    const frontmatter = extractFrontmatter(content);
     // Description should span multiple lines (block scalar)
     const descLines = frontmatter.split('\n').filter(l => l.startsWith('  '));
     expect(descLines.length).toBeGreaterThan(1);
@@ -813,9 +833,21 @@ describe('Codex generation (--host codex)', () => {
       // Must have safety advisory prose
       expect(content).toContain('Safety Advisory');
       // Must NOT have hooks: in frontmatter
-      const fmEnd = content.indexOf('\n---', 4);
-      const frontmatter = content.slice(4, fmEnd);
+      const frontmatter = extractFrontmatter(content);
       expect(frontmatter).not.toContain('hooks:');
+    }
+  });
+
+  test('root gstack descriptions stay within Codex CLI frontmatter limit', () => {
+    const skillFiles = [
+      path.join(ROOT, 'SKILL.md'),
+      path.join(AGENTS_DIR, 'gstack', 'SKILL.md'),
+    ];
+
+    for (const skillFile of skillFiles) {
+      const content = fs.readFileSync(skillFile, 'utf-8');
+      const description = extractBlockScalarDescription(extractFrontmatter(content));
+      expect(description.length).toBeLessThanOrEqual(1024);
     }
   });
 


### PR DESCRIPTION
## Summary

- keep the root `gstack` skill description under Codex CLI's current 1024-character frontmatter limit
- add a regression test covering the two root skill surfaces Codex loads today: `SKILL.md` and `.agents/skills/gstack/SKILL.md`
- preserve the existing root-skill behavior while trimming only the overlong frontmatter text

## Why this PR

On March 22, 2026, I tested current `main` with `codex-cli 0.116.0` and reproduced a live Codex compatibility error:

```text
failed to load skill /Users/test/.codex/skills/gstack/SKILL.md: invalid description: exceeds maximum length of 1024 characters
```

I also saw the same root-skill failure for:

```text
/Users/test/.codex/skills/gstack/.agents/skills/gstack/SKILL.md
```

I could not reproduce the symlink-specific claim from issue #333 on current `main`, but this root-skill frontmatter failure is a confirmed Codex loading bug on the current codepath.

PR #326 does not address this area. It does not touch the root `gstack` skill frontmatter or Codex root-skill loading.

Related to #333.

## Verification

- `bun test`
- `bun test test/gen-skill-docs.test.ts`
- `./setup --host codex`
- `codex exec --ephemeral -C /Users/test/.codex/skills/gstack -s read-only -o /tmp/gstack-codex-skills-after.txt "List any installed skills you have available. Return only names, comma-separated."`

## Result

Before this change, Codex emitted the root `gstack` `invalid description` error.

After this change:

- `gstack` appears in the installed skill list
- the root `gstack` `invalid description: exceeds maximum length of 1024 characters` error is gone
- the new static regression test keeps both root skill descriptions under the current Codex limit
