### PR TITLE
feat: add deslop skills for Claude and Codex

### DIFF
--- a/.agents/skills/gstack/agents/openai.yaml
+++ b/.agents/skills/gstack/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "gstack"
-  short_description: "Fast headless browser for QA testing and site dogfooding. Navigate pages, interact with elements, verify state, diff..."
+  short_description: "Fast headless browser for QA and dogfooding. Navigate pages, interact with elements, verify state, diff changes,..."
   default_prompt: "Use gstack for this task."
 policy:
   allow_implicit_invocation: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ Skills live in `.agents/skills/`. Invoke them by name (e.g., `/office-hours`).
 | `/plan-design-review` | Rate each design dimension 0-10, explain what a 10 looks like. |
 | `/design-consultation` | Build a complete design system from scratch. |
 | `/review` | Pre-landing PR review. Finds bugs that pass CI but break in prod. |
+| `/deslop` | Code quality analysis and focused cleanup against a compact engineering-principles reference. |
+| `/addtodeslop` | Extend the `/deslop` principles reference with a missing engineering rule. |
 | `/debug` | Systematic root-cause debugging. No fixes without investigation. |
 | `/design-review` | Design audit + fix loop with atomic commits. |
 | `/qa` | Open a real browser, find bugs, fix them, re-verify. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ gstack/
 ├── design-review/    # /design-review skill (design audit + fix loop)
 ├── ship/            # Ship workflow skill
 ├── review/          # PR review skill
+├── deslop/          # /deslop skill (engineering-principles cleanup analyzer)
+├── addtodeslop/     # /addtodeslop skill (extends the shared deslop principles reference)
 ├── plan-ceo-review/ # /plan-ceo-review skill
 ├── plan-eng-review/ # /plan-eng-review skill
 ├── autoplan/        # /autoplan skill (auto-review pipeline: CEO → design → eng)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ I'm [Garry Tan](https://x.com/garrytan), President & CEO of [Y Combinator](https
 
 Same person. Different era. The difference is the tooling.
 
-**gstack is how I do it.** It turns Claude Code into a virtual engineering team — a CEO who rethinks the product, an eng manager who locks architecture, a designer who catches AI slop, a reviewer who finds production bugs, a QA lead who opens a real browser, a security officer who runs OWASP + STRIDE audits, and a release engineer who ships the PR. Twenty specialists and eight power tools, all slash commands, all Markdown, all free, MIT license.
+**gstack is how I do it.** It turns Claude Code into a virtual engineering team — a CEO who rethinks the product, an eng manager who locks architecture, a designer who catches AI slop, a reviewer who finds production bugs, a QA lead who opens a real browser, a security officer who runs OWASP + STRIDE audits, a cleanup reviewer who pressure-tests maintainability, and a release engineer who ships the PR. More than two dozen slash commands, all Markdown, all free, MIT license.
 
 This is my open source software factory. I use it every day. I'm sharing it because these tools should be available to everyone.
 
@@ -46,11 +46,11 @@ Fork it. Improve it. Make it yours. And if you want to hate on free open source 
 
 Open Claude Code and paste this. Claude does the rest.
 
-> Install gstack: run **`git clone https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade. Then ask the user if they also want to add gstack to the current project so teammates get it.
+> Install gstack: run **`git clone https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /deslop, /addtodeslop, /ship, /land-and-deploy, /canary, /benchmark, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade. Then ask the user if they also want to add gstack to the current project so teammates get it.
 
 ### Step 2: Add to your repo so teammates get it (optional)
 
-> Add gstack to this project: run **`cp -Rf ~/.claude/skills/gstack .claude/skills/gstack && rm -rf .claude/skills/gstack/.git && cd .claude/skills/gstack && ./setup`** then add a "gstack" section to this project's CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, and tells Claude that if gstack skills aren't working, run `cd .claude/skills/gstack && ./setup` to build the binary and register skills.
+> Add gstack to this project: run **`cp -Rf ~/.claude/skills/gstack .claude/skills/gstack && rm -rf .claude/skills/gstack/.git && cd .claude/skills/gstack && ./setup`** then add a "gstack" section to this project's CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /deslop, /addtodeslop, /ship, /land-and-deploy, /canary, /benchmark, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, and tells Claude that if gstack skills aren't working, run `cd .claude/skills/gstack && ./setup` to build the binary and register skills.
 
 Real files get committed to your repo (not a submodule), so `git clone` just works. Everything lives inside `.claude/`. Nothing touches your PATH or runs in the background.
 
@@ -85,7 +85,7 @@ git clone https://github.com/garrytan/gstack.git ~/gstack
 cd ~/gstack && ./setup --host auto
 ```
 
-For Codex-compatible hosts, setup now supports both repo-local installs from `.agents/skills/gstack` and user-global installs from `~/.codex/skills/gstack`. All 28 skills work across all supported agents. Hook-based safety skills (careful, freeze, guard) use inline safety advisory prose on non-Claude hosts.
+For Codex-compatible hosts, setup now supports both repo-local installs from `.agents/skills/gstack` and user-global installs from `~/.codex/skills/gstack`. All supported skills work across all supported agents. Hook-based safety skills (careful, freeze, guard) use inline safety advisory prose on non-Claude hosts.
 
 ## See it work
 
@@ -146,6 +146,7 @@ Each skill feeds into the next. `/office-hours` writes a design doc that `/plan-
 | `/plan-design-review` | **Senior Designer** | Rates each design dimension 0-10, explains what a 10 looks like, then edits the plan to get there. AI Slop detection. Interactive — one AskUserQuestion per design choice. |
 | `/design-consultation` | **Design Partner** | Build a complete design system from scratch. Researches the landscape, proposes creative risks, generates realistic product mockups. |
 | `/review` | **Staff Engineer** | Find the bugs that pass CI but blow up in production. Auto-fixes the obvious ones. Flags completeness gaps. |
+| `/deslop` | **Cleanup Reviewer** | Pressure-test a file, directory, or diff against a compact engineering-principles reference. Reports the highest-value maintainability fixes and can implement the approved cleanup. |
 | `/investigate` | **Debugger** | Systematic root-cause debugging. Iron Law: no fixes without investigation. Traces data flow, tests hypotheses, stops after 3 failed fixes. |
 | `/design-review` | **Designer Who Codes** | Same audit as /plan-design-review, then fixes what it finds. Atomic commits, before/after screenshots. |
 | `/qa` | **QA Lead** | Test your app, find bugs, fix them with atomic commits, re-verify. Auto-generates regression tests for every fix. |
