### PR TITLE
fix(setup): patch SKILL.md name: field when --prefix is used

### DIFF
--- a/setup
+++ b/setup
@@ -281,7 +281,23 @@ link_claude_skill_dirs() {
       target="$skills_dir/$link_name"
       # Create or update symlink; skip if a real file/directory exists
       if [ -L "$target" ] || [ ! -e "$target" ]; then
-        ln -snf "gstack/$skill_name" "$target"
+        if [ "$link_name" != "$skill_name" ]; then
+          # Prefixed: create real dir with patched SKILL.md + symlinks for rest.
+          # Can't use a plain symlink because Claude Code reads the name: field
+          # from SKILL.md frontmatter, and the original says name: qa not gstack-qa.
+          rm -rf "$target"
+          mkdir -p "$target"
+          # Symlink all contents except SKILL.md (templates/, references/, etc.)
+          for item in "$skill_dir"/*; do
+            item_name="$(basename "$item")"
+            [ "$item_name" = "SKILL.md" ] && continue
+            ln -snf "$gstack_dir/$skill_name/$item_name" "$target/$item_name"
+          done
+          # Write SKILL.md with patched name: field so Claude Code registers it correctly
+          sed "s/^name: $skill_name\$/name: $link_name/" "$skill_dir/SKILL.md" > "$target/SKILL.md"
+        else
+          ln -snf "gstack/$skill_name" "$target"
+        fi
         linked+=("$link_name")
       fi
     fi


### PR DESCRIPTION
## Summary

- when `--prefix` creates `gstack-qa`, patch the `name:` field in SKILL.md to match
- create a real directory (not symlink) with patched SKILL.md + symlinked subdirs
- unprefixed skills still use plain symlinks (unchanged)

## Problem

`./setup --prefix` creates symlinks correctly:
```
~/.claude/skills/gstack-qa -> gstack/qa/
```

But the `name:` field inside `qa/SKILL.md` still says `name: qa`. Claude Code uses the frontmatter `name:` for skill registration, not the directory name.

Result: `gstack-upgrade` works (its SKILL.md says `name: gstack-upgrade`). Every other prefixed skill doesn't register because `name: qa` doesn't match the `gstack-qa` directory.

## Fix

When `link_name != skill_name` (prefix applied):
1. Create a real directory instead of a symlink
2. Symlink subdirs (`templates/`, `references/`) back to the original so relative paths resolve
3. Write SKILL.md with `sed "s/^name: $skill_name$/name: $link_name/"` so the `name:` field matches

When `link_name == skill_name` (no prefix): plain symlink, unchanged.

+17/-1 in `setup`.

## Verification

```
# Before fix:
head -2 ~/.claude/skills/gstack-qa/SKILL.md
  name: qa                    ← wrong

# After fix:
head -2 ~/.claude/skills/gstack-qa/SKILL.md
  name: gstack-qa             ← correct

# Subdirs still accessible through symlinks:
cat ~/.claude/skills/gstack-qa/templates/qa-report-template.md   ← works
```

Fixes #620.