### PR TITLE
fix: gracefully degrade AskUserQuestion in remote control mode

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -50,6 +50,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"gstack","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -51,6 +51,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"autoplan","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -108,6 +117,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -44,6 +44,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"benchmark","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -44,6 +44,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"browse","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -44,6 +44,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"canary","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -101,6 +110,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -45,6 +45,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"codex","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -102,6 +111,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -48,6 +48,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"cso","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -105,6 +114,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -49,6 +49,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"design-consultation","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -106,6 +115,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -49,6 +49,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"design-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -106,6 +115,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -46,6 +46,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"document-release","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -103,6 +112,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -60,6 +60,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"investigate","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -117,6 +126,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -43,6 +43,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"land-and-deploy","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -100,6 +109,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -51,6 +51,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"office-hours","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -108,6 +117,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -49,6 +49,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"plan-ceo-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -106,6 +115,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -47,6 +47,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"plan-design-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -104,6 +113,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -48,6 +48,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"plan-eng-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -105,6 +114,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -44,6 +44,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"qa-only","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -101,6 +110,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -50,6 +50,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"qa","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -107,6 +116,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -44,6 +44,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"retro","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -101,6 +110,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -47,6 +47,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -104,6 +113,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/scripts/resolvers/preamble.ts
+++ b/scripts/resolvers/preamble.ts
@@ -35,6 +35,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: \${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="\${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(${ctx.paths.binDir}/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"${ctx.skillName}","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -100,6 +109,24 @@ This only happens once. If \`TEL_PROMPTED\` is \`yes\`, skip this entirely.`;
 
 function generateAskUserFormat(_ctx: TemplateContext): string {
   return `## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The \`REMOTE_CONTROL\` value from the preamble output above
+2. The conversation history — if you can see \`Remote Control connecting…\` WITHOUT a
+   subsequent \`Remote Control disconnected.\`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the \`_BRANCH\` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -41,6 +41,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"setup-browser-cookies","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -47,6 +47,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"setup-deploy","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -104,6 +113,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -45,6 +45,15 @@ _TEL_START=$(date +%s)
 _SESSION_ID="$$-$(date +%s)"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
+# Detect remote control mode (Anthropic app remote control)
+# TTY detection is unreliable (Claude Code's Bash tool never has a real TTY).
+# Use explicit env var or check if gstack-config has it enabled.
+_REMOTE_CONTROL="${GSTACK_REMOTE_CONTROL:-}"
+if [ -z "$_REMOTE_CONTROL" ]; then
+  _REMOTE_CONTROL=$(~/.claude/skills/gstack/bin/gstack-config get remote_control 2>/dev/null || echo "")
+fi
+[ -z "$_REMOTE_CONTROL" ] && _REMOTE_CONTROL=0
+echo "REMOTE_CONTROL: $_REMOTE_CONTROL"
 mkdir -p ~/.gstack/analytics
 echo '{"skill":"ship","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 # zsh-compatible: use find instead of glob to avoid NOMATCH error
@@ -102,6 +111,24 @@ touch ~/.gstack/.telemetry-prompted
 This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
 
 ## AskUserQuestion Format
+
+**REMOTE CONTROL DETECTION:** Check if remote control is active by looking at BOTH:
+1. The `REMOTE_CONTROL` value from the preamble output above
+2. The conversation history — if you can see `Remote Control connecting…` WITHOUT a
+   subsequent `Remote Control disconnected.`, remote control is currently active
+
+If EITHER indicates remote control is active, do NOT use the AskUserQuestion tool.
+Instead:
+- Present the question and options as plain text in your response
+- Format options as a numbered list (1, 2, 3...) so the user can reply with a number
+- Include your recommendation inline: "I'd recommend option X because..."
+- Wait for the user to reply with their choice before proceeding
+- For yes/no questions, just ask directly in plain text
+
+This applies to ALL AskUserQuestion calls throughout the entire skill workflow,
+including telemetry prompts, lake intro, upgrade checks, and skill-specific questions.
+
+**When remote control is NOT active (normal terminal mode), use AskUserQuestion as usual:**
 
 **ALWAYS follow this structure for every AskUserQuestion call:**
 1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)


### PR DESCRIPTION
## Summary

- **Problem:** When Claude Code is used via the Anthropic app's remote control feature, `AskUserQuestion` renders an interactive terminal UI (arrow keys + Enter to select) that the user **cannot interact with**.
- **Fix:** The preamble instructions now tell Claude to detect remote control from the conversation context and fall back to plain text questions. Zero config — nothing for users to set up.

## How it works

The preamble instructions (shared by all 23+ skills) now include:

> Check if remote control is active by looking at BOTH:
> 1. The `REMOTE_CONTROL` value from the preamble bash output
> 2. The conversation history — if you see `Remote Control connecting…` without a subsequent `Remote Control disconnected.`, remote control is active

When detected, Claude presents questions as plain text with numbered options instead of calling `AskUserQuestion`. This applies to all skill questions including telemetry, lake intro, and skill-specific prompts.

## Why this approach

| Approach | Result |
|----------|--------|
| TTY detection (`! tty`) | Always triggers — Claude Code's Bash tool never has a real TTY |
| JWT token (`"application": "ccr"`) | Persists after disconnect, not real-time |
| Env var from Anthropic | Doesn't exist yet ([anthropics/claude-code#38428](https://github.com/anthropics/claude-code/issues/38428)) |
| CLAUDE.md instruction | Works but clutters install prompt and needs upgrade patching |
| **Conversation context detection** | **Zero config, self-contained in preamble, works immediately** |

## Changes

| File | What |
|------|------|
| `scripts/resolvers/preamble.ts` | Remote control detection in bash + conversation-based detection in instructions + plain text fallback |
| `*/SKILL.md` (23 files) | Auto-regenerated from preamble change |

## Test plan

- [x] `bun run gen:skill-docs` succeeds (both default and codex host)
- [x] `bun test` passes (329 pass, 11 pre-existing browse/playwright failures)
- [x] Manual test: Connected via remote control → Claude detected from conversation context → questions rendered as plain text
- [x] Manual test: Disconnected → Claude detected disconnect → back to normal AskUserQuestion
- [x] Verified no changes to README install prompt, CLAUDE.md, or upgrade flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)