### PR TITLE
fix: Codex skills use Claude co-author in commit messages

### DIFF
--- a/document-release/SKILL.md.tmpl
+++ b/document-release/SKILL.md.tmpl
@@ -280,7 +280,7 @@ committing.
 git commit -m "$(cat <<'EOF'
 docs: update project documentation for vX.Y.Z.W
 
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+{{CO_AUTHOR_TRAILER}}
 EOF
 )"
 ```

--- a/scripts/resolvers/index.ts
+++ b/scripts/resolvers/index.ts
@@ -12,7 +12,7 @@ import { generateCommandReference, generateSnapshotFlags, generateBrowseSetup } 
 import { generateDesignMethodology, generateDesignHardRules, generateDesignOutsideVoices, generateDesignReviewLite, generateDesignSketch } from './design';
 import { generateTestBootstrap, generateTestCoverageAuditPlan, generateTestCoverageAuditShip, generateTestCoverageAuditReview } from './testing';
 import { generateReviewDashboard, generatePlanFileReviewReport, generateSpecReviewLoop, generateBenefitsFrom, generateCodexSecondOpinion, generateAdversarialStep, generateCodexPlanReview, generatePlanCompletionAuditShip, generatePlanCompletionAuditReview, generatePlanVerificationExec } from './review';
-import { generateSlugEval, generateSlugSetup, generateBaseBranchDetect, generateDeployBootstrap, generateQAMethodology } from './utility';
+import { generateSlugEval, generateSlugSetup, generateBaseBranchDetect, generateDeployBootstrap, generateQAMethodology, generateCoAuthorTrailer } from './utility';
 
 export const RESOLVERS: Record<string, (ctx: TemplateContext) => string> = {
   SLUG_EVAL: generateSlugEval,
@@ -44,4 +44,5 @@ export const RESOLVERS: Record<string, (ctx: TemplateContext) => string> = {
   PLAN_COMPLETION_AUDIT_SHIP: generatePlanCompletionAuditShip,
   PLAN_COMPLETION_AUDIT_REVIEW: generatePlanCompletionAuditReview,
   PLAN_VERIFICATION_EXEC: generatePlanVerificationExec,
+  CO_AUTHOR_TRAILER: generateCoAuthorTrailer,
 };

--- a/scripts/resolvers/utility.ts
+++ b/scripts/resolvers/utility.ts
@@ -364,3 +364,10 @@ Minimum 0 per category.
 11. **Show screenshots to the user.** After every \`$B screenshot\`, \`$B snapshot -a -o\`, or \`$B responsive\` command, use the Read tool on the output file(s) so the user can see them inline. For \`responsive\` (3 files), Read all three. This is critical — without it, screenshots are invisible to the user.
 12. **Never refuse to use the browser.** When the user invokes /qa or /qa-only, they are requesting browser-based testing. Never suggest evals, unit tests, or other alternatives as a substitute. Even if the diff appears to have no UI changes, backend changes affect app behavior — always open the browser and test.`;
 }
+
+export function generateCoAuthorTrailer(ctx: TemplateContext): string {
+  if (ctx.host === 'codex') {
+    return 'Co-Authored-By: OpenAI Codex <noreply@openai.com>';
+  }
+  return 'Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>';
+}

--- a/ship/SKILL.md.tmpl
+++ b/ship/SKILL.md.tmpl
@@ -443,7 +443,7 @@ Save this summary — it goes into the PR body in Step 8.
 git commit -m "$(cat <<'EOF'
 chore: bump version and changelog (vX.Y.Z.W)
 
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+{{CO_AUTHOR_TRAILER}}
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary

- make the co-author trailer in `/ship` and `/document-release` host-specific via a `{{CO_AUTHOR_TRAILER}}` resolver
- Claude output unchanged: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
- Codex output now correct: `Co-Authored-By: OpenAI Codex <noreply@openai.com>`
- keep the change scoped to the co-author trailer only — no other template changes

## Problem

`ship/SKILL.md.tmpl` and `document-release/SKILL.md.tmpl` hardcode the Claude co-author trailer. When `gen-skill-docs --host codex` runs, the Claude trailer gets baked into the Codex skill output verbatim.

Codex users running `/ship` end up with commits like:

```
chore: bump version and changelog (v0.12.1.0)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
```

Wrong attribution in git history. Reported independently in #282 and #383.

## Fix

- add `generateCoAuthorTrailer(ctx)` in `scripts/resolvers/utility.ts` — returns the correct trailer based on `ctx.host`
- register as `CO_AUTHOR_TRAILER` in `scripts/resolvers/index.ts`
- replace the 2 hardcoded lines in `ship/SKILL.md.tmpl` and `document-release/SKILL.md.tmpl` with `{{CO_AUTHOR_TRAILER}}`

Same resolver pattern as `{{SLUG_EVAL}}`, `{{BROWSE_SETUP}}`, etc. +11/-3 lines total.

## Verification

```bash
bun run gen:skill-docs && bun run gen:skill-docs --host codex

# Claude — unchanged
grep "Co-Authored" ship/SKILL.md
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
grep "Co-Authored" document-release/SKILL.md
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

# Codex — now correct
grep "Co-Authored" .agents/skills/gstack-ship/SKILL.md
  Co-Authored-By: OpenAI Codex <noreply@openai.com>
grep "Co-Authored" .agents/skills/gstack-document-release/SKILL.md
  Co-Authored-By: OpenAI Codex <noreply@openai.com>

bun test test/skill-validation.test.ts test/gen-skill-docs.test.ts
  563 pass, 1 fail (pre-existing: package.json 0.12.0.0 != VERSION 0.12.1.0)

bun run gen:skill-docs --dry-run
  29 FRESH, 0 STALE
```

Fixes #282. Fixes #383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)