### PR TITLE
security: track cookie-imported domains and scope cookie imports

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -57,6 +57,9 @@ export class BrowserManager {
   private dialogAutoAccept: boolean = true;
   private dialogPromptText: string | null = null;
 
+  // ─── Cookie Origin Tracking ────────────────────────────────
+  private cookieImportedDomains: Set<string> = new Set();
+
   // ─── Handoff State ─────────────────────────────────────────
   private isHeaded: boolean = false;
   private consecutiveFailures: number = 0;
@@ -519,6 +522,19 @@ export class BrowserManager {
 
   getDialogPromptText(): string | null {
     return this.dialogPromptText;
+  }
+
+  // ─── Cookie Origin Tracking ────────────────────────────────
+  trackCookieImportDomains(domains: string[]): void {
+    for (const d of domains) this.cookieImportedDomains.add(d);
+  }
+
+  getCookieImportedDomains(): ReadonlySet<string> {
+    return this.cookieImportedDomains;
+  }
+
+  hasCookieImports(): boolean {
+    return this.cookieImportedDomains.size > 0;
   }
 
   // ─── Viewport ──────────────────────────────────────────────

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -314,32 +314,58 @@ export async function handleWriteCommand(
       }
 
       await page.context().addCookies(cookies);
+      const importedDomains = [...new Set(cookies.map((c: any) => c.domain).filter(Boolean))];
+      if (importedDomains.length > 0) bm.trackCookieImportDomains(importedDomains);
       return `Loaded ${cookies.length} cookies from ${filePath}`;
     }
 
     case 'cookie-import-browser': {
       // Two modes:
       // 1. Direct CLI import: cookie-import-browser <browser> --domain <domain> [--profile <profile>]
-      // 2. Open picker UI: cookie-import-browser [browser]
+      //    Requires --domain (or --all to explicitly import everything).
+      // 2. Open picker UI: cookie-import-browser [browser] (interactive domain selection)
       const browserArg = args[0];
       const domainIdx = args.indexOf('--domain');
       const profileIdx = args.indexOf('--profile');
+      const hasAll = args.includes('--all');
       const profile = (profileIdx !== -1 && profileIdx + 1 < args.length) ? args[profileIdx + 1] : 'Default';
 
       if (domainIdx !== -1 && domainIdx + 1 < args.length) {
-        // Direct import mode — no UI
+        // Direct import mode — scoped to specific domain
         const domain = args[domainIdx + 1];
         const browser = browserArg || 'comet';
         const result = await importCookies(browser, [domain], profile);
         if (result.cookies.length > 0) {
           await page.context().addCookies(result.cookies);
+          bm.trackCookieImportDomains([domain]);
         }
         const msg = [`Imported ${result.count} cookies for ${domain} from ${browser}`];
         if (result.failed > 0) msg.push(`(${result.failed} failed to decrypt)`);
         return msg.join(' ');
       }
 
-      // Picker UI mode — open in user's browser
+      if (hasAll) {
+        // Explicit all-cookies import — requires --all flag as a deliberate opt-in.
+        // Imports every non-expired cookie domain from the browser.
+        const browser = browserArg || 'comet';
+        const { listDomains } = await import('./cookie-import-browser');
+        const { domains } = listDomains(browser, profile);
+        const allDomainNames = domains.map(d => d.domain);
+        if (allDomainNames.length === 0) {
+          return `No cookies found in ${browser} (profile: ${profile})`;
+        }
+        const result = await importCookies(browser, allDomainNames, profile);
+        if (result.cookies.length > 0) {
+          await page.context().addCookies(result.cookies);
+          bm.trackCookieImportDomains(allDomainNames);
+        }
+        const msg = [`Imported ${result.count} cookies across ${Object.keys(result.domainCounts).length} domains from ${browser}`];
+        msg.push('(used --all: all browser cookies imported — consider --domain for tighter scoping)');
+        if (result.failed > 0) msg.push(`(${result.failed} failed to decrypt)`);
+        return msg.join(' ');
+      }
+
+      // Picker UI mode — open in user's browser for interactive domain selection
       const port = bm.serverPort;
       if (!port) throw new Error('Server port not available');
 
@@ -355,7 +381,7 @@ export async function handleWriteCommand(
         // open may fail silently — URL is in the message below
       }
 
-      return `Cookie picker opened at ${pickerUrl}\nDetected browsers: ${browsers.map(b => b.name).join(', ')}\nSelect domains to import, then close the picker when done.`;
+      return `Cookie picker opened at ${pickerUrl}\nDetected browsers: ${browsers.map(b => b.name).join(', ')}\nSelect domains to import, then close the picker when done.\n\nTip: For scripted imports, use --domain <domain> to scope cookies to a single domain.`;
     }
 
     default:


### PR DESCRIPTION
## Summary

- Adds cookie origin tracking to `BrowserManager` — every cookie import path now records which domains were imported
- The `cookie-import-browser` direct CLI mode now requires either `--domain <domain>` (scoped) or `--all` (explicit opt-in) for non-interactive use
- The `cookie-import` (JSON file) path also tracks imported domains
- The `--all` flag works but emits a warning recommending `--domain` for tighter scoping

## Why this matters

When cookies are imported without domain scoping, the headless browser gets access to every authenticated session in the user's real browser — Gmail, GitHub, banking, corporate SSO. A prompt injection via web page content could instruct the agent to navigate to a sensitive domain and exfiltrate data.

By tracking which domains had cookies imported, downstream commands can restrict operations to those origins. This PR is the **foundation** for origin-pinned JS execution (separate PR) — the `BrowserManager` now knows which domains have imported cookies.

## Changes

| File | What changed |
|------|-------------|
| `browse/src/browser-manager.ts` | Added `cookieImportedDomains` set + `trackCookieImportDomains()`, `getCookieImportedDomains()`, `hasCookieImports()` methods |
| `browse/src/write-commands.ts` | `cookie-import-browser`: added `--all` flag with warning, domain tracking on import. `cookie-import`: added domain tracking |

## Backward compatibility

- `cookie-import-browser chrome --domain .example.com` — works as before, now also tracked
- `cookie-import-browser chrome` (no flags) — opens picker UI as before (unchanged)
- `cookie-import-browser chrome --all` — new explicit opt-in for all cookies
- `cookie-import cookies.json` — works as before, now also tracked

No breaking changes. The `--all` flag is additive.

## Test plan

- [ ] `cookie-import-browser chrome --domain .github.com` imports only github cookies and tracks the domain
- [ ] `cookie-import-browser chrome --all` imports all cookies with a warning
- [ ] `cookie-import-browser chrome` (no flags) opens the picker UI as before
- [ ] `cookie-import cookies.json` tracks domains from the JSON file
- [ ] `bm.hasCookieImports()` returns true after any import, false before

Made with [Cursor](https://cursor.com)