### PR TITLE
feat: add marketplace skill discovery to planning flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Skills live in `.agents/skills/`. Invoke them by name (e.g., `/office-hours`).
 | `/plan-eng-review` | Lock architecture, data flow, edge cases, and tests. |
 | `/plan-design-review` | Rate each design dimension 0-10, explain what a 10 looks like. |
 | `/design-consultation` | Build a complete design system from scratch. |
+| `/find-skills` | Query the external Agent Skills / skills.sh marketplace for vendor/framework-specific skills. |
 | `/review` | Pre-landing PR review. Finds bugs that pass CI but break in prod. |
 | `/debug` | Systematic root-cause debugging. No fixes without investigation. |
 | `/design-review` | Design audit + fix loop with atomic commits. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ gstack/
 ├── benchmark/       # /benchmark skill (performance regression detection)
 ├── canary/          # /canary skill (post-deploy monitoring loop)
 ├── codex/           # /codex skill (multi-AI second opinion via OpenAI Codex CLI)
+├── find-skills/     # /find-skills skill (external marketplace search for Agent Skills / skills.sh)
 ├── land-and-deploy/ # /land-and-deploy skill (merge → deploy → canary verify)
 ├── office-hours/    # /office-hours skill (YC Office Hours — startup diagnostic + builder brainstorm)
 ├── investigate/     # /investigate skill (systematic root-cause debugging)

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Fork it. Improve it. Make it yours. And if you want to hate on free open source 
 
 Open Claude Code and paste this. Claude does the rest.
 
-> Install gstack: run **`git clone https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade. Then ask the user if they also want to add gstack to the current project so teammates get it.
+> Install gstack: run **`git clone https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /find-skills, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade. Then ask the user if they also want to add gstack to the current project so teammates get it.
 
 ### Step 2: Add to your repo so teammates get it (optional)
 
-> Add gstack to this project: run **`cp -Rf ~/.claude/skills/gstack .claude/skills/gstack && rm -rf .claude/skills/gstack/.git && cd .claude/skills/gstack && ./setup`** then add a "gstack" section to this project's CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, and tells Claude that if gstack skills aren't working, run `cd .claude/skills/gstack && ./setup` to build the binary and register skills.
+> Add gstack to this project: run **`cp -Rf ~/.claude/skills/gstack .claude/skills/gstack && rm -rf .claude/skills/gstack/.git && cd .claude/skills/gstack && ./setup`** then add a "gstack" section to this project's CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /find-skills, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, and tells Claude that if gstack skills aren't working, run `cd .claude/skills/gstack && ./setup` to build the binary and register skills.
 
 Real files get committed to your repo (not a submodule), so `git clone` just works. Everything lives inside `.claude/`. Nothing touches your PATH or runs in the background.
 
@@ -145,6 +145,7 @@ Each skill feeds into the next. `/office-hours` writes a design doc that `/plan-
 | `/plan-eng-review` | **Eng Manager** | Lock in architecture, data flow, diagrams, edge cases, and tests. Forces hidden assumptions into the open. |
 | `/plan-design-review` | **Senior Designer** | Rates each design dimension 0-10, explains what a 10 looks like, then edits the plan to get there. AI Slop detection. Interactive — one AskUserQuestion per design choice. |
 | `/design-consultation` | **Design Partner** | Build a complete design system from scratch. Researches the landscape, proposes creative risks, generates realistic product mockups. |
+| `/find-skills` | **Marketplace Search** | Find the best external Agent Skills / skills.sh skills for a technology or workflow query. |
 | `/review` | **Staff Engineer** | Find the bugs that pass CI but blow up in production. Auto-fixes the obvious ones. Flags completeness gaps. |
 | `/investigate` | **Debugger** | Systematic root-cause debugging. Iron Law: no fixes without investigation. Traces data flow, tests hypotheses, stops after 3 failed fixes. |
 | `/design-review` | **Designer Who Codes** | Same audit as /plan-design-review, then fixes what it finds. Atomic commits, before/after screenshots. |
@@ -165,6 +166,7 @@ Each skill feeds into the next. `/office-hours` writes a design doc that `/plan-
 
 | Skill | What it does |
 |-------|-------------|
+| `/find-skills` | **Marketplace Search** — query Agent Skills / skills.sh for external vendor/framework-specific skills and get copy-paste install commands. |
 | `/codex` | **Second Opinion** — independent code review from OpenAI Codex CLI. Three modes: review (pass/fail gate), adversarial challenge, and open consultation. Cross-model analysis when both `/review` and `/codex` have run. |
 | `/careful` | **Safety Guardrails** — warns before destructive commands (rm -rf, DROP TABLE, force-push). Say "be careful" to activate. Override any warning. |
 | `/freeze` | **Edit Lock** — restrict file edits to one directory. Prevents accidental changes outside scope while debugging. |
@@ -234,7 +236,7 @@ Data is stored in [Supabase](https://supabase.com) (open source Firebase alterna
 ## gstack
 Use /browse from gstack for all web browsing. Never use mcp__claude-in-chrome__* tools.
 Available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review,
-/design-consultation, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse,
+/design-consultation, /find-skills, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse,
 /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro,
 /investigate, /document-release, /codex, /cso, /autoplan, /careful, /freeze, /guard,
 /unfreeze, /gstack-upgrade.

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -8,7 +8,7 @@ description: |
   test a site, verify a deployment, dogfood a user flow, or file a bug with screenshots.
   Also suggest adjacent gstack skills by stage: brainstorm /office-hours; strategy
   /plan-ceo-review; architecture /plan-eng-review; design /plan-design-review or
-  /design-consultation; auto-review /autoplan; debugging /investigate; QA /qa; code review
+  /design-consultation; external marketplace /find-skills; auto-review /autoplan; debugging /investigate; QA /qa; code review
   /review; visual audit /design-review; shipping /ship; docs /document-release; retro
   /retro; second opinion /codex; prod safety /careful or /guard; scoped edits /freeze or
   /unfreeze; gstack upgrades /gstack-upgrade. If the user opts out of suggestions, stop

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -479,6 +479,36 @@ Then prepend a one-line HTML comment to the plan file:
   button, modal, layout, dashboard, sidebar, nav, dialog). Require 2+ matches. Exclude
   false positives ("page" alone, "UI" in acronyms).
 
+## External Skill Marketplace Check
+
+If `PROACTIVE` is `"false"`, skip this step entirely.
+
+Use this step when the user's request or current plan/design context clearly names a
+platform, vendor, framework, or tool that may already have a strong external skill in
+the Agent Skills / skills.sh marketplace.
+
+1. Extract 2-6 concrete technology keywords from the user's request or current plan/design context.
+2. Write the original request (or a short summary of the current plan/design) to a temp file:
+
+```bash
+TMP_QUERY=$(mktemp /tmp/gstack-marketplace-query-XXXX.txt)
+cat > "$TMP_QUERY" <<'EOF'
+[original user request or current plan/design summary]
+EOF
+~/.claude/skills/gstack/bin/gstack-marketplace-search --query-file "$TMP_QUERY" --keyword "keyword-1" --keyword "keyword-2" --limit 3 --json
+rm -f "$TMP_QUERY"
+```
+
+3. If the helper returns `"status": "ok"` with non-empty `results`, surface an
+   **External Skills Worth Considering** section with up to 3 results:
+   - scoped name
+   - one-line why it matches
+   - install command
+4. Never auto-install or auto-run marketplace skills. This step is recommendation-only.
+5. If the helper returns `unavailable` or no results, continue silently.
+6. If a gstack built-in skill already covers the need well, prefer the gstack skill and
+   present the external result only as optional context.
+
 ### Step 3: Load skill files from disk
 
 Read each file using the Read tool:

--- a/autoplan/SKILL.md.tmpl
+++ b/autoplan/SKILL.md.tmpl
@@ -137,6 +137,8 @@ Then prepend a one-line HTML comment to the plan file:
   button, modal, layout, dashboard, sidebar, nav, dialog). Require 2+ matches. Exclude
   false positives ("page" alone, "UI" in acronyms).
 
+{{MARKETPLACE_SKILL_DISCOVERY}}
+
 ### Step 3: Load skill files from disk
 
 Read each file using the Read tool:

