### PR TITLE
feat: add /bye skill — session-end safety check

### DIFF
--- a/bye/SKILL.md
+++ b/bye/SKILL.md
@@ -567,37 +567,71 @@ Print: `QUALITY: ✅ clean` or `QUALITY: ⚠️ <issues found>`
 
 ## Block 4: Linear Sync
 
-Check if Linear issues mentioned in the session are in the right status.
+Check if Linear issues mentioned in the session are in the right status. Uses MCP Linear tools (not CLI).
 
-### Step 4.1: Check Linear CLI
+### Step 4.1: Extract issue references
 
-```bash
-which linear 2>/dev/null || npx linear --version 2>/dev/null
+Collect `SEN-\d+` references from three sources:
+1. Commit messages from this session: `git log --oneline`
+2. Current branch: `git branch --show-current`
+3. Conversation context: scan for `SEN-XXX` mentions in the session history
+
+Deduplicate into a unique list. If none found, skip to Step 4.3 (forgotten issues alert).
+
+### Step 4.2: Check status via MCP (ask before acting)
+
+For each `SEN-XXX` found, call:
+
+```
+mcp__linear__get_issue(id: "SEN-XXX")
 ```
 
-If Linear CLI is not available, skip this entire block silently. Print `LINEAR: — skipped (CLI not available)`.
+Record: identifier, title, current state (state.name and state.type).
+If the tool fails for an issue: log the error and continue with the next ones.
 
-### Step 4.2: Extract issue references
+**Suggest state transitions:**
 
-Find SEN-XXX patterns in:
-1. Commit messages from this session
-2. Branch name
-3. PROGRESS.md entries added in Block 2
+| Current state | Session activity | Action |
+|---|---|---|
+| Todo / Backlog / Triage | Commits referencing the issue | Ask: "Move SEN-XXX to In Progress?" |
+| In Progress | Branch merged or PR merged | Ask: "Move SEN-XXX to Done?" |
+| In Progress | Commits but no merge | Report: "SEN-XXX: In Progress (activity this session)" |
+| Todo / Backlog | Mentioned in conversation, no commits | Report: "SEN-XXX mentioned, status: Todo" |
+| Done / Canceled | Any | Do nothing |
 
-```bash
-git log --since="today 00:00" --format="%s %b" | grep -oE 'SEN-[0-9]+' | sort -u
-git branch --show-current | grep -oE 'SEN-[0-9]+'
+To move, call:
+
+```
+mcp__linear__save_issue(id: "SEN-XXX", state: "In Progress")
 ```
 
-### Step 4.3: Check status (ask before acting)
+**Always ask before moving.** Never move automatically.
 
-For each issue found, check current status. If there's a mismatch:
-- Issue has commits but status is "Todo" → ask: "Move SEN-XXX to In Progress?"
-- Issue has merged PR but status is not "Done" → ask: "Move SEN-XXX to Done?"
+### Step 4.3: Forgotten issues alert
 
-Only change status if user confirms.
+After processing session issues, check for in-progress issues with no session activity:
 
-Print: `LINEAR: ✅ <N issues checked>` or `LINEAR: ⚠️ <mismatches found>` or `LINEAR: — skipped`
+```
+mcp__linear__list_issues(team: "SEN", state: "started")
+```
+
+Filter: issues returned that did NOT appear in session commits/conversation.
+If any found, report as informational alert (⚠️ in traffic light, not ❌ — does not block session end):
+
+```
+  Issues In Progress without activity this session:
+     SEN-704: Implement embedding cache
+     SEN-712: Review pipeline v2.3
+```
+
+If no forgotten issues: show nothing.
+
+### Fallback
+
+If MCP Linear is not available (tool not loaded, auth error):
+silent skip. Do not attempt CLI as fallback.
+
+Print: `LINEAR: ✅ <N issues checked>` or `LINEAR: ⚠️ <issues found>` or `LINEAR: — skipped (MCP not available)`
 
 ---
 

--- a/bye/SKILL.md.tmpl
+++ b/bye/SKILL.md.tmpl
@@ -261,37 +261,71 @@ Print: `QUALITY: ✅ clean` or `QUALITY: ⚠️ <issues found>`
 
 ## Block 4: Linear Sync
 
-Check if Linear issues mentioned in the session are in the right status.
+Check if Linear issues mentioned in the session are in the right status. Uses MCP Linear tools (not CLI).
 
-### Step 4.1: Check Linear CLI
+### Step 4.1: Extract issue references
 
