### PR TITLE
fix: make generated commit trailers host-aware

### DIFF
--- a/document-release/SKILL.md.tmpl
+++ b/document-release/SKILL.md.tmpl
@@ -277,9 +277,7 @@ committing.
 
 ```bash
 git commit -m "$(cat <<'EOF'
-docs: update project documentation for vX.Y.Z.W
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+docs: update project documentation for vX.Y.Z.W{{COMMIT_COAUTHOR_TRAILER_BLOCK}}
 EOF
 )"
 ```

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -60,6 +60,11 @@ interface TemplateContext {
   paths: HostPaths;
 }
 
+const HOST_COMMIT_COAUTHOR_TRAILERS: Record<Host, string> = {
+  claude: 'Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>',
+  codex: '',
+};
+
 // ─── Shared Design Constants ────────────────────────────────
 
 /** gstack's 10 AI slop anti-patterns — shared between DESIGN_METHODOLOGY and DESIGN_HARD_RULES */
@@ -2795,9 +2800,15 @@ function generateSlugSetup(ctx: TemplateContext): string {
   return `eval "$(${ctx.paths.binDir}/gstack-slug 2>/dev/null)" && mkdir -p ~/.gstack/projects/$SLUG`;
 }
 
+function generateCommitCoauthorTrailerBlock(ctx: TemplateContext): string {
+  const trailer = HOST_COMMIT_COAUTHOR_TRAILERS[ctx.host];
+  return trailer ? `\n\n${trailer}` : '';
+}
+
 const RESOLVERS: Record<string, (ctx: TemplateContext) => string> = {
   SLUG_EVAL: generateSlugEval,
   SLUG_SETUP: generateSlugSetup,
+  COMMIT_COAUTHOR_TRAILER_BLOCK: generateCommitCoauthorTrailerBlock,
   COMMAND_REFERENCE: generateCommandReference,
   SNAPSHOT_FLAGS: generateSnapshotFlags,
   PREAMBLE: generatePreamble,

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -1388,7 +1388,7 @@ Save this summary — it goes into the PR body in Step 8.
 5. Compose each commit message:
    - First line: `<type>: <summary>` (type = feat/fix/chore/refactor/docs)
    - Body: brief description of what this commit contains
-   - Only the **final commit** (VERSION + CHANGELOG) gets the version tag and co-author trailer:
+   - Only the **final commit** (VERSION + CHANGELOG) gets the version tag. If the current host uses a commit footer, include it only on that final commit:
 
 ```bash
 git commit -m "$(cat <<'EOF'

--- a/ship/SKILL.md.tmpl
+++ b/ship/SKILL.md.tmpl
@@ -399,13 +399,11 @@ Save this summary — it goes into the PR body in Step 8.
 5. Compose each commit message:
    - First line: `<type>: <summary>` (type = feat/fix/chore/refactor/docs)
    - Body: brief description of what this commit contains
-   - Only the **final commit** (VERSION + CHANGELOG) gets the version tag and co-author trailer:
+   - Only the **final commit** (VERSION + CHANGELOG) gets the version tag. If the current host uses a commit footer, include it only on that final commit:
 
 ```bash
 git commit -m "$(cat <<'EOF'
-chore: bump version and changelog (vX.Y.Z.W)
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+chore: bump version and changelog (vX.Y.Z.W){{COMMIT_COAUTHOR_TRAILER_BLOCK}}
 EOF
 )"
 ```

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -175,6 +175,14 @@ describe('gen-skill-docs', () => {
     expect(browseTmpl).toContain('{{PREAMBLE}}');
   });
 
+  test('ship and document-release templates use host-aware commit trailer placeholder', () => {
+    const shipTmpl = fs.readFileSync(path.join(ROOT, 'ship', 'SKILL.md.tmpl'), 'utf-8');
+    const documentReleaseTmpl = fs.readFileSync(path.join(ROOT, 'document-release', 'SKILL.md.tmpl'), 'utf-8');
+
+    expect(shipTmpl).toContain('{{COMMIT_COAUTHOR_TRAILER_BLOCK}}');
+    expect(documentReleaseTmpl).toContain('{{COMMIT_COAUTHOR_TRAILER_BLOCK}}');
+  });
+
   test('generated SKILL.md contains contributor mode check', () => {
     const content = fs.readFileSync(path.join(ROOT, 'SKILL.md'), 'utf-8');
     expect(content).toContain('Contributor Mode');
@@ -1167,6 +1175,24 @@ describe('Codex generation (--host codex)', () => {
   test('codex host does not include Codex design block in ship', () => {
     const codexContent = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-ship', 'SKILL.md'), 'utf-8');
     expect(codexContent).not.toContain('Codex design voice');
+  });
+
+  test('codex host omits AI co-author trailers from ship and document-release commit examples', () => {
+    const shipContent = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-ship', 'SKILL.md'), 'utf-8');
+    const documentReleaseContent = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-document-release', 'SKILL.md'), 'utf-8');
+
+    expect(shipContent).not.toContain('Co-Authored-By:');
+    expect(documentReleaseContent).not.toContain('Co-Authored-By:');
+    expect(shipContent).not.toContain('noreply@anthropic.com');
+    expect(documentReleaseContent).not.toContain('noreply@anthropic.com');
+  });
+
+  test('Claude output preserves Claude co-author trailers in ship and document-release', () => {
+    const shipContent = fs.readFileSync(path.join(ROOT, 'ship', 'SKILL.md'), 'utf-8');
+    const documentReleaseContent = fs.readFileSync(path.join(ROOT, 'document-release', 'SKILL.md'), 'utf-8');
+
+    expect(shipContent).toContain('Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>');
+    expect(documentReleaseContent).toContain('Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>');
   });
 });
 


### PR DESCRIPTION
## Summary

- move commit footer generation into `gen-skill-docs`
- keep the Claude trailer in Claude-generated skills
- omit AI `Co-Authored-By` trailers from generated Codex `/ship` and `/document-release` commit examples
- add regression coverage for both source templates and generated host outputs

## Problem

Generated Codex skill docs for `/ship` and `/document-release` included a hardcoded Claude `Co-Authored-By` trailer in their sample commit messages. That makes Codex-authored commits inherit the wrong AI footer.

## Fix

- add a host-aware `COMMIT_COAUTHOR_TRAILER_BLOCK` placeholder to the skill-doc generator
- update `ship/SKILL.md.tmpl` and `document-release/SKILL.md.tmpl` to use that placeholder instead of hardcoding a trailer
- preserve the existing Claude output and omit the footer entirely for Codex output
- add tests covering the templates and the generated Claude/Codex variants

Fixes #282.

## Verification

- `bun run gen:skill-docs`
- `bun run gen:skill-docs --host codex`
- `bun test test/gen-skill-docs.test.ts`
- `bun test`
