### PR TITLE
feat(codex): vary reasoning_effort by mode

### DIFF
--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -240,11 +240,18 @@ or sequencing issues. Be direct. Be terse. No compliments. Just the problems.
 THE PLAN:
 <plan content>"
 
-4. Run codex exec with **JSONL output** to capture reasoning traces (5-minute timeout):
+4. Determine reasoning effort based on consult type:
+   - If the prompt asks to **find problems, verify, validate, analyze threats, or audit**
+     → use `model_reasoning_effort="high"`
+   - If the prompt asks to **propose solutions, suggest fixes, provide directions, or answer questions**
+     → use `model_reasoning_effort="medium"`
+   - Default (ambiguous): `model_reasoning_effort="high"`
+
+5. Run codex exec with **JSONL output** to capture reasoning traces (5-minute timeout):
 
 For a **new session:**
 ```bash
-codex exec "<prompt>" -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" | python3 -c "
+codex exec "<prompt>" -s read-only -c 'model_reasoning_effort="<EFFORT>"' --enable web_search_cached --json 2>"$TMPERR" | python3 -c "
 import sys, json
 for line in sys.stdin:
     line = line.strip()
@@ -277,7 +284,7 @@ for line in sys.stdin:
 
 For a **resumed session** (user chose "Continue"):
 ```bash
-codex exec resume <session-id> "<prompt>" -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" | python3 -c "
+codex exec resume <session-id> "<prompt>" -s read-only -c 'model_reasoning_effort="<EFFORT>"' --enable web_search_cached --json 2>"$TMPERR" | python3 -c "
 <same python streaming parser as above>
 "
 ```
@@ -313,7 +320,7 @@ Session saved — run /codex again to continue this conversation.
 agentic coding model). This means as OpenAI ships newer models, /codex automatically
 uses them. If the user wants a specific model, pass `-m` through to codex.
 
-**Reasoning effort:** All modes use `xhigh` — maximum reasoning power. When reviewing code, breaking code, or consulting on architecture, you want the model thinking as hard as possible.
+**Reasoning effort:** Varies by mode. Review and challenge use `xhigh` — finding new defects requires maximum reasoning. Consult uses `high` (analysis/verification) or `medium` (solution proposals/directions) — answering known questions doesn't need the same depth as discovering unknown problems.
 
 **Web search:** All codex commands use `--enable web_search_cached` so Codex can look up
 docs and APIs during review. This is OpenAI's cached index — fast, no extra cost.


### PR DESCRIPTION
## Summary

- Review and challenge modes keep `xhigh` — finding new defects requires maximum reasoning depth
- Consult mode now uses `high` (analysis/verification) or `medium` (solution/direction proposals)
- Updates the "Model & Reasoning" documentation section to reflect the change

## Motivation

All codex modes were hardcoded to `reasoning_effort="xhigh"`. This makes sense for review/challenge where the goal is to discover unknown defects, but consult calls where the problem is already defined and only a direction is needed don't benefit from maximum reasoning — they just consume more tokens.

**Decision criteria:** "Finding new defects → xhigh. Answering known questions → high or medium."

## Changes

- `codex/SKILL.md.tmpl`: Added step 4 in Consult Mode (Step 2C) with reasoning effort selection logic
- `codex/SKILL.md.tmpl`: Changed consult `codex exec` calls from hardcoded `xhigh` to `<EFFORT>` placeholder
- `codex/SKILL.md.tmpl`: Updated "Model & Reasoning" section to document the per-mode strategy

## Test plan

- [ ] Run `/codex review` — should still use `xhigh`
- [ ] Run `/codex challenge` — should still use `xhigh`
- [ ] Run `/codex consult` with analysis prompt — should use `high`
- [ ] Run `/codex consult` with solution prompt — should use `medium`