### PR TITLE
feat(review): read `## Review` section from CLAUDE.md as repo-specific context

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -449,6 +449,14 @@ That is the point of `/review`.
 I do not want flattery here.
 I want the model imagining the production incident before it happens.
 
+### Repo-owned review context
+
+`/review` already uses `.claude/skills/review/checklist.md` for the actual rubric.
+
+If you need to calibrate `/review` for your specific repo — scope rules, high-risk paths, trust boundaries, auto-fix boundaries, escalation rules, or external consumers — add a `## Review` section to your project's `CLAUDE.md`.
+
+`/review` reads it before scope drift detection and uses it for risk and scope calibration. Skips silently if the section doesn't exist.
+
 ---
 
 ## `/investigate`

--- a/examples/CLAUDE.md.review.example
+++ b/examples/CLAUDE.md.review.example
@@ -1,0 +1,15 @@
+# Example: `## Review` section for CLAUDE.md
+
+Add this section to your project's `CLAUDE.md` to give `/review` repo-specific context.
+
+```markdown
+## Review
+
+- Source of truth for intent: if the PR or commit message links a GitHub issue / Linear ticket, read it before deciding scope drift.
+- High-risk paths: `db/migrate/**`, `app/services/billing/**`, `config/initializers/auth*`.
+- Never AUTO-FIX without explicit approval: money movement, auth/session logic, customer-visible API contract changes.
+- External consumers exist outside this repo: mobile app, webhooks, warehouse sync jobs.
+- Known hotspot: `app/services/reconciliation/**` has intentionally defensive duplication; do not flag it as dead code without tracing the call sites.
+- If a diff touches a high-risk path and the stated intent is silent about it, call out probable scope drift explicitly.
+- If auth or billing code changes, prefer ASK over AUTO-FIX unless the fix is obviously mechanical and reversible.
+```

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -288,6 +288,16 @@ You are running the `/review` workflow. Analyze the current branch's diff agains
 
 ---
 
+## Step 1.25: Read project review context (optional)
+
+Before the main review, check `CLAUDE.md` for a `## Review` section. If present, read it as additive repo-specific context — not a replacement for `.claude/skills/review/checklist.md`.
+
+Use it for scope calibration (source of truth for intent, ticketing conventions), risk calibration (high-risk paths, trust boundaries), escalation rules (who to involve for auth/billing changes), and auto-fix boundaries (areas that should never be AUTO-FIXed without explicit approval).
+
+If this context names an accessible ticketing source of truth, use it during Scope Drift Detection in Step 1.5. If no `## Review` section exists, skip silently.
+
+---
+
 ## Step 1.5: Scope Drift Detection
 
 Before reviewing code quality, check: **did they build what was requested — nothing more, nothing less?**

--- a/review/SKILL.md.tmpl
+++ b/review/SKILL.md.tmpl
@@ -37,6 +37,16 @@ You are running the `/review` workflow. Analyze the current branch's diff agains
 
 ---
 
+## Step 1.25: Read project review context (optional)
+
+Before the main review, check `CLAUDE.md` for a `## Review` section. If present, read it as additive repo-specific context — not a replacement for `.claude/skills/review/checklist.md`.
+
+Use it for scope calibration (source of truth for intent, ticketing conventions), risk calibration (high-risk paths, trust boundaries), escalation rules (who to involve for auth/billing changes), and auto-fix boundaries (areas that should never be AUTO-FIXed without explicit approval).
+
+If this context names an accessible ticketing source of truth, use it during Scope Drift Detection in Step 1.5. If no `## Review` section exists, skip silently.
+
+---
+
 ## Step 1.5: Scope Drift Detection
 
 Before reviewing code quality, check: **did they build what was requested — nothing more, nothing less?**


### PR DESCRIPTION
## feat(review): read `## Review` section from CLAUDE.md as repo-specific context

`/review` already reads several repo-local inputs: the mandatory checklist, the optional design checklist, `DESIGN.md` for design calibration, and `CLAUDE.md` for testing config.

What it doesn't have is a clean place for the other half: scope calibration (where intent lives, ticketing conventions), risk calibration (high-risk paths, trust boundaries), escalation rules (who to involve for auth/billing changes), and auto-fix boundaries (what should never be AUTO-FIXed without explicit approval).

Today that context usually ends up crammed into `checklist.md` (wrong shape), maintained in a fork of `review/SKILL.md` (drifts), or repeated manually in every review prompt (forgotten).

This PR adds a single optional step before scope drift detection: if `CLAUDE.md` has a `## Review` section, read it as additive context. If not, skip silently.

### What changes

Step 1.25 is added to `/review`, between branch check and scope drift detection:

1. Check `CLAUDE.md` for a `## Review` section.
2. If present, read it as additive repo-specific calibration.
3. If absent, skip silently.

The mandatory `.claude/skills/review/checklist.md` remains the source of truth for the rubric, severity, output format, and fix-vs-ask behavior. The `## Review` section is for everything else.

### Why CLAUDE.md

- `/review` already reads `CLAUDE.md` for testing guidance — this extends an existing pattern, not a new one.
- `CLAUDE.md` is already project-owned instruction space — teams version it with their code.
- Host-agnostic — works the same from Claude Code or `.agents` hosts.
- No new files, no new config surface, no new commands.
- The same convention naturally extends to other skills (`## Ship`, `## QA`) without new machinery.

### Files changed

| Area | Files | Existing code modified |
|------|-------|------------------------|
| Review skill | `review/SKILL.md.tmpl`, `review/SKILL.md` | +10 lines prompt text |
| Docs | `docs/skills.md` | +8 lines |
| Example | `examples/CLAUDE.md.review.example` | New |