-```bash
-which linear 2>/dev/null || npx linear --version 2>/dev/null
+Collect `SEN-\d+` references from three sources:
+1. Commit messages from this session: `git log --oneline`
+2. Current branch: `git branch --show-current`
+3. Conversation context: scan for `SEN-XXX` mentions in the session history
+
+Deduplicate into a unique list. If none found, skip to Step 4.3 (forgotten issues alert).
+
+### Step 4.2: Check status via MCP (ask before acting)
+
+For each `SEN-XXX` found, call:
+
+```
+mcp__linear__get_issue(id: "SEN-XXX")
 ```
 
-If Linear CLI is not available, skip this entire block silently. Print `LINEAR: — skipped (CLI not available)`.
+Record: identifier, title, current state (state.name and state.type).
+If the tool fails for an issue: log the error and continue with the next ones.
 
-### Step 4.2: Extract issue references
+**Suggest state transitions:**
 
-Find SEN-XXX patterns in:
-1. Commit messages from this session
-2. Branch name
-3. PROGRESS.md entries added in Block 2
+| Current state | Session activity | Action |
+|---|---|---|
+| Todo / Backlog / Triage | Commits referencing the issue | Ask: "Move SEN-XXX to In Progress?" |
+| In Progress | Branch merged or PR merged | Ask: "Move SEN-XXX to Done?" |
+| In Progress | Commits but no merge | Report: "SEN-XXX: In Progress (activity this session)" |
+| Todo / Backlog | Mentioned in conversation, no commits | Report: "SEN-XXX mentioned, status: Todo" |
+| Done / Canceled | Any | Do nothing |
 
-```bash
-git log --since="today 00:00" --format="%s %b" | grep -oE 'SEN-[0-9]+' | sort -u
-git branch --show-current | grep -oE 'SEN-[0-9]+'
+To move, call:
+
+```
+mcp__linear__save_issue(id: "SEN-XXX", state: "In Progress")
 ```
 
-### Step 4.3: Check status (ask before acting)
+**Always ask before moving.** Never move automatically.
 
-For each issue found, check current status. If there's a mismatch:
-- Issue has commits but status is "Todo" → ask: "Move SEN-XXX to In Progress?"
-- Issue has merged PR but status is not "Done" → ask: "Move SEN-XXX to Done?"
+### Step 4.3: Forgotten issues alert
 
-Only change status if user confirms.
+After processing session issues, check for in-progress issues with no session activity:
 
-Print: `LINEAR: ✅ <N issues checked>` or `LINEAR: ⚠️ <mismatches found>` or `LINEAR: — skipped`
+```
+mcp__linear__list_issues(team: "SEN", state: "started")
+```
+
+Filter: issues returned that did NOT appear in session commits/conversation.
+If any found, report as informational alert (⚠️ in traffic light, not ❌ — does not block session end):
+
+```
+  Issues In Progress without activity this session:
+     SEN-704: Implement embedding cache
+     SEN-712: Review pipeline v2.3
+```
+
+If no forgotten issues: show nothing.
+
+### Fallback
+
+If MCP Linear is not available (tool not loaded, auth error):
+silent skip. Do not attempt CLI as fallback.
+
+Print: `LINEAR: ✅ <N issues checked>` or `LINEAR: ⚠️ <issues found>` or `LINEAR: — skipped (MCP not available)`
 
 ---
 


### PR DESCRIPTION
## Summary

- **New skill: `/bye`** — session-end safety check that commits uncommitted work, updates PROGRESS/HANDOFF docs, runs lint, checks Linear issue status, and captures session learnings to memory
- Auto-fixes routine items (commits, doc updates, lint), asks only for unusual or destructive actions
- 6 sequential blocks with traffic light final report: ✅ ⚠️ ❌

## Origin story

Running 180 Claude Code sessions/month across 9 repos, the #1 source of wasted time is context loss between sessions: uncommitted changes, stale PROGRESS.md, forgotten Linear updates. `/ship` handles "push to remote" and `/review` handles "is this mergeable?" but nothing handled "is it safe to close this session?"

`/bye` fills that gap. It's the `/ship` for session hygiene.

## What it does

| Block | Action | Behavior |
|-------|--------|----------|
| Git Hygiene | Commit uncommitted, clean worktrees | Auto-fix |
| Documentation | Update PROGRESS.md, rewrite HANDOFF.md | Auto-fix (respects per-repo format) |
| Code Quality | Run lint --fix, report test failures, scan new TODOs | Auto-fix lint, report rest |
| Linear Sync | Check SEN-XXX issue status vs commits | Ask before changing |
| Memory | Capture feedback and project learnings | Auto-save explicit, ask ambiguous |
| Report | Traffic light summary + safe-to-close verdict | Display |

## Key design decisions

- **Respects per-repo doc patterns.** Detects which files exist (PROGRESS.md, HANDOFF.md, CLAUDE.md) and only updates what's there. Never creates files without asking.
- **Format detection.** Reads existing doc structure and replicates the pattern (headers, date format, section names) instead of imposing a template.
- **Skip gracefully.** No Linear CLI? Skip silently. No test runner? Skip. No linter? Skip. No errors for missing optional tooling.
- **Never pushes to remote.** Local commits only. Pushing is a separate decision.
- **Marked `sensitive: true`.** Factory Droids won't auto-invoke it.

## Files

- `bye/SKILL.md.tmpl` — 378 lines (source template)
- `bye/SKILL.md` — 684 lines, ~7.5k tokens (generated)

## Test plan

- [ ] Run `/bye` in a repo with uncommitted changes — verify auto-commit
- [ ] Run `/bye` in a repo with PROGRESS.md — verify append with correct format
- [ ] Run `/bye` in a repo with HANDOFF.md — verify rewrite preserves locked decisions
- [ ] Run `/bye` in a repo with no docs — verify it asks before creating
- [ ] Run `/bye` outside a git repo — verify graceful skip to memory-only
- [ ] Run `/bye` in a clean repo (nothing to do) — verify all-green report

🤖 Generated with [Claude Code](https://claude.com/claude-code)