### PR TITLE
fix: use codex co-author trailer in /ship

### DIFF
--- a/.agents/skills/gstack-ship/SKILL.md
+++ b/.agents/skills/gstack-ship/SKILL.md
@@ -1189,7 +1189,7 @@ Save this summary — it goes into the PR body in Step 8.
 git commit -m "$(cat <<'EOF'
 chore: bump version and changelog (vX.Y.Z.W)
 
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+Co-Authored-By: OpenAI Codex <noreply@openai.com>
 EOF
 )"
 ```

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -2167,6 +2167,13 @@ in the decision tree below.
 If you want to persist deploy settings for future runs, suggest the user run \`/setup-deploy\`.`;
 }
 
+function generateCoauthorTrailer(ctx: TemplateContext): string {
+  if (ctx.host === 'codex') {
+    return 'Co-Authored-By: OpenAI Codex <noreply@openai.com>';
+  }
+  return 'Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>';
+}
+
 const RESOLVERS: Record<string, (ctx: TemplateContext) => string> = {
   COMMAND_REFERENCE: generateCommandReference,
   SNAPSHOT_FLAGS: generateSnapshotFlags,
@@ -2185,6 +2192,7 @@ const RESOLVERS: Record<string, (ctx: TemplateContext) => string> = {
   TEST_FAILURE_TRIAGE: generateTestFailureTriage,
   SPEC_REVIEW_LOOP: generateSpecReviewLoop,
   DESIGN_SKETCH: generateDesignSketch,
+  COAUTHOR_TRAILER: generateCoauthorTrailer,
   BENEFITS_FROM: generateBenefitsFrom,
   CODEX_REVIEW_STEP: generateAdversarialStep,
   ADVERSARIAL_STEP: generateAdversarialStep,

--- a/ship/SKILL.md.tmpl
+++ b/ship/SKILL.md.tmpl
@@ -405,7 +405,7 @@ Save this summary — it goes into the PR body in Step 8.
 git commit -m "$(cat <<'EOF'
 chore: bump version and changelog (vX.Y.Z.W)
 
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+{{COAUTHOR_TRAILER}}
 EOF
 )"
 ```

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -834,6 +834,16 @@ describe('Codex generation (--host codex)', () => {
     expect(content).toContain('.agents/skills/gstack');
   });
 
+  test('ship co-author trailer is host-specific', () => {
+    const claudeShip = fs.readFileSync(path.join(ROOT, 'ship', 'SKILL.md'), 'utf-8');
+    expect(claudeShip).toContain('Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>');
+    expect(claudeShip).not.toContain('Co-Authored-By: OpenAI Codex <noreply@openai.com>');
+
+    const codexShip = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-ship', 'SKILL.md'), 'utf-8');
+    expect(codexShip).toContain('Co-Authored-By: OpenAI Codex <noreply@openai.com>');
+    expect(codexShip).not.toContain('Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>');
+  });
+
   // ─── Path rewriting regression tests ─────────────────────────
 
   test('sidecar paths point to .agents/skills/gstack/review/ (not gstack-review/)', () => {


### PR DESCRIPTION
## Summary

- make the `/ship` co-author trailer host-specific
- keep Claude output unchanged
- render an OpenAI Codex trailer in the generated Codex ship skill
- add generator coverage so the two hosts cannot drift back together

## Problem

Issue #282 is still live on current `main`.

`/ship` hardcodes this trailer in the template:

```text
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
```

That line is copied into the generated Codex ship skill today, so users running gstack under Codex get an Anthropic co-author in the final `/ship` commit message.

## Fix

- add a host-aware `COAUTHOR_TRAILER` placeholder in `ship/SKILL.md.tmpl`
- render the Anthropic trailer for Claude output
- render `Co-Authored-By: OpenAI Codex <noreply@openai.com>` for Codex output
- add a regression test in `test/gen-skill-docs.test.ts`

Fixes #282.

## Verification

- `bun run gen:skill-docs`
- `bun run gen:skill-docs --host codex`
- `bun test test/gen-skill-docs.test.ts`
- `bun test`
