### PR TITLE
fix: decouple doc generation from binary compilation in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "browse": "./browse/dist/browse"
   },
   "scripts": {
-    "build": "bun run gen:skill-docs && bun run gen:skill-docs --host codex && bun build --compile browse/src/cli.ts --outfile browse/dist/browse && bun build --compile browse/src/find-browse.ts --outfile browse/dist/find-browse && bun build --compile bin/gstack-global-discover.ts --outfile bin/gstack-global-discover && bash browse/scripts/build-node-server.sh && git rev-parse HEAD > browse/dist/.version && rm -f .*.bun-build || true",
+    "build": "bun run gen:skill-docs; bun run gen:skill-docs --host codex; bun build --compile browse/src/cli.ts --outfile browse/dist/browse && bun build --compile browse/src/find-browse.ts --outfile browse/dist/find-browse && bun build --compile bin/gstack-global-discover.ts --outfile bin/gstack-global-discover && bash browse/scripts/build-node-server.sh && git rev-parse HEAD > browse/dist/.version && rm -f .*.bun-build || true",
     "gen:skill-docs": "bun run scripts/gen-skill-docs.ts",
     "dev": "bun run browse/src/cli.ts",
     "server": "bun run browse/src/server.ts",


### PR DESCRIPTION
## Problem

The `build` script in `package.json` chains doc generation and binary compilation with `&&`:

```
bun run gen:skill-docs && bun run gen:skill-docs --host codex && bun build --compile ...
```

If `gen:skill-docs` fails (missing Codex host config, template error, etc.), the `&&` chain short-circuits — `bun build --compile` never runs. The trailing `|| true` masks the exit code, so `./setup` proceeds to the binary check at line 140 and reports `gstack setup failed: browse binary missing`.

Users end up with a broken install where the binary is missing, even though the compilation would have succeeded independently.

## Root cause

Doc generation and binary compilation are independent concerns chained as if they were sequential dependencies. A template error has no bearing on whether `browse/src/cli.ts` can compile.

## Fix

Replace `&&` with `;` for the two `gen:skill-docs` steps:

```diff
- "build": "bun run gen:skill-docs && bun run gen:skill-docs --host codex && bun build --compile ...
+ "build": "bun run gen:skill-docs; bun run gen:skill-docs --host codex; bun build --compile ...
```

**What changes:**
- Doc generation runs but its exit code no longer gates compilation
- Doc generation errors are still visible in stderr
- The `&&` chain between compile steps is preserved — if an actual compile step fails, subsequent steps are still skipped
- The trailing `|| true` behavior is unchanged

**What doesn't change:**
- `bun run build` still generates docs and compiles binaries in the same command
- Compile step failures still propagate correctly within the `&&` chain
- `./setup` binary existence check at line 140 still catches actual compile failures

## Verification

```bash
# Before fix: doc failure skips compilation
$ bash -c 'false && false && echo "BINARY COMPILED" || true'
(no output — binary never compiled)

# After fix: doc failure doesn't affect compilation
$ bash -c 'false; false; echo "BINARY COMPILED" || true'
BINARY COMPILED
```

## Test plan

- [x] Full `bun test` passes (only pre-existing #399 version mismatch fails — unrelated)
- [x] Shell simulation confirms doc failure no longer blocks compilation
- [x] Shell simulation confirms compile failure still blocks subsequent compile steps
- [x] `./setup` binary existence check (line 140) still catches actual compile failures

Fixes #482