### PR TITLE
security: add persistent command audit log to browse server

### DIFF
--- a/browse/src/audit.ts
+++ b/browse/src/audit.ts
@@ -1,0 +1,65 @@
+/**
+ * Persistent command audit log — forensic trail for all browse server commands.
+ *
+ * Writes append-only JSONL to .gstack/browse-audit.jsonl. Unlike the in-memory
+ * ring buffers (console, network, dialog), the audit log persists across server
+ * restarts and is never truncated by the server. Each entry records:
+ *
+ *   - timestamp, command, args (truncated), page origin
+ *   - duration, status (ok/error), error message if any
+ *   - whether cookies were imported (elevated security context)
+ *   - connection mode (headless/headed)
+ *
+ * All writes are best-effort — audit failures never cause command failures.
+ */
+
+import * as fs from 'fs';
+
+export interface AuditEntry {
+  ts: string;
+  cmd: string;
+  args: string;
+  origin: string;
+  durationMs: number;
+  status: 'ok' | 'error';
+  error?: string;
+  hasCookies: boolean;
+  mode: 'launched' | 'headed';
+}
+
+const MAX_ARGS_LENGTH = 200;
+const MAX_ERROR_LENGTH = 300;
+
+let auditPath: string | null = null;
+
+export function initAuditLog(logPath: string): void {
+  auditPath = logPath;
+}
+
+export function writeAuditEntry(entry: AuditEntry): void {
+  if (!auditPath) return;
+  try {
+    const truncatedArgs = entry.args.length > MAX_ARGS_LENGTH
+      ? entry.args.slice(0, MAX_ARGS_LENGTH) + '…'
+      : entry.args;
+    const truncatedError = entry.error && entry.error.length > MAX_ERROR_LENGTH
+      ? entry.error.slice(0, MAX_ERROR_LENGTH) + '…'
+      : entry.error;
+
+    const record: Record<string, unknown> = {
+      ts: entry.ts,
+      cmd: entry.cmd,
+      args: truncatedArgs,
+      origin: entry.origin,
+      durationMs: entry.durationMs,
+      status: entry.status,
+      hasCookies: entry.hasCookies,
+      mode: entry.mode,
+    };
+    if (truncatedError) record.error = truncatedError;
+
+    fs.appendFileSync(auditPath, JSON.stringify(record) + '\n');
+  } catch {
+    // Audit write failures are silent — never block command execution
+  }
+}

