### PR TITLE
feat: ship log — persistent record of /ship runs

### DIFF
--- a/.factory/skills/gstack-ship/SKILL.md
+++ b/.factory/skills/gstack-ship/SKILL.md
@@ -1911,6 +1911,46 @@ This step is automatic — never skip it, never ask for confirmation.
 
 ---
 
+## Step 8.8: Ship Log
+
+Append a structured entry to the global ship log so `/retro` can track shipping velocity over time.
+
+```bash
+mkdir -p ~/.gstack
+```
+
+Build a JSON object with these fields from earlier steps and append it to `~/.gstack/ship-log.json`:
+
+- **version**: the version string written to the VERSION file in Step 4
+- **date**: current UTC timestamp in ISO 8601 format
+- **branch**: the current feature branch name
+- **baseBranch**: the base branch detected in Step 0 (e.g., "main")
+- **prUrl**: the PR/MR URL created in Step 8 (empty string if PR creation failed or was skipped)
+- **reviewFindings**: integer count of issues found in Step 3.5 pre-landing review (0 if clean)
+- **testsRan**: boolean — whether the test suite ran in Step 3
+- **testsPassed**: boolean — whether all tests passed (after triage)
+
+Read the existing `~/.gstack/ship-log.json` array (or start with `[]` if the file does not exist), append the new entry, and write it back:
+
+```bash
+SHIP_LOG=~/.gstack/ship-log.json
+NEW_ENTRY='{"version":"VERSION","date":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","branch":"BRANCH","baseBranch":"BASE_BRANCH","prUrl":"PR_URL","reviewFindings":REVIEW_FINDINGS,"testsRan":TESTS_RAN,"testsPassed":TESTS_PASSED}'
+
+if [ -f "$SHIP_LOG" ]; then
+  # Remove trailing ] and append
+  sed -i '' -e '$ s/]$//' "$SHIP_LOG"
+  echo ",$NEW_ENTRY]" >> "$SHIP_LOG"
+else
+  echo "[$NEW_ENTRY]" > "$SHIP_LOG"
+fi
+```
+
+Substitute the uppercase placeholders with actual values from earlier steps. Use `true`/`false` (unquoted) for boolean fields.
+
+This step is automatic — never skip it, never ask for confirmation. If the file write fails, warn and continue. Never block the ship workflow for a log failure.
+
+---
+
 ## Important Rules
 
 - **Never skip tests.** If tests fail, stop.

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -1915,6 +1915,46 @@ This step is automatic — never skip it, never ask for confirmation.
 
 ---
 
+## Step 8.8: Ship Log
+
+Append a structured entry to the global ship log so `/retro` can track shipping velocity over time.
+
+```bash
+mkdir -p ~/.gstack
+```
+
+Build a JSON object with these fields from earlier steps and append it to `~/.gstack/ship-log.json`:
+
+- **version**: the version string written to the VERSION file in Step 4
+- **date**: current UTC timestamp in ISO 8601 format
+- **branch**: the current feature branch name
+- **baseBranch**: the base branch detected in Step 0 (e.g., "main")
+- **prUrl**: the PR/MR URL created in Step 8 (empty string if PR creation failed or was skipped)
+- **reviewFindings**: integer count of issues found in Step 3.5 pre-landing review (0 if clean)
+- **testsRan**: boolean — whether the test suite ran in Step 3
+- **testsPassed**: boolean — whether all tests passed (after triage)
+
+Read the existing `~/.gstack/ship-log.json` array (or start with `[]` if the file does not exist), append the new entry, and write it back:
+
+```bash
+SHIP_LOG=~/.gstack/ship-log.json
+NEW_ENTRY='{"version":"VERSION","date":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","branch":"BRANCH","baseBranch":"BASE_BRANCH","prUrl":"PR_URL","reviewFindings":REVIEW_FINDINGS,"testsRan":TESTS_RAN,"testsPassed":TESTS_PASSED}'
+
+if [ -f "$SHIP_LOG" ]; then
+  # Remove trailing ] and append
+  sed -i '' -e '$ s/]$//' "$SHIP_LOG"
+  echo ",$NEW_ENTRY]" >> "$SHIP_LOG"
+else
+  echo "[$NEW_ENTRY]" > "$SHIP_LOG"
+fi
+```
+
+Substitute the uppercase placeholders with actual values from earlier steps. Use `true`/`false` (unquoted) for boolean fields.
+
+This step is automatic — never skip it, never ask for confirmation. If the file write fails, warn and continue. Never block the ship workflow for a log failure.
+
+---
+
 ## Important Rules
 
 - **Never skip tests.** If tests fail, stop.