@@ -165,6 +166,7 @@ Each skill feeds into the next. `/office-hours` writes a design doc that `/plan-
 
 | Skill | What it does |
 |-------|-------------|
+| `/addtodeslop` | **Principles Curator** — research a missing cleanup principle and merge it into the shared `/deslop` engineering reference. |
 | `/codex` | **Second Opinion** — independent code review from OpenAI Codex CLI. Three modes: review (pass/fail gate), adversarial challenge, and open consultation. Cross-model analysis when both `/review` and `/codex` have run. |
 | `/careful` | **Safety Guardrails** — warns before destructive commands (rm -rf, DROP TABLE, force-push). Say "be careful" to activate. Override any warning. |
 | `/freeze` | **Edit Lock** — restrict file edits to one directory. Prevents accidental changes outside scope while debugging. |
@@ -234,7 +236,7 @@ Data is stored in [Supabase](https://supabase.com) (open source Firebase alterna
 ## gstack
 Use /browse from gstack for all web browsing. Never use mcp__claude-in-chrome__* tools.
 Available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review,
-/design-consultation, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse,
+/design-consultation, /review, /deslop, /addtodeslop, /ship, /land-and-deploy, /canary, /benchmark, /browse,
 /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro,
 /investigate, /document-release, /codex, /cso, /autoplan, /careful, /freeze, /guard,
 /unfreeze, /gstack-upgrade.

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,17 +4,17 @@ preamble-tier: 1
 version: 1.1.0
 description: |
   MANUAL TRIGGER ONLY: invoke only when user types /gstack.
-  Fast headless browser for QA testing and site dogfooding. Navigate pages, interact with
-  elements, verify state, diff before/after, take annotated screenshots, test responsive
-  layouts, forms, uploads, dialogs, and capture bug evidence. Use when asked to open or
-  test a site, verify a deployment, dogfood a user flow, or file a bug with screenshots.
-  Also suggest adjacent gstack skills by stage: brainstorm /office-hours; strategy
-  /plan-ceo-review; architecture /plan-eng-review; design /plan-design-review or
-  /design-consultation; auto-review /autoplan; debugging /investigate; QA /qa; code review
-  /review; visual audit /design-review; shipping /ship; docs /document-release; retro
-  /retro; second opinion /codex; prod safety /careful or /guard; scoped edits /freeze or
-  /unfreeze; gstack upgrades /gstack-upgrade. If the user opts out of suggestions, stop
-  and run gstack-config set proactive false; if they opt back in, run gstack-config set
+  Fast headless browser for QA and dogfooding. Navigate pages, interact with elements,
+  verify state, diff changes, take screenshots, and test responsive flows, forms,
+  uploads, and dialogs. Use when asked to open or test a site, verify a deployment,
+  dogfood a user flow, or file a browser-backed bug. Also suggest adjacent skills:
+  brainstorm /office-hours; strategy /plan-ceo-review; architecture /plan-eng-review;
+  design /plan-design-review or /design-consultation; auto-review /autoplan; debugging
+  /investigate; code review /review; cleanup /deslop; extend cleanup heuristics
+  /addtodeslop; QA /qa; visual audit /design-review; shipping /ship; docs
+  /document-release; retro /retro; second opinion /codex; safety /careful, /guard,
+  /freeze, or /unfreeze; upgrades /gstack-upgrade. If the user opts out, run
+  gstack-config set proactive false; if they opt back in, run gstack-config set
   proactive true.
 allowed-tools:
   - Bash

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -3,17 +3,17 @@ name: gstack
 preamble-tier: 1
 version: 1.1.0
 description: |
-  Fast headless browser for QA testing and site dogfooding. Navigate pages, interact with
-  elements, verify state, diff before/after, take annotated screenshots, test responsive
-  layouts, forms, uploads, dialogs, and capture bug evidence. Use when asked to open or
-  test a site, verify a deployment, dogfood a user flow, or file a bug with screenshots.
-  Also suggest adjacent gstack skills by stage: brainstorm /office-hours; strategy
-  /plan-ceo-review; architecture /plan-eng-review; design /plan-design-review or
-  /design-consultation; auto-review /autoplan; debugging /investigate; QA /qa; code review
-  /review; visual audit /design-review; shipping /ship; docs /document-release; retro
-  /retro; second opinion /codex; prod safety /careful or /guard; scoped edits /freeze or
-  /unfreeze; gstack upgrades /gstack-upgrade. If the user opts out of suggestions, stop
-  and run gstack-config set proactive false; if they opt back in, run gstack-config set
+  Fast headless browser for QA and dogfooding. Navigate pages, interact with elements,
+  verify state, diff changes, take screenshots, and test responsive flows, forms,
+  uploads, and dialogs. Use when asked to open or test a site, verify a deployment,
+  dogfood a user flow, or file a browser-backed bug. Also suggest adjacent skills:
+  brainstorm /office-hours; strategy /plan-ceo-review; architecture /plan-eng-review;
+  design /plan-design-review or /design-consultation; auto-review /autoplan; debugging
+  /investigate; code review /review; cleanup /deslop; extend cleanup heuristics
+  /addtodeslop; QA /qa; visual audit /design-review; shipping /ship; docs
+  /document-release; retro /retro; second opinion /codex; safety /careful, /guard,
+  /freeze, or /unfreeze; upgrades /gstack-upgrade. If the user opts out, run
+  gstack-config set proactive false; if they opt back in, run gstack-config set
   proactive true.
 allowed-tools:
   - Bash

--- a/addtodeslop/SKILL.md
+++ b/addtodeslop/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: addtodeslop
+preamble-tier: 2
+version: 1.0.0
+description: |
+  MANUAL TRIGGER ONLY: invoke only when user types /addtodeslop.
+  Extend the deslop engineering-principles reference. Research a missing
+  principle, draft a compact new section, merge it into the local deslop
+  reference, and keep the surrounding guide consistent. Use when asked to add a
+  principle to deslop, expand the cleanup playbook, or extend the deslop
+  reference with a missing engineering rule.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+  - WebSearch
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+## Preamble (run first)
+
+```bash
+_UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
+[ -n "$_UPD" ] && echo "$_UPD" || true
+mkdir -p ~/.gstack/sessions
+touch ~/.gstack/sessions/"$PPID"
+_SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
+find ~/.gstack/sessions -mmin +120 -type f -delete 2>/dev/null || true
+_CONTRIB=$(~/.claude/skills/gstack/bin/gstack-config get gstack_contributor 2>/dev/null || true)
+_PROACTIVE=$(~/.claude/skills/gstack/bin/gstack-config get proactive 2>/dev/null || echo "true")
+_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+echo "BRANCH: $_BRANCH"
+echo "PROACTIVE: $_PROACTIVE"
+source <(~/.claude/skills/gstack/bin/gstack-repo-mode 2>/dev/null) || true
+REPO_MODE=${REPO_MODE:-unknown}
+echo "REPO_MODE: $REPO_MODE"
+_LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no")
+echo "LAKE_INTRO: $_LAKE_SEEN"
+_TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
+_TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
+_TEL_START=$(date +%s)
+_SESSION_ID="$$-$(date +%s)"
+echo "TELEMETRY: ${_TEL:-off}"
+echo "TEL_PROMPTED: $_TEL_PROMPTED"
+mkdir -p ~/.gstack/analytics
+echo '{"skill":"addtodeslop","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+# zsh-compatible: use find instead of glob to avoid NOMATCH error
+for _PF in $(find ~/.gstack/analytics -maxdepth 1 -name '.pending-*' 2>/dev/null); do [ -f "$_PF" ] && ~/.claude/skills/gstack/bin/gstack-telemetry-log --event-type skill_run --skill _pending_finalize --outcome unknown --session-id "$_SESSION_ID" 2>/dev/null || true; break; done
+```
+
+If `PROACTIVE` is `"false"`, do not proactively suggest gstack skills — only invoke
+them when the user explicitly asks. The user opted out of proactive suggestions.
+
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+
+If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
+Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete
+thing when AI makes the marginal cost near-zero. Read more: https://garryslist.org/posts/boil-the-ocean"
+Then offer to open the essay in their default browser:
+
+```bash
+open https://garryslist.org/posts/boil-the-ocean
+touch ~/.gstack/.completeness-intro-seen
+```
+
+Only run `open` if the user says yes. Always run `touch` to mark as seen. This only happens once.
+
+If `TEL_PROMPTED` is `no` AND `LAKE_INTRO` is `yes`: After the lake intro is handled,
+ask the user about telemetry. Use AskUserQuestion:
+
+> Help gstack get better! Community mode shares usage data (which skills you use, how long
+> they take, crash info) with a stable device ID so we can track trends and fix bugs faster.
+> No code, file paths, or repo names are ever sent.
+> Change anytime with `gstack-config set telemetry off`.
+
+Options:
+- A) Help gstack get better! (recommended)
+- B) No thanks
+
+If A: run `~/.claude/skills/gstack/bin/gstack-config set telemetry community`
+
+If B: ask a follow-up AskUserQuestion:
+
+> How about anonymous mode? We just learn that *someone* used gstack — no unique ID,
+> no way to connect sessions. Just a counter that helps us know if anyone's out there.
+
+Options:
+- A) Sure, anonymous is fine
+- B) No thanks, fully off
+
+If B→A: run `~/.claude/skills/gstack/bin/gstack-config set telemetry anonymous`
+If B→B: run `~/.claude/skills/gstack/bin/gstack-config set telemetry off`
+
+Always run:
+```bash
+touch ~/.gstack/.telemetry-prompted
+```
+
+This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
+
+## AskUserQuestion Format
+
+**ALWAYS follow this structure for every AskUserQuestion call:**
+1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
+2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
+3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
+4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+
+Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+
+Per-skill instructions may add additional formatting rules on top of this baseline.
+
+## Completeness Principle — Boil the Lake
+
+AI makes completeness near-free. Always recommend the complete option over shortcuts — the delta is minutes with CC+gstack. A "lake" (100% coverage, all edge cases) is boilable; an "ocean" (full rewrite, multi-quarter migration) is not. Boil lakes, flag oceans.
+
+**Effort reference** — always show both scales:
+
+| Task type | Human team | CC+gstack | Compression |
+|-----------|-----------|-----------|-------------|
+| Boilerplate | 2 days | 15 min | ~100x |
+| Tests | 1 day | 15 min | ~50x |
+| Feature | 1 week | 30 min | ~30x |
+| Bug fix | 4 hours | 15 min | ~20x |
+
+Include `Completeness: X/10` for each option (10=all edge cases, 7=happy path, 3=shortcut).
+
+## Contributor Mode
+
+If `_CONTRIB` is `true`: you are in **contributor mode**. At the end of each major workflow step, rate your gstack experience 0-10. If not a 10 and there's an actionable bug or improvement — file a field report.
+
+**File only:** gstack tooling bugs where the input was reasonable but gstack failed. **Skip:** user app bugs, network errors, auth failures on user's site.
+
+**To file:** write `~/.gstack/contributor-logs/{slug}.md`:
+```
+# {Title}
+**What I tried:** {action} | **What happened:** {result} | **Rating:** {0-10}
+## Repro
+1. {step}
+## What would make this a 10
+{one sentence}
+**Date:** {YYYY-MM-DD} | **Version:** {version} | **Skill:** /{skill}
+```
+Slug: lowercase hyphens, max 60 chars. Skip if exists. Max 3/session. File inline, don't stop.
+
+## Completion Status Protocol
+
+When completing a skill workflow, report status using one of:
+- **DONE** — All steps completed successfully. Evidence provided for each claim.
+- **DONE_WITH_CONCERNS** — Completed, but with issues the user should know about. List each concern.
+- **BLOCKED** — Cannot proceed. State what is blocking and what was tried.
+- **NEEDS_CONTEXT** — Missing information required to continue. State exactly what you need.
+
+### Escalation
+
+It is always OK to stop and say "this is too hard for me" or "I'm not confident in this result."
+
+Bad work is worse than no work. You will not be penalized for escalating.
+- If you have attempted a task 3 times without success, STOP and escalate.
+- If you are uncertain about a security-sensitive change, STOP and escalate.
+- If the scope of work exceeds what you can verify, STOP and escalate.
+
+Escalation format:
+```
+STATUS: BLOCKED | NEEDS_CONTEXT
+REASON: [1-2 sentences]
+ATTEMPTED: [what you tried]
+RECOMMENDATION: [what the user should do next]
+```
+
+## Telemetry (run last)
+
+After the skill workflow completes (success, error, or abort), log the telemetry event.
+Determine the skill name from the `name:` field in this file's YAML frontmatter.
+Determine the outcome from the workflow result (success if completed normally, error
+if it failed, abort if the user interrupted).
+
+**PLAN MODE EXCEPTION — ALWAYS RUN:** This command writes telemetry to
+`~/.gstack/analytics/` (user config directory, not project files). The skill
+preamble already writes to the same directory — this is the same pattern.
+Skipping this command loses session duration and outcome data.
+
+Run this bash:
+
+```bash
+_TEL_END=$(date +%s)
+_TEL_DUR=$(( _TEL_END - _TEL_START ))
+rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
+~/.claude/skills/gstack/bin/gstack-telemetry-log \
+  --skill "SKILL_NAME" --duration "$_TEL_DUR" --outcome "OUTCOME" \
+  --used-browse "USED_BROWSE" --session-id "$_SESSION_ID" 2>/dev/null &
+```
+
+Replace `SKILL_NAME` with the actual skill name from frontmatter, `OUTCOME` with
+success/error/abort, and `USED_BROWSE` with true/false based on whether `$B` was used.
+If you cannot determine the outcome, use "unknown". This runs in the background and
+never blocks the user.
+
+## Plan Status Footer
+
+When you are in plan mode and about to call ExitPlanMode:
+
+1. Check if the plan file already has a `## GSTACK REVIEW REPORT` section.
+2. If it DOES — skip (a review skill already wrote a richer report).
+3. If it does NOT — run this command:
+
+\`\`\`bash
+~/.claude/skills/gstack/bin/gstack-review-read
+\`\`\`
+
+Then write a `## GSTACK REVIEW REPORT` section to the end of the plan file:
+
+- If the output contains review entries (JSONL lines before `---CONFIG---`): format the
+  standard report table with runs/status/findings per skill, same format as the review
+  skills use.
+- If the output is `NO_REVIEWS` or empty: write this placeholder table:
+
+\`\`\`markdown
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | \`/plan-ceo-review\` | Scope & strategy | 0 | — | — |
+| Codex Review | \`/codex review\` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | \`/plan-eng-review\` | Architecture & tests (required) | 0 | — | — |
+| Design Review | \`/plan-design-review\` | UI/UX gaps | 0 | — | — |
+
+**VERDICT:** NO REVIEWS YET — run \`/autoplan\` for full review pipeline, or individual reviews above.
+\`\`\`
+
+**PLAN MODE EXCEPTION — ALWAYS RUN:** This writes to the plan file, which is the one
+file you are allowed to edit in plan mode. The plan file review report is part of the
+plan's living status.
+
+# /addtodeslop — Extend the Deslop Reference
+
+Use this skill when the user asks to add a coding principle to deslop or wants
+the next missing principle researched and merged into the local reference.
+
+## Arguments
+
+- `/addtodeslop` — pick the most valuable missing principle
+- `/addtodeslop idempotency` — add a named principle
+- `/addtodeslop "something about API contracts"` — infer the best principle from a freeform description
+
+## Canonical Files
+
+Edit the canonical gstack files in the active checkout:
+
+- `~/.claude/skills/gstack/deslop/SKILL.md.tmpl`
+- `~/.claude/skills/gstack/deslop/references/principles.md`
+
+For repo-local installs, use:
+
+- `.claude/skills/gstack/deslop/SKILL.md.tmpl`
+- `.claude/skills/gstack/deslop/references/principles.md`
+
+Do not edit generated outputs by hand. If the deslop workflow changes, regenerate:
+
+```bash
+bun run gen:skill-docs
+bun run gen:skill-docs --host codex
+```
+
+## Workflow
+
+1. Read the canonical deslop principles reference listed above and build a list of principles already covered.
+2. Determine the target principle:
+   - If the user specified one, use it.
+   - If not, choose the highest-value missing principle that is well known, battle tested, and practically useful.
+3. Research the principle with the best available sources or tools in the current harness.
+4. Draft a compact section that matches the existing reference style:
+   - one-sentence definition
+   - why it matters
+   - common smells
+   - default fix
+   - caveats or tensions when needed
+5. Merge the new section into the appropriate category in the canonical principles reference.
+6. Update the Quick Diagnostic Guide, Principle Tensions, or other nearby sections if the new principle changes the navigation or decision framework.
+7. If the new principle changes how `/deslop` should operate, update the canonical `deslop/SKILL.md.tmpl` in the same change and regenerate the generated skill docs.
+8. Summarize what was added, where it was placed, and any adjacent sections that were updated.
+
+## Guardrails
+
+- Keep the reference compact. This is an operator guide, not a textbook.
+- Do not add synonyms for principles that are already represented under another name.
+- Prefer principles with direct code-review and refactoring value over abstract theory.
+- Match the tone and density of the existing reference.
+- If web access is unavailable, say so and proceed with clearly labeled limitations.
+
+## Output
+
+Report:
+
+1. The principle added or chosen
+2. Where it was placed in the reference
+3. Any guide sections updated alongside it
+4. Any open questions or follow-up principles worth adding later

--- a/addtodeslop/SKILL.md.tmpl
+++ b/addtodeslop/SKILL.md.tmpl
@@ -1,0 +1,87 @@
+---
+name: addtodeslop
+preamble-tier: 2
+version: 1.0.0
+description: |
+  Extend the deslop engineering-principles reference. Research a missing
+  principle, draft a compact new section, merge it into the local deslop
+  reference, and keep the surrounding guide consistent. Use when asked to add a
+  principle to deslop, expand the cleanup playbook, or extend the deslop
+  reference with a missing engineering rule.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+  - WebSearch
+---
+
+{{PREAMBLE}}
+
+# /addtodeslop — Extend the Deslop Reference
+
+Use this skill when the user asks to add a coding principle to deslop or wants
+the next missing principle researched and merged into the local reference.
+
+## Arguments
+
+- `/addtodeslop` — pick the most valuable missing principle
+- `/addtodeslop idempotency` — add a named principle
+- `/addtodeslop "something about API contracts"` — infer the best principle from a freeform description
+
+## Canonical Files
+
+Edit the canonical gstack files in the active checkout:
+
+- `~/.claude/skills/gstack/deslop/SKILL.md.tmpl`
+- `~/.claude/skills/gstack/deslop/references/principles.md`
+
+For repo-local installs, use:
+
+- `.claude/skills/gstack/deslop/SKILL.md.tmpl`
+- `.claude/skills/gstack/deslop/references/principles.md`
+
+Do not edit generated outputs by hand. If the deslop workflow changes, regenerate:
+
+```bash
+bun run gen:skill-docs
+bun run gen:skill-docs --host codex
+```
+
+## Workflow
+
+1. Read the canonical deslop principles reference listed above and build a list of principles already covered.
+2. Determine the target principle:
+   - If the user specified one, use it.
+   - If not, choose the highest-value missing principle that is well known, battle tested, and practically useful.
+3. Research the principle with the best available sources or tools in the current harness.
+4. Draft a compact section that matches the existing reference style:
+   - one-sentence definition
+   - why it matters
+   - common smells
+   - default fix
+   - caveats or tensions when needed
+5. Merge the new section into the appropriate category in the canonical principles reference.
+6. Update the Quick Diagnostic Guide, Principle Tensions, or other nearby sections if the new principle changes the navigation or decision framework.
+7. If the new principle changes how `/deslop` should operate, update the canonical `deslop/SKILL.md.tmpl` in the same change and regenerate the generated skill docs.
+8. Summarize what was added, where it was placed, and any adjacent sections that were updated.
+
+## Guardrails
+
+- Keep the reference compact. This is an operator guide, not a textbook.
+- Do not add synonyms for principles that are already represented under another name.
+- Prefer principles with direct code-review and refactoring value over abstract theory.
+- Match the tone and density of the existing reference.
+- If web access is unavailable, say so and proceed with clearly labeled limitations.
+
+## Output
+
+Report:
+
+1. The principle added or chosen
+2. Where it was placed in the reference
+3. Any guide sections updated alongside it
+4. Any open questions or follow-up principles worth adding later

--- a/deslop/SKILL.md
+++ b/deslop/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: deslop
+preamble-tier: 2
+version: 1.0.0
+description: |
+  MANUAL TRIGGER ONLY: invoke only when user types /deslop.
+  Code quality analyzer. Review a file, directory, or current diff against a
+  compact engineering-principles reference, report the highest-value fixes with
+  concrete before/after guidance, and implement approved cleanup. Use when asked
+  to "deslop" code, tighten a module, improve maintainability, or pressure-test
+  code quality against engineering principles.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+## Preamble (run first)
+
+```bash
+_UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
+[ -n "$_UPD" ] && echo "$_UPD" || true
+mkdir -p ~/.gstack/sessions
+touch ~/.gstack/sessions/"$PPID"
+_SESSIONS=$(find ~/.gstack/sessions -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' ')
+find ~/.gstack/sessions -mmin +120 -type f -delete 2>/dev/null || true
+_CONTRIB=$(~/.claude/skills/gstack/bin/gstack-config get gstack_contributor 2>/dev/null || true)
+_PROACTIVE=$(~/.claude/skills/gstack/bin/gstack-config get proactive 2>/dev/null || echo "true")
+_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+echo "BRANCH: $_BRANCH"
+echo "PROACTIVE: $_PROACTIVE"
+source <(~/.claude/skills/gstack/bin/gstack-repo-mode 2>/dev/null) || true
+REPO_MODE=${REPO_MODE:-unknown}
+echo "REPO_MODE: $REPO_MODE"
+_LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no")
+echo "LAKE_INTRO: $_LAKE_SEEN"
+_TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
+_TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
+_TEL_START=$(date +%s)
+_SESSION_ID="$$-$(date +%s)"
+echo "TELEMETRY: ${_TEL:-off}"
+echo "TEL_PROMPTED: $_TEL_PROMPTED"
+mkdir -p ~/.gstack/analytics
+echo '{"skill":"deslop","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+# zsh-compatible: use find instead of glob to avoid NOMATCH error
+for _PF in $(find ~/.gstack/analytics -maxdepth 1 -name '.pending-*' 2>/dev/null); do [ -f "$_PF" ] && ~/.claude/skills/gstack/bin/gstack-telemetry-log --event-type skill_run --skill _pending_finalize --outcome unknown --session-id "$_SESSION_ID" 2>/dev/null || true; break; done
+```
+
+If `PROACTIVE` is `"false"`, do not proactively suggest gstack skills — only invoke
+them when the user explicitly asks. The user opted out of proactive suggestions.
+
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If `JUST_UPGRADED <from> <to>`: tell user "Running gstack v{to} (just updated!)" and continue.
+
+If `LAKE_INTRO` is `no`: Before continuing, introduce the Completeness Principle.
+Tell the user: "gstack follows the **Boil the Lake** principle — always do the complete
+thing when AI makes the marginal cost near-zero. Read more: https://garryslist.org/posts/boil-the-ocean"
+Then offer to open the essay in their default browser:
+
+```bash
+open https://garryslist.org/posts/boil-the-ocean
+touch ~/.gstack/.completeness-intro-seen
+```
+
+Only run `open` if the user says yes. Always run `touch` to mark as seen. This only happens once.
+
+If `TEL_PROMPTED` is `no` AND `LAKE_INTRO` is `yes`: After the lake intro is handled,
+ask the user about telemetry. Use AskUserQuestion:
+
+> Help gstack get better! Community mode shares usage data (which skills you use, how long
+> they take, crash info) with a stable device ID so we can track trends and fix bugs faster.
+> No code, file paths, or repo names are ever sent.
+> Change anytime with `gstack-config set telemetry off`.
+
+Options:
+- A) Help gstack get better! (recommended)
+- B) No thanks
+
+If A: run `~/.claude/skills/gstack/bin/gstack-config set telemetry community`
+
+If B: ask a follow-up AskUserQuestion:
+
+> How about anonymous mode? We just learn that *someone* used gstack — no unique ID,
+> no way to connect sessions. Just a counter that helps us know if anyone's out there.
+
+Options:
+- A) Sure, anonymous is fine
+- B) No thanks, fully off
+
+If B→A: run `~/.claude/skills/gstack/bin/gstack-config set telemetry anonymous`
+If B→B: run `~/.claude/skills/gstack/bin/gstack-config set telemetry off`
+
+Always run:
+```bash
+touch ~/.gstack/.telemetry-prompted
+```
+
+This only happens once. If `TEL_PROMPTED` is `yes`, skip this entirely.
+
+## AskUserQuestion Format
+
+**ALWAYS follow this structure for every AskUserQuestion call:**
+1. **Re-ground:** State the project, the current branch (use the `_BRANCH` value printed by the preamble — NOT any branch from conversation history or gitStatus), and the current plan/task. (1-2 sentences)
+2. **Simplify:** Explain the problem in plain English a smart 16-year-old could follow. No raw function names, no internal jargon, no implementation details. Use concrete examples and analogies. Say what it DOES, not what it's called.
+3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — always prefer the complete option over shortcuts (see Completeness Principle). Include `Completeness: X/10` for each option. Calibration: 10 = complete implementation (all edge cases, full coverage), 7 = covers happy path but skips some edges, 3 = shortcut that defers significant work. If both options are 8+, pick the higher; if one is ≤5, flag it.
+4. **Options:** Lettered options: `A) ... B) ... C) ...` — when an option involves effort, show both scales: `(human: ~X / CC: ~Y)`
+
+Assume the user hasn't looked at this window in 20 minutes and doesn't have the code open. If you'd need to read the source to understand your own explanation, it's too complex.
+
+Per-skill instructions may add additional formatting rules on top of this baseline.
+
+## Completeness Principle — Boil the Lake
+
+AI makes completeness near-free. Always recommend the complete option over shortcuts — the delta is minutes with CC+gstack. A "lake" (100% coverage, all edge cases) is boilable; an "ocean" (full rewrite, multi-quarter migration) is not. Boil lakes, flag oceans.
+
+**Effort reference** — always show both scales:
+
+| Task type | Human team | CC+gstack | Compression |
+|-----------|-----------|-----------|-------------|
+| Boilerplate | 2 days | 15 min | ~100x |
+| Tests | 1 day | 15 min | ~50x |
+| Feature | 1 week | 30 min | ~30x |
+| Bug fix | 4 hours | 15 min | ~20x |
+
+Include `Completeness: X/10` for each option (10=all edge cases, 7=happy path, 3=shortcut).
+
+## Contributor Mode
+
+If `_CONTRIB` is `true`: you are in **contributor mode**. At the end of each major workflow step, rate your gstack experience 0-10. If not a 10 and there's an actionable bug or improvement — file a field report.
+
+**File only:** gstack tooling bugs where the input was reasonable but gstack failed. **Skip:** user app bugs, network errors, auth failures on user's site.
+
+**To file:** write `~/.gstack/contributor-logs/{slug}.md`:
+```
+# {Title}
+**What I tried:** {action} | **What happened:** {result} | **Rating:** {0-10}
+## Repro
+1. {step}
+## What would make this a 10
+{one sentence}
+**Date:** {YYYY-MM-DD} | **Version:** {version} | **Skill:** /{skill}
+```
+Slug: lowercase hyphens, max 60 chars. Skip if exists. Max 3/session. File inline, don't stop.
+
+## Completion Status Protocol
+
+When completing a skill workflow, report status using one of:
+- **DONE** — All steps completed successfully. Evidence provided for each claim.
+- **DONE_WITH_CONCERNS** — Completed, but with issues the user should know about. List each concern.
+- **BLOCKED** — Cannot proceed. State what is blocking and what was tried.
+- **NEEDS_CONTEXT** — Missing information required to continue. State exactly what you need.
+
+### Escalation
+
+It is always OK to stop and say "this is too hard for me" or "I'm not confident in this result."
+
+Bad work is worse than no work. You will not be penalized for escalating.
+- If you have attempted a task 3 times without success, STOP and escalate.
+- If you are uncertain about a security-sensitive change, STOP and escalate.
+- If the scope of work exceeds what you can verify, STOP and escalate.
+
+Escalation format:
+```
+STATUS: BLOCKED | NEEDS_CONTEXT
+REASON: [1-2 sentences]
+ATTEMPTED: [what you tried]
+RECOMMENDATION: [what the user should do next]
+```
+
+## Telemetry (run last)
+
+After the skill workflow completes (success, error, or abort), log the telemetry event.
+Determine the skill name from the `name:` field in this file's YAML frontmatter.
+Determine the outcome from the workflow result (success if completed normally, error
+if it failed, abort if the user interrupted).
+
+**PLAN MODE EXCEPTION — ALWAYS RUN:** This command writes telemetry to
+`~/.gstack/analytics/` (user config directory, not project files). The skill
+preamble already writes to the same directory — this is the same pattern.
+Skipping this command loses session duration and outcome data.
+
+Run this bash:
+
+```bash
+_TEL_END=$(date +%s)
+_TEL_DUR=$(( _TEL_END - _TEL_START ))
+rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
+~/.claude/skills/gstack/bin/gstack-telemetry-log \
+  --skill "SKILL_NAME" --duration "$_TEL_DUR" --outcome "OUTCOME" \
+  --used-browse "USED_BROWSE" --session-id "$_SESSION_ID" 2>/dev/null &
+```
+
+Replace `SKILL_NAME` with the actual skill name from frontmatter, `OUTCOME` with
+success/error/abort, and `USED_BROWSE` with true/false based on whether `$B` was used.
+If you cannot determine the outcome, use "unknown". This runs in the background and
+never blocks the user.
+
+## Plan Status Footer
+
+When you are in plan mode and about to call ExitPlanMode:
+
+1. Check if the plan file already has a `## GSTACK REVIEW REPORT` section.
+2. If it DOES — skip (a review skill already wrote a richer report).
+3. If it does NOT — run this command:
+
+\`\`\`bash
+~/.claude/skills/gstack/bin/gstack-review-read
+\`\`\`
+
+Then write a `## GSTACK REVIEW REPORT` section to the end of the plan file:
+
+- If the output contains review entries (JSONL lines before `---CONFIG---`): format the
+  standard report table with runs/status/findings per skill, same format as the review
+  skills use.
+- If the output is `NO_REVIEWS` or empty: write this placeholder table:
+
+\`\`\`markdown
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | \`/plan-ceo-review\` | Scope & strategy | 0 | — | — |
+| Codex Review | \`/codex review\` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | \`/plan-eng-review\` | Architecture & tests (required) | 0 | — | — |
+| Design Review | \`/plan-design-review\` | UI/UX gaps | 0 | — | — |
+
+**VERDICT:** NO REVIEWS YET — run \`/autoplan\` for full review pipeline, or individual reviews above.
+\`\`\`
+
+**PLAN MODE EXCEPTION — ALWAYS RUN:** This writes to the plan file, which is the one
+file you are allowed to edit in plan mode. The plan file review report is part of the
+plan's living status.
+
+## Step 0: Detect base branch
+
+Determine which branch this PR targets. Use the result as "the base branch" in all subsequent steps.
+
+1. Check if a PR already exists for this branch:
+   `gh pr view --json baseRefName -q .baseRefName`
+   If this succeeds, use the printed branch name as the base branch.
+
+2. If no PR exists (command fails), detect the repo's default branch:
+   `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`
+
+3. If both commands fail, fall back to `main`.
+
+Print the detected base branch name. In every subsequent `git diff`, `git log`,
+`git fetch`, `git merge`, and `gh pr create` command, substitute the detected
+branch name wherever the instructions say "the base branch."
+
+---
+
+# /deslop — Code Quality Analysis
+
+Use this skill when the user explicitly wants a code-quality pass rather than a
+bug hunt or product review.
+
+## Arguments
+
+- `/deslop` — analyze the current repo, current folder, or changed files
+- `/deslop path/to/file` — analyze one file
+- `/deslop src/server` — analyze one directory or subsystem
+- `/deslop current diff` — focus on the active changes against the base branch
+
+Interpret freeform target text sensibly. If the user gives a repo area, stay
+inside it.
+
+## Reference
+
+Read `~/.claude/skills/gstack/deslop/references/principles.md` before
+analyzing. For repo-local installs, use
+`.claude/skills/gstack/deslop/references/principles.md` instead.
+
+Keep context tight:
+
+1. Start with the Quick Diagnostic Guide, Principle Tensions, and Priority Matrix.
+2. Then load only the principle sections that match the smells you find.
+3. Do not dump the whole reference back to the user.
+
+## Workflow
+
+1. Determine the target and scope.
+   - If the user named a file or directory, stay inside it.
+   - If the user said "current diff", inspect `git diff <base>...HEAD`.
+   - If no target was given, prefer changed files against the base branch. If there are no changed files, prefer the current directory or the files already in discussion.
+2. Read the relevant files end to end. Use `git diff`, `rg`, and file reads to gather enough context before judging.
+3. Map each real issue to one or more principles from the reference.
+4. Report only the highest-signal findings. Default to 3-8 findings; go higher only if the code is clearly degraded.
+5. Offer concrete, minimal fixes. Prefer local cleanup over sweeping refactors.
+6. If the user asked only for analysis, stop after the report. Otherwise ask whether to implement the recommended changes.
+7. If the user approves implementation, make the smallest changes that materially improve the code and run the smallest relevant verification commands.
+
+## Output Format
+
+### Summary
+
+Give a 1-2 sentence overview of code health and the dominant themes.
+
+### Violations Found
+
+For each issue use this shape:
+
+`##### [Principle] - [Issue]`
+
+`**Location**: path:line`
+
+`**Problem**: one short description`
+
+`**Before**:` short snippet
+
+`**After**:` short snippet
+
+`**Why**:` one sentence tying the fix back to the principle
+
+### Recommendations
+
+Provide a prioritized numbered list, highest value first.
+
+Then ask:
+
+`Implement A) all recommended fixes, B) a subset, or C) report only?`
+
+## Guardrails
+
+- Do not recommend abstractions for one-off code. Respect KISS, YAGNI, and the rule of three.
+- Do not confuse incidental similarity with meaningful duplication.
+- Treat test code differently: prefer setup clarity over forced DRY.
+- Prefer the smallest change that materially improves the code.
+- Separate objective bugs from taste-only nits.
+- If a deeper refactor is warranted but too large for the current scope, label it as follow-up work instead of sneaking it into a small cleanup.
+
+## Implementation Mode
+
+If the user says to implement:
+
+1. Fix P0 and P1 issues first.
+2. Keep the diff tight and readable.
+3. Add or adjust focused tests when behavior changes or the cleanup removes real risk.
+4. Re-run relevant checks and summarize what changed.

