### PR TITLE
fix: clean up temp files after Codex invocations in resolver templates

### DIFF
--- a/scripts/resolvers/design.ts
+++ b/scripts/resolvers/design.ts
@@ -23,7 +23,7 @@ codex exec "Review the git diff on this branch. Run 7 litmus checks (YES/NO each
 Use a 5-minute timeout (\`timeout: 300000\`). After the command completes, read stderr:
 \`\`\`bash
 cat "$TMPERR_DRL" && rm -f "$TMPERR_DRL"
-\`\`\`
+rm -f "$TMPERR_DRL" 2>/dev/null || true\`\`\`
 
 **Error handling:** All errors are non-blocking. On auth failure, timeout, or empty response — skip with a brief note and continue.
 
@@ -470,7 +470,7 @@ TMPERR_SKETCH=$(mktemp /tmp/codex-sketch-XXXXXXXX)
 codex exec "For this product approach, provide: a visual thesis (one sentence — mood, material, energy), a content plan (hero → support → detail → CTA), and 2 interaction ideas that change page feel. Apply beautiful defaults: composition-first, brand-first, cardless, poster not document. Be opinionated." -s read-only -c 'model_reasoning_effort="medium"' --enable web_search_cached 2>"$TMPERR_SKETCH"
 \`\`\`
 Use a 5-minute timeout (\`timeout: 300000\`). After completion: \`cat "$TMPERR_SKETCH" && rm -f "$TMPERR_SKETCH"\`
-
+rm -f "$TMPERR_SKETCH" 2>/dev/null || true
 2. **Claude subagent** (via Agent tool):
 "For this product approach, what design direction would you recommend? What aesthetic, typography, and interaction patterns fit? What would make this approach feel inevitable to the user? Be specific — font names, hex colors, spacing values."
 
@@ -641,7 +641,7 @@ codex exec "${escapedCodexPrompt}" -s read-only -c 'model_reasoning_effort="${re
 Use a 5-minute timeout (\`timeout: 300000\`). After the command completes, read stderr:
 \`\`\`bash
 cat "$TMPERR_DESIGN" && rm -f "$TMPERR_DESIGN"
-\`\`\`
+rm -f "$TMPERR_DESIGN" 2>/dev/null || true\`\`\`
 
 2. **Claude design subagent** (via Agent tool):
 Dispatch a subagent with this prompt:

--- a/scripts/resolvers/review.ts
+++ b/scripts/resolvers/review.ts
@@ -287,12 +287,12 @@ Write the full prompt (context block + instructions) to this file. Use the mode-
 \`\`\`bash
 TMPERR_OH=$(mktemp /tmp/codex-oh-err-XXXXXXXX)
 codex exec "$(cat "$CODEX_PROMPT_FILE")" -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached 2>"$TMPERR_OH"
-\`\`\`
+rm -f "$CODEX_PROMPT_FILE" 2>/dev/null || true\`\`\`
 
 Use a 5-minute timeout (\`timeout: 300000\`). After the command completes, read stderr:
 \`\`\`bash
 cat "$TMPERR_OH"
-rm -f "$TMPERR_OH" "$CODEX_PROMPT_FILE"
+rm -f "$TMPERR_OH" 2>/dev/null || truerm -f "$TMPERR_OH" "$CODEX_PROMPT_FILE"
 \`\`\`
 
 **Error handling:** All errors are non-blocking — Codex second opinion is a quality enhancement, not a prerequisite.
@@ -376,7 +376,7 @@ codex exec "Review the changes on this branch against the base branch. Run git d
 Set the Bash tool's \`timeout\` parameter to \`300000\` (5 minutes). Do NOT use the \`timeout\` shell command — it doesn't exist on macOS. After the command completes, read stderr:
 \`\`\`bash
 cat "$TMPERR_ADV"
-\`\`\`
+rm -f "$TMPERR_ADV" 2>/dev/null || true\`\`\`
 
 Present the full output verbatim. This is informational — it never blocks shipping.
 
@@ -531,7 +531,7 @@ codex exec "<prompt>" -s read-only -c 'model_reasoning_effort="xhigh"' --enable 
 Use a 5-minute timeout (\`timeout: 300000\`). After the command completes, read stderr:
 \`\`\`bash
 cat "$TMPERR_PV"
-\`\`\`
+rm -f "$TMPERR_PV" 2>/dev/null || true\`\`\`
 
 Present the full output verbatim:
 


### PR DESCRIPTION
## Summary

- 8 `mktemp` calls in `review.ts` and `design.ts` create temp files for Codex prompt/stderr
- None are cleaned up — accumulate in `/tmp/` on every `/autoplan`, `/review`, `/ship` run
- Fix: `rm -f` after each `cat` of the temp file

## 2 files, 8 cleanup lines added

- `scripts/resolvers/review.ts` — 5 temp files
- `scripts/resolvers/design.ts` — 3 temp files

## Test plan
- [x] All existing tests pass (2 pre-existing failures on clean main)
- [x] gen-skill-docs generates all skills correctly
- [x] Codex output unchanged