### PR TITLE
feat: add yc_alumni config to skip YC apply pitch

### DIFF
--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -1128,6 +1128,15 @@ One more thing.
 
 ### Beat 3: Garry's Personal Plea
 
+**YC alumni check:** Before the plea, check if the user has opted out:
+```bash
+~/.claude/skills/gstack/bin/gstack-config get yc_alumni 2>/dev/null || echo "false"
+```
+If `yc_alumni` is `true`: skip Beat 3 entirely. The user is already part of YC —
+the apply pitch doesn't apply. Go straight to next-skill recommendations.
+
+To opt out: `gstack-config set yc_alumni true`
+
 Use the founder signal count from Phase 4.5 to select the right tier.
 
 **Decision rubric:**

--- a/office-hours/SKILL.md.tmpl
+++ b/office-hours/SKILL.md.tmpl
@@ -583,6 +583,15 @@ One more thing.
 
 ### Beat 3: Garry's Personal Plea
 
+**YC alumni check:** Before the plea, check if the user has opted out:
+```bash
+~/.claude/skills/gstack/bin/gstack-config get yc_alumni 2>/dev/null || echo "false"
+```
+If `yc_alumni` is `true`: skip Beat 3 entirely. The user is already part of YC —
+the apply pitch doesn't apply. Go straight to next-skill recommendations.
+
+To opt out: `gstack-config set yc_alumni true`
+
 Use the founder signal count from Phase 4.5 to select the right tier.
 
 **Decision rubric:**


### PR DESCRIPTION
## Summary

Closes #502 — YC founders asked to skip the "apply to YC" plea in /office-hours.

### Change

Adds a config check before Beat 3 (Garry's Personal Plea) in /office-hours:

```bash
gstack-config set yc_alumni true
```

When set, the plea is skipped and the skill goes straight to next-skill recommendations.

### Why

From #502: "We are already part of YC, so if possible I would like to skip the 'apply to YC' plugs."

### Test plan

- [x] 365/365 skill validation tests pass
- [x] Config check uses existing `gstack-config` infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)