### PR TITLE
feat(browse): add Firefox support via BROWSE_BROWSER=firefox

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -15,7 +15,14 @@
  *   restores state. Falls back to clean slate on any failure.
  */
 
-import { chromium, type Browser, type BrowserContext, type BrowserContextOptions, type Page, type Locator, type Cookie } from 'playwright';
+import { chromium, firefox, type Browser, type BrowserContext, type BrowserContextOptions, type Page, type Locator, type Cookie } from 'playwright';
+
+/** Resolve browser engine from BROWSE_BROWSER env var. Default: chromium. */
+function getBrowserType() {
+  const name = (process.env.BROWSE_BROWSER || 'chromium').toLowerCase();
+  if (name === 'firefox') return firefox;
+  return chromium;
+}
 import { addConsoleEntry, addNetworkEntry, addDialogEntry, networkBuffer, type DialogEntry } from './buffers';
 import { validateNavigationUrl } from './url-validation';
 
@@ -62,7 +69,7 @@ export class BrowserManager {
   private consecutiveFailures: number = 0;
 
   async launch() {
-    this.browser = await chromium.launch({ headless: true });
+    this.browser = await getBrowserType().launch({ headless: true });
 
     // Chromium crash → exit with clear message
     this.browser.on('disconnected', () => {
@@ -464,7 +471,7 @@ export class BrowserManager {
     // 2. Launch new headed browser (try-catch — if this fails, headless stays running)
     let newBrowser: Browser;
     try {
-      newBrowser = await chromium.launch({ headless: false, timeout: 15000 });
+      newBrowser = await getBrowserType().launch({ headless: false, timeout: 15000 });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       return `ERROR: Cannot open headed browser — ${msg}. Headless browser still running.`;


### PR DESCRIPTION
## Summary

- `BROWSE_BROWSER=firefox` launches Firefox instead of Chromium
- Introduces `getBrowserType()` resolver — replaces 2 hardcoded `chromium.launch()` calls
- Both `launch()` and `handoff()` use the resolver
- When unset: zero behavior change

```bash
BROWSE_BROWSER=firefox browse server
```

**Note:** PRs #372 (WebKit) and #373 (Edge) build on this refactor. Merge this first.

## 1 file, 10 lines changed

`browse/src/browser-manager.ts`

## Test plan
- [x] All 548 existing tests pass
- [x] Default: chromium unchanged
- [x] No remaining hardcoded `chromium.launch()`