### PR TITLE
feat(browse): multi-browser support — Firefox + WebKit/Safari via BROWSE_BROWSER

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -15,7 +15,25 @@
  *   restores state. Falls back to clean slate on any failure.
  */
 
-import { chromium, type Browser, type BrowserContext, type BrowserContextOptions, type Page, type Locator, type Cookie } from 'playwright';
+import { chromium, firefox, webkit, type Browser, type BrowserContext, type BrowserContextOptions, type Page, type Locator, type Cookie } from 'playwright';
+
+/**
+ * Resolve browser engine from BROWSE_BROWSER env var.
+ * Supported: chromium (default), firefox, webkit (Safari engine).
+ * Edge uses Chromium engine — set BROWSE_BROWSER=chromium (or omit).
+ */
+function getBrowserType() {
+  const name = (process.env.BROWSE_BROWSER || 'chromium').toLowerCase();
+  switch (name) {
+    case 'firefox': return firefox;
+    case 'webkit':
+    case 'safari': return webkit;
+    case 'chromium':
+    case 'chrome':
+    case 'edge':
+    default: return chromium;
+  }
+}
 import { addConsoleEntry, addNetworkEntry, addDialogEntry, networkBuffer, type DialogEntry } from './buffers';
 import { validateNavigationUrl } from './url-validation';
 
@@ -62,7 +80,9 @@ export class BrowserManager {
   private consecutiveFailures: number = 0;
 
   async launch() {
-    this.browser = await chromium.launch({ headless: true });
+    const browserType = getBrowserType();
+    console.error(`[browse] Launching ${browserType.name()} (headless)`);
+    this.browser = await browserType.launch({ headless: true });
 
     // Chromium crash → exit with clear message
     this.browser.on('disconnected', () => {
@@ -464,7 +484,7 @@ export class BrowserManager {
     // 2. Launch new headed browser (try-catch — if this fails, headless stays running)
     let newBrowser: Browser;
     try {
-      newBrowser = await chromium.launch({ headless: false, timeout: 15000 });
+      newBrowser = await getBrowserType().launch({ headless: false, timeout: 15000 });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       return `ERROR: Cannot open headed browser — ${msg}. Headless browser still running.`;


### PR DESCRIPTION
## Summary

- `BROWSE_BROWSER` env var selects Playwright engine: `chromium` (default), `firefox`, `webkit`
- Replaces 2 hardcoded `chromium.launch()` calls with `getBrowserType().launch()`
- Both `launch()` and `handoff()` respect the setting
- When unset: zero behavior change

## Usage

```bash
BROWSE_BROWSER=firefox browse server    # Firefox
BROWSE_BROWSER=webkit browse server     # Safari engine
BROWSE_BROWSER=chromium browse server   # default (also: chrome, edge)
browse server                           # chromium (unchanged)
```

## Mapping

| BROWSE_BROWSER | Playwright engine | Covers |
|----------------|------------------|--------|
| `chromium` (default) | `chromium` | Chrome, Edge, Brave, Arc, Comet |
| `firefox` | `firefox` | Firefox |
| `webkit` / `safari` | `webkit` | Safari engine |

## 1 file, 23 lines changed

`browse/src/browser-manager.ts` — added `getBrowserType()`, replaced 2 `chromium.launch()` calls.

## Test plan
- [x] All 548 existing tests pass
- [x] Default (no env var): chromium launch unchanged
- [x] No remaining hardcoded `chromium.launch()` references
- [x] Both `launch()` and `handoff()` use `getBrowserType()`