--- a/deslop/SKILL.md.tmpl
+++ b/deslop/SKILL.md.tmpl
@@ -1,0 +1,111 @@
+---
+name: deslop
+preamble-tier: 2
+version: 1.0.0
+description: |
+  Code quality analyzer. Review a file, directory, or current diff against a
+  compact engineering-principles reference, report the highest-value fixes with
+  concrete before/after guidance, and implement approved cleanup. Use when asked
+  to "deslop" code, tighten a module, improve maintainability, or pressure-test
+  code quality against engineering principles.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+{{PREAMBLE}}
+
+{{BASE_BRANCH_DETECT}}
+
+# /deslop — Code Quality Analysis
+
+Use this skill when the user explicitly wants a code-quality pass rather than a
+bug hunt or product review.
+
+## Arguments
+
+- `/deslop` — analyze the current repo, current folder, or changed files
+- `/deslop path/to/file` — analyze one file
+- `/deslop src/server` — analyze one directory or subsystem
+- `/deslop current diff` — focus on the active changes against the base branch
+
+Interpret freeform target text sensibly. If the user gives a repo area, stay
+inside it.
+
+## Reference
+
+Read `~/.claude/skills/gstack/deslop/references/principles.md` before
+analyzing. For repo-local installs, use
+`.claude/skills/gstack/deslop/references/principles.md` instead.
+
+Keep context tight:
+
+1. Start with the Quick Diagnostic Guide, Principle Tensions, and Priority Matrix.
+2. Then load only the principle sections that match the smells you find.
+3. Do not dump the whole reference back to the user.
+
+## Workflow
+
+1. Determine the target and scope.
+   - If the user named a file or directory, stay inside it.
+   - If the user said "current diff", inspect `git diff <base>...HEAD`.
+   - If no target was given, prefer changed files against the base branch. If there are no changed files, prefer the current directory or the files already in discussion.
+2. Read the relevant files end to end. Use `git diff`, `rg`, and file reads to gather enough context before judging.
+3. Map each real issue to one or more principles from the reference.
+4. Report only the highest-signal findings. Default to 3-8 findings; go higher only if the code is clearly degraded.
+5. Offer concrete, minimal fixes. Prefer local cleanup over sweeping refactors.
+6. If the user asked only for analysis, stop after the report. Otherwise ask whether to implement the recommended changes.
+7. If the user approves implementation, make the smallest changes that materially improve the code and run the smallest relevant verification commands.
+
+## Output Format
+
+### Summary
+
+Give a 1-2 sentence overview of code health and the dominant themes.
+
+### Violations Found
+
+For each issue use this shape:
+
+`##### [Principle] - [Issue]`
+
+`**Location**: path:line`
+
+`**Problem**: one short description`
+
+`**Before**:` short snippet
+
+`**After**:` short snippet
+
+`**Why**:` one sentence tying the fix back to the principle
+
+### Recommendations
+
+Provide a prioritized numbered list, highest value first.
+
+Then ask:
+
+`Implement A) all recommended fixes, B) a subset, or C) report only?`
+
+## Guardrails
+
+- Do not recommend abstractions for one-off code. Respect KISS, YAGNI, and the rule of three.
+- Do not confuse incidental similarity with meaningful duplication.
+- Treat test code differently: prefer setup clarity over forced DRY.
+- Prefer the smallest change that materially improves the code.
+- Separate objective bugs from taste-only nits.
+- If a deeper refactor is warranted but too large for the current scope, label it as follow-up work instead of sneaking it into a small cleanup.
+
+## Implementation Mode
+
+If the user says to implement:
+
+1. Fix P0 and P1 issues first.
+2. Keep the diff tight and readable.
+3. Add or adjust focused tests when behavior changes or the cleanup removes real risk.
+4. Re-run relevant checks and summarize what changed.

