### PR TITLE
fix(browse): use detached child_process.spawn on Windows for server p…

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -170,17 +170,31 @@ async function startServer(): Promise<ServerState> {
   // Start server as detached background process.
   // On Windows, Bun can't launch/connect to Playwright's Chromium (oven-sh/bun#4253, #9911).
   // Fall back to running the server under Node.js with Bun API polyfills.
+  // Additionally, Bun.spawn + unref() on Windows doesn't truly detach — the child dies
+  // when the CLI parent exits. Use Node's child_process.spawn with detached:true instead.
   const useNode = IS_WINDOWS && NODE_SERVER_SCRIPT;
   const serverCmd = useNode
     ? ['node', NODE_SERVER_SCRIPT]
     : ['bun', 'run', SERVER_SCRIPT];
-  const proc = Bun.spawn(serverCmd, {
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env, BROWSE_STATE_FILE: config.stateFile },
-  });
 
-  // Don't hold the CLI open
-  proc.unref();
+  if (IS_WINDOWS) {
+    // On Windows, Bun.spawn's unref() doesn't create a truly detached process.
+    // The server dies when the CLI exits. Use Node's child_process.spawn instead.
+    const { spawn: nodeSpawn } = require('child_process');
+    const child = nodeSpawn(serverCmd[0], serverCmd.slice(1), {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env, BROWSE_STATE_FILE: config.stateFile },
+    });
+    child.unref();
+  } else {
+    const proc = Bun.spawn(serverCmd, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, BROWSE_STATE_FILE: config.stateFile },
+    });
+    // Don't hold the CLI open
+    proc.unref();
+  }
 
   // Wait for state file to appear
   const start = Date.now();


### PR DESCRIPTION
## Summary
- Fix headless browser being completely non-functional on Windows
- Server subprocess now persists between CLI invocations

## Problem
On Windows, `Bun.spawn()` with `proc.unref()` doesn't truly detach the server subprocess — it dies when the CLI parent exits. This caused every `$B` command to start a fresh Chromium instance at `about:blank`, making `/browse`, `/qa`, and `/qa-only` skills completely broken on Windows.

**Symptoms:**
- Every command prints `[browse] Starting server...` (new server each time)
- `$B goto https://example.com` then `$B url` returns `about:blank`
- `$B snapshot -i` always returns "no accessible elements found"
- No pages render — not Next.js specific, ALL websites fail

## Root Cause
`Bun.spawn` + `proc.unref()` on Windows doesn't create a truly independent background process. When the CLI binary exits after sending a command, the child server process is killed by the OS.

The code already handles a similar Windows-specific Bun limitation (oven-sh/bun#4253, #9911) by falling back to Node.js for the server. But the *spawn mechanism* itself was still using `Bun.spawn`.

## Fix
On Windows, use Node's `child_process.spawn` with `{ detached: true, stdio: 'ignore' }` instead of `Bun.spawn`. This creates a truly detached process that survives parent exit on Windows. Non-Windows platforms continue using `Bun.spawn` unchanged.

## Testing
Tested on Windows 11 Enterprise (10.0.26200) with Next.js 16 + Turbopack:

**Before fix:**
