### PR TITLE
fix: generate Claude runtime under the install root

### DIFF
--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -22,6 +22,9 @@ import { generatePlanCompletionAuditShip, generatePlanCompletionAuditReview, gen
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const DRY_RUN = process.argv.includes('--dry-run');
+const OUTPUT_ROOT = process.env.GSTACK_SKILL_OUT_ROOT
+  ? path.resolve(process.env.GSTACK_SKILL_OUT_ROOT)
+  : null;
 
 // ─── Host Detection ─────────────────────────────────────────
 
@@ -2972,7 +2975,10 @@ const GENERATED_HEADER = `<!-- AUTO-GENERATED from {{SOURCE}} — do not edit di
 function processTemplate(tmplPath: string, host: Host = 'claude'): { outputPath: string; content: string } {
   const tmplContent = fs.readFileSync(tmplPath, 'utf-8');
   const relTmplPath = path.relative(ROOT, tmplPath);
-  let outputPath = tmplPath.replace(/\.tmpl$/, '');
+  const defaultOutputPath = tmplPath.replace(/\.tmpl$/, '');
+  let outputPath = OUTPUT_ROOT && host === 'claude'
+    ? path.join(OUTPUT_ROOT, path.relative(ROOT, defaultOutputPath))
+    : defaultOutputPath;
 
   // Determine skill directory relative to ROOT
   const skillDir = path.relative(ROOT, path.dirname(tmplPath));
@@ -2986,6 +2992,8 @@ function processTemplate(tmplPath: string, host: Host = 'claude'): { outputPath:
     fs.mkdirSync(outputDir, { recursive: true });
     outputPath = path.join(outputDir, 'SKILL.md');
   }
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
   // Extract skill name from frontmatter for TemplateContext
   const { name: extractedName, description: extractedDescription } = extractNameAndDescription(tmplContent);

--- a/setup
+++ b/setup
@@ -221,6 +221,37 @@ link_claude_skill_dirs() {
   fi
 }
 
+create_claude_runtime_root() {
+  local repo_root="$1"
+  local runtime_root="$2"
+  mkdir -p "$runtime_root"
+
+  (
+    cd "$repo_root"
+    GSTACK_SKILL_OUT_ROOT="$runtime_root" bun run scripts/gen-skill-docs.ts >/dev/null
+  )
+
+  for asset in bin browse review qa; do
+    local src="$repo_root/$asset"
+    local dst="$runtime_root/$asset"
+    if [ -d "$src" ] || [ -f "$src" ]; then
+      if [ -L "$dst" ] || [ ! -e "$dst" ]; then
+        ln -snf "$src" "$dst"
+      fi
+    fi
+  done
+
+  for file in ETHOS.md; do
+    local src="$repo_root/$file"
+    local dst="$runtime_root/$file"
+    if [ -f "$src" ]; then
+      if [ -L "$dst" ] || [ ! -e "$dst" ]; then
+        ln -snf "$src" "$dst"
+      fi
+    fi
+  done
+}
+
 # ─── Helper: link generated Codex skills into a skills parent directory ──
 # Installs from .agents/skills/gstack-* (the generated Codex-format skills)
 # instead of source dirs (which have Claude paths).
@@ -348,7 +379,11 @@ fi
 
 if [ "$INSTALL_CLAUDE" -eq 1 ]; then
   if [ "$SKILLS_BASENAME" = "skills" ]; then
-    link_claude_skill_dirs "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
+    CLAUDE_RUNTIME_ROOT="$INSTALL_SKILLS_DIR/gstack"
+    if [ "$INSTALL_GSTACK_DIR" != "$CLAUDE_RUNTIME_ROOT" ]; then
+      create_claude_runtime_root "$SOURCE_GSTACK_DIR" "$CLAUDE_RUNTIME_ROOT"
+    fi
+    link_claude_skill_dirs "$CLAUDE_RUNTIME_ROOT" "$INSTALL_SKILLS_DIR"
     if [ "$LOCAL_INSTALL" -eq 1 ]; then
       echo "gstack ready (project-local)."
       echo "  skills: $INSTALL_SKILLS_DIR"

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1478,6 +1478,23 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('ln -snf "gstack/$skill_name"');
   });
 
+  test('Claude install links skills from the generated runtime root', () => {
+    const claudeSection = setupContent.slice(
+      setupContent.indexOf('# 4. Install for Claude'),
+      setupContent.indexOf('# 5. Install for Codex')
+    );
+    expect(claudeSection).toContain('CLAUDE_RUNTIME_ROOT="$INSTALL_SKILLS_DIR/gstack"');
+    expect(claudeSection).toContain('link_claude_skill_dirs "$CLAUDE_RUNTIME_ROOT" "$INSTALL_SKILLS_DIR"');
+  });
+
+  test('create_claude_runtime_root runs generator from the source repo root', () => {
+    const fnStart = setupContent.indexOf('create_claude_runtime_root()');
+    const fnEnd = setupContent.indexOf('}', setupContent.indexOf('for asset in', fnStart));
+    const fnBody = setupContent.slice(fnStart, fnEnd);
+    expect(fnBody).toContain('cd "$repo_root"');
+    expect(fnBody).toContain('GSTACK_SKILL_OUT_ROOT="$runtime_root" bun run scripts/gen-skill-docs.ts');
+  });
+
   test('setup supports --host auto|claude|codex|kiro', () => {
     expect(setupContent).toContain('--host');
     expect(setupContent).toContain('claude|codex|kiro|auto');


### PR DESCRIPTION
## Summary
- generate Claude skill docs into the install root instead of reading directly from the source checkout
- link top-level Claude slash commands from the generated runtime root
- add setup regression coverage for runtime-root linking and repo-root generation

## Why
This keeps the Claude install self-contained under the chosen install root and makes the top-level skill links point at the runtime that setup actually generated.

## Testing
- bun test ./test/gen-skill-docs.test.ts --test-name-pattern 'setup script validation'
