### PR TITLE
fix: add feature-signal detection to ship version bump heuristic

### DIFF
--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -1580,9 +1580,10 @@ High-confidence findings (agreed on by multiple sources) should be prioritized f
 
 2. **Auto-decide the bump level based on the diff:**
    - Count lines changed (`git diff origin/<base>...HEAD --stat | tail -1`)
+   - Check for feature signals: new route/page files (e.g. `app/*/page.tsx`, `pages/*.ts`), new DB migration/schema files, new test files alongside new source files, or branch name starting with `feat/`
    - **MICRO** (4th digit): < 50 lines changed, trivial tweaks, typos, config
-   - **PATCH** (3rd digit): 50+ lines changed, bug fixes, small-medium features
-   - **MINOR** (2nd digit): **ASK the user** — only for major features or significant architectural changes
+   - **PATCH** (3rd digit): 50+ lines changed, no feature signals detected
+   - **MINOR** (2nd digit): **ASK the user** if ANY feature signal is detected, OR 500+ lines changed, OR new modules/packages added
    - **MAJOR** (1st digit): **ASK the user** — only for milestones or breaking changes
 
 3. Compute the new version:

--- a/ship/SKILL.md.tmpl
+++ b/ship/SKILL.md.tmpl
@@ -322,9 +322,10 @@ For each classified comment:
 
 2. **Auto-decide the bump level based on the diff:**
    - Count lines changed (`git diff origin/<base>...HEAD --stat | tail -1`)
+   - Check for feature signals: new route/page files (e.g. `app/*/page.tsx`, `pages/*.ts`), new DB migration/schema files, new test files alongside new source files, or branch name starting with `feat/`
    - **MICRO** (4th digit): < 50 lines changed, trivial tweaks, typos, config
-   - **PATCH** (3rd digit): 50+ lines changed, bug fixes, small-medium features
-   - **MINOR** (2nd digit): **ASK the user** — only for major features or significant architectural changes
+   - **PATCH** (3rd digit): 50+ lines changed, no feature signals detected
+   - **MINOR** (2nd digit): **ASK the user** if ANY feature signal is detected, OR 500+ lines changed, OR new modules/packages added
    - **MAJOR** (1st digit): **ASK the user** — only for milestones or breaking changes
 
 3. Compute the new version:


### PR DESCRIPTION
## Problem

The `/ship` skill (Step 4: Version bump) uses a line-count-only heuristic:
- **MICRO**: < 50 lines
- **PATCH**: 50+ lines (auto)
- **MINOR**: asks user (but the ask never triggers automatically)

In practice, MINOR is never auto-triggered because every real session exceeds 50 lines, so PATCH is always auto-picked. Over 23 sessions on a real product, features like full health score engines, reports pages, coaching signal layers, and PDF import all shipped as PATCH bumps.

## Solution

Add feature-signal detection before the line-count check. If ANY of these signals are detected, the skill asks the user about MINOR instead of auto-picking PATCH:

- New route/page files (e.g. `app/*/page.tsx`, `pages/*.ts`)
- New DB migration/schema files
- New test files alongside new source files
- Branch name starting with `feat/`
- 500+ lines changed
- New modules/packages added

The MICRO and MAJOR thresholds are unchanged. PATCH still auto-picks when there are no feature signals and < 500 lines.

## Changes

- `ship/SKILL.md.tmpl` — Updated Step 4 auto-decide heuristic
- `ship/SKILL.md` — Regenerated from template

## Test Plan

- Run `/ship` on a branch with `feat/` prefix → should ask about MINOR
- Run `/ship` on a branch that adds new `app/*/page.tsx` files → should ask about MINOR
- Run `/ship` on a branch with a 30-line config tweak → should auto-pick MICRO
- Run `/ship` on a branch with a 60-line bug fix (no feature signals) → should auto-pick PATCH

Closes #527