### PR TITLE
fix: --local install creates missing gstack/ symlink so skills resolve

### DIFF
--- a/setup
+++ b/setup
@@ -87,6 +87,9 @@ if [ "$LOCAL_INSTALL" -eq 1 ]; then
   fi
   INSTALL_SKILLS_DIR="$(pwd)/.claude/skills"
   mkdir -p "$INSTALL_SKILLS_DIR"
+  # Per-skill symlinks point at gstack/<skill>, so create a gstack/ symlink
+  # back to the repo root so the chain resolves (e.g. qa -> gstack/qa -> repo/qa)
+  ln -snf "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR/gstack"
   HOST="claude"
   INSTALL_CODEX=0
 fi


### PR DESCRIPTION
## Summary

`./setup --local` is broken. Per-skill symlinks (`qa -> gstack/qa`) never resolve because there's no `gstack/` directory inside `.claude/skills/`.

**Root cause:** `link_claude_skill_dirs` creates relative symlinks like `qa -> gstack/qa`. For global installs this works because the repo *is* `~/.claude/skills/gstack/`. For `--local`, the skills dir is `$(pwd)/.claude/skills/` and nothing creates the `gstack/` entry inside it.

**Fix:** One line. Create `ln -snf "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR/gstack"` in the `--local` block so the symlink chain resolves: `.claude/skills/qa -> gstack/qa -> /path/to/repo/qa/SKILL.md`.

## Repro

```bash
git clone https://github.com/garrytan/gstack && cd gstack
bun install && ./setup --local --no-prefix
ls -la .claude/skills/qa/SKILL.md   # No such file or directory
```

After fix:

```bash
./setup --local --no-prefix
ls -la .claude/skills/qa/SKILL.md   # resolves correctly
```

## Test plan
- [x] `rm -rf .claude/skills && ./setup --local --no-prefix` — all 28 skills linked, `SKILL.md` resolves
- [x] Global install (`./setup` without `--local`) unchanged — `INSTALL_SKILLS_DIR` block not entered
- [x] `bun test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)