### PR TITLE
feat: add MCP server packaging checks to /review and /ship

### DIFF
--- a/review/checklist.md
+++ b/review/checklist.md
@@ -154,6 +154,18 @@ To do this: use Grep to find all references to the sibling values (e.g., grep fo
 - Internal tools not distributed outside the team
 - Test-only CI changes (adding test steps, not publish steps)
 
+#### MCP Server Packaging
+When the diff adds or modifies an MCP server package (look for `glama.json`, `mcpServers` in package.json, or a `server.ts` entry point):
+
+- **`package.json` exports point to `src/` not `dist/`** — MCP registries (Glama, etc.) run Docker builds that execute the compiled output. If `"exports"` or `"main"` resolves to a `.ts` file or a `src/` path, the server will fail to start in the registry's container. Fix: change to `"./dist/index.js"` (or equivalent compiled output path). This is AUTO-FIX if the dist path is unambiguous.
+- **ESM imports missing `.js` extensions** — If `tsconfig.json` uses `"moduleResolution": "NodeNext"` or `"Node16"`, TypeScript requires all relative imports to include `.js` extensions (e.g., `import { foo } from "./foo.js"` not `"./foo"`). Using `"bundler"` moduleResolution locally can hide this because bundlers resolve extensions automatically, but Node.js ESM does not. Grep for `from "\./` in `.ts` files and flag any import missing `.js`. This is AUTO-FIX.
+- **`moduleResolution: "bundler"` on a Node.js MCP package** — `bundler` mode is correct for frontend/Vite projects but wrong for Node.js packages distributed via npm or Docker. If the package is a standalone Node.js MCP server, `tsconfig.json` should use `"module": "NodeNext"` and `"moduleResolution": "NodeNext"`. Flag if `bundler` is set on a non-frontend package. This is ASK.
+- **`glama.json` missing or malformed** — If the diff adds a Glama MCP server but no `glama.json` exists at the repo root, flag it. Required fields: `$schema` and `maintainers` array. Fix: create `glama.json` with `{"$schema": "https://glama.ai/mcp/schemas/server.json", "maintainers": ["<github-username>"]}`. This is AUTO-FIX if the GitHub username is determinable from git config.
+
+**DO NOT flag:**
+- Frontend packages using `"moduleResolution": "bundler"` — correct for that context
+- MCP packages that are consumed as libraries (not standalone servers) — Docker packaging doesn't apply
+
 ---
 
 ## Severity Classification

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -1846,7 +1846,23 @@ EOF
 **If neither CLI is available:**
 Print the branch name, remote URL, and instruct the user to create the PR/MR manually via the web UI. Do not stop — the code is pushed and ready.
 
-**Output the PR/MR URL** — then proceed to Step 8.5.
+**Output the PR/MR URL** — then proceed to Step 8.25.
+
+---
+
+## Step 8.25: MCP Registry Sync Reminder (conditional)
+
+After creating the PR, check if this repo contains an MCP server registered with an external registry:
+
+```bash
+[ -f glama.json ] && echo "GLAMA_REGISTERED=true" || echo "GLAMA_REGISTERED=false"
+```
+
+If `GLAMA_REGISTERED=true`: output this one-line reminder before continuing:
+
+> **Glama reminder:** After this PR merges, go to [glama.ai/mcp/servers](https://glama.ai/mcp/servers), find your server, and hit **Sync** to trigger a fresh Docker build. Glama caches Docker layers and will not pick up the new commit automatically.
+
+This is informational only — do not block or ask for confirmation. Proceed to Step 8.5.
 
 ---
 

--- a/ship/SKILL.md.tmpl
+++ b/ship/SKILL.md.tmpl
@@ -581,7 +581,23 @@ EOF
 **If neither CLI is available:**
 Print the branch name, remote URL, and instruct the user to create the PR/MR manually via the web UI. Do not stop — the code is pushed and ready.
 
-**Output the PR/MR URL** — then proceed to Step 8.5.
+**Output the PR/MR URL** — then proceed to Step 8.25.
+
+---
+
+## Step 8.25: MCP Registry Sync Reminder (conditional)
+
+After creating the PR, check if this repo contains an MCP server registered with an external registry:
+
+```bash
+[ -f glama.json ] && echo "GLAMA_REGISTERED=true" || echo "GLAMA_REGISTERED=false"
+```
+
+If `GLAMA_REGISTERED=true`: output this one-line reminder before continuing:
+
+> **Glama reminder:** After this PR merges, go to [glama.ai/mcp/servers](https://glama.ai/mcp/servers), find your server, and hit **Sync** to trigger a fresh Docker build. Glama caches Docker layers and will not pick up the new commit automatically.
+
+This is informational only — do not block or ask for confirmation. Proceed to Step 8.5.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds MCP server packaging checks to \`/review\` and a Glama sync reminder to \`/ship\`, based on failure patterns hit when publishing a Node.js MCP server to Glama. Every pattern here caused a real build failure.

### \`review/checklist.md\` — new "MCP Server Packaging" section (Pass 2, Informational)

- **\`package.json\` exports pointing to \`src/\` instead of \`dist/\`** — AUTO-FIX
- **ESM imports missing \`.js\` extensions under \`NodeNext\` module resolution** — AUTO-FIX
- **\`moduleResolution: "bundler"\` on a standalone Node.js MCP server** — ASK
- **Missing or malformed \`glama.json\`** — AUTO-FIX

### \`ship/SKILL.md.tmpl\` — new Step 8.25 (conditional)

After PR creation, checks for \`glama.json\` and prints a one-line reminder to hit **Sync** in the Glama UI. Glama caches Docker layers aggressively and won't pick up new commits automatically.

### Evidence

All four issues were found on a real production MCP server (https://github.com/kalraakshit042/ai-compass):

1. **Wrong exports path** — \`package.json\` had \`"default": "./src/index.ts"\`. Glama's Docker build ran the compiled output and got: \`Cannot find module '/app/packages/core/src/recommend'\`. Fix: change to \`"./dist/index.js"\`.

2. **Missing \`.js\` extensions** — \`tsconfig.json\` used \`"moduleResolution": "bundler"\` which resolved extensionless imports locally. After switching to \`NodeNext\` for the Docker build: \`Cannot find module '/app/packages/core/dist/recommend'\`. Fix: add \`.js\` to every relative import.

3. **Glama Docker cache** — After fixing both above and pushing a new commit, Glama still ran the old build from cached layers. No error message — just silently wrong behavior. Fix: hit the "Sync" button in the Glama UI.

### Test plan

- [x] 601/601 skill validation tests pass (\`bun test test/skill-parser.test.ts test/skill-validation.test.ts test/gen-skill-docs.test.ts\`)
- [x] No conflicts with existing checklist categories
- [x] Rebased cleanly on latest main (GitLab MR support preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)