### PR TITLE
Add community projects section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,14 @@ Available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-desig
 /unfreeze, /gstack-upgrade.
 ```
 
+## Community
+
+Projects built on gstack:
+
+| Project | What it does |
+|---|---|
+| [gstack Studio](https://github.com/habiz/gstack-studio) | Browser UI that guides you through the gstack ideation sprint |
+
 ## License
 
 MIT. Free forever. Go build something.


### PR DESCRIPTION
gstack Studio is an open source browser UI that wraps the product ideation sprint (office-hours → CEO review → design review → eng review → design doc) for non-technical founders and PMs who can't work in the terminal.
Built with Bun, runs locally via npx gstack-studio, sessions saved to ~/.gstack-studio/sessions/. MIT licensed.
Adding a community section to the README so projects building on gstack have a place to live. Happy to keep this minimal, one line per project.