### PR TITLE
fix: auto-upgrade marker no longer masks newer remote versions

### DIFF
--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -113,12 +113,11 @@ if [ -f "$MARKER_FILE" ]; then
   OLD="$(cat "$MARKER_FILE" 2>/dev/null | tr -d '[:space:]')"
   rm -f "$MARKER_FILE"
   rm -f "$SNOOZE_FILE"
-  mkdir -p "$STATE_DIR"
-  echo "UP_TO_DATE $LOCAL" > "$CACHE_FILE"
   if [ -n "$OLD" ]; then
     echo "JUST_UPGRADED $OLD $LOCAL"
   fi
-  exit 0
+  # Don't exit — fall through to remote check in case
+  # more updates landed since the upgrade
 fi
 
 # ─── Step 3: Check cache freshness ──────────────────────────

--- a/browse/test/gstack-update-check.test.ts
+++ b/browse/test/gstack-update-check.test.ts
@@ -92,6 +92,35 @@ describe('gstack-update-check', () => {
     expect(cache).toContain('UP_TO_DATE');
   });
 
+  // ─── Path C2: Just-upgraded marker + newer remote ──────────
+  test('just-upgraded marker does not mask newer remote version', () => {
+    writeFileSync(join(gstackDir, 'VERSION'), '0.4.0\n');
+    writeFileSync(join(stateDir, 'just-upgraded-from'), '0.3.3\n');
+    writeFileSync(join(gstackDir, 'REMOTE_VERSION'), '0.5.0\n');
+
+    const { exitCode, stdout } = run();
+    expect(exitCode).toBe(0);
+    // Should output both the just-upgraded notice AND the new upgrade
+    expect(stdout).toContain('JUST_UPGRADED 0.3.3 0.4.0');
+    expect(stdout).toContain('UPGRADE_AVAILABLE 0.4.0 0.5.0');
+    // Cache should reflect the upgrade available, not UP_TO_DATE
+    const cache = readFileSync(join(stateDir, 'last-update-check'), 'utf-8');
+    expect(cache).toContain('UPGRADE_AVAILABLE 0.4.0 0.5.0');
+  });
+
+  // ─── Path C3: Just-upgraded marker + remote matches local ──
+  test('just-upgraded with no further updates writes UP_TO_DATE cache', () => {
+    writeFileSync(join(gstackDir, 'VERSION'), '0.4.0\n');
+    writeFileSync(join(stateDir, 'just-upgraded-from'), '0.3.3\n');
+    writeFileSync(join(gstackDir, 'REMOTE_VERSION'), '0.4.0\n');
+
+    const { exitCode, stdout } = run();
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('JUST_UPGRADED 0.3.3 0.4.0');
+    const cache = readFileSync(join(stateDir, 'last-update-check'), 'utf-8');
+    expect(cache).toContain('UP_TO_DATE');
+  });
+
   // ─── Path D1: Fresh cache, UP_TO_DATE ───────────────────────
   test('exits silently when cache says UP_TO_DATE and is fresh', () => {
     writeFileSync(join(gstackDir, 'VERSION'), '0.3.3\n');


### PR DESCRIPTION
## Problem

When a `just-upgraded-from` marker file persists across sessions, `gstack-update-check` short-circuits at Step 2 (line 112–122) — it writes `UP_TO_DATE` to cache and exits immediately, **never fetching the remote VERSION**. Users silently stay on old versions, potentially missing dozens of commits.

Reported in #515: a user upgraded from 0.9.3.0 → 0.9.4.0, then missed 42 commits because the marker caused Step 4 (remote fetch) to be skipped entirely.

## Root cause

```bash
# Step 2 — before fix
if [ -f "$MARKER_FILE" ]; then
  ...
  echo "UP_TO_DATE $LOCAL" > "$CACHE_FILE"  # ← premature
  ...
  exit 0  # ← never reaches remote check
fi
```

The script assumes "just upgraded = up to date", which isn't true if the remote advanced between the upgrade and the next session.

## Fix

Remove the `exit 0` and the premature `UP_TO_DATE` cache write. The script now:

1. Consumes and deletes the marker (same as before)
2. Clears the snooze file (same as before)
3. Outputs `JUST_UPGRADED` for the preamble (same as before)
4. **Falls through** to Step 3 (cache check) → Step 4 (remote fetch)

If no further updates exist, Step 4 writes `UP_TO_DATE` to cache as normal. If a newer version landed, the user sees both `JUST_UPGRADED` and `UPGRADE_AVAILABLE` in the same session.

## Changes

- `bin/gstack-update-check` — remove early exit and premature cache write from Step 2 (+2/−3 lines)
- `browse/test/gstack-update-check.test.ts` — add two regression tests:
  - **Path C2**: marker present + remote has newer version → outputs both notices, cache reflects `UPGRADE_AVAILABLE`
  - **Path C3**: marker present + remote matches local → outputs `JUST_UPGRADED`, cache reflects `UP_TO_DATE`

## Test plan

- [x] All 35 existing + 2 new tests pass (`bun test browse/test/gstack-update-check.test.ts`)
- [x] Full `bun test` passes (only pre-existing #399 version mismatch fails — unrelated)
- [x] Existing "just-upgraded clears snooze file" test still passes
- [x] Existing "outputs JUST_UPGRADED and deletes marker" test still passes (falls through to remote fetch, which writes `UP_TO_DATE` on unreachable remote)

Fixes #515