### PR TITLE
fix: fall back to dirname/unknown when git context is absent

### DIFF
--- a/bin/gstack-slug
+++ b/bin/gstack-slug
@@ -6,10 +6,13 @@
 # Security: output is sanitized to [a-zA-Z0-9._-] only, preventing
 # shell injection when consumed via source or eval.
 set -euo pipefail
-RAW_SLUG=$(git remote get-url origin 2>/dev/null | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-')
-RAW_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-')
+RAW_SLUG=$(git remote get-url origin 2>/dev/null | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-' || true)
+RAW_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || true)
 # Strip any characters that aren't alphanumeric, dot, hyphen, or underscore
 SLUG=$(printf '%s' "$RAW_SLUG" | tr -cd 'a-zA-Z0-9._-')
 BRANCH=$(printf '%s' "$RAW_BRANCH" | tr -cd 'a-zA-Z0-9._-')
+# Fall back to directory name / "unknown" when git context is absent
+SLUG="${SLUG:-$(basename "$PWD" | tr -cd 'a-zA-Z0-9._-')}"
+BRANCH="${BRANCH:-unknown}"
 echo "SLUG=$SLUG"
 echo "BRANCH=$BRANCH"


### PR DESCRIPTION
## Problem

`gstack-review-log` uses `set -euo pipefail`, which treats empty strings as unbound variables. When run outside a git repo (or in a repo with no remote configured), `gstack-slug` produces empty strings for `SLUG` and `BRANCH`, causing:

```
gstack-review-log: line 8: SLUG: unbound variable
gstack-review-log: line 9: BRANCH: unbound variable
```

This breaks any gstack review skill (e.g. `/autoplan`, `/plan-ceo-review`) when the working directory isn't a git repo with a remote.

## Fix

Two changes in `gstack-slug`:
1. Add `|| true` to the git commands so `set -e` doesn't abort when git context is missing
2. Fall back to `basename "$PWD"` for `SLUG` and `"unknown"` for `BRANCH` when the values are empty

## Repro

Run any gstack review skill in a directory with no git remote configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)