### PR TITLE
fix: screenshot misidentifies relative dot-paths as CSS selectors

### DIFF
--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -114,7 +114,11 @@ export async function handleMetaCommand(
 
       // Separate target (selector/@ref) from output path
       for (const arg of remaining) {
-        if (arg.startsWith('@e') || arg.startsWith('@c') || arg.startsWith('.') || arg.startsWith('#') || arg.includes('[')) {
+        // File paths containing / and ending with an image/pdf extension are never CSS selectors
+        const isFilePath = arg.includes('/') && /\.(png|jpe?g|webp|pdf)$/i.test(arg);
+        if (isFilePath) {
+          outputPath = arg;
+        } else if (arg.startsWith('@e') || arg.startsWith('@c') || arg.startsWith('.') || arg.startsWith('#') || arg.includes('[')) {
           targetSelector = arg;
         } else {
           outputPath = arg;

--- a/browse/test/commands.test.ts
+++ b/browse/test/commands.test.ts
@@ -543,6 +543,17 @@ describe('Visual', () => {
     }
   });
 
+  test('screenshot treats relative dot-slash path as file path, not CSS selector', async () => {
+    await handleWriteCommand('goto', [baseUrl + '/basic.html'], bm);
+    // ./path/to/file.png must be treated as output path, not a CSS class selector (#495)
+    const relPath = './browse-test-dotpath.png';
+    const absPath = path.resolve(relPath);
+    const result = await handleMetaCommand('screenshot', [relPath], bm, async () => {});
+    expect(result).toContain('Screenshot saved');
+    expect(fs.existsSync(absPath)).toBe(true);
+    fs.unlinkSync(absPath);
+  });
+
   test('screenshot with nonexistent selector throws timeout', async () => {
     await handleWriteCommand('goto', [baseUrl + '/basic.html'], bm);
     try {


### PR DESCRIPTION
## Problem

`browse screenshot ./path/to/file.png` fails with CSS parser error because the argument classifier treats any argument starting with `.` as a CSS class selector. Same problem with `.gstack/screenshots/page.png`.

```
screenshot: Unexpected token "/" while parsing css selector "./path/to/file.png"
```

Absolute paths like `/tmp/file.png` work fine because they dont start with `.`.

## Root Cause

In `browse/src/meta-commands.ts` line 117, the condition `arg.startsWith('.')` catches both CSS selectors (`.my-class`) and relative file paths (`./screenshots/page.png`) without distinguishing them.

## Fix

Added a file path check before the CSS selector check. If an argument contains `/` AND ends with an image/pdf extension (`.png`, `.jpg`, `.jpeg`, `.webp`, `.pdf`), it is unambiguously a file path and not a CSS selector.

```typescript
const isFilePath = arg.includes('/') && /\.(png|jpe?g|webp|pdf)$/i.test(arg);
```

This is safe because:
- CSS selectors like `.menu-item` never contain `/` (this is not valid CSS)
- Real CSS selectors like `.class` dont end with `.png`
- Relative paths like `./test.png` always contain `/` and end with extension

The existing CSS selector detection stays unchanged for everything else - only file paths with `/` and image extension get special handling.

## Testing

Added test case for `./browse-test-dotpath.png` path (could not run full integration tests locally since Playwright browsers were not installed, but the logic is minimal and deterministic).

| Before | After |
|--------|-------|
| `./path.png` -> CSS selector -> parse error | `./path.png` -> file path -> works |
| `.gstack/file.png` -> CSS selector -> error | `.gstack/file.png` -> file path -> works |
| `.my-class` -> CSS selector | `.my-class` -> CSS selector (unchanged) |
| `/tmp/file.png` -> file path | `/tmp/file.png` -> file path (unchanged) |

Closes #495