### PR TITLE
fix(security): remove currentUrl from unauthenticated /health endpoint

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -321,13 +321,15 @@ async function start() {
       }
 
       // Health check — no auth required (now async)
+      // Note: currentUrl omitted from unauthenticated response to prevent
+      // information disclosure (any localhost process could see what page
+      // the user is browsing). Use /command with auth for full status.
       if (url.pathname === '/health') {
         const healthy = await browserManager.isHealthy();
         return new Response(JSON.stringify({
           status: healthy ? 'healthy' : 'unhealthy',
           uptime: Math.floor((Date.now() - startTime) / 1000),
           tabs: browserManager.getTabCount(),
-          currentUrl: browserManager.getCurrentUrl(),
         }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

- `/health` endpoint responds without auth (before `validateAuth` check)
- Response includes `currentUrl` — leaks what page the user is browsing
- Any process on localhost can query this without the auth token
- Fix: remove `currentUrl` from unauthenticated response

```diff
- status, uptime, tabs, currentUrl  ← leaked to any localhost process
+ status, uptime, tabs              ← non-sensitive only
```

Authenticated callers can still get the URL via `/command`.

## 1 file, 3 lines changed

`browse/src/server.ts`

## Test plan
- [x] All existing tests pass (24 pre-existing failures on clean main)
- [x] /health still returns status, uptime, tabs
- [x] currentUrl no longer exposed without auth