### PR TITLE
fix(setup): namespace skill symlinks with gstack- prefix (#267, #284)

### DIFF
--- a/setup
+++ b/setup
@@ -23,11 +23,13 @@ esac
 # ─── Parse flags ──────────────────────────────────────────────
 HOST="claude"
 LOCAL_INSTALL=0
+SKILL_PREFIX=1
 while [ $# -gt 0 ]; do
   case "$1" in
     --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
+    --no-prefix) SKILL_PREFIX=0; shift ;;
     *) shift ;;
   esac
 done
@@ -199,6 +201,9 @@ fi
 mkdir -p "$HOME/.gstack/projects"
 
 # ─── Helper: link Claude skill subdirectories into a skills parent directory ──
+# When SKILL_PREFIX=1 (default), symlinks are prefixed with "gstack-" to avoid
+# namespace pollution (e.g., gstack-review instead of review).
+# Use --no-prefix to restore the old flat names.
 link_claude_skill_dirs() {
   local gstack_dir="$1"
   local skills_dir="$2"
@@ -208,16 +213,56 @@ link_claude_skill_dirs() {
       skill_name="$(basename "$skill_dir")"
       # Skip node_modules
       [ "$skill_name" = "node_modules" ] && continue
-      target="$skills_dir/$skill_name"
+      # Apply gstack- prefix unless --no-prefix or already prefixed
+      if [ "$SKILL_PREFIX" -eq 1 ]; then
+        case "$skill_name" in
+          gstack-*) link_name="$skill_name" ;;
+          *)        link_name="gstack-$skill_name" ;;
+        esac
+      else
+        link_name="$skill_name"
+      fi
+      target="$skills_dir/$link_name"
       # Create or update symlink; skip if a real file/directory exists
       if [ -L "$target" ] || [ ! -e "$target" ]; then
         ln -snf "gstack/$skill_name" "$target"
-        linked+=("$skill_name")
+        linked+=("$link_name")
       fi
     fi
   done
   if [ ${#linked[@]} -gt 0 ]; then
     echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+# ─── Helper: remove old unprefixed Claude skill symlinks ──────────────────────
+# Migration: when switching from flat names to gstack- prefixed names,
+# clean up stale symlinks that point into the gstack directory.
+cleanup_old_claude_symlinks() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local removed=()
+  for skill_dir in "$gstack_dir"/*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "node_modules" ] && continue
+      # Skip already-prefixed dirs (gstack-upgrade) — no old symlink to clean
+      case "$skill_name" in gstack-*) continue ;; esac
+      old_target="$skills_dir/$skill_name"
+      # Only remove if it's a symlink pointing into gstack/
+      if [ -L "$old_target" ]; then
+        link_dest="$(readlink "$old_target" 2>/dev/null || true)"
+        case "$link_dest" in
+          gstack/*|*/gstack/*)
+            rm -f "$old_target"
+            removed+=("$skill_name")
+            ;;
+        esac
+      fi
+    fi
+  done
+  if [ ${#removed[@]} -gt 0 ]; then
+    echo "  cleaned up old symlinks: ${removed[*]}"
   fi
 }
 
@@ -348,6 +393,10 @@ fi
 
 if [ "$INSTALL_CLAUDE" -eq 1 ]; then
   if [ "$SKILLS_BASENAME" = "skills" ]; then
+    # Clean up old unprefixed symlinks from previous installs
+    if [ "$SKILL_PREFIX" -eq 1 ]; then
+      cleanup_old_claude_symlinks "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
+    fi
     link_claude_skill_dirs "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
     if [ "$LOCAL_INSTALL" -eq 1 ]; then
       echo "gstack ready (project-local)."


### PR DESCRIPTION
Closes #267
Closes #284

## The problem

gstack installs 27 skills as **flat symlinks** in `~/.claude/skills/` — names like `review`, `ship`, `qa`, `browse`. These are generic names that **collide with other skill packs** and make it impossible to tell which skills belong to gstack vs. something else.

Issue #267 (6 👍) and #284 (2 👍) have been asking for this — it's the #2 most-requested change by community reactions.

Every other skill pack uses namespaced names (`superpowers:brainstorming`, `example-skills:pdf`). gstack is the outlier dumping 27 generic names into the global namespace. As the ecosystem grows, this gets worse.

## The fix (1 file, 51 lines)

The `setup` script now prefixes all Claude skill symlinks with `gstack-`:

```
Before: ~/.claude/skills/review    → gstack/review
After:  ~/.claude/skills/gstack-review → gstack/review
```

This matches what gstack **already does for Codex** via `codexSkillName()` — the Claude side was just missing the same treatment.

**What's in the diff:**
- `link_claude_skill_dirs()` applies `gstack-` prefix (skips `gstack-upgrade` to avoid double-prefix)
- New `cleanup_old_claude_symlinks()` removes stale flat symlinks on upgrade
- `--no-prefix` flag for users who want the old behavior

**What's NOT in the diff:** templates, docs, tests. Those come in a follow-up PR to keep this reviewable.

## Backward compatibility

| | |
|---|---|
| `./setup` | New default — prefixed names (`gstack-review`) |
| `./setup --no-prefix` | Opt-out — old flat names (`review`) |
| Upgrade path | Old symlinks auto-cleaned on re-run |
| Codex/Kiro | Unchanged (already prefixed) |

## How to test

```bash
cd ~/.claude/skills/gstack && ./setup
ls ~/.claude/skills/gstack-*     # ✓ gstack-review, gstack-ship, etc.
ls ~/.claude/skills/review 2>&1  # ✗ gone (cleaned up)

# Backward compat:
./setup --no-prefix
ls ~/.claude/skills/review       # ✓ restored
```

## Follow-up

This is PR 1 of 2. A follow-up PR will update SKILL.md templates and docs to reference `/gstack-review` instead of `/review`. Kept separate to make each PR easy to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)