### PR TITLE
fix: auto-upgrade respects auto_upgrade config

### DIFF
--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -99,6 +99,56 @@ check_snooze() {
   return 1  # snooze expired
 }
 
+# ─── Auto-upgrade helper ──────────────────────────────────
+# try_auto_upgrade <local_version> <remote_version>
+#   Attempts auto-upgrade if auto_upgrade config is true.
+#   Outputs JUST_UPGRADED on success and returns 0.
+#   Returns 1 on failure (caller should fall through to UPGRADE_AVAILABLE).
+try_auto_upgrade() {
+  local local_ver="$1" remote_ver="$2"
+
+  local auto_cfg
+  auto_cfg=$("$GSTACK_DIR/bin/gstack-config" get auto_upgrade 2>/dev/null || true)
+  [ "$auto_cfg" = "true" ] || return 1
+
+  # Find the git install directory
+  # GSTACK_INSTALL_DIR: env override for testability (same pattern as GSTACK_DIR)
+  local install_dir="${GSTACK_INSTALL_DIR:-}"
+  if [ -z "$install_dir" ]; then
+    if [ -d "$HOME/.claude/skills/gstack/.git" ]; then
+      install_dir="$HOME/.claude/skills/gstack"
+    elif [ -d "$HOME/.gstack/repos/gstack/.git" ]; then
+      install_dir="$HOME/.gstack/repos/gstack"
+    fi
+  fi
+  [ -n "$install_dir" ] || return 1
+  [ -d "$install_dir/.git" ] || return 1
+
+  # Skip if working tree is dirty (don't destroy local modifications)
+  if [ -n "$(cd "$install_dir" && git status --porcelain 2>/dev/null)" ]; then
+    return 1
+  fi
+
+  # Best-effort upgrade: fetch, reset, setup. Failure falls through to UPGRADE_AVAILABLE.
+  local default_branch
+  default_branch="$(cd "$install_dir" && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')"
+  default_branch="${default_branch:-main}"
+
+  if ! (cd "$install_dir" && git fetch origin >/dev/null 2>&1 && git reset --hard "origin/$default_branch" >/dev/null 2>&1 && ./setup >/dev/null 2>&1); then
+    return 1
+  fi
+
+  # Read new version from the upgraded install
+  local new_ver
+  new_ver="$(cat "$install_dir/VERSION" 2>/dev/null | tr -d '[:space:]')"
+
+  # Success — update cache, clean any stale marker (prevent double JUST_UPGRADED)
+  echo "UP_TO_DATE ${new_ver:-$remote_ver}" > "$CACHE_FILE"
+  rm -f "$STATE_DIR/just-upgraded-from"
+  echo "JUST_UPGRADED $local_ver ${new_ver:-$remote_ver}"
+  return 0
+}
+
 # ─── Step 1: Read local version ──────────────────────────────
 LOCAL=""
 if [ -f "$VERSION_FILE" ]; then
@@ -145,6 +195,10 @@ if [ -f "$CACHE_FILE" ]; then
         CACHED_OLD="$(echo "$CACHED" | awk '{print $2}')"
         if [ "$CACHED_OLD" = "$LOCAL" ]; then
           CACHED_NEW="$(echo "$CACHED" | awk '{print $3}')"
+          # Auto-upgrade takes priority over snooze (user opted in to silent updates)
+          if try_auto_upgrade "$LOCAL" "$CACHED_NEW"; then
+            exit 0
+          fi
           if check_snooze "$CACHED_NEW"; then
             exit 0  # snoozed — stay quiet
           fi
@@ -198,6 +252,12 @@ fi
 
 # Versions differ — upgrade available
 echo "UPGRADE_AVAILABLE $LOCAL $REMOTE" > "$CACHE_FILE"
+
+# Auto-upgrade if configured (before snooze check or prompting)
+if try_auto_upgrade "$LOCAL" "$REMOTE"; then
+  exit 0
+fi
+
 if check_snooze "$REMOTE"; then
   exit 0  # snoozed — stay quiet
 fi

--- a/browse/test/gstack-update-check.test.ts
+++ b/browse/test/gstack-update-check.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync, mkdirSync, symlinkSync, utimesSync } from 'fs';
+import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync, mkdirSync, symlinkSync, utimesSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -466,6 +466,162 @@ describe('gstack-update-check', () => {
   });
 
   // ─── Split TTL tests ─────────────────────────────────────────
