### PR TITLE
feat: gstack-risk-score — predict ship risk from git history

### DIFF
--- a/bin/gstack-risk-score
+++ b/bin/gstack-risk-score
@@ -17,6 +17,7 @@ set -euo pipefail
 
 JSON_MODE=""
 [ "${1:-}" = "--json" ] && JSON_MODE=1
+export JSON_MODE
 
 # Detect base branch
 BASE=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || \


### PR DESCRIPTION
## Summary

- Computes 0-100 risk score for the current branch
- Analyzes: fix ratio, bus factor, test gaps, core file changes, change size, recent reverts
- Outputs human-readable or `--json` for integration with /ship

```bash
$ gstack-risk-score

SHIP RISK SCORE: 34/100 (moderate)

  ⚠  app/services/payment.rb
     62% fix ratio — 8/13 commits are fixes (+15 risk)
  ⚠  app/services/payment.rb
     only alice in last 6 months (+10 risk)
  ○  branch
     3 source files changed, 0 test files (+20 risk)
  ✓  2 test files included
```

## 1 file, 157 lines

`bin/gstack-risk-score` — bash + inline Python. Pure git analysis, no new dependencies.

## Test plan
- [x] All existing tests pass
- [x] Detects base branch via `gh pr view` / `gh repo view` / fallback to main
- [x] `--json` outputs machine-readable format
- [x] Score capped at 100