--- a/ship/SKILL.md.tmpl
+++ b/ship/SKILL.md.tmpl
@@ -633,6 +633,46 @@ This step is automatic — never skip it, never ask for confirmation.
 
 ---
 
+## Step 8.8: Ship Log
+
+Append a structured entry to the global ship log so `/retro` can track shipping velocity over time.
+
+```bash
+mkdir -p ~/.gstack
+```
+
+Build a JSON object with these fields from earlier steps and append it to `~/.gstack/ship-log.json`:
+
+- **version**: the version string written to the VERSION file in Step 4
+- **date**: current UTC timestamp in ISO 8601 format
+- **branch**: the current feature branch name
+- **baseBranch**: the base branch detected in Step 0 (e.g., "main")
+- **prUrl**: the PR/MR URL created in Step 8 (empty string if PR creation failed or was skipped)
+- **reviewFindings**: integer count of issues found in Step 3.5 pre-landing review (0 if clean)
+- **testsRan**: boolean — whether the test suite ran in Step 3
+- **testsPassed**: boolean — whether all tests passed (after triage)
+
+Read the existing `~/.gstack/ship-log.json` array (or start with `[]` if the file does not exist), append the new entry, and write it back:
+
+```bash
+SHIP_LOG=~/.gstack/ship-log.json
+NEW_ENTRY='{"version":"VERSION","date":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","branch":"BRANCH","baseBranch":"BASE_BRANCH","prUrl":"PR_URL","reviewFindings":REVIEW_FINDINGS,"testsRan":TESTS_RAN,"testsPassed":TESTS_PASSED}'
+
+if [ -f "$SHIP_LOG" ]; then
+  # Remove trailing ] and append
+  sed -i '' -e '$ s/]$//' "$SHIP_LOG"
+  echo ",$NEW_ENTRY]" >> "$SHIP_LOG"
+else
+  echo "[$NEW_ENTRY]" > "$SHIP_LOG"
+fi
+```
+
+Substitute the uppercase placeholders with actual values from earlier steps. Use `true`/`false` (unquoted) for boolean fields.
+
+This step is automatic — never skip it, never ask for confirmation. If the file write fails, warn and continue. Never block the ship workflow for a log failure.
+
+---
+
 ## Important Rules
 
 - **Never skip tests.** If tests fail, stop.


### PR DESCRIPTION
## Summary

- Adds **Step 8.8: Ship Log** to the `/ship` workflow template (`ship/SKILL.md.tmpl`)
- After every `/ship` run completes, appends a structured JSON entry to `~/.gstack/ship-log.json` with version, date, branch, base branch, PR URL, review findings count, and test pass/fail status
- Enables `/retro` to track shipping velocity, review finding rates, and test health over time
- Addresses P2 TODO item: "Ship log — persistent record of /ship runs"

### Entry format
```json
{
  "version": "0.x.y.z",
  "date": "2026-03-29T...",
  "branch": "feat/foo",
  "baseBranch": "main",
  "prUrl": "https://github.com/...",
  "reviewFindings": 3,
  "testsRan": true,
  "testsPassed": true
}
```

## Test plan
- [x] `bun run gen:skill-docs` regenerates `ship/SKILL.md` and `.factory/skills/gstack-ship/SKILL.md` successfully
- [x] `bun test test/skill-validation.test.ts test/gen-skill-docs.test.ts` passes (601 pass, 0 fail)
- [ ] Manual: run `/ship` on a feature branch and verify `~/.gstack/ship-log.json` is created with correct entry
- [ ] Manual: run `/ship` again and verify the entry is appended (array grows)
- [ ] Manual: run `/retro` and verify it can read the ship log data