--- a/bin/gstack-marketplace-search.ts
+++ b/bin/gstack-marketplace-search.ts
@@ -1,0 +1,322 @@
+#!/usr/bin/env bun
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { createHash } from 'crypto';
+import { spawnSync } from 'child_process';
+
+interface RawSkill {
+  name?: string;
+  description?: string;
+  author?: string;
+  stars?: number;
+  forks?: number;
+  githubUrl?: string;
+  scopedName?: string;
+}
+
+interface SearchQuery {
+  text: string;
+  source: 'full' | 'keyword';
+}
+
+interface RankedSkill {
+  name: string;
+  description: string;
+  author: string;
+  scopedName: string;
+  githubUrl: string;
+  stars: number;
+  forks: number;
+  installCommand: string;
+  matchedKeywords: string[];
+  sourceQueries: string[];
+  score: number;
+}
+
+interface SearchResponse {
+  status: 'ok' | 'unavailable';
+  query: string;
+  keywords: string[];
+  queries: string[];
+  results: RankedSkill[];
+  reason?: string;
+}
+
+const KNOWN_KEYWORDS: Array<{ canonical: string; patterns: RegExp[] }> = [
+  { canonical: 'supabase', patterns: [/\bsupabase\b/i] },
+  { canonical: 'vercel', patterns: [/\bvercel\b/i] },
+  { canonical: 'azure cli', patterns: [/\bazure cli\b/i, /\baz\s+cli\b/i, /\baz\b/i] },
+  { canonical: 'github cli', patterns: [/\bgithub cli\b/i, /\bgh cli\b/i, /\bgh\b/i] },
+  { canonical: 'nextjs', patterns: [/\bnext\.?js\b/i, /\bnextjs\b/i] },
+  { canonical: 'postgres', patterns: [/\bpostgres(?:ql)?\b/i] },
+  { canonical: 'prisma', patterns: [/\bprisma\b/i] },
+  { canonical: 'drizzle', patterns: [/\bdrizzle\b/i] },
+  { canonical: 'tailwind', patterns: [/\btailwind\b/i] },
+  { canonical: 'docker', patterns: [/\bdocker\b/i] },
+  { canonical: 'kubernetes', patterns: [/\bkubernetes\b/i, /\bk8s\b/i] },
+  { canonical: 'terraform', patterns: [/\bterraform\b/i] },
+  { canonical: 'openai', patterns: [/\bopenai\b/i] },
+  { canonical: 'anthropic', patterns: [/\banthropic\b/i, /\bclaude\b/i] },
+  { canonical: 'stripe', patterns: [/\bstripe\b/i] },
+  { canonical: 'react', patterns: [/\breact\b/i] },
+  { canonical: 'vue', patterns: [/\bvue\b/i] },
+  { canonical: 'svelte', patterns: [/\bsvelte\b/i] },
+];
+
+const STOPWORDS = new Set([
+  'build', 'using', 'with', 'need', 'help', 'make', 'this', 'that', 'from',
+  'into', 'have', 'about', 'should', 'would', 'there', 'their', 'when', 'what',
+  'where', 'which', 'while', 'before', 'after', 'without', 'through', 'query',
+  'skill', 'skills', 'mode', 'plan', 'design', 'review', 'flow',
+]);
+
+function parseArgs(argv: string[]) {
+  let query = '';
+  let queryFile = '';
+  let limit = 3;
+  let outputJson = false;
+  const explicitKeywords: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--query') query = argv[++i] ?? '';
+    else if (arg === '--query-file') queryFile = argv[++i] ?? '';
+    else if (arg === '--keyword') explicitKeywords.push((argv[++i] ?? '').trim());
+    else if (arg === '--limit') limit = Math.max(1, Number(argv[++i] ?? 3) || 3);
+    else if (arg === '--json') outputJson = true;
+  }
+
+  if (!query && queryFile) query = fs.readFileSync(queryFile, 'utf-8');
+
+  if (!query.trim()) {
+    throw new Error('Usage: gstack-marketplace-search --query <text> [--keyword <term>] [--limit <n>] [--json]');
+  }
+
+  return { query: query.trim(), explicitKeywords, limit, outputJson };
+}
+
+export function extractKeywords(text: string): string[] {
+  const matches = new Set<string>();
+
+  for (const entry of KNOWN_KEYWORDS) {
+    if (entry.patterns.some(pattern => pattern.test(text))) {
+      matches.add(entry.canonical);
+    }
+  }
+
+  if (matches.size === 0) {
+    const generic = text
+      .toLowerCase()
+      .split(/[^a-z0-9.+#-]+/)
+      .filter(token => token.length >= 4 && !STOPWORDS.has(token))
+      .slice(0, 4);
+    for (const token of generic) matches.add(token);
+  }
+
+  return Array.from(matches).slice(0, 6);
+}
+
+export function parseMarketplaceOutput(raw: string): RawSkill[] {
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  if (start === -1 || end === -1 || end < start) return [];
+  const parsed = JSON.parse(raw.slice(start, end + 1));
+  return Array.isArray(parsed.skills) ? parsed.skills : [];
+}
+
+function buildQueries(query: string, explicitKeywords: string[]): SearchQuery[] {
+  const keywords = Array.from(new Set([
+    ...explicitKeywords.map(k => k.trim().toLowerCase()).filter(Boolean),
+    ...extractKeywords(query),
+  ])).slice(0, 6);
+
+  const trimmedQuery = query.split(/\s+/).slice(0, 12).join(' ').trim();
+  const queries: SearchQuery[] = [];
+  if (trimmedQuery) queries.push({ text: trimmedQuery, source: 'full' });
+  for (const keyword of keywords.slice(0, 3)) queries.push({ text: keyword, source: 'keyword' });
+  return queries;
+}
+
+function commandExists(bin: string): boolean {
+  const result = spawnSync('which', [bin], { encoding: 'utf-8' });
+  return result.status === 0;
+}
+
+function getStateDir(): string {
+  return process.env.GSTACK_STATE_DIR || path.join(process.env.HOME || '', '.gstack');
+}
+
+function readCache(key: string): SearchResponse | null {
+  const cacheFile = path.join(getStateDir(), 'cache', 'marketplace-search', `${key}.json`);
+  if (!fs.existsSync(cacheFile)) return null;
+  const stat = fs.statSync(cacheFile);
+  if (Date.now() - stat.mtimeMs > 24 * 60 * 60 * 1000) return null;
+  return JSON.parse(fs.readFileSync(cacheFile, 'utf-8')) as SearchResponse;
+}
+
+function writeCache(key: string, data: SearchResponse) {
+  const cacheDir = path.join(getStateDir(), 'cache', 'marketplace-search');
+  fs.mkdirSync(cacheDir, { recursive: true });
+  fs.writeFileSync(path.join(cacheDir, `${key}.json`), JSON.stringify(data, null, 2));
+}
+
+function runSearchQuery(query: SearchQuery, limit: number): RawSkill[] | null {
+  if (process.env.GSTACK_MARKETPLACE_FIXTURE) {
+    const raw = fs.readFileSync(process.env.GSTACK_MARKETPLACE_FIXTURE, 'utf-8');
+    return parseMarketplaceOutput(raw);
+  }
+
+  const queryArgs = query.text.split(/\s+/).filter(Boolean).slice(0, 12);
+  const commonArgs = ['search', ...queryArgs, '--json', '--limit', String(limit), '--sort', 'stars'];
+
+  if (commandExists('skills')) {
+    const result = spawnSync('skills', commonArgs, { encoding: 'utf-8', timeout: 30000 });
+    if (result.status === 0) return parseMarketplaceOutput(result.stdout || result.stderr || '');
+  }
+
+  if (commandExists('npx')) {
+    const result = spawnSync('npx', ['-y', 'agent-skills-cli', ...commonArgs], {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    if (result.status === 0) return parseMarketplaceOutput((result.stdout || '') + (result.stderr || ''));
+  }
+
+  return null;
+}
+
+export function rankSkills(rawSkills: Array<RawSkill & { query: SearchQuery }>, keywords: string[], limit: number): RankedSkill[] {
+  const ranked = new Map<string, RankedSkill>();
+
+  for (let index = 0; index < rawSkills.length; index++) {
+    const raw = rawSkills[index];
+    const key = raw.scopedName || raw.githubUrl || `${raw.author}:${raw.name}`;
+    if (!key) continue;
+
+    const name = raw.name || 'unknown';
+    const description = raw.description || '';
+    const author = raw.author || 'unknown';
+    const scopedName = raw.scopedName || `@${author}/${name}`;
+    const githubUrl = raw.githubUrl || '';
+    const stars = raw.stars || 0;
+    const forks = raw.forks || 0;
+    const haystack = `${name} ${scopedName} ${description}`.toLowerCase();
+    const matchedKeywords = keywords.filter(keyword => haystack.includes(keyword.toLowerCase()));
+    const exactNameMatch = matchedKeywords.some(keyword =>
+      name.toLowerCase().includes(keyword) || scopedName.toLowerCase().includes(keyword)
+    );
+
+    const score =
+      Math.max(0, 100 - index * 3) +
+      matchedKeywords.length * 18 +
+      (exactNameMatch ? 20 : 0) +
+      (raw.query.source === 'keyword' ? 8 : 4) +
+      Math.min(18, Math.floor(Math.log10(stars + 1) * 6));
+
+    const next: RankedSkill = {
+      name,
+      description,
+      author,
+      scopedName,
+      githubUrl,
+      stars,
+      forks,
+      installCommand: `npx skills add ${scopedName}`,
+      matchedKeywords,
+      sourceQueries: [raw.query.text],
+      score,
+    };
+
+    const existing = ranked.get(key);
+    if (!existing || next.score > existing.score) {
+      ranked.set(key, existing
+        ? {
+            ...next,
+            sourceQueries: Array.from(new Set([...existing.sourceQueries, ...next.sourceQueries])),
+            matchedKeywords: Array.from(new Set([...existing.matchedKeywords, ...next.matchedKeywords])),
+          }
+        : next);
+    } else {
+      existing.sourceQueries = Array.from(new Set([...existing.sourceQueries, raw.query.text]));
+      existing.matchedKeywords = Array.from(new Set([...existing.matchedKeywords, ...next.matchedKeywords]));
+    }
+  }
+
+  return Array.from(ranked.values())
+    .sort((a, b) => b.score - a.score || b.stars - a.stars)
+    .slice(0, limit);
+}
+
+function formatText(response: SearchResponse): string {
+  if (response.status !== 'ok') {
+    return `Marketplace unavailable: ${response.reason ?? 'unknown reason'}`;
+  }
+  if (response.results.length === 0) {
+    return `No marketplace matches found for: ${response.query}`;
+  }
+  const lines = [`Marketplace matches for: ${response.query}`, ''];
+  response.results.forEach((result, index) => {
+    lines.push(`${index + 1}. ${result.scopedName} — ${result.description}`);
+    lines.push(`   Why: matched ${result.matchedKeywords.join(', ') || 'query context'}`);
+    lines.push(`   Install: ${result.installCommand}`);
+    if (result.githubUrl) lines.push(`   Source: ${result.githubUrl}`);
+  });
+  return lines.join('\n');
+}
+
+async function main() {
+  try {
+    const { query, explicitKeywords, limit, outputJson } = parseArgs(process.argv.slice(2));
+    const keywords = Array.from(new Set([
+      ...explicitKeywords.map(k => k.trim().toLowerCase()).filter(Boolean),
+      ...extractKeywords(query),
+    ])).slice(0, 6);
+    const queries = buildQueries(query, explicitKeywords);
+    const cacheKey = createHash('sha1')
+      .update(JSON.stringify({ query, keywords, limit }))
+      .digest('hex');
+
+    if (!process.env.GSTACK_MARKETPLACE_FIXTURE) {
+      const cached = readCache(cacheKey);
+      if (cached) {
+        console.log(outputJson ? JSON.stringify(cached, null, 2) : formatText(cached));
+        return;
+      }
+    }
+
+    const rawHits: Array<RawSkill & { query: SearchQuery }> = [];
+    for (const searchQuery of queries) {
+      const hits = runSearchQuery(searchQuery, Math.max(limit, 5));
+      if (!hits) continue;
+      for (const hit of hits) rawHits.push({ ...hit, query: searchQuery });
+    }
+
+    const response: SearchResponse = rawHits.length > 0
+      ? {
+          status: 'ok',
+          query,
+          keywords,
+          queries: queries.map(item => item.text),
+          results: rankSkills(rawHits, keywords, limit),
+        }
+      : {
+          status: 'unavailable',
+          query,
+          keywords,
+          queries: queries.map(item => item.text),
+          results: [],
+          reason: 'skills CLI unavailable or search failed',
+        };
+
+    if (!process.env.GSTACK_MARKETPLACE_FIXTURE) writeCache(cacheKey, response);
+    console.log(outputJson ? JSON.stringify(response, null, 2) : formatText(response));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -362,6 +362,36 @@ If browse is not available, that's fine — visual research is optional. The ski
 
 ---
 
+## External Skill Marketplace Check
+
+If `PROACTIVE` is `"false"`, skip this step entirely.
+
+Use this step when the user's request or current plan/design context clearly names a
+platform, vendor, framework, or tool that may already have a strong external skill in
+the Agent Skills / skills.sh marketplace.
+
+1. Extract 2-6 concrete technology keywords from the user's request or current plan/design context.
+2. Write the original request (or a short summary of the current plan/design) to a temp file:
+
+```bash
+TMP_QUERY=$(mktemp /tmp/gstack-marketplace-query-XXXX.txt)
+cat > "$TMP_QUERY" <<'EOF'
+[original user request or current plan/design summary]
+EOF
+~/.claude/skills/gstack/bin/gstack-marketplace-search --query-file "$TMP_QUERY" --keyword "keyword-1" --keyword "keyword-2" --limit 3 --json
+rm -f "$TMP_QUERY"
+```
+
+3. If the helper returns `"status": "ok"` with non-empty `results`, surface an
+   **External Skills Worth Considering** section with up to 3 results:
+   - scoped name
+   - one-line why it matches
+   - install command
+4. Never auto-install or auto-run marketplace skills. This step is recommendation-only.
+5. If the helper returns `unavailable` or no results, continue silently.
+6. If a gstack built-in skill already covers the need well, prefer the gstack skill and
+   present the external result only as optional context.
+
 ## Phase 1: Product Context
 
 Ask the user a single question that covers everything you need to know. Pre-fill what you can infer from the codebase.

--- a/design-consultation/SKILL.md.tmpl
+++ b/design-consultation/SKILL.md.tmpl
@@ -69,6 +69,8 @@ If browse is not available, that's fine — visual research is optional. The ski
 
 ---
 
+{{MARKETPLACE_SKILL_DISCOVERY}}
+
 ## Phase 1: Product Context
 
 Ask the user a single question that covers everything you need to know. Pre-fill what you can infer from the codebase.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -9,6 +9,7 @@ Detailed guides for every gstack skill — philosophy, workflow, and examples.
 | [`/plan-eng-review`](#plan-eng-review) | **Eng Manager** | Lock in architecture, data flow, diagrams, edge cases, and tests. Forces hidden assumptions into the open. |
 | [`/plan-design-review`](#plan-design-review) | **Senior Designer** | Interactive plan-mode design review. Rates each dimension 0-10, explains what a 10 looks like, fixes the plan. Works in plan mode. |
 | [`/design-consultation`](#design-consultation) | **Design Partner** | Build a complete design system from scratch. Knows the landscape, proposes creative risks, generates realistic product mockups. Design at the heart of all other phases. |
+| [`/find-skills`](#find-skills) | **Marketplace Search** | Query Agent Skills / skills.sh for the best external vendor/framework-specific skills and copyable install commands. |
 | [`/review`](#review) | **Staff Engineer** | Find the bugs that pass CI but blow up in production. Auto-fixes the obvious ones. Flags completeness gaps. |
 | [`/investigate`](#investigate) | **Debugger** | Systematic root-cause debugging. Iron Law: no fixes without investigation. Traces data flow, tests hypotheses, stops after 3 failed fixes. |
 | [`/design-review`](#design-review) | **Designer Who Codes** | Live-site visual audit + fix loop. 80-item audit, then fixes what it finds. Atomic commits, before/after screenshots. |
@@ -87,6 +88,30 @@ Recommends A because you learn from real usage. CRM data comes naturally in week
 Both modes end with a design doc written to `~/.gstack/projects/` — and that doc feeds directly into `/plan-ceo-review` and `/plan-eng-review`. The full lifecycle is now: `office-hours → plan → implement → review → QA → ship → retro`.
 
 After the design doc is approved, `/office-hours` reflects on what it noticed about how you think — not generic praise, but specific callbacks to things you said during the session. The observations appear in the design doc too, so you re-encounter them when you re-read later.
+
+---
+
+## `/find-skills`
+
+This is the manual parity path for the external marketplace.
+
+Sometimes the right next step is not another built-in gstack workflow skill, but a
+specialized external skill published by the vendor or ecosystem you are working in.
+That is what `/find-skills` is for.
+
+Give it a query like:
+
+- `supabase auth nextjs`
+- `vercel deployment`
+- `azure cli`
+- `github cli workflow automation`
+
+It runs the marketplace search, dedupes the results, ranks the best matches, and gives
+you copy-paste install commands. It never auto-installs anything — recommendation only.
+
+This is also the manual fallback for the new planning/design marketplace recommendation
+layer. If an automatic planning flow mentions an external skill and you want to dig
+deeper, `/find-skills` is the direct command to use.
 
 ---
 

--- a/find-skills/SKILL.md
+++ b/find-skills/SKILL.md
@@ -1,24 +1,15 @@
 ---
-name: gstack
-version: 1.1.0
+name: find-skills
+version: 1.0.0
 description: |
-  Fast headless browser for QA testing and site dogfooding. Navigate pages, interact with
-  elements, verify state, diff before/after, take annotated screenshots, test responsive
-  layouts, forms, uploads, dialogs, and capture bug evidence. Use when asked to open or
-  test a site, verify a deployment, dogfood a user flow, or file a bug with screenshots.
-  Also suggest adjacent gstack skills by stage: brainstorm /office-hours; strategy
-  /plan-ceo-review; architecture /plan-eng-review; design /plan-design-review or
-  /design-consultation; external marketplace /find-skills; auto-review /autoplan; debugging /investigate; QA /qa; code review
-  /review; visual audit /design-review; shipping /ship; docs /document-release; retro
-  /retro; second opinion /codex; prod safety /careful or /guard; scoped edits /freeze or
-  /unfreeze; gstack upgrades /gstack-upgrade. If the user opts out of suggestions, stop
-  and run gstack-config set proactive false; if they opt back in, run gstack-config set
-  proactive true.
+  Find external agent skills from the Agent Skills / skills.sh marketplace for a given
+  technology or workflow query. Use when asked to "find a skill for X", "search skills
+  for supabase/vercel/azure/github cli", or "what external skill should I install".
+  Proactively suggest when the user asks for vendor-specific help that gstack does not
+  directly provide as a built-in workflow skill.
 allowed-tools:
   - Bash
-  - Read
   - AskUserQuestion
-
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->
@@ -49,7 +40,7 @@ _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"gstack","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+echo '{"skill":"find-skills","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
 for _PF in $(find ~/.gstack/analytics -maxdepth 1 -name '.pending-*' 2>/dev/null); do [ -f "$_PF" ] && ~/.claude/skills/gstack/bin/gstack-telemetry-log --event-type skill_run --skill _pending_finalize --outcome unknown --session-id "$_SESSION_ID" 2>/dev/null || true; break; done
 ```
@@ -299,370 +290,49 @@ Then write a `## GSTACK REVIEW REPORT` section to the end of the plan file:
 file you are allowed to edit in plan mode. The plan file review report is part of the
 plan's living status.
 
-If `PROACTIVE` is `false`: do NOT proactively suggest other gstack skills during this session.
-Only run skills the user explicitly invokes. This preference persists across sessions via
-`gstack-config`.
+# /find-skills
 
-# gstack browse: QA Testing & Dogfooding
+Find the best external marketplace skills for the user's current need.
 
-Persistent headless Chromium. First call auto-starts (~3s), then ~100-200ms per command.
-Auto-shuts down after 30 min idle. State persists between calls (cookies, tabs, sessions).
+**HARD GATE:** Recommendation-only. Do NOT auto-install or auto-run third-party skills.
 
-## SETUP (run this check BEFORE any browse command)
+## Workflow
 
-```bash
-_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-B=""
-[ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
-[ -z "$B" ] && B=~/.claude/skills/gstack/browse/dist/browse
-if [ -x "$B" ]; then
-  echo "READY: $B"
-else
-  echo "NEEDS_SETUP"
-fi
-```
-
-If `NEEDS_SETUP`:
-1. Tell the user: "gstack browse needs a one-time build (~10 seconds). OK to proceed?" Then STOP and wait.
-2. Run: `cd <SKILL_DIR> && ./setup`
-3. If `bun` is not installed: `curl -fsSL https://bun.sh/install | bash`
-
-## IMPORTANT
-
-- Use the compiled binary via Bash: `$B <command>`
-- NEVER use `mcp__claude-in-chrome__*` tools. They are slow and unreliable.
-- Browser persists between calls — cookies, login sessions, and tabs carry over.
-- Dialogs (alert/confirm/prompt) are auto-accepted by default — no browser lockup.
-- **Show screenshots:** After `$B screenshot`, `$B snapshot -a -o`, or `$B responsive`, always use the Read tool on the output PNG(s) so the user can see them. Without this, screenshots are invisible.
-
-## QA Workflows
-
-### Test a user flow (login, signup, checkout, etc.)
+1. If the user already gave a clear query, use it.
+2. If the query is vague, ask one AskUserQuestion to sharpen the technology/workflow target.
+3. Extract 2-6 concrete technology keywords from the request.
+4. Write the request to a temp file and run:
 
 ```bash
-# 1. Go to the page
-$B goto https://app.example.com/login
-
-# 2. See what's interactive
-$B snapshot -i
-
-# 3. Fill the form using refs
-$B fill @e3 "test@example.com"
-$B fill @e4 "password123"
-$B click @e5
-
-# 4. Verify it worked
-$B snapshot -D              # diff shows what changed after clicking
-$B is visible ".dashboard"  # assert the dashboard appeared
-$B screenshot /tmp/after-login.png
+TMP_QUERY=$(mktemp /tmp/gstack-marketplace-query-XXXX.txt)
+cat > "$TMP_QUERY" <<'EOF'
+[user query]
+EOF
+~/.claude/skills/gstack/bin/gstack-marketplace-search --query-file "$TMP_QUERY" --keyword "keyword-1" --keyword "keyword-2" --limit 5 --json
+rm -f "$TMP_QUERY"
 ```
 
-### Verify a deployment / check prod
+5. Present the top matches as:
+   - scoped name
+   - one-line why it matches
+   - install command
+   - source repo URL
 
-```bash
-$B goto https://yourapp.com
-$B text                          # read the page — does it load?
-$B console                       # any JS errors?
-$B network                       # any failed requests?
-$B js "document.title"           # correct title?
-$B is visible ".hero-section"    # key elements present?
-$B screenshot /tmp/prod-check.png
+6. If no results exist, say so plainly and suggest refining the query.
+7. If the marketplace CLI is unavailable, say so plainly and continue without error.
+
+## Output format
+
+Use this structure:
+
+```markdown
+## External Skills Worth Considering
+
+1. `@scope/name`
+   Why: {1 sentence}
+   Install: `npx skills add @scope/name`
+   Source: {github url}
 ```
 
-### Dogfood a feature end-to-end
-
-```bash
-# Navigate to the feature
-$B goto https://app.example.com/new-feature
-
-# Take annotated screenshot — shows every interactive element with labels
-$B snapshot -i -a -o /tmp/feature-annotated.png
-
-# Find ALL clickable things (including divs with cursor:pointer)
-$B snapshot -C
-
-# Walk through the flow
-$B snapshot -i          # baseline
-$B click @e3            # interact
-$B snapshot -D          # what changed? (unified diff)
-
-# Check element states
-$B is visible ".success-toast"
-$B is enabled "#next-step-btn"
-$B is checked "#agree-checkbox"
-
-# Check console for errors after interactions
-$B console
-```
-
-### Test responsive layouts
-
-```bash
-# Quick: 3 screenshots at mobile/tablet/desktop
-$B goto https://yourapp.com
-$B responsive /tmp/layout
-
-# Manual: specific viewport
-$B viewport 375x812     # iPhone
-$B screenshot /tmp/mobile.png
-$B viewport 1440x900    # Desktop
-$B screenshot /tmp/desktop.png
-
-# Element screenshot (crop to specific element)
-$B screenshot "#hero-banner" /tmp/hero.png
-$B snapshot -i
-$B screenshot @e3 /tmp/button.png
-
-# Region crop
-$B screenshot --clip 0,0,800,600 /tmp/above-fold.png
-
-# Viewport only (no scroll)
-$B screenshot --viewport /tmp/viewport.png
-```
-
-### Test file upload
-
-```bash
-$B goto https://app.example.com/upload
-$B snapshot -i
-$B upload @e3 /path/to/test-file.pdf
-$B is visible ".upload-success"
-$B screenshot /tmp/upload-result.png
-```
-
-### Test forms with validation
-
-```bash
-$B goto https://app.example.com/form
-$B snapshot -i
-
-# Submit empty — check validation errors appear
-$B click @e10                        # submit button
-$B snapshot -D                       # diff shows error messages appeared
-$B is visible ".error-message"
-
-# Fill and resubmit
-$B fill @e3 "valid input"
-$B click @e10
-$B snapshot -D                       # diff shows errors gone, success state
-```
-
-### Test dialogs (delete confirmations, prompts)
-
-```bash
-# Set up dialog handling BEFORE triggering
-$B dialog-accept              # will auto-accept next alert/confirm
-$B click "#delete-button"     # triggers confirmation dialog
-$B dialog                     # see what dialog appeared
-$B snapshot -D                # verify the item was deleted
-
-# For prompts that need input
-$B dialog-accept "my answer"  # accept with text
-$B click "#rename-button"     # triggers prompt
-```
-
-### Test authenticated pages (import real browser cookies)
-
-```bash
-# Import cookies from your real browser (opens interactive picker)
-$B cookie-import-browser
-
-# Or import a specific domain directly
-$B cookie-import-browser comet --domain .github.com
-
-# Now test authenticated pages
-$B goto https://github.com/settings/profile
-$B snapshot -i
-$B screenshot /tmp/github-profile.png
-```
-
-### Compare two pages / environments
-
-```bash
-$B diff https://staging.app.com https://prod.app.com
-```
-
-### Multi-step chain (efficient for long flows)
-
-```bash
-echo '[
-  ["goto","https://app.example.com"],
-  ["snapshot","-i"],
-  ["fill","@e3","test@test.com"],
-  ["fill","@e4","password"],
-  ["click","@e5"],
-  ["snapshot","-D"],
-  ["screenshot","/tmp/result.png"]
-]' | $B chain
-```
-
-## Quick Assertion Patterns
-
-```bash
-# Element exists and is visible
-$B is visible ".modal"
-
-# Button is enabled/disabled
-$B is enabled "#submit-btn"
-$B is disabled "#submit-btn"
-
-# Checkbox state
-$B is checked "#agree"
-
-# Input is editable
-$B is editable "#name-field"
-
-# Element has focus
-$B is focused "#search-input"
-
-# Page contains text
-$B js "document.body.textContent.includes('Success')"
-
-# Element count
-$B js "document.querySelectorAll('.list-item').length"
-
-# Specific attribute value
-$B attrs "#logo"    # returns all attributes as JSON
-
-# CSS property
-$B css ".button" "background-color"
-```
-
-## Snapshot System
-
-The snapshot is your primary tool for understanding and interacting with pages.
-
-```
--i        --interactive           Interactive elements only (buttons, links, inputs) with @e refs
--c        --compact               Compact (no empty structural nodes)
--d <N>    --depth                 Limit tree depth (0 = root only, default: unlimited)
--s <sel>  --selector              Scope to CSS selector
--D        --diff                  Unified diff against previous snapshot (first call stores baseline)
--a        --annotate              Annotated screenshot with red overlay boxes and ref labels
--o <path> --output                Output path for annotated screenshot (default: <temp>/browse-annotated.png)
--C        --cursor-interactive    Cursor-interactive elements (@c refs — divs with pointer, onclick)
-```
-
-All flags can be combined freely. `-o` only applies when `-a` is also used.
-Example: `$B snapshot -i -a -C -o /tmp/annotated.png`
-
-**Ref numbering:** @e refs are assigned sequentially (@e1, @e2, ...) in tree order.
-@c refs from `-C` are numbered separately (@c1, @c2, ...).
-
-After snapshot, use @refs as selectors in any command:
-```bash
-$B click @e3       $B fill @e4 "value"     $B hover @e1
-$B html @e2        $B css @e5 "color"      $B attrs @e6
-$B click @c1       # cursor-interactive ref (from -C)
-```
-
-**Output format:** indented accessibility tree with @ref IDs, one element per line.
-```
-  @e1 [heading] "Welcome" [level=1]
-  @e2 [textbox] "Email"
-  @e3 [button] "Submit"
-```
-
-Refs are invalidated on navigation — run `snapshot` again after `goto`.
-
-## Command Reference
-
-### Navigation
-| Command | Description |
-|---------|-------------|
-| `back` | History back |
-| `forward` | History forward |
-| `goto <url>` | Navigate to URL |
-| `reload` | Reload page |
-| `url` | Print current URL |
-
-### Reading
-| Command | Description |
-|---------|-------------|
-| `accessibility` | Full ARIA tree |
-| `forms` | Form fields as JSON |
-| `html [selector]` | innerHTML of selector (throws if not found), or full page HTML if no selector given |
-| `links` | All links as "text → href" |
-| `text` | Cleaned page text |
-
-### Interaction
-| Command | Description |
-|---------|-------------|
-| `click <sel>` | Click element |
-| `cookie <name>=<value>` | Set cookie on current page domain |
-| `cookie-import <json>` | Import cookies from JSON file |
-| `cookie-import-browser [browser] [--domain d]` | Import cookies from Comet, Chrome, Arc, Brave, or Edge (opens picker, or use --domain for direct import) |
-| `dialog-accept [text]` | Auto-accept next alert/confirm/prompt. Optional text is sent as the prompt response |
-| `dialog-dismiss` | Auto-dismiss next dialog |
-| `fill <sel> <val>` | Fill input |
-| `header <name>:<value>` | Set custom request header (colon-separated, sensitive values auto-redacted) |
-| `hover <sel>` | Hover element |
-| `press <key>` | Press key — Enter, Tab, Escape, ArrowUp/Down/Left/Right, Backspace, Delete, Home, End, PageUp, PageDown, or modifiers like Shift+Enter |
-| `scroll [sel]` | Scroll element into view, or scroll to page bottom if no selector |
-| `select <sel> <val>` | Select dropdown option by value, label, or visible text |
-| `type <text>` | Type into focused element |
-| `upload <sel> <file> [file2...]` | Upload file(s) |
-| `useragent <string>` | Set user agent |
-| `viewport <WxH>` | Set viewport size |
-| `wait <sel|--networkidle|--load>` | Wait for element, network idle, or page load (timeout: 15s) |
-
-### Inspection
-| Command | Description |
-|---------|-------------|
-| `attrs <sel|@ref>` | Element attributes as JSON |
-| `console [--clear|--errors]` | Console messages (--errors filters to error/warning) |
-| `cookies` | All cookies as JSON |
-| `css <sel> <prop>` | Computed CSS value |
-| `dialog [--clear]` | Dialog messages |
-| `eval <file>` | Run JavaScript from file and return result as string (path must be under /tmp or cwd) |
-| `is <prop> <sel>` | State check (visible/hidden/enabled/disabled/checked/editable/focused) |
-| `js <expr>` | Run JavaScript expression and return result as string |
-| `network [--clear]` | Network requests |
-| `perf` | Page load timings |
-| `storage [set k v]` | Read all localStorage + sessionStorage as JSON, or set <key> <value> to write localStorage |
-
-### Visual
-| Command | Description |
-|---------|-------------|
-| `diff <url1> <url2>` | Text diff between pages |
-| `pdf [path]` | Save as PDF |
-| `responsive [prefix]` | Screenshots at mobile (375x812), tablet (768x1024), desktop (1280x720). Saves as {prefix}-mobile.png etc. |
-| `screenshot [--viewport] [--clip x,y,w,h] [selector|@ref] [path]` | Save screenshot (supports element crop via CSS/@ref, --clip region, --viewport) |
-
-### Snapshot
-| Command | Description |
-|---------|-------------|
-| `snapshot [flags]` | Accessibility tree with @e refs for element selection. Flags: -i interactive only, -c compact, -d N depth limit, -s sel scope, -D diff vs previous, -a annotated screenshot, -o path output, -C cursor-interactive @c refs |
-
-### Meta
-| Command | Description |
-|---------|-------------|
-| `chain` | Run commands from JSON stdin. Format: [["cmd","arg1",...],...] |
-
-### Tabs
-| Command | Description |
-|---------|-------------|
-| `closetab [id]` | Close tab |
-| `newtab [url]` | Open new tab |
-| `tab <id>` | Switch to tab |
-| `tabs` | List open tabs |
-
-### Server
-| Command | Description |
-|---------|-------------|
-| `handoff [message]` | Open visible Chrome at current page for user takeover |
-| `restart` | Restart server |
-| `resume` | Re-snapshot after user takeover, return control to AI |
-| `status` | Health check |
-| `stop` | Shutdown server |
-
-## Tips
-
-1. **Navigate once, query many times.** `goto` loads the page; then `text`, `js`, `screenshot` all hit the loaded page instantly.
-2. **Use `snapshot -i` first.** See all interactive elements, then click/fill by ref. No CSS selector guessing.
-3. **Use `snapshot -D` to verify.** Baseline → action → diff. See exactly what changed.
-4. **Use `is` for assertions.** `is visible .modal` is faster and more reliable than parsing page text.
-5. **Use `snapshot -a` for evidence.** Annotated screenshots are great for bug reports.
-6. **Use `snapshot -C` for tricky UIs.** Finds clickable divs that the accessibility tree misses.
-7. **Check `console` after actions.** Catch JS errors that don't surface visually.
-8. **Use `chain` for long flows.** Single command, no per-step CLI overhead.
+If gstack already has a strong built-in skill for the same need, say that first, then
+present external skills as optional complements.

--- a/find-skills/SKILL.md.tmpl
+++ b/find-skills/SKILL.md.tmpl
@@ -1,0 +1,62 @@
+---
+name: find-skills
+version: 1.0.0
+description: |
+  Find external agent skills from the Agent Skills / skills.sh marketplace for a given
+  technology or workflow query. Use when asked to "find a skill for X", "search skills
+  for supabase/vercel/azure/github cli", or "what external skill should I install".
+  Proactively suggest when the user asks for vendor-specific help that gstack does not
+  directly provide as a built-in workflow skill.
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+{{PREAMBLE}}
+
+# /find-skills
+
+Find the best external marketplace skills for the user's current need.
+
+**HARD GATE:** Recommendation-only. Do NOT auto-install or auto-run third-party skills.
+
+## Workflow
+
+1. If the user already gave a clear query, use it.
+2. If the query is vague, ask one AskUserQuestion to sharpen the technology/workflow target.
+3. Extract 2-6 concrete technology keywords from the request.
+4. Write the request to a temp file and run:
+
+```bash
+TMP_QUERY=$(mktemp /tmp/gstack-marketplace-query-XXXX.txt)
+cat > "$TMP_QUERY" <<'EOF'
+[user query]
+EOF
+~/.claude/skills/gstack/bin/gstack-marketplace-search --query-file "$TMP_QUERY" --keyword "keyword-1" --keyword "keyword-2" --limit 5 --json
+rm -f "$TMP_QUERY"
+```
+
+5. Present the top matches as:
+   - scoped name
+   - one-line why it matches
+   - install command
+   - source repo URL
+
+6. If no results exist, say so plainly and suggest refining the query.
+7. If the marketplace CLI is unavailable, say so plainly and continue without error.
+
+## Output format
+
+Use this structure:
+
+```markdown
+## External Skills Worth Considering
+
+1. `@scope/name`
+   Why: {1 sentence}
+   Install: `npx skills add @scope/name`
+   Source: {github url}
+```
+
+If gstack already has a strong built-in skill for the same need, say that first, then
+present external skills as optional complements.

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -368,6 +368,36 @@ eval "$(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)"
 
 Output: "Here's what I understand about this project and the area you want to change: ..."
 
+## External Skill Marketplace Check
+
+If `PROACTIVE` is `"false"`, skip this step entirely.
+
+Use this step when the user's request or current plan/design context clearly names a
+platform, vendor, framework, or tool that may already have a strong external skill in
+the Agent Skills / skills.sh marketplace.
+
+1. Extract 2-6 concrete technology keywords from the user's request or current plan/design context.
+2. Write the original request (or a short summary of the current plan/design) to a temp file:
+
+```bash
+TMP_QUERY=$(mktemp /tmp/gstack-marketplace-query-XXXX.txt)
+cat > "$TMP_QUERY" <<'EOF'
+[original user request or current plan/design summary]
+EOF
+~/.claude/skills/gstack/bin/gstack-marketplace-search --query-file "$TMP_QUERY" --keyword "keyword-1" --keyword "keyword-2" --limit 3 --json
+rm -f "$TMP_QUERY"
+```
+
+3. If the helper returns `"status": "ok"` with non-empty `results`, surface an
+   **External Skills Worth Considering** section with up to 3 results:
+   - scoped name
+   - one-line why it matches
+   - install command
+4. Never auto-install or auto-run marketplace skills. This step is recommendation-only.
+5. If the helper returns `unavailable` or no results, continue silently.
+6. If a gstack built-in skill already covers the need well, prefer the gstack skill and
+   present the external result only as optional context.
+
 ---
 
 ## Phase 2A: Startup Mode — YC Product Diagnostic

--- a/office-hours/SKILL.md.tmpl
+++ b/office-hours/SKILL.md.tmpl
@@ -75,6 +75,8 @@ Understand the project and the area the user wants to change.
 
 Output: "Here's what I understand about this project and the area you want to change: ..."
 
+{{MARKETPLACE_SKILL_DISCOVERY}}
+
 ---
 
 ## Phase 2A: Startup Mode — YC Product Diagnostic

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -420,6 +420,36 @@ the handoff note to inform your analysis and avoid redundant questions.
 Tell the user: "Found a handoff note from your prior CEO review session. I'll use that
 context to pick up where we left off."
 
+## External Skill Marketplace Check
+
+If `PROACTIVE` is `"false"`, skip this step entirely.
+
+Use this step when the user's request or current plan/design context clearly names a
+platform, vendor, framework, or tool that may already have a strong external skill in
+the Agent Skills / skills.sh marketplace.
+
+1. Extract 2-6 concrete technology keywords from the user's request or current plan/design context.
+2. Write the original request (or a short summary of the current plan/design) to a temp file:
+
+```bash
+TMP_QUERY=$(mktemp /tmp/gstack-marketplace-query-XXXX.txt)
+cat > "$TMP_QUERY" <<'EOF'
+[original user request or current plan/design summary]
+EOF
+~/.claude/skills/gstack/bin/gstack-marketplace-search --query-file "$TMP_QUERY" --keyword "keyword-1" --keyword "keyword-2" --limit 3 --json
+rm -f "$TMP_QUERY"
+```
+
+3. If the helper returns `"status": "ok"` with non-empty `results`, surface an
+   **External Skills Worth Considering** section with up to 3 results:
+   - scoped name
+   - one-line why it matches
+   - install command
+4. Never auto-install or auto-run marketplace skills. This step is recommendation-only.
+5. If the helper returns `unavailable` or no results, continue silently.
+6. If a gstack built-in skill already covers the need well, prefer the gstack skill and
+   present the external result only as optional context.
+
 ## Prerequisite Skill Offer
 
 When the design doc check above prints "No design doc found," offer the prerequisite

--- a/plan-ceo-review/SKILL.md.tmpl
+++ b/plan-ceo-review/SKILL.md.tmpl
@@ -127,6 +127,8 @@ the handoff note to inform your analysis and avoid redundant questions.
 Tell the user: "Found a handoff note from your prior CEO review session. I'll use that
 context to pick up where we left off."
 
+{{MARKETPLACE_SKILL_DISCOVERY}}
+
 {{BENEFITS_FROM}}
 
 **Mid-session detection:** During Step 0A (Premise Challenge), if the user can't

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -400,6 +400,36 @@ Analyze the plan. If it involves NONE of: new UI screens/pages, changes to exist
 
 Report findings before proceeding to Step 0.
 
+## External Skill Marketplace Check
+
+If `PROACTIVE` is `"false"`, skip this step entirely.
+
+Use this step when the user's request or current plan/design context clearly names a
+platform, vendor, framework, or tool that may already have a strong external skill in
+the Agent Skills / skills.sh marketplace.
+
+1. Extract 2-6 concrete technology keywords from the user's request or current plan/design context.
+2. Write the original request (or a short summary of the current plan/design) to a temp file:
+
+```bash
+TMP_QUERY=$(mktemp /tmp/gstack-marketplace-query-XXXX.txt)
+cat > "$TMP_QUERY" <<'EOF'
+[original user request or current plan/design summary]
+EOF
+~/.claude/skills/gstack/bin/gstack-marketplace-search --query-file "$TMP_QUERY" --keyword "keyword-1" --keyword "keyword-2" --limit 3 --json
+rm -f "$TMP_QUERY"
+```
+
+3. If the helper returns `"status": "ok"` with non-empty `results`, surface an
+   **External Skills Worth Considering** section with up to 3 results:
+   - scoped name
+   - one-line why it matches
+   - install command
+4. Never auto-install or auto-run marketplace skills. This step is recommendation-only.
+5. If the helper returns `unavailable` or no results, continue silently.
+6. If a gstack built-in skill already covers the need well, prefer the gstack skill and
+   present the external result only as optional context.
+
 ## Step 0: Design Scope Assessment
 
 ### 0A. Initial Design Rating

--- a/plan-design-review/SKILL.md.tmpl
+++ b/plan-design-review/SKILL.md.tmpl
@@ -107,6 +107,8 @@ Analyze the plan. If it involves NONE of: new UI screens/pages, changes to exist
 
 Report findings before proceeding to Step 0.
 
+{{MARKETPLACE_SKILL_DISCOVERY}}
+
 ## Step 0: Design Scope Assessment
 
 ### 0A. Initial Design Rating

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -351,6 +351,36 @@ DESIGN=$(ls -t ~/.gstack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | head
 ```
 If a design doc exists, read it. Use it as the source of truth for the problem statement, constraints, and chosen approach. If it has a `Supersedes:` field, note that this is a revised design — check the prior version for context on what changed and why.
 
+## External Skill Marketplace Check
+
+If `PROACTIVE` is `"false"`, skip this step entirely.
+
+Use this step when the user's request or current plan/design context clearly names a
+platform, vendor, framework, or tool that may already have a strong external skill in
+the Agent Skills / skills.sh marketplace.
+
+1. Extract 2-6 concrete technology keywords from the user's request or current plan/design context.
+2. Write the original request (or a short summary of the current plan/design) to a temp file:
+
+```bash
+TMP_QUERY=$(mktemp /tmp/gstack-marketplace-query-XXXX.txt)
+cat > "$TMP_QUERY" <<'EOF'
+[original user request or current plan/design summary]
+EOF
+~/.claude/skills/gstack/bin/gstack-marketplace-search --query-file "$TMP_QUERY" --keyword "keyword-1" --keyword "keyword-2" --limit 3 --json
+rm -f "$TMP_QUERY"
+```
+
+3. If the helper returns `"status": "ok"` with non-empty `results`, surface an
+   **External Skills Worth Considering** section with up to 3 results:
+   - scoped name
+   - one-line why it matches
+   - install command
+4. Never auto-install or auto-run marketplace skills. This step is recommendation-only.
+5. If the helper returns `unavailable` or no results, continue silently.
+6. If a gstack built-in skill already covers the need well, prefer the gstack skill and
+   present the external result only as optional context.
+
 ## Prerequisite Skill Offer
 
 When the design doc check above prints "No design doc found," offer the prerequisite

--- a/plan-eng-review/SKILL.md.tmpl
+++ b/plan-eng-review/SKILL.md.tmpl
@@ -75,6 +75,8 @@ DESIGN=$(ls -t ~/.gstack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | head
 ```
 If a design doc exists, read it. Use it as the source of truth for the problem statement, constraints, and chosen approach. If it has a `Supersedes:` field, note that this is a revised design — check the prior version for context on what changed and why.
 
+{{MARKETPLACE_SKILL_DISCOVERY}}
+
 {{BENEFITS_FROM}}
 
 ### Step 0: Scope Challenge

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -2797,9 +2797,42 @@ function generateSlugSetup(ctx: TemplateContext): string {
   return `eval "$(${ctx.paths.binDir}/gstack-slug 2>/dev/null)" && mkdir -p ~/.gstack/projects/$SLUG`;
 }
 
+function generateMarketplaceSkillDiscovery(ctx: TemplateContext): string {
+  return `## External Skill Marketplace Check
+
+If \`PROACTIVE\` is \`"false"\`, skip this step entirely.
+
+Use this step when the user's request or current plan/design context clearly names a
+platform, vendor, framework, or tool that may already have a strong external skill in
+the Agent Skills / skills.sh marketplace.
+
+1. Extract 2-6 concrete technology keywords from the user's request or current plan/design context.
+2. Write the original request (or a short summary of the current plan/design) to a temp file:
+
+\`\`\`bash
+TMP_QUERY=$(mktemp /tmp/gstack-marketplace-query-XXXX.txt)
+cat > "$TMP_QUERY" <<'EOF'
+[original user request or current plan/design summary]
+EOF
+${ctx.paths.binDir}/gstack-marketplace-search --query-file "$TMP_QUERY" --keyword "keyword-1" --keyword "keyword-2" --limit 3 --json
+rm -f "$TMP_QUERY"
+\`\`\`
+
+3. If the helper returns \`"status": "ok"\` with non-empty \`results\`, surface an
+   **External Skills Worth Considering** section with up to 3 results:
+   - scoped name
+   - one-line why it matches
+   - install command
+4. Never auto-install or auto-run marketplace skills. This step is recommendation-only.
+5. If the helper returns \`unavailable\` or no results, continue silently.
+6. If a gstack built-in skill already covers the need well, prefer the gstack skill and
+   present the external result only as optional context.`;
+}
+
 const RESOLVERS: Record<string, (ctx: TemplateContext) => string> = {
   SLUG_EVAL: generateSlugEval,
   SLUG_SETUP: generateSlugSetup,
+  MARKETPLACE_SKILL_DISCOVERY: generateMarketplaceSkillDiscovery,
   COMMAND_REFERENCE: generateCommandReference,
   SNAPSHOT_FLAGS: generateSnapshotFlags,
   PREAMBLE: generatePreamble,

--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -27,6 +27,7 @@ const SKILL_FILES = [
   'plan-ceo-review/SKILL.md',
   'plan-eng-review/SKILL.md',
   'setup-browser-cookies/SKILL.md',
+  'find-skills/SKILL.md',
   'plan-design-review/SKILL.md',
   'design-review/SKILL.md',
   'gstack-upgrade/SKILL.md',

--- a/test/marketplace-search.test.ts
+++ b/test/marketplace-search.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { spawnSync } from "child_process";
+import { extractKeywords, parseMarketplaceOutput, rankSkills } from "../bin/gstack-marketplace-search.ts";
+
+const scriptPath = join(import.meta.dir, "..", "bin", "gstack-marketplace-search.ts");
+
+describe("gstack-marketplace-search", () => {
+  test("extractKeywords finds common platform terms", () => {
+    const keywords = extractKeywords("Build a Next.js app on Vercel with Supabase auth and GitHub CLI deploy scripts");
+    expect(keywords).toContain("nextjs");
+    expect(keywords).toContain("vercel");
+    expect(keywords).toContain("supabase");
+    expect(keywords).toContain("github cli");
+  });
+
+  test("parseMarketplaceOutput strips prelude noise before JSON", () => {
+    const raw = `- Searching marketplace...\n{\"skills\":[{\"name\":\"supabase\",\"author\":\"supabase\",\"description\":\"Use Supabase\",\"stars\":100,\"forks\":10,\"githubUrl\":\"https://github.com/supabase/agent-skills/tree/main/skills/supabase\",\"scopedName\":\"@supabase/supabase\"}]}`;
+    const skills = parseMarketplaceOutput(raw);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].scopedName).toBe("@supabase/supabase");
+  });
+
+  test("rankSkills dedupes duplicate scoped names and prefers exact matches", () => {
+    const ranked = rankSkills([
+      {
+        name: "supabase",
+        description: "Supabase auth and database",
+        author: "supabase",
+        stars: 100,
+        forks: 10,
+        githubUrl: "https://github.com/supabase/agent-skills/tree/main/skills/supabase",
+        scopedName: "@supabase/supabase",
+        query: { text: "supabase", source: "keyword" as const },
+      },
+      {
+        name: "postgres-patterns",
+        description: "Postgres optimization",
+        author: "someone",
+        stars: 1000,
+        forks: 10,
+        githubUrl: "https://github.com/someone/postgres-patterns",
+        scopedName: "@someone/postgres-patterns",
+        query: { text: "supabase", source: "full" as const },
+      },
+      {
+        name: "supabase",
+        description: "Duplicate entry",
+        author: "supabase",
+        stars: 90,
+        forks: 9,
+        githubUrl: "https://github.com/supabase/agent-skills/tree/main/skills/supabase",
+        scopedName: "@supabase/supabase",
+        query: { text: "vercel", source: "keyword" as const },
+      },
+    ], ["supabase", "vercel"], 5);
+
+    expect(ranked).toHaveLength(2);
+    expect(ranked[0].scopedName).toBe("@supabase/supabase");
+    expect(ranked[0].sourceQueries).toContain("supabase");
+    expect(ranked[0].matchedKeywords).toContain("supabase");
+  });
+
+  test("CLI mode returns normalized JSON from fixture input", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "gstack-marketplace-"));
+    const fixture = join(tempDir, "fixture.json");
+    writeFileSync(fixture, `- Searching marketplace...\n${JSON.stringify({
+      skills: [
+        {
+          name: "nextjs-supabase-auth",
+          description: "Expert integration of Supabase Auth with Next.js",
+          author: "sickn33",
+          stars: 200,
+          forks: 50,
+          githubUrl: "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/nextjs-supabase-auth",
+          scopedName: "@sickn33/nextjs-supabase-auth",
+        },
+        {
+          name: "vercel-deploy",
+          description: "Deploy apps to Vercel",
+          author: "vercel",
+          stars: 150,
+          forks: 20,
+          githubUrl: "https://github.com/vercel/skills/tree/main/skills/vercel-deploy",
+          scopedName: "@vercel/vercel-deploy",
+        },
+      ],
+    })}`);
+
+    const result = spawnSync("bun", [
+      "run",
+      scriptPath,
+      "--query",
+      "Build a Next.js app on Vercel with Supabase auth",
+      "--keyword",
+      "nextjs",
+      "--keyword",
+      "vercel",
+      "--keyword",
+      "supabase",
+      "--json",
+    ], {
+      env: { ...process.env, GSTACK_MARKETPLACE_FIXTURE: fixture },
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+
+    rmSync(tempDir, { recursive: true, force: true });
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.status).toBe("ok");
+    expect(json.results.length).toBeGreaterThan(0);
+    expect(json.results[0]).toHaveProperty("installCommand");
+  });
+});

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -546,6 +546,7 @@ describe('v0.4.1 preamble features', () => {
     'SKILL.md', 'browse/SKILL.md', 'qa/SKILL.md',
     'qa-only/SKILL.md',
     'setup-browser-cookies/SKILL.md',
+    'find-skills/SKILL.md',
     'ship/SKILL.md', 'review/SKILL.md',
     'plan-ceo-review/SKILL.md', 'plan-eng-review/SKILL.md',
     'retro/SKILL.md',
@@ -728,6 +729,43 @@ describe('investigate skill structure', () => {
   for (const section of ['Iron Law', 'Root Cause', 'Pattern Analysis', 'Hypothesis',
                           'DEBUG REPORT', '3-strike', 'BLOCKED']) {
     test(`contains ${section}`, () => expect(content).toContain(section));
+  }
+});
+
+describe('find-skills skill structure', () => {
+  const content = fs.readFileSync(path.join(ROOT, 'find-skills', 'SKILL.md'), 'utf-8');
+
+  test('contains hard gate against auto-install', () => {
+    expect(content).toContain('HARD GATE');
+    expect(content).toContain('Do NOT auto-install');
+  });
+
+  test('uses marketplace search helper', () => {
+    expect(content).toContain('gstack-marketplace-search');
+  });
+
+  test('contains external skills output section', () => {
+    expect(content).toContain('External Skills Worth Considering');
+    expect(content).toContain('npx skills add');
+  });
+});
+
+describe('marketplace skill discovery integration', () => {
+  const marketplaceSkills = [
+    'office-hours/SKILL.md',
+    'plan-ceo-review/SKILL.md',
+    'plan-eng-review/SKILL.md',
+    'plan-design-review/SKILL.md',
+    'design-consultation/SKILL.md',
+    'autoplan/SKILL.md',
+  ];
+
+  for (const skill of marketplaceSkills) {
+    test(`${skill} contains marketplace discovery block`, () => {
+      const content = fs.readFileSync(path.join(ROOT, skill), 'utf-8');
+      expect(content).toContain('External Skill Marketplace Check');
+      expect(content).toContain('gstack-marketplace-search');
+    });
   }
 });
 
@@ -1398,6 +1436,7 @@ describe('Skill trigger phrases', () => {
     'qa', 'qa-only', 'ship', 'review', 'investigate', 'office-hours',
     'plan-ceo-review', 'plan-eng-review', 'plan-design-review',
     'design-review', 'design-consultation', 'retro', 'document-release',
+    'find-skills',
     'codex', 'browse', 'setup-browser-cookies',
   ];
 
@@ -1418,6 +1457,7 @@ describe('Skill trigger phrases', () => {
     'qa', 'qa-only', 'ship', 'review', 'investigate', 'office-hours',
     'plan-ceo-review', 'plan-eng-review', 'plan-design-review',
     'design-review', 'design-consultation', 'retro', 'document-release',
+    'find-skills',
   ];
 
   for (const skill of SKILLS_REQUIRING_PROACTIVE) {


### PR DESCRIPTION
## Summary

Closes #419.

Adds a marketplace-aware recommendation layer for planning/design flows plus a manual `/find-skills` command for parity with Agent Skills / skills.sh search.

### What changed
- Added `bin/gstack-marketplace-search.ts`
  - queries the marketplace via `skills search <query> --json`
  - falls back to `npx -y agent-skills-cli search <query> --json`
  - strips CLI prelude noise, normalizes results, ranks matches, and caches responses under `~/.gstack/cache/marketplace-search/`
- Added a new manual skill:
  - `find-skills/SKILL.md.tmpl`
  - `find-skills/SKILL.md`
- Added a shared generator resolver in `scripts/gen-skill-docs.ts`
  - injects an **External Skill Marketplace Check** into:
    - `/office-hours`
    - `/plan-ceo-review`
    - `/plan-eng-review`
    - `/plan-design-review`
    - `/design-consultation`
    - `/autoplan`
- Updated docs / registration surfaces:
  - root `SKILL.md.tmpl`
  - `README.md`
  - `AGENTS.md`
  - `CLAUDE.md`
  - `docs/skills.md`
  - `scripts/skill-check.ts`
  - `test/skill-validation.test.ts`

## Behavior

When `PROACTIVE=true`, the planning/design skills can now:
1. take the original user request or current plan/design summary
2. extract concrete technology keywords
3. query the external marketplace
4. surface the top matching external skills with install commands

This is recommendation-only in v1:
- no auto-install
- no auto-run of third-party skills
- silent fallback when the marketplace CLI is unavailable

## Manual parity path

Users can now explicitly run `/find-skills <query>` to search the marketplace on demand.

## Related context

Related but distinct from #113:
- #113 is about publishing gstack’s own skills to skills.sh
- this PR is about gstack consuming the marketplace to recommend third-party skills

## Verification

- `gh issue create --repo garrytan/gstack ...` created #419
- `bun run scripts/gen-skill-docs.ts`
- `bun run scripts/gen-skill-docs.ts --host codex`
- `bun test test/marketplace-search.test.ts`
- `bun test test/skill-validation.test.ts -t "find-skills skill structure|marketplace skill discovery integration"`
- `bun run skill:check`
- `bun run scripts/gen-skill-docs.ts --dry-run`
- `bun run scripts/gen-skill-docs.ts --host codex --dry-run`
- `bun test`

## Notes

This PR intentionally stops short of auto-installing external skills. The recommendation layer is meant to improve planning quality without adding hidden side effects or third-party execution risk.