### PR TITLE
fix: auto-select default after 10s timeout in setup prefix prompt

### DIFF
--- a/setup
+++ b/setup
@@ -62,8 +62,14 @@ if [ "$SKILL_PREFIX_FLAG" -eq 0 ]; then
       echo "  2) Namespaced: /gstack-qa, /gstack-ship, /gstack-review"
       echo "     Use this if you run other skill packs alongside gstack to avoid conflicts."
       echo ""
-      printf "Choice [1/2] (default: 1): "
-      read -r _prefix_choice </dev/tty 2>/dev/null || _prefix_choice=""
+      printf "Choice [1/2] (default: 1, auto-selects in 10s): "
+      if read -t 10 -r _prefix_choice </dev/tty 2>/dev/null; then
+        : # User made a choice or pressed Enter
+      else
+        _prefix_choice=""
+        echo ""
+        echo "  (timed out — using short names)"
+      fi
       case "$_prefix_choice" in
         2) SKILL_PREFIX=1 ;;
         *) SKILL_PREFIX=0 ;;


### PR DESCRIPTION
## Summary

- The interactive skill-naming prompt in `setup` blocked indefinitely, hanging automated CI installs, Conductor workspace setups, and any unattended environment where stdin is a TTY but nobody is watching
- Adds a 10-second timeout via `read -t 10` that auto-selects the default (short names) if the user doesn't respond
- Prints a clear `(timed out — using short names)` message when it auto-selects

## Test plan

- [ ] Run `./setup` and let the prompt time out — should auto-select short names after 10s
- [ ] Run `./setup` and press Enter — should select short names (default)
- [ ] Run `./setup` and type `2` — should select namespaced names
- [ ] Run `./setup --no-prefix` — should skip the prompt entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)