### PR TITLE
fix: remove preemptive context warnings in plan-eng-review

### DIFF
--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -330,7 +330,7 @@ plan's living status.
 Review this plan thoroughly before making any code changes. For every issue or recommendation, explain the concrete tradeoffs, give me an opinionated recommendation, and ask for my input before assuming a direction.
 
 ## Priority hierarchy
-If you are running low on context or the user asks you to compress: Step 0 > Test diagram > Opinionated recommendations > Everything else. Never skip Step 0 or the test diagram.
+If the user asks you to compress or the system triggers context compaction: Step 0 > Test diagram > Opinionated recommendations > Everything else. Never skip Step 0 or the test diagram. Do not preemptively warn about context limits — the system handles compaction automatically.
 
 ## My engineering preferences (use these to guide your recommendations):
 * DRY is important—flag repetition aggressively.

--- a/plan-eng-review/SKILL.md.tmpl
+++ b/plan-eng-review/SKILL.md.tmpl
@@ -27,7 +27,7 @@ allowed-tools:
 Review this plan thoroughly before making any code changes. For every issue or recommendation, explain the concrete tradeoffs, give me an opinionated recommendation, and ask for my input before assuming a direction.
 
 ## Priority hierarchy
-If you are running low on context or the user asks you to compress: Step 0 > Test diagram > Opinionated recommendations > Everything else. Never skip Step 0 or the test diagram.
+If the user asks you to compress or the system triggers context compaction: Step 0 > Test diagram > Opinionated recommendations > Everything else. Never skip Step 0 or the test diagram. Do not preemptively warn about context limits -- the system handles compaction automatically.
 
 ## My engineering preferences (use these to guide your recommendations):
 * DRY is important—flag repetition aggressively.


### PR DESCRIPTION
## Problem

The `plan-eng-review` skill's priority hierarchy instruction tells the model to watch for low context:

> "If you are running low on context..."

This causes premature compression warnings on 1M context window models. At 27% usage on a 1M window, ~730K tokens remain — far from any real constraint. The model doesn't have precise token-counting ability and relies on heuristics, so this instruction makes it "context-anxious" regardless of actual available space.

| Context Used | 200K remaining | 1M remaining | Should warn? |
|---|---|---|---|
| 27% | ~146K | ~130K | 200K: maybe. 1M: absolutely not |
| 50% | ~100K | ~500K | 200K: yes. 1M: no |
| 80% | ~40K | ~200K | Both: yes |

## Solution

- Replace the self-monitoring trigger with system-level and user-initiated triggers only
- The model now compresses when: (1) the user explicitly asks, or (2) Claude Code's own compaction system fires
- Explicitly instructs the model not to preemptively warn about context limits

## Changes

- `plan-eng-review/SKILL.md.tmpl` — Updated priority hierarchy instruction
- `plan-eng-review/SKILL.md` — Regenerated from template

## Test Plan

- Run `/plan-eng-review` on a 1M context model with a long conversation — verify no premature compression warnings
- Run on a 200K context model — verify compaction still works when system triggers it
- Verify user can still say "compress" to trigger manual compression

Closes #510