### PR TITLE
fix(security): skip hidden directories in skill template discovery

### DIFF
--- a/scripts/discover-skills.ts
+++ b/scripts/discover-skills.ts
@@ -10,7 +10,7 @@ const SKIP = new Set(['node_modules', '.git', 'dist']);
 
 function subdirs(root: string): string[] {
   return fs.readdirSync(root, { withFileTypes: true })
-    .filter(d => d.isDirectory() && !SKIP.has(d.name))
+    .filter(d => d.isDirectory() && !d.name.startsWith('.') && !SKIP.has(d.name))
     .map(d => d.name);
 }
 


### PR DESCRIPTION
## Summary

- `discoverTemplates()` in `scripts/discover-skills.ts` scans subdirectories for `.tmpl` files
- SKIP set only blocks `node_modules`, `.git`, `dist`
- Hidden directories (`.claude/`, `.agents/`, `.codex/`) were being scanned
- These contain symlinked skill installs — a malicious `.tmpl` in a symlinked skill directory would be discovered and processed by `gen-skill-docs`

## Fix

```diff
- .filter(d => d.isDirectory() && !SKIP.has(d.name))
+ .filter(d => d.isDirectory() && !d.name.startsWith('.') && !SKIP.has(d.name))
```

Skips all dot-prefixed directories. All 28 legitimate skills still generate. All tests pass.

## 1 file, 1 line changed

`scripts/discover-skills.ts`

## Test plan
- [x] All existing tests pass (0 fail)
- [x] 28 Claude skills still generate
- [x] 27 Codex skills still generate
- [x] `.claude/`, `.agents/`, `.codex/` directories skipped