### PR TITLE
fix: auth-gate /refs and /activity/* endpoints

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -41,7 +41,14 @@ const IDLE_TIMEOUT_MS = parseInt(process.env.BROWSE_IDLE_TIMEOUT || '1800000', 1
 
 function validateAuth(req: Request): boolean {
   const header = req.headers.get('authorization');
-  return header === `Bearer ${AUTH_TOKEN}`;
+  if (header === `Bearer ${AUTH_TOKEN}`) return true;
+  // Fallback: accept token as query parameter (for EventSource which can't set headers)
+  try {
+    const url = new URL(req.url);
+    return url.searchParams.get('token') === AUTH_TOKEN;
+  } catch {
+    return false;
+  }
 }
 
 // ─── Help text (auto-generated from COMMAND_DESCRIPTIONS) ────────
@@ -840,8 +847,11 @@ async function start() {
         });
       }
 
-      // Refs endpoint — no auth required (localhost-only), does NOT reset idle timer
+      // Refs endpoint — auth required, does NOT reset idle timer
       if (url.pathname === '/refs') {
+        if (!validateAuth(req)) {
+          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+        }
         const refs = browserManager.getRefMap();
         return new Response(JSON.stringify({
           refs,
@@ -851,13 +861,15 @@ async function start() {
           status: 200,
           headers: {
             'Content-Type': 'application/json',
-            'Access-Control-Allow-Origin': '*',
           },
         });
       }
 
-      // Activity stream — SSE, no auth (localhost-only), does NOT reset idle timer
+      // Activity stream — SSE, auth required, does NOT reset idle timer
       if (url.pathname === '/activity/stream') {
+        if (!validateAuth(req)) {
+          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+        }
         const afterId = parseInt(url.searchParams.get('after') || '0', 10);
         const encoder = new TextEncoder();
 
@@ -905,20 +917,21 @@ async function start() {
             'Content-Type': 'text/event-stream',
             'Cache-Control': 'no-cache',
             'Connection': 'keep-alive',
-            'Access-Control-Allow-Origin': '*',
           },
         });
       }
 
-      // Activity history — REST, no auth (localhost-only), does NOT reset idle timer
+      // Activity history — REST, auth required, does NOT reset idle timer
       if (url.pathname === '/activity/history') {
+        if (!validateAuth(req)) {
+          return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+        }
         const limit = parseInt(url.searchParams.get('limit') || '50', 10);
         const { entries, totalAdded } = getActivityHistory(limit);
         return new Response(JSON.stringify({ entries, totalAdded, subscribers: getSubscriberCount() }), {
           status: 200,
           headers: {
             'Content-Type': 'application/json',
-            'Access-Control-Allow-Origin': '*',
           },
         });
       }

--- a/browse/test/endpoint-auth.test.ts
+++ b/browse/test/endpoint-auth.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Verifies that /refs, /activity/stream, and /activity/history require bearer auth
+ * and no longer send Access-Control-Allow-Origin: * headers.
+ *
+ * Uses the same subprocess server pattern as sidebar-integration.test.ts.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { spawn, type Subprocess } from 'bun';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+let serverProc: Subprocess | null = null;
+let serverPort: number = 0;
+let authToken: string = '';
+let tmpDir: string = '';
+let stateFile: string = '';
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'endpoint-auth-'));
+  stateFile = path.join(tmpDir, 'browse.json');
+
+  const serverScript = path.resolve(__dirname, '..', 'src', 'server.ts');
+  serverProc = spawn(['bun', 'run', serverScript], {
+    env: {
+      ...process.env,
+      BROWSE_STATE_FILE: stateFile,
+      BROWSE_HEADLESS_SKIP: '1',
+      BROWSE_PORT: '0',
+      BROWSE_IDLE_TIMEOUT: '300',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  // Wait for state file with port + token
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(stateFile)) {
+      try {
+        const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+        if (state.port && state.token) {
+          serverPort = state.port;
+          authToken = state.token;
+          break;
+        }
+      } catch {}
+    }
+    await new Promise(r => setTimeout(r, 100));
+  }
+  if (!serverPort) throw new Error('Server did not start in time');
+}, 20000);
+
+afterAll(() => {
+  if (serverProc) { try { serverProc.kill(); } catch {} }
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+function url(pathname: string): string {
+  return `http://127.0.0.1:${serverPort}${pathname}`;
+}
+
+// ─── /refs ────────────────────────────────────────────────────────
+
+describe('/refs auth', () => {
+  test('rejects request without auth token', async () => {
+    const resp = await fetch(url('/refs'));
+    expect(resp.status).toBe(401);
+    const body = await resp.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  test('rejects request with wrong token', async () => {
+    const resp = await fetch(url('/refs'), {
+      headers: { 'Authorization': 'Bearer wrong-token' },
+    });
+    expect(resp.status).toBe(401);
+  });
+
+  test('accepts request with valid bearer token', async () => {
+    const resp = await fetch(url('/refs'), {
+      headers: { 'Authorization': `Bearer ${authToken}` },
+    });
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body).toHaveProperty('refs');
+  });
+
+  test('accepts token as query parameter', async () => {
+    const resp = await fetch(url(`/refs?token=${authToken}`));
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body).toHaveProperty('refs');
+  });
+
+  test('does not include Access-Control-Allow-Origin header', async () => {
+    const resp = await fetch(url('/refs'), {
+      headers: { 'Authorization': `Bearer ${authToken}` },
+    });
+    expect(resp.headers.get('access-control-allow-origin')).toBeNull();
+  });
+});
+
+// ─── /activity/stream ─────────────────────────────────────────────
+
+describe('/activity/stream auth', () => {
+  test('rejects request without auth token', async () => {
+    const resp = await fetch(url('/activity/stream?after=0'));
+    expect(resp.status).toBe(401);
+    const body = await resp.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  test('accepts request with valid bearer token', async () => {
+    const controller = new AbortController();
+    // SSE streams never complete — abort after checking headers
+    setTimeout(() => controller.abort(), 500);
+    try {
+      const resp = await fetch(url('/activity/stream?after=0'), {
+        headers: { 'Authorization': `Bearer ${authToken}` },
+        signal: controller.signal,
+      });
+      expect(resp.status).toBe(200);
+      expect(resp.headers.get('content-type')).toBe('text/event-stream');
+      expect(resp.headers.get('access-control-allow-origin')).toBeNull();
+    } catch (e: any) {
+      // AbortError is expected if the abort fires before headers arrive
+      if (e.name !== 'AbortError') throw e;
+    }
+  });
+
+  test('accepts token as query parameter (EventSource compat)', async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 500);
+    try {
+      const resp = await fetch(url(`/activity/stream?after=0&token=${authToken}`), {
+        signal: controller.signal,
+      });
+      expect(resp.status).toBe(200);
+      expect(resp.headers.get('content-type')).toBe('text/event-stream');
+    } catch (e: any) {
+      if (e.name !== 'AbortError') throw e;
+    }
+  });
+});
+
+// ─── /activity/history ────────────────────────────────────────────
+
+describe('/activity/history auth', () => {
+  test('rejects request without auth token', async () => {
+    const resp = await fetch(url('/activity/history'));
+    expect(resp.status).toBe(401);
+    const body = await resp.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  test('rejects request with wrong token', async () => {
+    const resp = await fetch(url('/activity/history'), {
+      headers: { 'Authorization': 'Bearer wrong-token' },
+    });
+    expect(resp.status).toBe(401);
+  });
+
+  test('accepts request with valid bearer token', async () => {
+    const resp = await fetch(url('/activity/history'), {
+      headers: { 'Authorization': `Bearer ${authToken}` },
+    });
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body).toHaveProperty('entries');
+  });
+
+  test('does not include Access-Control-Allow-Origin header', async () => {
+    const resp = await fetch(url('/activity/history'), {
+      headers: { 'Authorization': `Bearer ${authToken}` },
+    });
+    expect(resp.headers.get('access-control-allow-origin')).toBeNull();
+  });
+});

--- a/extension/background.js
+++ b/extension/background.js
@@ -125,10 +125,13 @@ async function executeCommand(command, args) {
 
 async function fetchAndRelayRefs() {
   const base = getBaseUrl();
-  if (!base || !isConnected) return;
+  if (!base || !isConnected || !authToken) return;
 
   try {
-    const resp = await fetch(`${base}/refs`, { signal: AbortSignal.timeout(3000) });
+    const resp = await fetch(`${base}/refs`, {
+      signal: AbortSignal.timeout(3000),
+      headers: { 'Authorization': `Bearer ${authToken}` },
+    });
     if (!resp.ok) return;
     const data = await resp.json();
 

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -469,7 +469,7 @@ function connectSSE() {
   if (!serverUrl) return;
   if (eventSource) { eventSource.close(); eventSource = null; }
 
-  const url = `${serverUrl}/activity/stream?after=${lastId}`;
+  const url = `${serverUrl}/activity/stream?after=${lastId}${serverToken ? `&token=${serverToken}` : ''}`;
   eventSource = new EventSource(url);
 
   eventSource.addEventListener('activity', (e) => {
@@ -493,7 +493,10 @@ function connectSSE() {
 async function fetchRefs() {
   if (!serverUrl) return;
   try {
-    const resp = await fetch(`${serverUrl}/refs`, { signal: AbortSignal.timeout(3000) });
+    const resp = await fetch(`${serverUrl}/refs`, {
+      signal: AbortSignal.timeout(3000),
+      headers: authHeaders(),
+    });
     if (!resp.ok) return;
     const data = await resp.json();
 


### PR DESCRIPTION
## Summary
- Require bearer auth on `/refs`, `/activity/stream`, and `/activity/history` endpoints — previously any local process or website could read browse state without authentication
- Remove `Access-Control-Allow-Origin: *` headers from those endpoints so web pages can no longer read responses via cross-origin fetch
- Add query-parameter token fallback to `validateAuth` for `EventSource` compatibility (it cannot set custom headers)
- Update Chrome extension callers (`background.js`, `sidepanel.js`) to pass auth tokens on all three endpoints

## Test plan
- [x] New `browse/test/endpoint-auth.test.ts` — 12 tests covering all three endpoints
- [x] Unauthenticated requests return 401
- [x] Wrong token returns 401
- [x] Valid bearer header returns 200
- [x] Query-parameter token returns 200 (EventSource compat)
- [x] `Access-Control-Allow-Origin` header is absent from authenticated responses
- [x] Existing `sidebar-integration.test.ts` still passes (13/13)
- [x] Existing `activity.test.ts` still passes (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)