### PR TITLE
security: enforce frozen lockfile during setup

### DIFF
--- a/setup
+++ b/setup
@@ -170,7 +170,7 @@ if [ "$NEEDS_BUILD" -eq 1 ]; then
   echo "Building browse binary..."
   (
     cd "$SOURCE_GSTACK_DIR"
-    bun install
+    bun install --frozen-lockfile
     bun run build
   )
   # Safety net: write .version if build script didn't (e.g., git not available during build)


### PR DESCRIPTION
## Summary

- Changes `bun install` to `bun install --frozen-lockfile` in the main build block of the `setup` script
- Prevents dependency confusion attacks where a compromised npm publish of `playwright`, `puppeteer-core`, or any transitive dependency resolves to a malicious version at install time
- The `.agents/` generation block (line 199) already uses `--frozen-lockfile` with a fallback — this makes the main build path consistent

## Why this matters

gstack's setup runs `bun install` which resolves `^1.58.2` to the latest compatible version. If an attacker publishes a compromised version of any dependency in the resolution range, every new `./setup` or `/gstack-upgrade` run would pull it. With `--frozen-lockfile`, only versions pinned in `bun.lock` are installed.

## Risk

Low. If `bun.lock` is missing or stale (e.g., after a dependency bump in `package.json` without running `bun install` to update the lock), setup will fail with a clear error instead of silently resolving new versions. This is the correct behavior — maintainers should commit an updated lockfile.

## Test plan

- [x] Verify `./setup` succeeds with existing `bun.lock`
- [ ] Verify `./setup` fails clearly when `bun.lock` is deleted (expected: error message about frozen lockfile)

Made with [Cursor](https://cursor.com)