+
+  // ─── Auto-upgrade tests ────────────────────────────────────
+
+  /**
+   * Helper: create a mock git install dir with a fake setup script.
+   * The setup script just writes the target version to VERSION.
+   */
+  function createMockInstallDir(version: string, targetVersion: string): string {
+    const installDir = mkdtempSync(join(tmpdir(), 'gstack-install-test-'));
+    // Create a bare-minimum git repo
+    Bun.spawnSync(['git', 'init'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'config', 'user.email', 'test@test.com'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'config', 'user.name', 'Test'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    writeFileSync(join(installDir, 'VERSION'), version + '\n');
+    // Create a mock setup script that writes targetVersion
+    writeFileSync(join(installDir, 'setup'), `#!/bin/bash\necho "${targetVersion}" > "$( cd "$(dirname "$0")" && pwd)/VERSION"\n`);
+    chmodSync(join(installDir, 'setup'), 0o755);
+    // Initial commit + set up fake remote
+    Bun.spawnSync(['git', 'add', '-A'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'commit', '-m', 'init'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    // Create a bare remote and push to it
+    const bareDir = mkdtempSync(join(tmpdir(), 'gstack-bare-test-'));
+    Bun.spawnSync(['git', 'init', '--bare'], { cwd: bareDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'remote', 'add', 'origin', bareDir], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    // Update setup to write target version, commit, push
+    writeFileSync(join(installDir, 'VERSION'), targetVersion + '\n');
+    Bun.spawnSync(['git', 'add', '-A'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'commit', '-m', 'bump'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'push', '-u', 'origin', 'main'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' }) ||
+    Bun.spawnSync(['git', 'push', '-u', 'origin', 'master'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    // Reset local to old version to simulate "behind remote"
+    writeFileSync(join(installDir, 'VERSION'), version + '\n');
+    Bun.spawnSync(['git', 'add', '-A'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'reset', '--hard', 'HEAD~1'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    return installDir;
+  }
+
+  test('auto_upgrade: true on slow path → JUST_UPGRADED', () => {
+    const installDir = createMockInstallDir('0.3.3', '0.4.0');
+    writeFileSync(join(gstackDir, 'VERSION'), '0.3.3\n');
+    writeFileSync(join(gstackDir, 'REMOTE_VERSION'), '0.4.0\n');
+    writeConfig('auto_upgrade: true\n');
+
+    const { exitCode, stdout } = run({ GSTACK_INSTALL_DIR: installDir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('JUST_UPGRADED 0.3.3 0.4.0');
+    // Cache should say UP_TO_DATE
+    const cache = readFileSync(join(stateDir, 'last-update-check'), 'utf-8');
+    expect(cache).toContain('UP_TO_DATE');
+    // Marker should not exist (cleaned by try_auto_upgrade)
+    expect(existsSync(join(stateDir, 'just-upgraded-from'))).toBe(false);
+    rmSync(installDir, { recursive: true, force: true });
+  });
+
+  test('auto_upgrade: true on cached path → JUST_UPGRADED', () => {
+    const installDir = createMockInstallDir('0.3.3', '0.4.0');
+    writeFileSync(join(gstackDir, 'VERSION'), '0.3.3\n');
+    // Pre-populate cache to test the cache-hit path
+    writeFileSync(join(stateDir, 'last-update-check'), 'UPGRADE_AVAILABLE 0.3.3 0.4.0');
+    writeConfig('auto_upgrade: true\n');
+
+    const { exitCode, stdout } = run({ GSTACK_INSTALL_DIR: installDir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('JUST_UPGRADED 0.3.3 0.4.0');
+    rmSync(installDir, { recursive: true, force: true });
+  });
+
+  test('auto_upgrade: false still outputs UPGRADE_AVAILABLE', () => {
+    writeFileSync(join(gstackDir, 'VERSION'), '0.3.3\n');
+    writeFileSync(join(gstackDir, 'REMOTE_VERSION'), '0.4.0\n');
+    writeConfig('auto_upgrade: false\n');
+
+    const { exitCode, stdout } = run();
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('UPGRADE_AVAILABLE 0.3.3 0.4.0');
+  });
+
+  test('auto_upgrade: true without git install dir → UPGRADE_AVAILABLE', () => {
+    writeFileSync(join(gstackDir, 'VERSION'), '0.3.3\n');
+    writeFileSync(join(gstackDir, 'REMOTE_VERSION'), '0.4.0\n');
+    writeConfig('auto_upgrade: true\n');
+    // Point GSTACK_INSTALL_DIR at a nonexistent path to prevent finding real install
+    const { exitCode, stdout } = run({ GSTACK_INSTALL_DIR: '/tmp/nonexistent-gstack-dir' });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('UPGRADE_AVAILABLE 0.3.3 0.4.0');
+  });
+
+  test('auto_upgrade: true but setup fails → UPGRADE_AVAILABLE', () => {
+    const installDir = mkdtempSync(join(tmpdir(), 'gstack-fail-test-'));
+    // Git repo but setup script that fails
+    Bun.spawnSync(['git', 'init'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'config', 'user.email', 'test@test.com'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'config', 'user.name', 'Test'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    writeFileSync(join(installDir, 'VERSION'), '0.3.3\n');
+    writeFileSync(join(installDir, 'setup'), '#!/bin/bash\nexit 1\n');
+    chmodSync(join(installDir, 'setup'), 0o755);
+    Bun.spawnSync(['git', 'add', '-A'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'commit', '-m', 'init'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    // Create bare remote
+    const bareDir = mkdtempSync(join(tmpdir(), 'gstack-bare-fail-'));
+    Bun.spawnSync(['git', 'init', '--bare'], { cwd: bareDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'remote', 'add', 'origin', bareDir], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'push', '-u', 'origin', 'main'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' }) ||
+    Bun.spawnSync(['git', 'push', '-u', 'origin', 'master'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+
+    writeFileSync(join(gstackDir, 'VERSION'), '0.3.3\n');
+    writeFileSync(join(gstackDir, 'REMOTE_VERSION'), '0.4.0\n');
+    writeConfig('auto_upgrade: true\n');
+
+    const { exitCode, stdout } = run({ GSTACK_INSTALL_DIR: installDir });
+    expect(exitCode).toBe(0);
+    // Should fall through to UPGRADE_AVAILABLE since self-upgrade failed
+    expect(stdout).toBe('UPGRADE_AVAILABLE 0.3.3 0.4.0');
+    rmSync(installDir, { recursive: true, force: true });
+    rmSync(bareDir, { recursive: true, force: true });
+  });
+
+  test('auto_upgrade with snooze: auto-upgrade takes priority', () => {
+    const installDir = createMockInstallDir('0.3.3', '0.4.0');
+    writeFileSync(join(gstackDir, 'VERSION'), '0.3.3\n');
+    writeFileSync(join(stateDir, 'last-update-check'), 'UPGRADE_AVAILABLE 0.3.3 0.4.0');
+    writeConfig('auto_upgrade: true\n');
+    // Snooze is active but auto_upgrade should take priority
+    writeSnooze('0.4.0', 1, nowEpoch() - 60);
+
+    const { exitCode, stdout } = run({ GSTACK_INSTALL_DIR: installDir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('JUST_UPGRADED 0.3.3 0.4.0');
+    rmSync(installDir, { recursive: true, force: true });
+  });
+
+  test('auto_upgrade: dirty install dir → UPGRADE_AVAILABLE', () => {
+    const installDir = mkdtempSync(join(tmpdir(), 'gstack-dirty-test-'));
+    Bun.spawnSync(['git', 'init'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'config', 'user.email', 'test@test.com'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'config', 'user.name', 'Test'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    writeFileSync(join(installDir, 'VERSION'), '0.3.3\n');
+    writeFileSync(join(installDir, 'setup'), '#!/bin/bash\necho "0.4.0" > VERSION\n');
+    chmodSync(join(installDir, 'setup'), 0o755);
+    Bun.spawnSync(['git', 'add', '-A'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'commit', '-m', 'init'], { cwd: installDir, stdout: 'pipe', stderr: 'pipe' });
+    // Make working tree dirty
+    writeFileSync(join(installDir, 'dirty-file.txt'), 'local change\n');
+
+    writeFileSync(join(gstackDir, 'VERSION'), '0.3.3\n');
+    writeFileSync(join(gstackDir, 'REMOTE_VERSION'), '0.4.0\n');
+    writeConfig('auto_upgrade: true\n');
+
+    const { exitCode, stdout } = run({ GSTACK_INSTALL_DIR: installDir });
+    expect(exitCode).toBe(0);
+    // Should fall through since install dir is dirty
+    expect(stdout).toBe('UPGRADE_AVAILABLE 0.3.3 0.4.0');
+    // Dirty file should still exist (not destroyed)
+    expect(existsSync(join(installDir, 'dirty-file.txt'))).toBe(true);
+    rmSync(installDir, { recursive: true, force: true });
+  });
 
   test('UP_TO_DATE cache expires after 60 min (not 720)', () => {
     writeFileSync(join(gstackDir, 'VERSION'), '0.3.3\n');


### PR DESCRIPTION
## Summary
- `gstack-update-check` now checks `auto_upgrade` config before outputting `UPGRADE_AVAILABLE`
- When `auto_upgrade: true`, attempts best-effort upgrade on **both** cache-hit and slow-fetch paths
- Skips if install dir has local modifications (dirty-tree guard)
- Failure falls through gracefully to manual prompt

## Changes
- **`bin/gstack-update-check`** — added `try_auto_upgrade()` with dirty-tree check, called from both output paths
- **7 new tests** covering both paths, failure modes, snooze priority, dirty tree

## Related
- #515 (stale marker — avoids worsening, doesn't fix)

## Test plan
- [x] All 40 update-check tests pass (33 existing + 7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)