### PR TITLE
feat(scripts): add publish pipeline and skill evaluation runner

### DIFF
--- a/scripts/evaluate-skills.sh
+++ b/scripts/evaluate-skills.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVAL_DIR="$HOME/.gstack"
+EVAL_LOG="$EVAL_DIR/eval-log.txt"
+
+TIER1=(review ship investigate qa browse)
+TIER2=(autoplan retro document-release land-and-deploy canary)
+TIER3=(careful freeze guard unfreeze setup-deploy)
+TIER4=(benchmark codex cso design-review design-consultation office-hours plan-ceo-review plan-design-review plan-eng-review qa-only setup-browser-cookies gstack-upgrade)
+
+ALL_SKILLS=("${TIER1[@]}" "${TIER2[@]}" "${TIER3[@]}" "${TIER4[@]}")
+
+mkdir -p "$EVAL_DIR"
+touch "$EVAL_LOG"
+
+is_evaluated() {
+  local skill="$1"
+  grep -q "^${skill} " "$EVAL_LOG" 2>/dev/null
+}
+
+cmd_mark() {
+  local skill="$1"
+  local today
+  today="$(date +%Y-%m-%d)"
+  # Remove existing entry if present, then add fresh
+  grep -v "^${skill} " "$EVAL_LOG" > "$EVAL_LOG.tmp" || true
+  mv "$EVAL_LOG.tmp" "$EVAL_LOG"
+  echo "${skill} ${today} evaluated" >> "$EVAL_LOG"
+  echo "Marked '${skill}' as evaluated (${today})"
+}
+
+cmd_reset() {
+  local skill="$1"
+  grep -v "^${skill} " "$EVAL_LOG" > "$EVAL_LOG.tmp" || true
+  mv "$EVAL_LOG.tmp" "$EVAL_LOG"
+  echo "Reset '${skill}' from eval log"
+}
+
+cmd_reset_all() {
+  > "$EVAL_LOG"
+  echo "Eval log cleared"
+}
+
+print_tier() {
+  local tier_name="$1"
+  shift
+  local skills=("$@")
+
+  echo ""
+  echo "## ${tier_name}"
+  for skill in "${skills[@]}"; do
+    if is_evaluated "$skill"; then
+      echo "  [x] ${skill}"
+    else
+      echo "  [ ] ${skill}"
+      echo "      To evaluate: /skill-creator review ${skill}/SKILL.md"
+    fi
+  done
+}
+
+cmd_show() {
+  local evaluated=0
+  local total=${#ALL_SKILLS[@]}
+
+  for skill in "${ALL_SKILLS[@]}"; do
+    if is_evaluated "$skill"; then
+      evaluated=$((evaluated + 1))
+    fi
+  done
+
+  echo "=== gstack skill evaluation checklist ==="
+  echo "Progress: ${evaluated}/${total} skills evaluated"
+
+  print_tier "Tier 1 (critical path)" "${TIER1[@]}"
+  print_tier "Tier 2 (automation)" "${TIER2[@]}"
+  print_tier "Tier 3 (safety)" "${TIER3[@]}"
+  print_tier "Tier 4 (specialty)" "${TIER4[@]}"
+
+  echo ""
+}
+
+# --- Main ---
+
+case "${1:-}" in
+  mark)
+    if [[ -z "${2:-}" ]]; then
+      echo "Usage: evaluate-skills.sh mark <skill>" >&2
+      exit 1
+    fi
+    cmd_mark "$2"
+    ;;
+  reset)
+    if [[ -z "${2:-}" ]]; then
+      echo "Usage: evaluate-skills.sh reset <skill>" >&2
+      exit 1
+    fi
+    cmd_reset "$2"
+    ;;
+  reset-all)
+    cmd_reset_all
+    ;;
+  "")
+    cmd_show
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    echo "Usage: evaluate-skills.sh [mark <skill> | reset <skill> | reset-all]" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─── publish.sh ──────────────────────────────────────────────────────────────
+# Publish gstack skills to ~/.claude/skills/ via symlinks.
+# Creates $SKILLS_DIR/gstack/ with shared assets and skill dirs, then
+# creates discovery symlinks so Claude finds each skill at $SKILLS_DIR/<skill>.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ─── Flag parsing ────────────────────────────────────────────────────────────
+
+DRY_RUN=false
+FORCE=false
+SKILLS_DIR_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --force)
+      FORCE=true
+      shift
+      ;;
+    --skills-dir)
+      if [[ -z "${2:-}" ]]; then
+        echo "Missing value for --skills-dir" >&2
+        echo "Usage: publish.sh [--dry-run] [--force] [--skills-dir <path>]" >&2
+        exit 1
+      fi
+      SKILLS_DIR_OVERRIDE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: publish.sh [--dry-run] [--force] [--skills-dir <path>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ─── Determine directories ──────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_DIR="$(dirname "$SCRIPT_DIR")"
+SKILLS_DIR="${SKILLS_DIR_OVERRIDE:-$HOME/.claude/skills}"
+GSTACK_DIR="$SKILLS_DIR/gstack"
+
+echo "Source:  $SOURCE_DIR"
+echo "Target:  $GSTACK_DIR"
+echo "Skills:  $SKILLS_DIR"
+[ "$DRY_RUN" = true ] && echo "Mode:    dry-run"
+[ "$FORCE" = true ] && echo "Force:   yes"
+echo ""
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+run_cmd() {
+  if [ "$DRY_RUN" = true ]; then
+    echo "  [dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+asset_count=0
+skill_count=0
+discovery_count=0
+skip_count=0
+
+# ─── Step 1: Create gstack dir ──────────────────────────────────────────────
+
+echo "==> Creating gstack directory"
+run_cmd mkdir -p "$GSTACK_DIR"
+
+# ─── Step 2: Symlink shared assets (not inside a skill dir) ─────────────────
+
+echo ""
+echo "==> Deploying shared assets"
+
+# bin/ directory
+echo "  bin/ -> $SOURCE_DIR/bin"
+run_cmd ln -snf "$SOURCE_DIR/bin" "$GSTACK_DIR/bin"
+asset_count=$((asset_count + 1))
+
+# ETHOS.md
+echo "  ETHOS.md -> $SOURCE_DIR/ETHOS.md"
+run_cmd ln -snf "$SOURCE_DIR/ETHOS.md" "$GSTACK_DIR/ETHOS.md"
+asset_count=$((asset_count + 1))
+
+# SKILL.md (root skill)
+echo "  SKILL.md -> $SOURCE_DIR/SKILL.md"
+run_cmd ln -snf "$SOURCE_DIR/SKILL.md" "$GSTACK_DIR/SKILL.md"
+asset_count=$((asset_count + 1))
+
+# ─── Step 3: Symlink skill directories ──────────────────────────────────────
+
+echo ""
+echo "==> Deploying skill directories"
+
+for skill_md in "$SOURCE_DIR"/*/SKILL.md; do
+  skill_path="$(dirname "$skill_md")"
+  skill_name="$(basename "$skill_path")"
+
+  # Skip node_modules
+  [ "$skill_name" = "node_modules" ] && continue
+
+  echo "  $skill_name/ -> $SOURCE_DIR/$skill_name"
+  run_cmd ln -snf "$SOURCE_DIR/$skill_name" "$GSTACK_DIR/$skill_name"
+  skill_count=$((skill_count + 1))
+done
+
+# ─── Step 4: Create discovery symlinks ───────────────────────────────────────
+
+echo ""
+echo "==> Creating discovery symlinks"
+
+shopt -s nullglob
+for skill_dir in "$GSTACK_DIR"/*/; do
+  [ ! -d "$skill_dir" ] && continue
+  skill_name="$(basename "$skill_dir")"
+  target="$SKILLS_DIR/$skill_name"
+
+  # If it's already a symlink or doesn't exist, create/update
+  if [ -L "$target" ] || [ ! -e "$target" ]; then
+    echo "  $skill_name -> gstack/$skill_name"
+    run_cmd ln -snf "gstack/$skill_name" "$target"
+    discovery_count=$((discovery_count + 1))
+  elif [ "$FORCE" = true ]; then
+    echo "  $skill_name -> gstack/$skill_name (overwriting real directory)"
+    run_cmd rm -rf "$target"
+    run_cmd ln -snf "gstack/$skill_name" "$target"
+    discovery_count=$((discovery_count + 1))
+  else
+    echo "  WARNING: Skipping $skill_name — real directory exists. Use --force to overwrite."
+    skip_count=$((skip_count + 1))
+  fi
+done
+shopt -u nullglob
+
+# ─── Step 5: Stamp version ──────────────────────────────────────────────────
+
+echo ""
+echo "==> Stamping version"
+
+VERSION_COMMIT="$(cd "$SOURCE_DIR" && git rev-parse HEAD 2>/dev/null || echo "unknown")"
+VERSION_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+VERSION_CONTENT="$VERSION_COMMIT $VERSION_DATE"
+
+echo "  $VERSION_CONTENT"
+if [ "$DRY_RUN" = true ]; then
+  echo "  [dry-run] write $GSTACK_DIR/.publish-version"
+else
+  echo "$VERSION_CONTENT" > "$GSTACK_DIR/.publish-version"
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "==> Done"
+echo "  Skills linked:     $skill_count"
+echo "  Discovery links:   $discovery_count"
+echo "  Shared assets:     $asset_count"
+echo "  Skipped:           $skip_count"
+echo "  Version:           $VERSION_CONTENT"


### PR DESCRIPTION
## Summary
- **scripts/publish.sh**: Standalone publish script that deploys all 27 gstack skills to `~/.claude/skills/gstack/` via symlinks, with discovery links at `~/.claude/skills/<skill>`. Supports `--dry-run`, `--force`, and `--skills-dir` flags. Includes clobber guards and version stamping.
- **scripts/evaluate-skills.sh**: Guided evaluation runner with 4 priority tiers, progress tracking in `~/.gstack/eval-log.txt`, and `/skill-creator` invocation suggestions.

## Changes
- New file: `scripts/publish.sh` — skill deployment via symlinks (mirrors setup script pattern)
- New file: `scripts/evaluate-skills.sh` — evaluation checklist with mark/reset/reset-all commands

## Acceptance Criteria
- [x] `scripts/publish.sh` deploys all 27 skills with discovery symlinks
- [x] `scripts/publish.sh --dry-run` shows actions without executing
- [x] `scripts/publish.sh --force` overwrites existing non-symlink directories
- [x] Existing skills (convex, copywriting, etc.) are untouched
- [x] `scripts/evaluate-skills.sh` lists all 27 skills in 4 priority tiers
- [x] Mark/reset/reset-all commands work correctly
- [x] Idempotent — running publish twice produces same result

## Test plan
- [x] Dry-run produces correct output
- [x] Full publish creates 27 skill dirs + discovery symlinks
- [x] Existing skills preserved
- [x] Version stamp written
- [x] Evaluate script mark/reset/reset-all all work
- [x] Syntax validation passes (bash -n)

🤖 Generated with [Claude Code](https://claude.com/claude-code)