### PR TITLE
fix: sync package.json version with VERSION file (0.11.10.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gstack",
-  "version": "0.11.9.0",
+  "version": "0.11.10.0",
   "description": "Garry's Stack — Claude Code skills + fast headless browser. One repo, one install, entire AI engineering workflow.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Fixes #399.

`VERSION` says `0.11.10.0`. `package.json` says `0.11.9.0`. PR #360 bumped one but not the other.

One-line fix. Test passes: `gen-skill-docs > package.json version matches VERSION file`.

🤖 Generated with [Claude Code](https://claude.ai/code)