### PR TITLE
fix: patch SKILL.md name: field when --prefix is used

### DIFF
--- a/bin/gstack-relink
+++ b/bin/gstack-relink
@@ -45,6 +45,10 @@ for skill_dir in "$INSTALL_DIR"/*/; do
   case "$skill" in bin|browse|design|docs|extension|lib|node_modules|scripts|test|.git|.github) continue ;; esac
   [ -f "$skill_dir/SKILL.md" ] || continue
 
+  # Read current name: from frontmatter
+  current_name=$(grep -m1 '^name:' "$skill_dir/SKILL.md" 2>/dev/null | sed 's/^name:[[:space:]]*//' | tr -d '[:space:]')
+  [ -z "$current_name" ] && current_name="$skill"
+
   if [ "$PREFIX" = "true" ]; then
     # Don't double-prefix directories already named gstack-*
     case "$skill" in
@@ -55,6 +59,7 @@ for skill_dir in "$INSTALL_DIR"/*/; do
     # Remove old flat symlink if it exists (and isn't the same as the new link)
     [ "$link_name" != "$skill" ] && [ -L "$SKILLS_DIR/$skill" ] && rm -f "$SKILLS_DIR/$skill"
   else
+    link_name="$skill"
     # Create flat symlink, remove gstack-* if exists
     ln -sfn "$INSTALL_DIR/$skill" "$SKILLS_DIR/$skill"
     # Don't remove gstack-* dirs that are their real name (e.g., gstack-upgrade)
@@ -63,6 +68,14 @@ for skill_dir in "$INSTALL_DIR"/*/; do
       *)        [ -L "$SKILLS_DIR/gstack-$skill" ] && rm -f "$SKILLS_DIR/gstack-$skill" ;;
     esac
   fi
+
+  # Patch SKILL.md name: field to match the linked name so the host agent
+  # registers the skill under the correct command (fixes #620)
+  if [ "$link_name" != "$current_name" ]; then
+    _tmp="$(mktemp)"
+    sed "1,/^---$/s/^name:.*$/name: $link_name/" "$skill_dir/SKILL.md" > "$_tmp" && mv "$_tmp" "$skill_dir/SKILL.md"
+  fi
+
   SKILL_COUNT=$((SKILL_COUNT + 1))
 done
 

--- a/setup
+++ b/setup
@@ -293,6 +293,12 @@ link_claude_skill_dirs() {
         ln -snf "gstack/$dir_name" "$target"
         linked+=("$link_name")
       fi
+      # Patch SKILL.md name: field to match the linked name so Claude Code
+      # registers the skill under the correct command (e.g., /gstack-qa not /qa)
+      if [ "$link_name" != "$skill_name" ]; then
+        _tmp="$(mktemp)"
+        sed "1,/^---$/s/^name:.*$/name: $link_name/" "$skill_dir/SKILL.md" > "$_tmp" && mv "$_tmp" "$skill_dir/SKILL.md"
+      fi
     fi
   done
   if [ ${#linked[@]} -gt 0 ]; then


### PR DESCRIPTION
## Summary

`./setup --prefix` creates symlinks (`gstack-qa → gstack/qa`) but doesn't update the `name:` frontmatter field inside each SKILL.md. Claude Code uses `name:` for skill registration — so the skill registers as `/qa` instead of `/gstack-qa`, making the prefix mode non-functional.

After creating each symlink, `setup` now patches the `name:` field to match the linked name. Same fix applied to `bin/gstack-relink` for prefix changes after initial setup.

## Root cause

`link_claude_skill_dirs()` reads `name:` from SKILL.md (line 279) and computes the correct `link_name` with prefix (line 282-288), but only uses it for the symlink target — the SKILL.md `name:` field stays unchanged. Claude Code ignores the symlink name and reads `name:` from frontmatter.

## What changed

- **`setup`**: after `ln -snf`, patches `name:` in SKILL.md when `link_name != skill_name`
- **`bin/gstack-relink`**: same patch logic for prefix changes after setup

Uses portable sed (tmpfile + mv) — works on both macOS and Linux. No-op for unprefixed mode and already-prefixed skills (`gstack-upgrade`).

## Verified

```
# Before (qa/SKILL.md):
name: qa          ← Claude registers as /qa

# After setup --prefix:
name: gstack-qa   ← Claude registers as /gstack-qa
```

## Test plan

- [x] `sed` patch correctly rewrites `name: qa` → `name: gstack-qa`
- [x] Already-prefixed skills (`gstack-upgrade`) are unaffected (link_name == skill_name)
- [x] Unprefixed mode (`--no-prefix`) does not trigger the patch
- [x] Switching prefix modes via `gstack-relink` patches in both directions

Fixes #620