### PR TITLE
fix(build): decouple doc generation from binary compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "browse": "./browse/dist/browse"
   },
   "scripts": {
-    "build": "bun run gen:skill-docs && bun run gen:skill-docs --host codex && bun build --compile browse/src/cli.ts --outfile browse/dist/browse && bun build --compile browse/src/find-browse.ts --outfile browse/dist/find-browse && bun build --compile bin/gstack-global-discover.ts --outfile bin/gstack-global-discover && bash browse/scripts/build-node-server.sh && git rev-parse HEAD > browse/dist/.version && rm -f .*.bun-build || true",
+    "build": "bun run build:docs; bun run build:binaries",
+    "build:docs": "bun run gen:skill-docs && bun run gen:skill-docs --host codex",
+    "build:binaries": "bun build --compile browse/src/cli.ts --outfile browse/dist/browse && bun build --compile browse/src/find-browse.ts --outfile browse/dist/find-browse && bun build --compile bin/gstack-global-discover.ts --outfile bin/gstack-global-discover && bash browse/scripts/build-node-server.sh && git rev-parse HEAD > browse/dist/.version && rm -f .*.bun-build || true",
     "gen:skill-docs": "bun run scripts/gen-skill-docs.ts",
     "dev": "bun run browse/src/cli.ts",
     "server": "bun run browse/src/server.ts",


### PR DESCRIPTION
## Summary

- split `build` into `build:docs` and `build:binaries`
- use `;` so binary compilation runs even if doc generation fails
- browse binary is no longer blocked by template errors

## Problem

After upgrading gstack, `browse/dist/browse` is missing. `./setup` reports "gstack ready" but every browse command fails with ENOENT.

The `build` script chains everything with `&&`:
```
bun run gen:skill-docs && bun run gen:skill-docs --host codex && bun build --compile browse/src/cli.ts ...
```

If `gen:skill-docs` fails (missing Codex host config, template syntax error, stale resolver), the `&&` chain stops. `bun build --compile` never runs. The trailing `|| true` masks the exit code — `./setup` doesn't detect the failure.

## Reproduction

1. Upgrade gstack (e.g. v0.11.15.0 → v0.11.18.2) with a stale Codex config
2. Run `./setup`
3. `gen:skill-docs --host codex` fails, entire build chain aborts
4. `./setup` prints "gstack ready"
5. `$B goto https://example.com` → `zsh: no such file or directory: browse/dist/browse`

## Fix

```json
"build": "bun run build:docs; bun run build:binaries",
"build:docs": "bun run gen:skill-docs && bun run gen:skill-docs --host codex",
"build:binaries": "bun build --compile ... && git rev-parse HEAD > browse/dist/.version ..."
```

`;` runs `build:binaries` regardless of `build:docs` exit code. Doc generation errors still print to stderr but the browse binary that users need always gets compiled.

+3/-1 in `package.json`.

Fixes #482.