### PR TITLE
fix(browse): ensure .gstack/ dir exists before acquiring lock

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -262,6 +262,9 @@ async function ensureServer(): Promise<ServerState> {
     }
   }
 
+  // Ensure .gstack/ directory exists before acquiring lock (fixes ENOENT on first run)
+  ensureStateDir(config);
+
   // Acquire lock to prevent concurrent restart races (TOCTOU)
   const releaseLock = acquireServerLock();
   if (!releaseLock) {


### PR DESCRIPTION
## Summary

Fixes issue #358 where `acquireServerLock()` fails silently when the `.gstack/` directory does not exist, causing every browse command to print "Another instance is starting the server, waiting..." and timeout on first run.

## Root Cause

`ensureStateDir()` was called inside `startServer()` (cli.ts L165), but `acquireServerLock()` runs **before** `startServer()` in `ensureServer()` (L266). The lock path is `${config.stateFile}.lock` which resolves to `<project>/.gstack/browse.json.lock`.

When `.gstack/` does not exist:
1. `fs.openSync(lockPath, O_CREAT | O_EXCL)` throws ENOENT (parent dir missing)
2. Falls into outer catch → `fs.readFileSync(lockPath)` also throws ENOENT  
3. Falls into inner catch → `return null`
4. `ensureServer()` sees `null` → prints "Another instance is starting..."
5. Wait loop never resolves → timeout

## Fix

Call `ensureStateDir(config)` before `acquireServerLock()` to guarantee the parent directory exists.

## Test Plan

- [x] `mkdir -p /tmp/test-repo && cd /tmp/test-repo && git init && ~/.claude/skills/gstack/browse/dist/browse goto https://example.com` now works on first run
- [x] Existing tests pass

Fixes #358