### PR TITLE
fix(setup): make gstack skills discoverable by Factory Droid

### DIFF
--- a/setup
+++ b/setup
@@ -565,6 +565,52 @@ link_factory_skill_dirs() {
   if [ ${#linked[@]} -gt 0 ]; then
     echo "  linked skills: ${linked[*]}"
   fi
+
+  # Register skills in ~/.agents/.skill-lock.json with sourceType=github.
+  # Droid's lockfile ONLY loads entries with sourceType=github. Entries with
+  # sourceType=local are completely ignored — and no working skill uses it.
+  if [ -f "$HOME/.agents/.skill-lock.json" ]; then
+    python3 -c "
+import json, hashlib, os, datetime
+lock_path = '$HOME/.agents/.skill-lock.json'
+agents_skills = '$HOME/.agents/skills'
+with open(lock_path) as f:
+    lock = json.load(f)
+now_str = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.') + '000Z'
+added = []
+for entry in os.listdir(agents_skills):
+    if not entry.startswith('gstack'):
+        continue
+    skill_md = os.path.join(agents_skills, entry, 'SKILL.md')
+    if not os.path.isfile(skill_md):
+        continue
+    hasher = hashlib.sha1()
+    for root, dirs, files in os.walk(os.path.join(agents_skills, entry)):
+        dirs.sort()
+        for fname in sorted(files):
+            fpath = os.path.join(root, fname)
+            try:
+                with open(fpath, 'rb') as fh:
+                    hasher.update(fh.read())
+            except:
+                pass
+    lock['skills'][entry] = {
+        'source': 'gstack/' + entry,
+        'sourceType': 'github',
+        'sourceUrl': 'file://' + os.path.join(agents_skills, entry),
+        'skillPath': 'SKILL.md',
+        'skillFolderHash': hasher.hexdigest(),
+        'installedAt': now_str,
+        'updatedAt': now_str
+    }
+    added.append(entry)
+with open(lock_path, 'w') as f:
+    json.dump(lock, f, indent=2)
+print('  registered skills: ' + ' '.join(added))
+"
+  else
+    echo "  warning: ~/.agents/.skill-lock.json not found — skill registration skipped" >&2
+  fi
 }
 
 # 4. Install for Claude (default)


### PR DESCRIPTION
## Problem

Skills installed via `cd ~/gstack && ./setup --host factory` did not appear in Droid's `/` menu. The skills existed on disk but were invisible to Droid's discovery system.

## Reproduction

1. Install gstack for Factory Droid:
   ```bash
   cd ~/gstack && ./setup --host factory
   ```
2. Restart Droid
3. Type `/` — no gstack skills appear (debug, fix, test, qa, etc. are missing)
4. Check the installed entries:
   ```bash
   ls ~/gstack/.factory/skills/    # generated skill directories exist in the repo
   ls -l ~/.factory/skills/        # gstack entries exist, but as absolute symlinks into ~/gstack
   ls ~/.agents/skills/            # empty — skills not copied here
   ```

## Root Cause: Three Bugs in `link_factory_skill_dirs()`

### Bug 1: Wrong target for installed skill contents

The original install did create entries in `~/.factory/skills/`, but they pointed to the wrong place for discovery. gstack generated Factory skills in `~/gstack/.factory/skills/` and then linked `~/.factory/skills/` entries back into that project directory, while Droid expects the canonical skill contents to live under `~/.agents/skills/`.

### Bug 2: Absolute symlinks

gstack created absolute symlinks in `~/.factory/skills/`:
```bash
ln -snf /Users/will/gstack/.factory/skills/gstack-qa ~/.factory/skills/gstack-qa
```
Droid follows only **relative** symlinks (`../../.agents/skills/{skill}`). Absolute paths are ignored.

### Bug 3: Wrong `sourceType` in lockfile

gstack registered entries with `sourceType: "local"`:
```json
{
  "sourceType": "local",
  "sourceUrl": "file:///Users/will/gstack/.factory/skills/gstack-qa"
}
```
Droid's lockfile reader **ignores** `sourceType: "local"` entirely. Zero of the 57 working skills use this value — all use `sourceType: "github"`.

## How Droid Discovers Skills (Two-Tier System)

```
Droid startup
    │
    ├── Tier 1: Scans ~/.factory/skills/
    │       ├── Follows relative symlinks ──→ ~/.agents/skills/{skill}/SKILL.md
    │       └── Ignores: absolute symlinks and project-local targets
    │
    └── Tier 2: Reads ~/.agents/.skill-lock.json (if present)
            ├── sourceType: "github"  ──→ loads skill ✓
            └── sourceType: "local"  ──→ ignores skill ✗
```

A skill appears in `/` when **both** conditions are met:
1. Relative symlink exists in `~/.factory/skills/` pointing to `~/.agents/skills/{skill}`
2. Lockfile entry has `sourceType: "github"` in `~/.agents/.skill-lock.json`

## The Fix (3 commits)

### Commit 1: Use relative symlinks in `~/.factory/skills/`

Changed from absolute paths to the pattern all working skills use:
```bash
ln -snf "../../.agents/skills/$skill_name" "$target"
```

This commit also removes the old skip for the root `gstack` skill, so that directory can now be linked like the rest of the skill set.

### Commit 2: Copy skills to `~/.agents/skills/`

Droid reads skill files from `~/.agents/skills/`. Symlinks pointing into `~/gstack/.factory/skills/` do not work — must be real directories.
```bash
cp -r "$skill_dir" "$HOME/.agents/skills/$skill_name"
```

This means Factory now reads a copied snapshot from `~/.agents/skills/`, not directly from the repo checkout. If you edit a skill in `~/gstack`, rerun `./setup --host factory` to refresh Droid's copy.

### Commit 3: Register with `sourceType: "github"`

Updated the Python lockfile registration script to use the only `sourceType` Droid actually loads:
```json
{
  "source": "gstack/gstack-qa",
  "sourceType": "github",
  "sourceUrl": "file:///Users/will/.agents/skills/gstack-qa"
}
```

## Validation

After applying the fix:

```bash
# 1. Install
cd ~/gstack && ./setup --host factory

# 2. Verify filesystem layout
ls -l ~/.factory/skills/gstack-qa
# should show: ../../.agents/skills/gstack-qa

test -d ~/.agents/skills/gstack-qa && echo "copied"
# should print: copied

# 3. Verify lockfile
python3 -c "
import json
with open('$HOME/.agents/.skill-lock.json') as f:
    lock = json.load(f)
for name, entry in lock['skills'].items():
    if name.startswith('gstack'):
        print(f'{name}: sourceType={entry[\"sourceType\"]}')"

# 4. If ~/.agents/.skill-lock.json does not exist yet, setup prints a warning
# and skips registration. In that case, start Droid once so it creates the
# lockfile, then rerun:
#   cd ~/gstack && ./setup --host factory

# 5. Restart Droid
# Type /qa in Droid — skill now appears ✓
```
