### PR TITLE
fix(windows): use stdio array in Bun.spawnSync

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -236,7 +236,7 @@ async function startServer(): Promise<ServerState> {
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
       `{detached:true,stdio:'ignore',env:Object.assign({},process.env,` +
       `{BROWSE_STATE_FILE:${JSON.stringify(config.stateFile)}})}).unref()`;
-    Bun.spawnSync(['node', '-e', launcherCode], { stdio: 'ignore' });
+    Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'] });
   } else {
     // macOS/Linux: Bun.spawn + unref works correctly
     proc = Bun.spawn(['bun', 'run', SERVER_SCRIPT], {


### PR DESCRIPTION
## Summary

Fixes the browse daemon failing on Windows with `stdio must be an array` error.

**One-line change**: `{ stdio: 'ignore' }` → `{ stdio: ['ignore', 'ignore', 'ignore'] }`

## Root Cause

`Bun.spawnSync` requires `stdio` to be an array, not a string. The Windows code path at `browse/src/cli.ts:239` passed the string form. macOS/Linux take the `else` branch which already uses an array (`['ignore', 'pipe', 'pipe']`), so this was never caught.

## Before

```
$ browse goto https://example.com
[browse] Starting server...
[browse] stdio must be an array
```

## After

```
$ browse goto https://example.com
[browse] Starting server...
Navigated to https://example.com (200)
```

## Test Plan

- [x] Verified fix on Windows 10 Pro with Bun 1.3.11
- [x] Recompiled browse.exe and confirmed end-to-end navigation works

Fixes #454