--- a/deslop/references/principles.md
+++ b/deslop/references/principles.md
@@ -1,0 +1,270 @@
+# Deslop Principles Reference
+
+This is the compact gstack reference used by `/deslop`.
+
+Use it as a checklist, not dogma:
+
+1. Start with the quick guide and priority matrix.
+2. Load only the sections that match the smells you actually see.
+3. Prefer a few high-confidence findings over a long list of style nits.
+
+## Quick Diagnostic Guide
+
+| Symptom | Likely principle | Default move |
+| --- | --- | --- |
+| Function is hard to hold in your head | Cognitive Load, Small Functions | Split by responsibility |
+| Deep nesting | Guard Clauses | Exit early and flatten flow |
+| Duplicate code in 3+ places | DRY | Extract shared behavior |
+| Repeated data in multiple places | Single Source of Truth | Pick one authoritative owner |
+| Magic numbers or unclear names | Self-Documenting Code | Name the concept |
+| A type or module does too many jobs | Separation of Concerns | Split by responsibility |
+| Long method chains | Law of Demeter | Delegate through a local seam |
+| Constructor creates its own collaborators | Dependency Injection | Pass dependencies in |
+| Command both mutates and returns rich data | Command-Query Separation | Separate mutation from query |
+| Invalid data handled late | Parse, Don't Validate | Normalize at the boundary |
+| Same request can be safely repeated | Idempotency | Preserve that property |
+| Failure is swallowed or vague | Fail Fast, Observability | Raise clearly and log context |
+| Cleanup never happens | Boy Scout Rule | Leave touched code cleaner |
+
+## Priority Matrix
+
+| Priority | Type | Examples | Default action |
+| --- | --- | --- | --- |
+| P0 | Security or correctness | Trust-boundary bugs, unsafe mutation, data loss | Fix now |
+| P1 | High-risk maintainability | Silent failures, undefined ownership, brittle branches | Fix in this change |
+| P2 | Medium maintainability | Duplication, wrong abstraction, over-coupling | Fix when touching the area |
+| P3 | Low-impact polish | Naming, constants, light cleanup | Fix if cheap |
+
+Bias upward for quick wins. Bias downward if the fix is risky and untested.
+
+## Principle Tensions
+
+- DRY vs Wrong Abstraction: Duplication is often cheaper than a premature abstraction. Extract only when the repeated behavior is truly the same concept.
+- YAGNI vs Flexibility: Small seams are good; speculative frameworks are not.
+- DAMP Tests vs DRY Tests: Tests should read like intent, even if that means repeating setup.
+- Postel vs Security: Be generous only inside trusted boundaries. At external boundaries, parse strictly and fail closed.
+
+## Part I: Clean Code
+
+### KISS
+
+- Prefer the most direct design that solves the real problem.
+- Smells: helper pyramids, unnecessary indirection, configurable behavior for one caller.
+- Default fix: inline, delete, or simplify until the code path is obvious.
+
+### YAGNI
+
+- Do not build extension points before there is evidence they are needed.
+- Smells: dead flags, unused hooks, generic abstractions with one implementation.
+- Default fix: remove speculative flexibility and keep the present use case explicit.
+
+### Small Functions
+
+- A function should do one thing at one level of abstraction.
+- Smells: 50-line methods, mixed parsing and orchestration, boolean parameters that fork behavior.
+- Default fix: extract helpers with names that explain the step.
+
+### Guard Clauses
+
+- Handle invalid or exceptional cases first, then keep the happy path straight.
+- Smells: 3+ nesting levels, inverted flow, deeply nested conditionals.
+- Default fix: early return for invalid states, then let the main path read top to bottom.
+
+### Cognitive Load
+
+- Optimize for how hard code is to understand, not how clever it is.
+- Smells: heavy branching, mutable shared state, context that must be remembered across many lines.
+- Default fix: shorten scopes, reduce branching, and give intermediate concepts names.
+
+### Single Level of Abstraction
+
+- Keep one function at one conceptual altitude.
+- Smells: a method that mixes HTTP parsing, business rules, and SQL details.
+- Default fix: move low-level details into helpers or move orchestration into a higher-level function.
+
+### Self-Documenting Code
+
+- Names should carry intent so comments do not need to explain basic behavior.
+- Smells: `tmp`, `data2`, `process()`, magic constants, comments that merely translate syntax to English.
+- Default fix: rename values and extract named constants for important domain concepts.
+
+### Documentation Discipline
+
+- Code explains how; comments explain why, invariants, or surprising tradeoffs.
+- Smells: stale comments, comments narrating obvious code, missing explanation for non-obvious constraints.
+- Default fix: delete misleading comments and keep only the context future readers truly need.
+
+### Least Surprise
+
+- APIs and behavior should match what a reasonable caller expects.
+- Smells: inconsistent return shapes, hidden mutation, helpers with surprising side effects.
+- Default fix: align naming, return values, and side effects with common expectations.
+
+## Part II: Architecture
+
+### DRY
+
+- Keep one authoritative implementation per concept.
+- Smells: same validation, mapping, or policy logic repeated in multiple places.
+- Default fix: extract shared behavior only when the rule is actually shared and stable.
+
+### Single Source of Truth
+
+- Every important fact should have one owner.
+- Smells: duplicated configuration, mirrored state, derived data stored in multiple places.
+- Default fix: choose the owner and derive everything else from it.
+
+### Separation of Concerns
+
+- Give each module one primary reason to change.
+- Smells: route handlers doing parsing, business logic, persistence, and presentation.
+- Default fix: separate orchestration from domain rules from IO details.
+
+### Modularity
+
+- Modules should hide internals and expose small interfaces.
+- Smells: callers reaching through multiple layers, broad imports, internal structures leaking out.
+- Default fix: collapse hidden details behind a narrower public seam.
+
+### Encapsulation
+
+- Bind data with the behavior that preserves its invariants.
+- Smells: callers pulling internal state out, modifying it, and pushing it back later.
+- Default fix: move operations to the owner of the data.
+
+### Law of Demeter
+
+- Talk to your collaborators, not your collaborators' collaborators.
+- Smells: `a.b().c().d()` chains and remote knowledge of internal structure.
+- Default fix: add a local method on the nearer object and call that instead.
+
+### Orthogonality
+
+- Changes in one concept should not force edits in unrelated areas.
+- Smells: adding a mode requires touching routing, rendering, storage, and logging in parallel.
+- Default fix: decouple the shared concept from unrelated concerns.
+
+### Dependency Injection
+
+- Pass dependencies in; do not construct hidden globals inside business logic.
+- Smells: hard-coded clients, time sources, random generators, or service constructors inside methods.
+- Default fix: inject collaborators so tests and alternate environments remain simple.
+
+### Composition Over Inheritance
+
+- Prefer assembling small behaviors over extending deep class hierarchies.
+- Smells: deep inheritance trees, fragile overrides, parent classes with broad responsibilities.
+- Default fix: extract shared behavior into collaborators or small composable helpers.
+
+### SOLID
+
+- Use SRP to find oversized modules.
+- Use OCP carefully: extend through small seams, not speculative frameworks.
+- Use LSP and ISP to keep interfaces honest and small.
+- Use DIP when high-level logic depends on concrete IO details.
+
+### Convention Over Configuration
+
+- Sensible defaults beat repetitive setup.
+- Smells: the same configuration copied across every caller.
+- Default fix: make the common path automatic and keep escape hatches explicit.
+
+### Command-Query Separation
+
+- A function should either change state or answer a question, not both in a surprising way.
+- Smells: "getter" methods with mutation, writes that also return expensive computed state.
+- Default fix: split mutation from query unless the combined API is clearly intentional.
+
+### Code Reusability
+
+- Reuse is earned after repetition, not designed in advance.
+- Smells: abstract base types with one implementation, utility packages with no real callers.
+- Default fix: keep concrete code until reuse becomes obvious.
+
+## Part III: Data and State
+
+### Parse, Don't Validate
+
+- Turn untrusted inputs into trusted domain values at the boundary.
+- Smells: raw dictionaries and loosely typed maps flowing deep into business logic.
+- Default fix: parse once, then operate on values that prove their own validity.
+
+### Immutability
+
+- Limit mutation to well-defined ownership boundaries.
+- Smells: objects modified in place across many scopes, hidden shared state, temporal coupling.
+- Default fix: return new values when practical and isolate the few places that mutate.
+
+### Idempotency
+
+- Repeating the same action should not create unintended side effects when the operation is meant to be retry-safe.
+- Smells: duplicate jobs, duplicate writes, repeated side effects on retry.
+- Default fix: add idempotency keys, existence checks, or safe upsert behavior.
+
+## Part IV: Reliability and Operations
+
+### Fail Fast
+
+- Detect invalid state early and loudly.
+- Smells: swallowed exceptions, broad fallback paths, errors discovered far downstream.
+- Default fix: validate at entry points, raise precise errors, and stop on impossible state.
+
+### Design by Contract
+
+- Make preconditions, invariants, and postconditions explicit.
+- Smells: hidden assumptions about inputs, missing shape checks, unclear return guarantees.
+- Default fix: define the contract at the seam and enforce it near the boundary.
+
+### Postel's Law
+
+- Inside trusted systems, accept slightly varied input if that improves compatibility.
+- At external trust boundaries, do not be liberal; parse strictly.
+- Default fix: be conservative in what you emit, but do not weaken security or invariants for convenience.
+
+### Resilience
+
+- Systems should fail clearly and degrade deliberately under partial failure.
+- Smells: retries without limits, silent fallback behavior, missing timeout handling.
+- Default fix: set clear timeout, retry, and fallback policies with visible error paths.
+
+### Least Privilege
+
+- Give code and users only the permissions they need.
+- Smells: overbroad access tokens, wide write surfaces, admin-by-default behavior.
+- Default fix: narrow scopes, enforce ownership, and fail closed on unauthorized access.
+
+### Boy Scout Rule
+
+- Leave touched code cleaner than you found it.
+- Smells: obvious dead code, stale names, unaddressed local mess in files you are already editing.
+- Default fix: pay down small debt while in the file, but do not turn a focused change into a giant rewrite.
+
+### Observability
+
+- Production behavior should be understandable from logs, metrics, traces, and structured metadata.
+- Smells: silent failures, generic errors, missing request context, logs without identifiers.
+- Default fix: emit structured events with enough context to explain what happened without leaking secrets.
+
+## Default Recommendations by Smell
+
+- Duplicate logic in 2 places: note it, but do not force extraction unless the concept is stable.
+- Duplicate logic in 3+ places: DRY issue. Recommend consolidation.
+- Boolean flag changing behavior: consider splitting into named functions or strategies.
+- Long parameter list: consider a value object only if the parameters form a real concept.
+- Large class or module: split by responsibility, not by arbitrary file size.
+- Giant cleanup opportunity with no tests: recommend staging the work instead of doing it blindly.
+
+## Context-Specific Exceptions
+
+- Prototypes and spikes: optimize for learning, then delete or harden before shipping.
+- Test code: descriptive setup is often better than abstract helpers.
+- Very small scripts: structure matters less than clarity.
+- Hot paths: measure before abstracting or de-abstracting for performance.
+- Generated code: fix the generator, not the generated output.
+
+## What `/deslop` Should Not Do
+
+- Do not turn a clean concrete implementation into a generic framework.
+- Do not flag every stylistic preference as a principle violation.
+- Do not recommend a rewrite when a local cleanup solves the real risk.
+- Do not ignore trust boundaries, concurrency, or operational failure modes while nitpicking formatting.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -10,6 +10,8 @@ Detailed guides for every gstack skill — philosophy, workflow, and examples.
 | [`/plan-design-review`](#plan-design-review) | **Senior Designer** | Interactive plan-mode design review. Rates each dimension 0-10, explains what a 10 looks like, fixes the plan. Works in plan mode. |
 | [`/design-consultation`](#design-consultation) | **Design Partner** | Build a complete design system from scratch. Knows the landscape, proposes creative risks, generates realistic product mockups. Design at the heart of all other phases. |
 | [`/review`](#review) | **Staff Engineer** | Find the bugs that pass CI but blow up in production. Auto-fixes the obvious ones. Flags completeness gaps. |
+| [`/deslop`](#deslop) | **Cleanup Reviewer** | Pressure-test a file, directory, or diff against a compact engineering-principles reference. Reports the highest-value maintainability fixes and can implement approved cleanup. |
+| [`/addtodeslop`](#addtodeslop) | **Principles Curator** | Research a missing cleanup principle and merge it into the shared `/deslop` reference. Keeps the guide compact and battle-tested. |
 | [`/investigate`](#investigate) | **Debugger** | Systematic root-cause debugging. Iron Law: no fixes without investigation. Traces data flow, tests hypotheses, stops after 3 failed fixes. |
 | [`/design-review`](#design-review) | **Designer Who Codes** | Live-site visual audit + fix loop. 80-item audit, then fixes what it finds. Atomic commits, before/after screenshots. |
 | [`/qa`](#qa) | **QA Lead** | Test your app, find bugs, fix them with atomic commits, re-verify. Auto-generates regression tests for every fix. |
@@ -448,6 +450,53 @@ That is the point of `/review`.
 
 I do not want flattery here.
 I want the model imagining the production incident before it happens.
+
+---
+
+## `/deslop`
+
+This is the maintainability pressure test.
+
+`/review` is about production bugs and release risk. `/deslop` is about whether
+the code has started to rot even if it still technically works. It reads a file,
+directory, or diff against a compact engineering-principles reference and
+reports the highest-value cleanup moves.
+
+The emphasis is not "style." It is signal:
+
+* cognitive load that makes code hard to hold in your head
+* duplication that is now expensive enough to consolidate
+* mixed responsibilities that make a module brittle
+* hidden ownership problems that create drift
+* error handling that is technically present but operationally vague
+
+The output is concrete. For each issue it gives the principle, the location, a
+short before/after example, and the smallest fix that actually improves the
+code. If you approve, it implements the cleanup and runs the narrowest useful
+verification.
+
+In practice I use `/deslop` when a file "feels bad" but I want a disciplined
+cleanup pass instead of an improvised refactor.
+
+---
+
+## `/addtodeslop`
+
+This is the curator for the `/deslop` playbook itself.
+
+Over time you notice recurring cleanup patterns that are not yet in the shared
+reference. `/addtodeslop` researches one missing principle, writes a compact new
+section in the same voice as the existing guide, and updates nearby navigation
+if the new idea changes how `/deslop` should triage issues.
+
+It is intentionally conservative:
+
+* no textbook-sized essays
+* no duplicate principles under new names
+* no speculative theory with weak code-review value
+
+If the new principle changes how `/deslop` should operate, it updates the
+template and regenerates the Claude and Codex outputs in the same change.
 
 ---
 

--- a/setup
+++ b/setup
@@ -262,7 +262,7 @@ link_codex_skill_dirs() {
 
 # ─── Helper: create .agents/skills/gstack/ sidecar symlinks ──────────
 # Codex/Gemini/Cursor read skills from .agents/skills/. We link runtime
-# assets (bin/, browse/dist/, review/, qa/, etc.) so skill templates can
+# assets (bin/, browse/dist/, review/, qa/, deslop reference files, etc.) so skill templates can
 # resolve paths like $SKILL_ROOT/review/design-checklist.md.
 create_agents_sidecar() {
   local repo_root="$1"
@@ -290,6 +290,15 @@ create_agents_sidecar() {
       fi
     fi
   done
+
+  # deslop reference assets (template + principles reference, but not SKILL.md)
+  mkdir -p "$agents_gstack/deslop/references"
+  if [ -f "$SOURCE_GSTACK_DIR/deslop/SKILL.md.tmpl" ]; then
+    ln -snf "$SOURCE_GSTACK_DIR/deslop/SKILL.md.tmpl" "$agents_gstack/deslop/SKILL.md.tmpl"
+  fi
+  if [ -f "$SOURCE_GSTACK_DIR/deslop/references/principles.md" ]; then
+    ln -snf "$SOURCE_GSTACK_DIR/deslop/references/principles.md" "$agents_gstack/deslop/references/principles.md"
+  fi
 }
 
 # ─── Helper: create a minimal ~/.codex/skills/gstack runtime root ───────────
@@ -309,7 +318,7 @@ create_codex_runtime_root() {
     rm -rf "$codex_gstack"
   fi
 
-  mkdir -p "$codex_gstack" "$codex_gstack/browse" "$codex_gstack/gstack-upgrade" "$codex_gstack/review"
+  mkdir -p "$codex_gstack" "$codex_gstack/browse" "$codex_gstack/gstack-upgrade" "$codex_gstack/review" "$codex_gstack/deslop/references"
 
   if [ -f "$agents_dir/gstack/SKILL.md" ]; then
     ln -snf "$agents_dir/gstack/SKILL.md" "$codex_gstack/SKILL.md"
@@ -335,6 +344,13 @@ create_codex_runtime_root() {
   # ETHOS.md — referenced by "Search Before Building" in all skill preambles
   if [ -f "$gstack_dir/ETHOS.md" ]; then
     ln -snf "$gstack_dir/ETHOS.md" "$codex_gstack/ETHOS.md"
+  fi
+  # deslop reference assets (template + principles reference, but not SKILL.md)
+  if [ -f "$gstack_dir/deslop/SKILL.md.tmpl" ]; then
+    ln -snf "$gstack_dir/deslop/SKILL.md.tmpl" "$codex_gstack/deslop/SKILL.md.tmpl"
+  fi
+  if [ -f "$gstack_dir/deslop/references/principles.md" ]; then
+    ln -snf "$gstack_dir/deslop/references/principles.md" "$codex_gstack/deslop/references/principles.md"
   fi
 }
 
@@ -394,7 +410,7 @@ if [ "$INSTALL_KIRO" -eq 1 ]; then
   KIRO_GSTACK="$KIRO_SKILLS/gstack"
   # Remove old whole-dir symlink from previous installs
   [ -L "$KIRO_GSTACK" ] && rm -f "$KIRO_GSTACK"
-  mkdir -p "$KIRO_GSTACK" "$KIRO_GSTACK/browse" "$KIRO_GSTACK/gstack-upgrade" "$KIRO_GSTACK/review"
+  mkdir -p "$KIRO_GSTACK" "$KIRO_GSTACK/browse" "$KIRO_GSTACK/gstack-upgrade" "$KIRO_GSTACK/review" "$KIRO_GSTACK/deslop/references"
   ln -snf "$SOURCE_GSTACK_DIR/bin" "$KIRO_GSTACK/bin"
   ln -snf "$SOURCE_GSTACK_DIR/browse/dist" "$KIRO_GSTACK/browse/dist"
   ln -snf "$SOURCE_GSTACK_DIR/browse/bin" "$KIRO_GSTACK/browse/bin"
@@ -412,6 +428,13 @@ if [ "$INSTALL_KIRO" -eq 1 ]; then
       ln -snf "$SOURCE_GSTACK_DIR/review/$f" "$KIRO_GSTACK/review/$f"
     fi
   done
+  # deslop reference assets (template + principles reference, but not SKILL.md)
+  if [ -f "$SOURCE_GSTACK_DIR/deslop/SKILL.md.tmpl" ]; then
+    ln -snf "$SOURCE_GSTACK_DIR/deslop/SKILL.md.tmpl" "$KIRO_GSTACK/deslop/SKILL.md.tmpl"
+  fi
+  if [ -f "$SOURCE_GSTACK_DIR/deslop/references/principles.md" ]; then
+    ln -snf "$SOURCE_GSTACK_DIR/deslop/references/principles.md" "$KIRO_GSTACK/deslop/references/principles.md"
+  fi
 
   # Rewrite root SKILL.md paths for Kiro
   sed -e "s|~/.claude/skills/gstack|~/.kiro/skills/gstack|g" \

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1353,7 +1353,7 @@ describe('setup script validation', () => {
   });
 
   test('create_agents_sidecar links runtime assets', () => {
-    // Sidecar must link bin, browse, review, qa
+    // Sidecar must link bin, browse, review, qa, and deslop reference assets.
     const fnStart = setupContent.indexOf('create_agents_sidecar()');
     const fnEnd = setupContent.indexOf('}', setupContent.indexOf('done', fnStart));
     const fnBody = setupContent.slice(fnStart, fnEnd);
@@ -1361,6 +1361,8 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('browse');
     expect(fnBody).toContain('review');
     expect(fnBody).toContain('qa');
+    expect(fnBody).toContain('deslop/references');
+    expect(fnBody).toContain('deslop/SKILL.md.tmpl');
   });
 
   test('create_codex_runtime_root exposes only runtime assets', () => {
@@ -1376,6 +1378,9 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('design-checklist.md');
     expect(fnBody).toContain('greptile-triage.md');
     expect(fnBody).toContain('TODOS-format.md');
+    expect(fnBody).toContain('deslop/references/principles.md');
+    expect(fnBody).toContain('deslop/SKILL.md.tmpl');
+    expect(fnBody).not.toContain('ln -snf "$gstack_dir/deslop/SKILL.md"');
     expect(fnBody).not.toContain('ln -snf "$gstack_dir" "$codex_gstack"');
   });
 


### PR DESCRIPTION
## Summary
- add the `deslop` skill, which reviews a file, directory, or diff against a compact engineering-principles reference and proposes the highest-value cleanup fixes
- add the `addtodeslop` skill, which researches a missing cleanup principle and extends the shared deslop reference in the same voice and structure
- wire both skills into the current Claude and Codex install surfaces, including setup/runtime paths so the shared deslop reference resolves in Codex installs
- update the skill listings and deep-dive docs so both skills are discoverable in the current gstack workflow

## Verification
- `bun run gen:skill-docs`
- `bun run gen:skill-docs --host codex`
- `bun run skill:check`

## Attribution
- skill content adapted from Theta-Tech-AI `llm-public-utils`
- source: https://github.com/Theta-Tech-AI/llm-public-utils/blob/production/slash_commands/deslop.md
- source: https://github.com/Theta-Tech-AI/llm-public-utils/blob/production/slash_commands/addtodeslop.md