### PR TITLE
fix: /health no longer leaks daemon bearer token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bun.lock
 .env.*
 !.env.example
 supabase/.temp/
+extension/auth-token.json

--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -46,6 +46,9 @@ export class BrowserManager {
   /** Server port — set after server starts, used by cookie-import-browser command */
   public serverPort: number = 0;
 
+  /** Extension directory path — set during headed launch, used by server for auth token bootstrap */
+  public extensionPath: string | null = null;
+
   // ─── Ref Map (snapshot → @e1, @e2, @c1, @c2, ...) ────────
   private refMap: Map<string, RefEntry> = new Map();
 
@@ -219,6 +222,7 @@ export class BrowserManager {
 
     // Find the gstack extension directory for auto-loading
     const extensionPath = this.findExtensionPath();
+    this.extensionPath = extensionPath;
     const launchArgs = ['--hide-crash-restore-bubble'];
     if (extensionPath) {
       launchArgs.push(`--disable-extensions-except=${extensionPath}`);

--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -742,6 +742,11 @@ async function shutdown() {
   // Clean up state file
   try { fs.unlinkSync(config.stateFile); } catch {}
 
+  // Clean up auth token from extension directory
+  if (browserManager.extensionPath) {
+    try { fs.unlinkSync(path.join(browserManager.extensionPath, 'auth-token.json')); } catch {}
+  }
+
   process.exit(0);
 }
 
@@ -799,6 +804,17 @@ async function start() {
     if (headed) {
       await browserManager.launchHeaded();
       console.log(`[browse] Launched headed Chromium with extension`);
+
+      // Write auth token to extension directory so the Chrome extension can
+      // bootstrap without the server exposing the token on /health.
+      // The file is only readable by the extension via chrome.runtime.getURL().
+      if (browserManager.extensionPath) {
+        const tokenFile = path.join(browserManager.extensionPath, 'auth-token.json');
+        const tmpTokenFile = tokenFile + '.tmp';
+        fs.writeFileSync(tmpTokenFile, JSON.stringify({ token: AUTH_TOKEN }), { mode: 0o600 });
+        fs.renameSync(tmpTokenFile, tokenFile);
+        console.log(`[browse] Auth token written to extension directory`);
+      }
     } else {
       await browserManager.launch();
     }
@@ -825,7 +841,6 @@ async function start() {
           uptime: Math.floor((Date.now() - startTime) / 1000),
           tabs: browserManager.getTabCount(),
           currentUrl: browserManager.getCurrentUrl(),
-          token: AUTH_TOKEN,  // Extension uses this for Bearer auth
           chatEnabled: true,
           agent: {
             status: agentStatus,

--- a/browse/src/sidebar-agent.ts
+++ b/browse/src/sidebar-agent.ts
@@ -66,12 +66,17 @@ function writeToInbox(message: string, pageUrl?: string, sessionId?: string): vo
 // ─── Auth ────────────────────────────────────────────────────────
 
 async function refreshToken(): Promise<string | null> {
+  // Read token from the 0o600 state file instead of /health (which no longer
+  // exposes the token) to prevent unauthenticated local processes from
+  // harvesting the bearer token.
   try {
-    const resp = await fetch(`${SERVER_URL}/health`, { signal: AbortSignal.timeout(3000) });
-    if (!resp.ok) return null;
-    const data = await resp.json() as any;
-    authToken = data.token || null;
-    return authToken;
+    const stateFile = process.env.BROWSE_STATE_FILE;
+    if (stateFile) {
+      const data = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+      authToken = data.token || null;
+      return authToken;
+    }
+    return null;
   } catch {
     return null;
   }

--- a/browse/test/health-no-token.test.ts
+++ b/browse/test/health-no-token.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Verify the /health endpoint does not leak the auth token.
+ *
+ * This is a static analysis test: it reads the server source to confirm the
+ * /health JSON response object does not include a `token` property.  A runtime
+ * test would require spinning up the full Playwright stack, which is covered by
+ * E2E tests — this gate-tier check catches regressions cheaply.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('health endpoint security', () => {
+  test('/health response does not contain auth token', () => {
+    const serverSrc = fs.readFileSync(
+      path.resolve(__dirname, '../src/server.ts'),
+      'utf-8',
+    );
+
+    // Extract the /health handler block — starts at `if (url.pathname === '/health')`
+    // and ends at the next top-level `if (url.pathname` or route handler.
+    const healthStart = serverSrc.indexOf("if (url.pathname === '/health')");
+    expect(healthStart).toBeGreaterThan(-1);
+
+    // Find the closing of the health response (next route handler)
+    const nextRoute = serverSrc.indexOf('if (url.pathname', healthStart + 1);
+    const healthBlock = serverSrc.slice(healthStart, nextRoute > -1 ? nextRoute : undefined);
+
+    // The JSON.stringify object inside the health handler must NOT reference
+    // AUTH_TOKEN or include a `token:` property.
+    expect(healthBlock).not.toContain('AUTH_TOKEN');
+    expect(healthBlock).not.toMatch(/\btoken\s*:/);
+  });
+
+  test('auth token is written to state file (0o600) for trusted clients', () => {
+    const serverSrc = fs.readFileSync(
+      path.resolve(__dirname, '../src/server.ts'),
+      'utf-8',
+    );
+
+    // The state file write block should still include the token
+    const stateFileBlock = serverSrc.indexOf('// Write state file');
+    expect(stateFileBlock).toBeGreaterThan(-1);
+
+    const stateSection = serverSrc.slice(stateFileBlock, stateFileBlock + 500);
+    expect(stateSection).toContain('token: AUTH_TOKEN');
+    expect(stateSection).toContain('mode: 0o600');
+  });
+
+  test('sidebar-agent reads token from state file, not /health', () => {
+    const agentSrc = fs.readFileSync(
+      path.resolve(__dirname, '../src/sidebar-agent.ts'),
+      'utf-8',
+    );
+
+    // refreshToken should read from BROWSE_STATE_FILE, not fetch /health
+    const refreshStart = agentSrc.indexOf('async function refreshToken');
+    expect(refreshStart).toBeGreaterThan(-1);
+
+    const refreshBlock = agentSrc.slice(refreshStart, refreshStart + 500);
+    expect(refreshBlock).toContain('BROWSE_STATE_FILE');
+    expect(refreshBlock).not.toContain('/health');
+  });
+
+  test('extension reads token from auth-token.json, not /health response', () => {
+    const bgSrc = fs.readFileSync(
+      path.resolve(__dirname, '../../extension/background.js'),
+      'utf-8',
+    );
+
+    // checkHealth should NOT extract token from health response data
+    expect(bgSrc).not.toContain('data.token');
+
+    // Should read from auth-token.json via chrome.runtime.getURL
+    expect(bgSrc).toContain('auth-token.json');
+    expect(bgSrc).toContain('chrome.runtime.getURL');
+  });
+});

--- a/extension/background.js
+++ b/extension/background.js
@@ -44,8 +44,18 @@ async function checkHealth() {
     if (!resp.ok) { setDisconnected(); return; }
     const data = await resp.json();
     if (data.status === 'healthy') {
-      // Capture auth token from health response
-      if (data.token) authToken = data.token;
+      // Bootstrap auth token from extension-local file (written by server on
+      // headed launch with mode 0o600). Only the extension runtime can resolve
+      // chrome.runtime.getURL, so external processes cannot steal the token.
+      if (!authToken) {
+        try {
+          const tokenResp = await fetch(chrome.runtime.getURL('auth-token.json'));
+          if (tokenResp.ok) {
+            const tokenData = await tokenResp.json();
+            if (tokenData.token) authToken = tokenData.token;
+          }
+        } catch { /* token file may not exist yet */ }
+      }
       // Forward chatEnabled so sidepanel can show/hide chat tab
       setConnected({ ...data, chatEnabled: !!data.chatEnabled });
     } else {


### PR DESCRIPTION
## Summary
- **Removed `token: AUTH_TOKEN` from the `/health` endpoint response** — any local process could previously fetch the bearer token from the unauthenticated health check and replay it against privileged endpoints
- **Chrome extension** now reads the auth token from `auth-token.json` written to the extension directory (mode `0o600`) on headed launch, using `chrome.runtime.getURL()` which is only accessible to the extension runtime
- **Sidebar agent** now reads the token from the `0o600` state file (`BROWSE_STATE_FILE` env var) instead of fetching `/health`
- Auth token file is cleaned up on server shutdown and gitignored

## Test plan
- [ ] Verify `bun test` passes (includes new `health-no-token.test.ts` static analysis test)
- [ ] Run `$B connect` and confirm the Chrome extension still authenticates via `auth-token.json`
- [ ] Verify sidebar agent still relays events (reads token from state file)
- [ ] Confirm `curl http://127.0.0.1:34567/health` no longer returns a `token` field
- [ ] Verify server shutdown cleans up `extension/auth-token.json`
