### PR TITLE
feat: add /wwsd — What Would Steve (Jobs) Do? (domain expert lens critique)

### DIFF
--- a/wwsd/SKILL.md
+++ b/wwsd/SKILL.md
@@ -22,14 +22,15 @@ If no topic is given, ask for one before proceeding.
 
 ```bash
 git branch --show-current 2>/dev/null
-cat ~/.claude/roadmap.md 2>/dev/null | head -50
 ```
 
-Also read any design docs or plan files referenced in the conversation.
-The goal is to have enough product/company context to make the critique specific,
-not generic.
+Also read the project roadmap and any design docs or plan files referenced in the
+conversation. The goal is to have enough product/company context to make the critique
+specific, not generic.
 
 ---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
 
 ## Step 2: Select the lenses
 

--- a/wwsd/SKILL.md.tmpl
+++ b/wwsd/SKILL.md.tmpl
@@ -22,12 +22,11 @@ If no topic is given, ask for one before proceeding.
 
 ```bash
 git branch --show-current 2>/dev/null
-cat ~/.claude/roadmap.md 2>/dev/null | head -50
 ```
 
-Also read any design docs or plan files referenced in the conversation.
-The goal is to have enough product/company context to make the critique specific,
-not generic.
+Also read the project roadmap and any design docs or plan files referenced in the
+conversation. The goal is to have enough product/company context to make the critique
+specific, not generic.
 
 ---
 


### PR DESCRIPTION
## What this adds

A new `/wwsd` skill — *What Would Steve (Jobs) Do?* — that runs any product, plan, or decision through the mental models of 16 domain experts (lenses).

## How it works

1. Reads project context (current branch, roadmap, referenced docs)
2. Ranks the top 5 most relevant lenses for the topic
3. Auto-runs the top 3; user can opt in to lenses 4 and 5 via "add 4", "add 5"
4. Structured output per lens: VERDICT → WHAT [NAME] WOULD CHANGE → WHAT [NAME] WOULD DOUBLE DOWN ON → THE UNCOMFORTABLE QUESTION
5. Synthesis: CONSENSUS, TENSION (where lenses diverged + why), THE ONE THING

## Lens library (16 lenses)

| Lens | Domain |
|------|--------|
| George Kurtz | Security (assume breach, telemetry at scale) |
| Dario Amodei | AI safety & trust |
| Sam Altman | AI scale & ecosystem |
| Patrick Collison | Developer experience |
| Steve Jobs | Product design |
| Werner Vogels | Infrastructure scale |
| Boris Cherny | AI-first developer tools & agents |
| Drew Houston | Growth / PLG |
| CISA/SEC | Compliance & regulation |
| Mitchell Hashimoto | Open source moat |
| Parker Conrad | Platform thinking |
| Elon Musk | First principles |
| Vinod Khosla | Deep tech bets |
| Marc Andreessen | Venture scale ambition |
| Brian Chesky | Founder mode & experience design |
| YC (Graham/Tan) | Founder-market fit |

## Files

- `wwsd/SKILL.md.tmpl` — template (edit this, run `bun run gen:skill-docs`)
- `wwsd/SKILL.md` — generated Claude output
- Codex output auto-generated at setup via `discoverTemplates()`

## Notes

- Template follows the dual-host pattern: `~/.claude/skills/gstack` paths rewritten to `$GSTACK_ROOT` for Codex
- Tier 1 static tests pass; no new test failures introduced (9 pre-existing failures on main unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)