### PR TITLE
feat: add Antigravity / Gemini CLI as supported host

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,6 @@ bun run skill:check      # health dashboard for all skills
 ## Key conventions
 
 - SKILL.md files are **generated** from `.tmpl` templates. Edit the template, not the output.
-- Run `bun run gen:skill-docs --host codex` to regenerate Codex-specific output.
+- Run `bun run gen:skill-docs --host codex` to regenerate Codex/Antigravity-specific output.
 - The browse binary provides headless browser access. Use `$B <command>` in skills.
 - Safety skills (careful, freeze, guard) use inline advisory prose — always confirm before destructive operations.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Open Claude Code and paste this. Claude does the rest.
 
 Real files get committed to your repo (not a submodule), so `git clone` just works. Everything lives inside `.claude/`. Nothing touches your PATH or runs in the background.
 
-### Codex, Gemini CLI, or Cursor
+### Codex, Gemini CLI, Antigravity, or Cursor
 
 gstack works on any agent that supports the [SKILL.md standard](https://github.com/anthropics/claude-code). Skills live in `.agents/skills/` and are discovered automatically.
 
@@ -84,6 +84,15 @@ Or let setup auto-detect which agents you have installed:
 git clone https://github.com/garrytan/gstack.git ~/gstack
 cd ~/gstack && ./setup --host auto
 ```
+
+For Antigravity / Gemini CLI specifically:
+
+```bash
+git clone https://github.com/garrytan/gstack.git ~/gstack
+cd ~/gstack && ./setup --host antigravity
+```
+
+`setup --host antigravity` (or `--host gemini`) creates the runtime root at `~/.gemini/skills/gstack` and installs all skills with rewritten paths. Both `--host antigravity` and `--host gemini` are accepted and do the same thing.
 
 For Codex-compatible hosts, setup now supports both repo-local installs from `.agents/skills/gstack` and user-global installs from `~/.codex/skills/gstack`. All 28 skills work across all supported agents. Hook-based safety skills (careful, freeze, guard) use inline safety advisory prose on non-Claude hosts.
 

--- a/setup
+++ b/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# gstack setup — build browser binary + register skills with Claude Code / Codex
+# gstack setup — build browser binary + register skills with Claude Code / Codex / Antigravity
 set -e
 
 if ! command -v bun >/dev/null 2>&1; then
@@ -24,27 +24,32 @@ esac
 HOST="claude"
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, antigravity, gemini, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     *) shift ;;
   esac
 done
 
 case "$HOST" in
-  claude|codex|kiro|auto) ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, or auto)" >&2; exit 1 ;;
+  claude|codex|kiro|antigravity|gemini|auto) ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, antigravity, gemini, or auto)" >&2; exit 1 ;;
 esac
+
+# Normalize gemini → antigravity (same host)
+[ "$HOST" = "gemini" ] && HOST="antigravity"
 
 # For auto: detect which agents are installed
 INSTALL_CLAUDE=0
 INSTALL_CODEX=0
 INSTALL_KIRO=0
+INSTALL_ANTIGRAVITY=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
+  command -v gemini >/dev/null 2>&1 && INSTALL_ANTIGRAVITY=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_ANTIGRAVITY" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
@@ -53,6 +58,8 @@ elif [ "$HOST" = "codex" ]; then
   INSTALL_CODEX=1
 elif [ "$HOST" = "kiro" ]; then
   INSTALL_KIRO=1
+elif [ "$HOST" = "antigravity" ]; then
+  INSTALL_ANTIGRAVITY=1
 fi
 
 migrate_direct_codex_install() {
@@ -418,6 +425,62 @@ if [ "$INSTALL_KIRO" -eq 1 ]; then
     echo "gstack ready (kiro)."
     echo "  browse: $BROWSE_BIN"
     echo "  kiro skills: $KIRO_SKILLS"
+  fi
+fi
+
+# 6b. Install for Antigravity / Gemini CLI (copy from .agents/skills, rewrite paths)
+if [ "$INSTALL_ANTIGRAVITY" -eq 1 ]; then
+  GEMINI_SKILLS="$HOME/.gemini/skills"
+  AGENTS_DIR="$SOURCE_GSTACK_DIR/.agents/skills"
+  mkdir -p "$GEMINI_SKILLS"
+
+  # Create gstack dir with symlinks for runtime assets, copy+sed for SKILL.md
+  GEMINI_GSTACK="$GEMINI_SKILLS/gstack"
+  # Remove old whole-dir symlink from previous installs
+  [ -L "$GEMINI_GSTACK" ] && rm -f "$GEMINI_GSTACK"
+  mkdir -p "$GEMINI_GSTACK" "$GEMINI_GSTACK/browse" "$GEMINI_GSTACK/gstack-upgrade" "$GEMINI_GSTACK/review"
+  ln -snf "$SOURCE_GSTACK_DIR/bin" "$GEMINI_GSTACK/bin"
+  ln -snf "$SOURCE_GSTACK_DIR/browse/dist" "$GEMINI_GSTACK/browse/dist"
+  ln -snf "$SOURCE_GSTACK_DIR/browse/bin" "$GEMINI_GSTACK/browse/bin"
+  # ETHOS.md — referenced by "Search Before Building" in all skill preambles
+  if [ -f "$SOURCE_GSTACK_DIR/ETHOS.md" ]; then
+    ln -snf "$SOURCE_GSTACK_DIR/ETHOS.md" "$GEMINI_GSTACK/ETHOS.md"
+  fi
+  # gstack-upgrade skill
+  if [ -f "$AGENTS_DIR/gstack-upgrade/SKILL.md" ]; then
+    ln -snf "$AGENTS_DIR/gstack-upgrade/SKILL.md" "$GEMINI_GSTACK/gstack-upgrade/SKILL.md"
+  fi
+  # Review runtime assets (individual files, not whole dir)
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$SOURCE_GSTACK_DIR/review/$f" ]; then
+      ln -snf "$SOURCE_GSTACK_DIR/review/$f" "$GEMINI_GSTACK/review/$f"
+    fi
+  done
+
+  # Rewrite root SKILL.md paths for Gemini CLI
+  sed -e "s|~/.claude/skills/gstack|~/.gemini/skills/gstack|g" \
+      -e "s|\.claude/skills/gstack|.gemini/skills/gstack|g" \
+      -e "s|\.claude/skills|.gemini/skills|g" \
+      "$SOURCE_GSTACK_DIR/SKILL.md" > "$GEMINI_GSTACK/SKILL.md"
+
+  if [ ! -d "$AGENTS_DIR" ]; then
+    echo "  warning: no .agents/skills/ directory found — run 'bun run build' first" >&2
+  else
+    for skill_dir in "$AGENTS_DIR"/gstack*/; do
+      [ -f "$skill_dir/SKILL.md" ] || continue
+      skill_name="$(basename "$skill_dir")"
+      target_dir="$GEMINI_SKILLS/$skill_name"
+      mkdir -p "$target_dir"
+      # Generated Codex skills use $HOME/.codex (not ~/), plus $GSTACK_ROOT variables.
+      # Rewrite the default GSTACK_ROOT value and any remaining literal paths.
+      sed -e 's|\$HOME/.codex/skills/gstack|$HOME/.gemini/skills/gstack|g' \
+          -e "s|~/.codex/skills/gstack|~/.gemini/skills/gstack|g" \
+          -e "s|~/.claude/skills/gstack|~/.gemini/skills/gstack|g" \
+          "$skill_dir/SKILL.md" > "$target_dir/SKILL.md"
+    done
+    echo "gstack ready (antigravity/gemini)."
+    echo "  browse: $BROWSE_BIN"
+    echo "  gemini skills: $GEMINI_SKILLS"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Adds Antigravity (Gemini CLI) as a supported host, closing #350.

- `./setup --host antigravity` (or `--host gemini`) installs skills to `~/.gemini/skills/`
- `./setup --host auto` auto-detects Gemini CLI via `command -v gemini`
- Follows the exact same pattern as the existing Kiro integration:
  - Copy from `.agents/skills/` with path rewriting via `sed`
  - Symlink runtime assets (`bin/`, `browse/dist/`, `ETHOS.md`)
  - Create minimal runtime root at `~/.gemini/skills/gstack/`

## Changes

| File | Change |
|------|--------|
| `setup` | Add `INSTALL_ANTIGRAVITY` flag, `--host antigravity`/`--host gemini`, Gemini CLI auto-detection, Step 6b install section |
| `README.md` | Add Antigravity to host list, install instructions |
| `AGENTS.md` | Mention Antigravity in key conventions |

## Test plan

- [ ] `./setup --host antigravity` creates `~/.gemini/skills/gstack/` with correct symlinks
- [ ] `./setup --host gemini` works as alias (normalized to antigravity)
- [ ] `./setup --host auto` detects `gemini` binary when present
- [ ] Rewritten SKILL.md files reference `~/.gemini/skills/gstack` (not codex/claude)
- [ ] Existing claude/codex/kiro installs unaffected

Closes #350