### PR TITLE
fix: add Write tool to sidebar agent + surface empty responses

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -430,7 +430,7 @@ function spawnClaude(userMessage: string, extensionUrl?: string | null): void {
 
   const prompt = `${systemPrompt}\n\n<user-message>\n${escapedMessage}\n</user-message>`;
   const args = ['-p', prompt, '--model', 'opus', '--output-format', 'stream-json', '--verbose',
-    '--allowedTools', 'Bash,Read,Glob,Grep'];
+    '--allowedTools', 'Bash,Read,Write,Glob,Grep'];
   if (sidebarSession?.claudeSessionId) {
     args.push('--resume', sidebarSession.claudeSessionId);
   }

--- a/browse/src/sidebar-agent.ts
+++ b/browse/src/sidebar-agent.ts
@@ -162,7 +162,7 @@ async function askClaude(queueEntry: any): Promise<void> {
     // Use args from queue entry (server sets --model, --allowedTools, prompt framing).
     // Fall back to defaults only if queue entry has no args (backward compat).
     let claudeArgs = args || ['-p', prompt, '--output-format', 'stream-json', '--verbose',
-      '--allowedTools', 'Bash,Read,Glob,Grep'];
+      '--allowedTools', 'Bash,Read,Write,Glob,Grep'];
 
     // Validate cwd exists — queue may reference a stale worktree
     let effectiveCwd = cwd || process.cwd();

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -306,6 +306,12 @@ body::after {
   font-family: var(--font-mono);
 }
 
+.agent-empty {
+  color: var(--muted);
+  font-size: 12px;
+  font-style: italic;
+}
+
 /* Thinking dots animation */
 .agent-thinking {
   display: flex;

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -157,8 +157,15 @@ function handleAgentEvent(entry) {
     // Remove thinking indicator
     const thinking = document.getElementById('agent-thinking');
     if (thinking) thinking.remove();
-    // Add timestamp
     if (agentContainer) {
+      // Show notice when Claude finished but produced no text output
+      if (!agentTextEl) {
+        const notice = document.createElement('div');
+        notice.className = 'agent-empty';
+        notice.textContent = 'Done (no text output)';
+        agentContainer.appendChild(notice);
+      }
+      // Add timestamp
       const ts = document.createElement('span');
       ts.className = 'chat-time';
       ts.textContent = formatChatTime(entry.ts);


### PR DESCRIPTION
## Summary

- Adds `Write` to `--allowedTools` in both `server.ts` (line 433) and `sidebar-agent.ts` (line 165), enabling the sidebar agent to create files (CSVs, exports, etc.) when users ask
- Surfaces a "Done (no text output)" notice in the sidebar UI when Claude finishes without producing text output, instead of leaving an empty response bubble
- Adds `.agent-empty` CSS class for the notice styling

Addresses the P1 TODO: "Sidebar agent needs Write tool + better error visibility"

## Changes

| File | Change |
|------|--------|
| `browse/src/server.ts` | Add `Write` to `--allowedTools` |
| `browse/src/sidebar-agent.ts` | Add `Write` to fallback `--allowedTools` |
| `extension/sidepanel.js` | Show "Done (no text output)" when `agent_done` fires with no `agentTextEl` |
| `extension/sidepanel.css` | Add `.agent-empty` style (muted, italic, 12px) |

## Test plan

- [x] `bun test test/skill-validation.test.ts test/gen-skill-docs.test.ts` -- 601/601 pass
- [ ] Manual: ask sidebar to "write a CSV file" and verify it creates the file
- [ ] Manual: send a message that produces only tool output (no text) and verify the "Done (no text output)" notice appears