### PR TITLE
fix(security): validate JSON input in gstack-review-log

### DIFF
--- a/bin/gstack-review-log
+++ b/bin/gstack-review-log
@@ -6,4 +6,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"
-echo "$1" >> "$GSTACK_HOME/projects/$SLUG/$BRANCH-reviews.jsonl"
+
+# Validate: input must be parseable JSON (reject malformed or injection attempts)
+INPUT="$1"
+if ! printf '%s' "$INPUT" | python3 -c "import json,sys; json.load(sys.stdin)" 2>/dev/null; then
+  # Not valid JSON — refuse to append
+  echo "gstack-review-log: invalid JSON, skipping" >&2
+  exit 1
+fi
+
+echo "$INPUT" >> "$GSTACK_HOME/projects/$SLUG/$BRANCH-reviews.jsonl"


### PR DESCRIPTION
## Summary

- `gstack-review-log` appends `$1` directly to JSONL with no validation
- Malformed input corrupts the review log; crafted input could inject content
- Fix: validate input is parseable JSON before appending, reject with exit 1

```bash
# Before: anything goes
gstack-review-log 'not json'     → appended to JSONL (corrupt)

# After: validated
gstack-review-log 'not json'     → "invalid JSON, skipping" (exit 1)
gstack-review-log '{"valid":1}'  → appended (exit 0)
```

## 1 file, 7 lines added

`bin/gstack-review-log`

## Test plan
- [x] Valid JSON appended correctly
- [x] Invalid JSON rejected with exit 1
- [x] Malformed JSON (unclosed brace) rejected