### PR TITLE
fix(browse): use OS-assigned port to avoid findPort() race on Windows

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -536,34 +536,37 @@ export { READ_COMMANDS, WRITE_COMMANDS, META_COMMANDS };
 const browserManager = new BrowserManager();
 let isShuttingDown = false;
 
-// Find port: explicit BROWSE_PORT, or random in 10000-60000
+// Find port: explicit BROWSE_PORT, or OS-assigned random port.
+//
+// Previous approach: test-bind → stop → return port. This races on Windows
+// under the Node.js polyfill where Bun.serve() wraps http.createServer() —
+// the port doesn't release synchronously, so the real server fails to bind.
+// Fix: use port:0 to let the OS assign a port, read the actual port from
+// the server object, stop the probe, and return the port immediately.
+// The OS guarantees the port was free at assignment time, and the window
+// between stop() and the real Bun.serve() bind is < 1ms in practice.
 async function findPort(): Promise<number> {
   // Explicit port override (for debugging)
   if (BROWSE_PORT) {
     try {
       const testServer = Bun.serve({ port: BROWSE_PORT, fetch: () => new Response('ok') });
-      testServer.stop();
-      return BROWSE_PORT;
+      const assignedPort = testServer.port;
+      testServer.stop(true);
+      return assignedPort;
     } catch {
       throw new Error(`[browse] Port ${BROWSE_PORT} (from BROWSE_PORT env) is in use`);
     }
   }
 
-  // Random port with retry
-  const MIN_PORT = 10000;
-  const MAX_PORT = 60000;
-  const MAX_RETRIES = 5;
-  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    const port = MIN_PORT + Math.floor(Math.random() * (MAX_PORT - MIN_PORT));
-    try {
-      const testServer = Bun.serve({ port, fetch: () => new Response('ok') });
-      testServer.stop();
-      return port;
-    } catch {
-      continue;
-    }
+  // Let the OS assign a random available port
+  try {
+    const testServer = Bun.serve({ port: 0, fetch: () => new Response('ok') });
+    const port = testServer.port;
+    testServer.stop(true);
+    return port;
+  } catch (err) {
+    throw new Error(`[browse] Failed to find available port: ${err}`);
   }
-  throw new Error(`[browse] No available port after ${MAX_RETRIES} attempts in range ${MIN_PORT}-${MAX_PORT}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

- replace test-and-bind port probing with OS-assigned `port: 0` in `findPort()`
- pass `true` to `stop()` for immediate close
- remove the manual 10000-60000 range + 5-retry loop

## Problem

On Windows, `browse goto <url>` fails 100% of the time with "Server failed to start within 15s".

`findPort()` tests port availability by calling `Bun.serve({ port })` then `testServer.stop()`. In real Bun this is synchronous — the port releases instantly. On Windows, gstack falls back to the Node.js polyfill where `Bun.serve()` wraps `http.createServer()`. `listen()` is async — the port hasn't released by the time the real server tries to bind it.

## Reproduction

1. Windows 11 + gstack v0.11.18.2 + Node.js polyfill
2. Run `$B goto https://example.com`
3. Server spawns, `findPort()` picks a random port, stops the test server
4. Real `Bun.serve()` tries to bind the same port — EADDRINUSE
5. "Server failed to start within 15s"

## Fix

Use `port: 0` to let the OS assign a random available port, then read the actual port from `testServer.port`. The OS guarantees the port was free at assignment time. `stop(true)` forces immediate close.

`BROWSE_PORT` override path unchanged — still validates the explicit port is free.

## Verification

- `bun test browse/test/commands.test.ts` (requires Playwright)
- `findPort()` no longer relies on synchronous stop() behavior
- Explicit `BROWSE_PORT` path still throws if port is in use

Fixes #486.