### PR TITLE
fix(security): sanitize telemetry JSONL inputs against injection

### DIFF
--- a/bin/gstack-telemetry-log
+++ b/bin/gstack-telemetry-log
@@ -151,6 +151,14 @@ fi
 # ─── Construct and append JSON ───────────────────────────────
 mkdir -p "$ANALYTICS_DIR"
 
+# Sanitize string fields for JSON safety (strip quotes, backslashes, control chars)
+json_safe() { printf '%s' "$1" | tr -d '"\\\n\r\t' | head -c 200; }
+SKILL="$(json_safe "$SKILL")"
+OUTCOME="$(json_safe "$OUTCOME")"
+SESSION_ID="$(json_safe "$SESSION_ID")"
+SOURCE="$(json_safe "$SOURCE")"
+EVENT_TYPE="$(json_safe "$EVENT_TYPE")"
+
 # Escape null fields
 ERR_FIELD="null"
 [ -n "$ERROR_CLASS" ] && ERR_FIELD="\"$ERROR_CLASS\""


### PR DESCRIPTION
## Summary

- `SKILL`, `OUTCOME`, `SESSION_ID`, `SOURCE`, `EVENT_TYPE` go directly into `printf %s` for JSONL output with no sanitization
- A skill name containing `"` breaks the JSON; `","injected":"true` injects fields
- Fix: `json_safe()` helper strips quotes, backslashes, and control chars from all string fields before JSONL construction

```bash
# Before: injection possible
gstack-telemetry-log --skill 'review","injected":"true'
# → {"skill":"review","injected":"true",...}  ← broken JSON / field injection

# After: sanitized
# → {"skill":"reviewinjectedtrue",...}  ← safe
```

Note: `ERROR_MESSAGE` was already partially sanitized (line 159 uses `sed 's/"/\\"/g'`). This fix covers the 5 fields that were not.

## 1 file, 8 lines added

`bin/gstack-telemetry-log` — added `json_safe()` function + 5 sanitization calls.

## Test plan
- [x] All existing tests pass
- [x] Normal inputs unchanged
- [x] Injection attempt produces valid JSON (quotes stripped)