### PR TITLE
fix(setup): make gstack skills discoverable and usable in Factory Droid

### DIFF
--- a/setup
+++ b/setup
@@ -912,7 +912,7 @@ link_factory_skill_dirs() {
   local gstack_dir="$1"
   local skills_dir="$2"
   local factory_dir="$gstack_dir/.factory/skills"
-  local linked=()
+  local installed=()
 
   if [ ! -d "$factory_dir" ]; then
     echo "  Generating .factory/ skill docs..."
@@ -929,14 +929,17 @@ link_factory_skill_dirs() {
       skill_name="$(basename "$skill_dir")"
       [ "$skill_name" = "gstack" ] && continue
       target="$skills_dir/$skill_name"
-      if [ -L "$target" ] || [ ! -e "$target" ]; then
-        _link_or_copy "$skill_dir" "$target"
-        linked+=("$skill_name")
-      fi
+      # Factory documents ~/.factory/skills as its user-level skill root. Keep
+      # the install self-contained there and use a real directory so Droid does
+      # not have to follow a directory symlink during discovery. These gstack-*
+      # paths are installer-owned and are refreshed on every setup run.
+      rm -rf "$target"
+      cp -R "$skill_dir" "$target"
+      installed+=("$skill_name")
     fi
   done
-  if [ ${#linked[@]} -gt 0 ]; then
-    echo "  linked skills: ${linked[*]}"
+  if [ ${#installed[@]} -gt 0 ]; then
+    echo "  installed skills: ${installed[*]}"
   fi
 }
 

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2450,6 +2450,19 @@ describe('setup script validation', () => {
     expect(fnBody).not.toContain('_link_or_copy "$gstack_dir" "$codex_gstack"');
   });
 
+  test('Factory installs real skill directories only in its documented user root', () => {
+    const fnStart = setupContent.indexOf('link_factory_skill_dirs()');
+    const fnEnd = setupContent.indexOf('\nlink_opencode_skill_dirs()', fnStart);
+    const fnBody = setupContent.slice(fnStart, fnEnd);
+
+    expect(fnBody).toContain('target="$skills_dir/$skill_name"');
+    expect(fnBody).toContain('rm -rf "$target"');
+    expect(fnBody).toContain('cp -R "$skill_dir" "$target"');
+    expect(fnBody).not.toContain('.agents');
+    expect(fnBody).not.toContain('.skill-lock.json');
+    expect(fnBody).not.toContain('_link_or_copy "$skill_dir" "$target"');
+  });
+
   test('direct Codex installs are migrated out of ~/.codex/skills/gstack', () => {
     expect(setupContent).toContain('migrate_direct_codex_install');
     expect(setupContent).toContain('$HOME/.gstack/repos/gstack');


### PR DESCRIPTION
## Problem

`./setup --host factory` generated Factory-specific skills correctly, but installed the per-skill entries in `~/.factory/skills` as directory symlinks. Droid does not reliably discover those symlinked directories, so gstack skills may be missing from the `/` menu.

## Rewrite

This branch is rebuilt on current `main`, resolving the PR's merge conflicts and retaining the newer runtime-root and cross-platform setup behavior.

Factory skills are now installed as real directories directly in Factory's documented user skill root:

```
~/.factory/skills/gstack-*
```

Each setup run refreshes those installer-owned directories from the generated `.factory/skills/gstack-*` output. The root `gstack` runtime directory remains managed by `create_factory_runtime_root()`.

The rewrite deliberately does not:

- create or write `~/.agents/skills`
- create or modify `~/.agents/.skill-lock.json`
- register local files as fake GitHub-sourced skills
- share Factory-generated files with another host's namespace

## Validation

- `bash -n setup`
- `bun run gen:skill-docs --host codex`
- `bun test test/gen-skill-docs.test.ts test/setup-windows-fallback.test.ts` — 411 pass
- isolated install smoke test verifies:
  - an old directory symlink is replaced by a real directory
  - rerunning setup refreshes the copied skill
  - no `~/.agents` directory is created

Closes #661.
