### PR TITLE
fix(browse): resolve EADDRINUSE race condition on Windows via hardened polyfill and retry logic

### DIFF
--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -16,10 +16,11 @@ const { spawnSync, spawn } = require('child_process');
 globalThis.Bun = {
   serve(options) {
     const { port, hostname = '127.0.0.1', fetch } = options;
+    let currentPort = port;
 
     const server = http.createServer(async (nodeReq, nodeRes) => {
       try {
-        const url = `http://${hostname}:${port}${nodeReq.url}`;
+        const url = `http://${hostname}:${currentPort}${nodeReq.url}`;
         const headers = new Headers();
         for (const [key, val] of Object.entries(nodeReq.headers)) {
           if (val) headers.set(key, Array.isArray(val) ? val[0] : val);
@@ -55,13 +56,66 @@ globalThis.Bun = {
       }
     });
 
-    server.listen(port, hostname);
-
-    return {
-      stop() { server.close(); },
-      port,
-      hostname,
+    const runtimeErrorHandler = (err) => {
+      const msg = err && err.message ? err.message : String(err);
+      console.error(`[browse] Node HTTP server runtime error: ${msg}`);
     };
+    server.on('error', runtimeErrorHandler);
+
+    let onListening;
+    let onError;
+    const cleanupStartupListeners = () => {
+      if (onListening) server.off('listening', onListening);
+      if (onError) server.off('error', onError);
+    };
+
+    const serverHandle = {
+      stop() {
+        server.off('error', runtimeErrorHandler);
+        server.close();
+      },
+      port: currentPort,
+      hostname,
+      ready: null,
+    };
+
+    const ready = new Promise((resolve, reject) => {
+      onListening = () => {
+        try {
+          const addr = server.address();
+          if (addr && typeof addr === 'object' && typeof addr.port === 'number') {
+            currentPort = addr.port;
+            serverHandle.port = addr.port;
+          }
+          cleanupStartupListeners();
+          resolve();
+        } catch (err) {
+          cleanupStartupListeners();
+          reject(err);
+        }
+      };
+
+      onError = (err) => {
+        cleanupStartupListeners();
+        reject(err);
+      };
+
+      server.once('listening', onListening);
+      server.once('error', onError);
+
+      try {
+        server.listen(port, hostname);
+      } catch (err) {
+        cleanupStartupListeners();
+        reject(err);
+      }
+    });
+
+    // Avoid unhandled rejection if a caller forgets to await ready.
+    ready.catch(() => {});
+    serverHandle.ready = ready;
+
+    return serverHandle;
   },
 
   spawnSync(cmd, options = {}) {

--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -161,12 +161,24 @@ export { READ_COMMANDS, WRITE_COMMANDS, META_COMMANDS };
 const browserManager = new BrowserManager();
 let isShuttingDown = false;
 
+type ServerWithOptionalReady = {
+  stop: () => void;
+  ready?: Promise<void>;
+};
+
+async function awaitServerReady(server: ServerWithOptionalReady): Promise<void> {
+  if (server.ready && typeof server.ready.then === 'function') {
+    await server.ready;
+  }
+}
+
 // Find port: explicit BROWSE_PORT, or random in 10000-60000
 async function findPort(): Promise<number> {
   // Explicit port override (for debugging)
   if (BROWSE_PORT) {
     try {
-      const testServer = Bun.serve({ port: BROWSE_PORT, fetch: () => new Response('ok') });
+      const testServer = Bun.serve({ port: BROWSE_PORT, fetch: () => new Response('ok') }) as unknown as ServerWithOptionalReady;
+      await awaitServerReady(testServer);
       testServer.stop();
       return BROWSE_PORT;
     } catch {
@@ -181,7 +193,8 @@ async function findPort(): Promise<number> {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     const port = MIN_PORT + Math.floor(Math.random() * (MAX_PORT - MIN_PORT));
     try {
-      const testServer = Bun.serve({ port, fetch: () => new Response('ok') });
+      const testServer = Bun.serve({ port, fetch: () => new Response('ok') }) as unknown as ServerWithOptionalReady;
+      await awaitServerReady(testServer);
       testServer.stop();
       return port;
     } catch {
@@ -294,6 +307,95 @@ if (process.platform === 'win32') {
   });
 }
 
+function createFetchHandler(startTime: number) {
+  return async (req: Request) => {
+    resetIdleTimer();
+
+    const url = new URL(req.url);
+
+    // Cookie picker routes — no auth required (localhost-only)
+    if (url.pathname.startsWith('/cookie-picker')) {
+      return handleCookiePickerRoute(url, req, browserManager);
+    }
+
+    // Health check — no auth required (now async)
+    if (url.pathname === '/health') {
+      const healthy = await browserManager.isHealthy();
+      return new Response(JSON.stringify({
+        status: healthy ? 'healthy' : 'unhealthy',
+        uptime: Math.floor((Date.now() - startTime) / 1000),
+        tabs: browserManager.getTabCount(),
+        currentUrl: browserManager.getCurrentUrl(),
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // All other endpoints require auth
+    if (!validateAuth(req)) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (url.pathname === '/command' && req.method === 'POST') {
+      const body = await req.json();
+      return handleCommand(body);
+    }
+
+    return new Response('Not found', { status: 404 });
+  };
+}
+
+function isAddressInUseError(err: any): boolean {
+  if (!err) return false;
+  if (err.code === 'EADDRINUSE') return true;
+  const message = String(err.message || err);
+  return (
+    message.includes('EADDRINUSE') ||
+    message.toLowerCase().includes('address already in use') ||
+    message.includes('(from BROWSE_PORT env) is in use')
+  );
+}
+
+async function startServerWithRetry(startTime: number, maxRetries = 5): Promise<{ server: ServerWithOptionalReady; port: number }> {
+  const basePort = BROWSE_PORT ? parseInt(String(BROWSE_PORT), 10) : await findPort();
+  let lastErr: any = null;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const port = basePort + (attempt - 1);
+    let server: ServerWithOptionalReady | null = null;
+
+    try {
+      server = Bun.serve({
+        port,
+        hostname: '127.0.0.1',
+        fetch: createFetchHandler(startTime),
+      }) as unknown as ServerWithOptionalReady;
+      await awaitServerReady(server);
+      return { server, port };
+    } catch (err: any) {
+      if (server) {
+        try { server.stop(); } catch {}
+      }
+
+      if (isAddressInUseError(err) && attempt < maxRetries) {
+        console.warn(`[browse] Port ${port} in use, retrying... (${attempt}/${maxRetries})`);
+        lastErr = err;
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  if (lastErr) {
+    throw new Error(`[browse] Failed to bind after ${maxRetries} attempts: ${lastErr.message || lastErr}`);
+  }
+  throw new Error(`[browse] Failed to bind after ${maxRetries} attempts`);
+}
+
 // ─── Start ─────────────────────────────────────────────────────
 async function start() {
   // Clear old log files
@@ -301,55 +403,11 @@ async function start() {
   try { fs.unlinkSync(NETWORK_LOG_PATH); } catch {}
   try { fs.unlinkSync(DIALOG_LOG_PATH); } catch {}
 
-  const port = await findPort();
-
   // Launch browser
   await browserManager.launch();
 
   const startTime = Date.now();
-  const server = Bun.serve({
-    port,
-    hostname: '127.0.0.1',
-    fetch: async (req) => {
-      resetIdleTimer();
-
-      const url = new URL(req.url);
-
-      // Cookie picker routes — no auth required (localhost-only)
-      if (url.pathname.startsWith('/cookie-picker')) {
-        return handleCookiePickerRoute(url, req, browserManager);
-      }
-
-      // Health check — no auth required (now async)
-      if (url.pathname === '/health') {
-        const healthy = await browserManager.isHealthy();
-        return new Response(JSON.stringify({
-          status: healthy ? 'healthy' : 'unhealthy',
-          uptime: Math.floor((Date.now() - startTime) / 1000),
-          tabs: browserManager.getTabCount(),
-          currentUrl: browserManager.getCurrentUrl(),
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        });
-      }
-
-      // All other endpoints require auth
-      if (!validateAuth(req)) {
-        return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-          status: 401,
-          headers: { 'Content-Type': 'application/json' },
-        });
-      }
-
-      if (url.pathname === '/command' && req.method === 'POST') {
-        const body = await req.json();
-        return handleCommand(body);
-      }
-
-      return new Response('Not found', { status: 404 });
-    },
-  });
+  const { port } = await startServerWithRetry(startTime, 5);
 
   // Write state file (atomic: write .tmp then rename)
   const state = {


### PR DESCRIPTION
Fixes #486

## Summary
This PR resolves #486 by addressing a **TOCTOU (Time-of-Check to Time-of-Use)** race condition in the `browse` server startup, specifically affecting Windows users running under the Node.js polyfill.

It introduces a "Mechanical Resilience" pattern that allows the server to gracefully recover from port collisions instead of crashing the daemon.

---

## The Problem
On Windows/Node.js, `server.listen()` is an asynchronous operation.

The current implementation uses `findPort()` to check for a free port, but due to the delay between the check and the actual `listen()` call, the port can be reclaimed by the OS or another process.

Because the Node.js polyfill handled this via an asynchronous `'error'` event rather than a synchronous exception, the error was going unhandled, leading to a process crash.

---

## The Solution: Two-Layer Defense

### 1. Polyfill Hardening (`browse/src/bun-polyfill.cjs`)
- Updated `Bun.serve` to return a `ready` Promise.
- Attached one-time `listening` and `error` listeners **before** the `listen()` call to ensure no events are missed.
- Implemented a "zero-leak" cleanup strategy that removes startup listeners once the server is bound or fails.

### 2. Retry Orchestration (`browse/src/server.ts`)
- Introduced `startServerWithRetry`.
- Instead of relying on pre-check validation (`findPort()`), the server now attempts to bind directly.
- On `EADDRINUSE`, the logic:
  - Catches the error
  - Increments the port
  - Retries (up to 5 attempts)

This ensures the `browse` daemon remains stable even under high concurrency or port contention.

---

## Technical Rigor & Evidence

I verified the fix by:
- Injecting a 10-second artificial delay in `server.ts`
- Manually occupying the selected port using a background script to force a collision

### Before Fix
```
node:events:496
throw er; // Unhandled 'error' event
```

### After Fix
```
[browse] Node HTTP server runtime error: listen EADDRINUSE: address already in use 127.0.0.1:45789
[browse] Port 45789 in use, retrying... (1/5)
[browse] Server running on http://127.0.0.1:45790 (PID: 46840)
```

---

## Impact

- **Zero New Dependencies**  
  Uses only native Node.js and Bun APIs.

- **Backward Compatible**  
  Native Bun runtime behavior remains unchanged.

- **Improved UX**  
  Eliminates a major cause of "Browse server won't start" issues on Windows.