### PR TITLE
feat: add pre-mortem step to plan-eng-review

### DIFF
--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -318,8 +318,13 @@ Options:
 If they skip: "No worries — standard review. If you ever want sharper input, try
 /office-hours first next time." Then proceed normally. Do not re-offer later in the session.
 
-### Step 0: Scope Challenge
-Before reviewing anything, answer these questions:
+### Step 0: Pre-mortem
+Before reviewing anything, perform a pre-mortem:
+> "It's 3 months later and this plan failed. What are the top 3 reasons it failed?"
+Think from the perspective of production reality, not the plan's logic. Name specific failure modes (data loss, performance cliff, security hole, team confusion), not abstract concerns. Present the 3 failure modes to the user before proceeding.
+
+### Step 0.1: Scope Challenge
+After the pre-mortem, answer these questions:
 1. **What existing code already partially or fully solves each sub-problem?** Can we capture outputs from existing flows rather than building parallel ones?
 2. **What is the minimum set of changes that achieves the stated goal?** Flag any work that could be deferred without blocking the core objective. Be ruthless about scope creep.
 3. **Complexity check:** If the plan touches more than 8 files or introduces more than 2 new classes/services, treat that as a smell and challenge whether the same goal can be achieved with fewer moving parts.


### PR DESCRIPTION
## Summary

Adds a **Pre-mortem** step (Step 0) before Scope Challenge in `/plan-eng-review`:

> "It's 3 months later and this plan failed. What are the top 3 reasons it failed?"

This forces **inversion thinking** — identifying failure modes from production reality before reviewing plan logic. The existing Scope Challenge becomes Step 0.1.

### Why

Pre-mortem is a well-documented technique (Gary Klein, "Performing a Project Premortem", HBR 2007) that catches blind spots traditional plan review misses. By imagining the plan has already failed, reviewers shift from "does this look reasonable?" to "what specifically will break?" — surfacing concrete risks like data loss, performance cliffs, or team confusion.

### What changes

- `plan-eng-review/SKILL.md`: New Step 0 (Pre-mortem) with 3-failure-mode prompt
- Existing Step 0 (Scope Challenge) renumbered to Step 0.1
- No other changes to the review flow

### Boil the Lake score

This is a ~5-line addition that makes every subsequent plan review more thorough. Completeness: 9/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)