### PR TITLE
feat: add install.bat and uninstall.bat for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Fork it. Improve it. Make it yours. And if you want to hate on free open source 
 
 ### Step 1: Install on your machine
 
+**Windows — double-click:**
+
+Download this repo and run `install.bat`. It clones gstack, finds Git Bash automatically, runs setup, and installs everything. To remove, run `uninstall.bat`.
+
+**Any platform — via Claude Code:**
+
 Open Claude Code and paste this. Claude does the rest.
 
 > Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade. Then ask the user if they also want to add gstack to the current project so teammates get it.

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal
+
+set TARGET=%USERPROFILE%\.claude\skills\gstack
+
+echo Installing gstack to %TARGET% ...
+
+if exist "%TARGET%" (
+    echo Existing installation found. Removing...
+    rmdir /s /q "%TARGET%"
+)
+
+xcopy /e /i /q "%~dp0" "%TARGET%"
+
+cd /d "%TARGET%"
+
+:: Find Git Bash and run setup
+set "GITBASH="
+if exist "%ProgramFiles%\Git\bin\bash.exe" set "GITBASH=%ProgramFiles%\Git\bin\bash.exe"
+if "%GITBASH%"=="" if exist "%ProgramFiles(x86)%\Git\bin\bash.exe" set "GITBASH=%ProgramFiles(x86)%\Git\bin\bash.exe"
+if "%GITBASH%"=="" for /f "delims=" %%i in ('where bash 2^>nul') do set "GITBASH=%%i"
+
+if "%GITBASH%"=="" (
+    echo.
+    echo WARNING: Git Bash not found. Skipping setup.
+    echo Install Git for Windows, then re-run install.bat, or run ./setup from Git Bash manually.
+    echo.
+) else (
+    echo Running setup via Git Bash...
+    "%GITBASH%" -c "cd '%TARGET%' && ./setup"
+)
+
+echo.
+echo gstack installed globally. Available in all Claude Code sessions.
+echo Skills: all gstack skills are now available.
+echo.
+echo To uninstall, run uninstall.bat
+pause

--- a/uninstall.bat
+++ b/uninstall.bat
@@ -1,0 +1,17 @@
+@echo off
+setlocal
+
+set TARGET=%USERPROFILE%\.claude\skills\gstack
+
+if not exist "%TARGET%" (
+    echo gstack is not installed at %TARGET%
+    pause
+    exit /b 0
+)
+
+echo Uninstalling gstack from %TARGET% ...
+rmdir /s /q "%TARGET%"
+
+echo.
+echo gstack uninstalled.
+pause


### PR DESCRIPTION
## Summary
- Adds `install.bat`: one-click Windows installer that copies gstack to `~/.claude/skills/gstack/`, auto-detects Git Bash (checks Program Files, x86, then PATH), and runs `./setup` through it
- Adds `uninstall.bat`: clean removal of `~/.claude/skills/gstack/`
- Updates README with Windows double-click install instructions

## Why
The existing `./setup` script is bash-only. Windows users running CMD or PowerShell get `'bash' is not recognized`. This adds a native .bat wrapper that finds Git Bash automatically and delegates to the existing setup script — no changes to setup itself.

## Test plan
- [ ] Run `install.bat` from CMD — installs and runs setup via Git Bash
- [ ] Run `install.bat` from PowerShell — same result
- [ ] Run `install.bat` on machine without Git Bash — shows helpful warning
- [ ] Run `uninstall.bat` — cleanly removes installation
- [ ] Verify all skills work after install.bat completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)