### PR TITLE
feat: browser selection rule — use Claude for Chrome for visual analysis tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,9 +153,10 @@ Rules:
 ## Browser interaction
 
 When you need to interact with a browser (QA, dogfooding, cookie setup), use the
-`/browse` skill or run the browse binary directly via `$B <command>`. NEVER use
-`mcp__claude-in-chrome__*` tools — they are slow, unreliable, and not what this
-project uses.
+`/browse` skill or run the browse binary directly via `$B <command>`. For competitive
+analysis, design analysis, or UX experience evaluation, use Claude for Chrome
+(`mcp__claude-in-chrome__*`) instead — headless browsers cannot capture animations,
+visual hierarchy, and interaction quality that these tasks require.
 
 ## Vendored symlink awareness
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -321,10 +321,16 @@ If `NEEDS_SETUP`:
 2. Run: `cd <SKILL_DIR> && ./setup`
 3. If `bun` is not installed: `curl -fsSL https://bun.sh/install | bash`
 
-## IMPORTANT
+## Browser Selection Rule
 
-- Use the compiled binary via Bash: `$B <command>`
-- NEVER use `mcp__claude-in-chrome__*` tools. They are slow and unreliable.
+**Choose the right browser for the task:**
+
+| Scenario | Browser | Why |
+|----------|---------|-----|
+| **Competitive analysis, design analysis, UX evaluation** | Claude for Chrome (`mcp__claude-in-chrome__*`) | Requires real visual experience — animations, interactions, design quality, and visual hierarchy that headless browsers cannot fully capture |
+| **QA testing, deploy verification, functional regression, form testing, performance checks** | Headless Chromium (`$B <command>`) | Fast, scriptable, suited for automated assertions and batch operations |
+
+**Headless Chromium rules (when using `$B`):**
 - Browser persists between calls — cookies, login sessions, and tabs carry over.
 - Dialogs (alert/confirm/prompt) are auto-accepted by default — no browser lockup.
 - **Show screenshots:** After `$B screenshot`, `$B snapshot -a -o`, or `$B responsive`, always use the Read tool on the output PNG(s) so the user can see them. Without this, screenshots are invisible.

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -27,10 +27,16 @@ Auto-shuts down after 30 min idle. State persists between calls (cookies, tabs, 
 
 {{BROWSE_SETUP}}
 
-## IMPORTANT
+## Browser Selection Rule
 
-- Use the compiled binary via Bash: `$B <command>`
-- NEVER use `mcp__claude-in-chrome__*` tools. They are slow and unreliable.
+**Choose the right browser for the task:**
+
+| Scenario | Browser | Why |
+|----------|---------|-----|
+| **Competitive analysis, design analysis, UX evaluation** | Claude for Chrome (`mcp__claude-in-chrome__*`) | Requires real visual experience — animations, interactions, design quality, and visual hierarchy that headless browsers cannot fully capture |
+| **QA testing, deploy verification, functional regression, form testing, performance checks** | Headless Chromium (`$B <command>`) | Fast, scriptable, suited for automated assertions and batch operations |
+
+**Headless Chromium rules (when using `$B`):**
 - Browser persists between calls — cookies, login sessions, and tabs carry over.
 - Dialogs (alert/confirm/prompt) are auto-accepted by default — no browser lockup.
 - **Show screenshots:** After `$B screenshot`, `$B snapshot -a -o`, or `$B responsive`, always use the Read tool on the output PNG(s) so the user can see them. Without this, screenshots are invisible.


### PR DESCRIPTION
## Summary
- Replace the blanket ban on `mcp__claude-in-chrome__*` with a task-based browser selection rule
- Headless Chromium (`$B`) remains the default for QA, deploy verification, functional regression, form testing, and performance checks
- Claude for Chrome is now recommended for competitive analysis, design analysis, and UX evaluation — tasks where real visual experience (animations, interaction quality, visual hierarchy) matters and headless browsers cannot fully capture

## Motivation
Headless browsers are great for automated testing but fundamentally cannot render animations, evaluate visual hierarchy, or assess interaction quality the way a real browser can. For tasks like competitive analysis or design review, Claude for Chrome provides the visual fidelity needed for meaningful assessment.

## Changes
- `CLAUDE.md` — Updated browser interaction section with task-based routing
- `SKILL.md` — Replaced "IMPORTANT" section with a "Browser Selection Rule" table
- `SKILL.md.tmpl` — Same change in the template to keep them in sync

## Test plan
- [ ] Verify `/browse` skill still defaults to headless for QA workflows
- [ ] Verify Claude for Chrome is suggested for design/competitive analysis tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)