--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -57,6 +57,9 @@ export class BrowserManager {
   private dialogAutoAccept: boolean = true;
   private dialogPromptText: string | null = null;
 
+  // ─── Cookie Import Tracking (for audit log) ───────────────
+  private _hasCookieImports: boolean = false;
+
   // ─── Handoff State ─────────────────────────────────────────
   private isHeaded: boolean = false;
   private consecutiveFailures: number = 0;
@@ -519,6 +522,15 @@ export class BrowserManager {
 
   getDialogPromptText(): string | null {
     return this.dialogPromptText;
+  }
+
+  // ─── Cookie Import Tracking ────────────────────────────────
+  markCookiesImported(): void {
+    this._hasCookieImports = true;
+  }
+
+  hasCookieImports(): boolean {
+    return this._hasCookieImports;
   }
 
   // ─── Viewport ──────────────────────────────────────────────

--- a/browse/src/config.ts
+++ b/browse/src/config.ts
@@ -20,6 +20,7 @@ export interface BrowseConfig {
   consoleLog: string;
   networkLog: string;
   dialogLog: string;
+  auditLog: string;
 }
 
 /**
@@ -70,6 +71,7 @@ export function resolveConfig(
     consoleLog: path.join(stateDir, 'browse-console.log'),
     networkLog: path.join(stateDir, 'browse-network.log'),
     dialogLog: path.join(stateDir, 'browse-dialog.log'),
+    auditLog: path.join(stateDir, 'browse-audit.jsonl'),
   };
 }
 

--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -23,6 +23,7 @@ import { COMMAND_DESCRIPTIONS } from './commands';
 import { handleSnapshot, SNAPSHOT_FLAGS } from './snapshot';
 import { resolveConfig, ensureStateDir, readVersionHash } from './config';
 import { emitActivity, subscribe, getActivityAfter, getActivityHistory, getSubscriberCount } from './activity';
+import { initAuditLog, writeAuditEntry } from './audit';
 // Bun.spawn used instead of child_process.spawn (compiled bun binaries
 // fail posix_spawn on all executables including /bin/bash)
 import * as fs from 'fs';
@@ -33,6 +34,7 @@ import * as crypto from 'crypto';
 // ─── Config ─────────────────────────────────────────────────────
 const config = resolveConfig();
 ensureStateDir(config);
+initAuditLog(config.auditLog);
 
 // ─── Auth ───────────────────────────────────────────────────────
 const AUTH_TOKEN = crypto.randomUUID();
@@ -707,15 +709,27 @@ async function handleCommand(body: any): Promise<Response> {
     }
 
     // Activity: emit command_end (success)
+    const successDuration = Date.now() - startTime;
     emitActivity({
       type: 'command_end',
       command,
       args,
       url: browserManager.getCurrentUrl(),
-      duration: Date.now() - startTime,
+      duration: successDuration,
       status: 'ok',
       result: result,
       tabs: browserManager.getTabCount(),
+      mode: browserManager.getConnectionMode(),
+    });
+
+    writeAuditEntry({
+      ts: new Date().toISOString(),
+      cmd: command,
+      args: args.join(' '),
+      origin: browserManager.getCurrentUrl(),
+      durationMs: successDuration,
+      status: 'ok',
+      hasCookies: browserManager.hasCookieImports(),
       mode: browserManager.getConnectionMode(),
     });
 
@@ -726,15 +740,28 @@ async function handleCommand(body: any): Promise<Response> {
     });
   } catch (err: any) {
     // Activity: emit command_end (error)
+    const errorDuration = Date.now() - startTime;
     emitActivity({
       type: 'command_end',
       command,
       args,
       url: browserManager.getCurrentUrl(),
-      duration: Date.now() - startTime,
+      duration: errorDuration,
       status: 'error',
       error: err.message,
       tabs: browserManager.getTabCount(),
+      mode: browserManager.getConnectionMode(),
+    });
+
+    writeAuditEntry({
+      ts: new Date().toISOString(),
+      cmd: command,
+      args: args.join(' '),
+      origin: browserManager.getCurrentUrl(),
+      durationMs: errorDuration,
+      status: 'error',
+      error: err.message,
+      hasCookies: browserManager.hasCookieImports(),
       mode: browserManager.getConnectionMode(),
     });
 

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -314,6 +314,7 @@ export async function handleWriteCommand(
       }
 
       await page.context().addCookies(cookies);
+      bm.markCookiesImported();
       return `Loaded ${cookies.length} cookies from ${filePath}`;
     }
 
@@ -333,6 +334,7 @@ export async function handleWriteCommand(
         const result = await importCookies(browser, [domain], profile);
         if (result.cookies.length > 0) {
           await page.context().addCookies(result.cookies);
+          bm.markCookiesImported();
         }
         const msg = [`Imported ${result.count} cookies for ${domain} from ${browser}`];
         if (result.failed > 0) msg.push(`(${result.failed} failed to decrypt)`);


### PR DESCRIPTION
## Summary

- Every browse server command is now logged to `.gstack/browse-audit.jsonl` as append-only JSONL
- Each entry records: timestamp, command, args, page origin, duration, status, error, whether cookies are imported, and connection mode
- The audit log persists across server restarts (unlike the in-memory ring buffers)
- All writes are best-effort — audit failures never block command execution

## Why this matters

The browse server executes commands on behalf of AI agents — navigating pages, clicking elements, running JavaScript, importing cookies. When something goes wrong (unexpected navigation, data exfiltration, prompt injection), there's currently no persistent forensic trail. The in-memory ring buffers (console, network, dialog) are capped at 50K entries and lost on server restart.

The audit log creates a persistent record of every command the server processed. Example use cases:

```bash
# What commands ran in the last session?
cat .gstack/browse-audit.jsonl | jq .

# Which commands ran with imported cookies? (elevated risk)
cat .gstack/browse-audit.jsonl | jq 'select(.hasCookies == true)'

# What JS was executed and on which origins?
cat .gstack/browse-audit.jsonl | jq 'select(.cmd == "js" or .cmd == "eval")'

# What failed?
cat .gstack/browse-audit.jsonl | jq 'select(.status == "error")'
```

## Changes

| File | What changed |
|------|-------------|
| `browse/src/audit.ts` | **New file.** `initAuditLog()` and `writeAuditEntry()` — append-only JSONL writer with truncation |
| `browse/src/config.ts` | Added `auditLog` path to `BrowseConfig` (`.gstack/browse-audit.jsonl`) |
| `browse/src/server.ts` | Initialize audit log on startup, write entries on command success and error |
| `browse/src/browser-manager.ts` | Added `markCookiesImported()` and `hasCookieImports()` for the `hasCookies` audit field |
| `browse/src/write-commands.ts` | Call `markCookiesImported()` on `cookie-import` and `cookie-import-browser` |

## Design decisions

- **Append-only, never truncated by server.** The console/network/dialog logs are cleared on each server start. The audit log is not — it accumulates across sessions. Users can rotate or truncate it manually if it grows large.
- **Args truncated to 200 chars, errors to 300 chars.** Prevents the log from growing unboundedly if large payloads are passed (e.g., `js` with a long expression).
- **`hasCookies` boolean flag.** Makes it trivial to filter for elevated-risk commands — any command that ran while browser cookies were imported from the user's real browser.
- **Independent of other security PRs.** The `hasCookieImports()` tracking added here is minimal (just a boolean). It's compatible with but doesn't depend on #615 (domain-level tracking).

## Test plan

- [ ] Start browse server, run a few commands (`goto`, `snapshot`, `js`), verify `.gstack/browse-audit.jsonl` contains entries
- [ ] Import cookies, run commands, verify `hasCookies: true` in subsequent entries
- [ ] Trigger an error (e.g., `js` with invalid expression), verify error entry is logged
- [ ] Restart server, verify audit log is preserved (not cleared)
- [ ] Verify `jq` queries above work against the log format

Made with [Cursor](https://cursor.com)