### PR TITLE
[codex] add first-class OpenCode host support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bin/gstack-global-discover
 .claude/skills/
 .agents/
 .factory/
+.opencode/
 .context/
 extension/.auth.json
 .gstack-worktrees/

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Real files get committed to your repo (not a submodule), so `git clone` just wor
 > git clone https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
 > ```
 
-### Codex, Gemini CLI, or Cursor
+### Codex, OpenCode, Gemini CLI, or Cursor
 
-gstack works on any agent that supports the [SKILL.md standard](https://github.com/anthropics/claude-code). Skills live in `.agents/skills/` and are discovered automatically.
+gstack works on any agent that supports the [SKILL.md standard](https://github.com/anthropics/claude-code). Generated skills live in `.agents/skills/` or `.opencode/skills/` depending on host and are discovered automatically.
 
 Install to one repo:
 
@@ -83,6 +83,28 @@ cd ~/gstack && ./setup --host codex
 links the generated Codex skills at the top level. This avoids duplicate skill
 discovery from the source repo checkout.
 
+### OpenCode
+
+OpenCode has first-class gstack install support.
+
+Project-local install:
+
+```bash
+git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git .opencode/skills/gstack
+cd .opencode/skills/gstack && ./setup --host opencode
+```
+
+User-global install:
+
+```bash
+git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack
+cd ~/gstack && ./setup --host opencode
+```
+
+`setup --host opencode` installs generated skills into `.opencode/skills/` for
+repo-local installs or `~/.config/opencode/skills/` for global installs, with the
+runtime root at `.../skills/gstack`.
+
 Or let setup auto-detect which agents you have installed:
 
 ```bash
@@ -90,7 +112,7 @@ git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gst
 cd ~/gstack && ./setup --host auto
 ```
 
-For Codex-compatible hosts, setup now supports both repo-local installs from `.agents/skills/gstack` and user-global installs from `~/.codex/skills/gstack`. All 31 skills work across all supported agents. Hook-based safety skills (careful, freeze, guard) use inline safety advisory prose on non-Claude hosts.
+For Codex-compatible hosts, setup now supports repo-local installs from `.agents/skills/gstack` plus first-class OpenCode installs from `.opencode/skills/gstack` or `~/.config/opencode/skills/gstack`. Hook-based safety skills (careful, freeze, guard) use inline safety advisory prose on non-Claude hosts.
 
 ### Factory Droid
 

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -32,9 +32,10 @@ const HOST_ARG_VAL: HostArg = (() => {
   const val = HOST_ARG.includes('=') ? HOST_ARG.split('=')[1] : process.argv[process.argv.indexOf(HOST_ARG) + 1];
   if (val === 'codex' || val === 'agents') return 'codex';
   if (val === 'factory' || val === 'droid') return 'factory';
+  if (val === 'opencode') return 'opencode';
   if (val === 'claude') return 'claude';
   if (val === 'all') return 'all';
-  throw new Error(`Unknown host: ${val}. Use claude, codex, factory, droid, agents, or all.`);
+  throw new Error(`Unknown host: ${val}. Use claude, codex, opencode, factory, droid, agents, or all.`);
 })();
 
 // For single-host mode, HOST is the host. For --host all, it's set per iteration below.
@@ -188,6 +189,18 @@ function transformFrontmatter(content: string, host: Host): string {
     return `---\nname: ${name}\ndescription: |\n${indentedDesc}\n---` + body;
   }
 
+  if (host === 'opencode') {
+    const MAX_DESC = 1024;
+    if (description.length > MAX_DESC) {
+      throw new Error(
+        `OpenCode description for "${name}" is ${description.length} chars (max ${MAX_DESC}). ` +
+        `Compress the description in the .tmpl file.`
+      );
+    }
+    const indentedDesc = description.split('\n').map(l => `  ${l}`).join('\n');
+    return `---\nname: ${name}\ndescription: |\n${indentedDesc}\ncompatibility: opencode\n---` + body;
+  }
+
   if (host === 'factory') {
     const sensitive = /^sensitive:\s*true/m.test(frontmatter);
     const indentedDesc = description.split('\n').map(l => `  ${l}`).join('\n');
@@ -240,8 +253,9 @@ interface ExternalHostConfig {
 }
 
 const EXTERNAL_HOST_CONFIG: Record<string, ExternalHostConfig> = {
-  codex:   { hostSubdir: '.agents',  generateMetadata: true,  descriptionLimit: 1024 },
-  factory: { hostSubdir: '.factory', generateMetadata: false },
+  codex:    { hostSubdir: '.agents',   generateMetadata: true,  descriptionLimit: 1024 },
+  factory:  { hostSubdir: '.factory',  generateMetadata: false },
+  opencode: { hostSubdir: '.opencode', generateMetadata: false, descriptionLimit: 1024 },
 };
 
 // ─── Template Processing ────────────────────────────────────
@@ -395,7 +409,7 @@ function findTemplates(): string[] {
   return discoverTemplates(ROOT).map(t => path.join(ROOT, t.tmpl));
 }
 
-const ALL_HOSTS: Host[] = ['claude', 'codex', 'factory'];
+const ALL_HOSTS: Host[] = ['claude', 'codex', 'factory', 'opencode'];
 const hostsToRun: Host[] = HOST_ARG_VAL === 'all' ? ALL_HOSTS : [HOST];
 const failures: { host: string; error: Error }[] = [];
 

--- a/scripts/resolvers/preamble.ts
+++ b/scripts/resolvers/preamble.ts
@@ -14,7 +14,7 @@ import type { TemplateContext } from './types';
  */
 
 function generatePreambleBash(ctx: TemplateContext): string {
-  const hostConfigDir: Record<string, string> = { codex: '.codex', factory: '.factory' };
+  const hostConfigDir: Record<string, string> = { codex: '.codex', factory: '.factory', opencode: '.config/opencode' };
   const runtimeRoot = (ctx.host !== 'claude')
     ? `_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 GSTACK_ROOT="$HOME/${hostConfigDir[ctx.host]}/skills/gstack"

--- a/scripts/resolvers/types.ts
+++ b/scripts/resolvers/types.ts
@@ -1,4 +1,4 @@
-export type Host = 'claude' | 'codex' | 'factory';
+export type Host = 'claude' | 'codex' | 'factory' | 'opencode';
 
 export interface HostPaths {
   skillRoot: string;
@@ -26,6 +26,13 @@ export const HOST_PATHS: Record<Host, HostPaths> = {
   factory: {
     skillRoot: '$GSTACK_ROOT',
     localSkillRoot: '.factory/skills/gstack',
+    binDir: '$GSTACK_BIN',
+    browseDir: '$GSTACK_BROWSE',
+    designDir: '$GSTACK_DESIGN',
+  },
+  opencode: {
+    skillRoot: '$GSTACK_ROOT',
+    localSkillRoot: '.opencode/skills/gstack',
     binDir: '$GSTACK_BIN',
     browseDir: '$GSTACK_BROWSE',
     designDir: '$GSTACK_DESIGN',

--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -142,6 +142,37 @@ if (fs.existsSync(FACTORY_DIR)) {
   console.log('\n  Factory Skills: .factory/skills/ not found (run: bun run gen:skill-docs --host factory)');
 }
 
+// ─── OpenCode Skills ────────────────────────────────────────
+
+const OPENCODE_DIR = path.join(ROOT, '.opencode', 'skills');
+if (fs.existsSync(OPENCODE_DIR)) {
+  console.log('\n  OpenCode Skills (.opencode/skills/):');
+  const opencodeDirs = fs.readdirSync(OPENCODE_DIR).sort();
+  let opencodeCount = 0;
+  let opencodeMissing = 0;
+  for (const dir of opencodeDirs) {
+    const skillMd = path.join(OPENCODE_DIR, dir, 'SKILL.md');
+    if (fs.existsSync(skillMd)) {
+      opencodeCount++;
+      const content = fs.readFileSync(skillMd, 'utf-8');
+      const hasClaude = content.includes('.claude/skills');
+      if (hasClaude) {
+        hasErrors = true;
+        console.log(`  \u274c ${dir.padEnd(30)} — contains .claude/skills reference`);
+      } else {
+        console.log(`  \u2705 ${dir.padEnd(30)} — OK`);
+      }
+    } else {
+      opencodeMissing++;
+      hasErrors = true;
+      console.log(`  \u274c ${dir.padEnd(30)} — SKILL.md missing`);
+    }
+  }
+  console.log(`  Total: ${opencodeCount} skills, ${opencodeMissing} missing`);
+} else {
+  console.log('\n  OpenCode Skills: .opencode/skills/ not found (run: bun run gen:skill-docs --host opencode)');
+}
+
 // ─── Freshness ──────────────────────────────────────────────
 
 console.log('\n  Freshness (Claude):');
@@ -184,6 +215,20 @@ try {
     console.log(`      ${line}`);
   }
   console.log('      Run: bun run gen:skill-docs --host factory');
+}
+
+console.log('\n  Freshness (OpenCode):');
+try {
+  execSync('bun run scripts/gen-skill-docs.ts --host opencode --dry-run', { cwd: ROOT, stdio: 'pipe' });
+  console.log('  \u2705 All OpenCode generated files are fresh');
+} catch (err: any) {
+  hasErrors = true;
+  const output = err.stdout?.toString() || '';
+  console.log('  \u274c OpenCode generated files are stale:');
+  for (const line of output.split('\n').filter((l: string) => l.startsWith('STALE'))) {
+    console.log(`      ${line}`);
+  }
+  console.log('      Run: bun run gen:skill-docs --host opencode');
 }
 
 console.log('');

--- a/setup
+++ b/setup
@@ -91,8 +91,8 @@ fi
 
 # --local: install to .claude/skills/ in the current working directory
 if [ "$LOCAL_INSTALL" -eq 1 ]; then
-  if [ "$HOST" = "codex" ]; then
-    echo "Error: --local is only supported for Claude Code (not Codex)." >&2
+  if [ "$HOST" != "claude" ] && [ "$HOST" != "auto" ]; then
+    echo "Error: --local is only supported for Claude Code." >&2
     exit 1
   fi
   INSTALL_SKILLS_DIR="$(pwd)/.claude/skills"
@@ -695,7 +695,7 @@ if [ "$INSTALL_CODEX" -eq 1 ]; then
   echo "  codex skills: $CODEX_SKILLS"
 fi
 
-# 6. Install for Kiro CLI (copy from .agents/skills, rewrite paths)
+# 6. Install for OpenCode
 if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   if [ "$OPENCODE_REPO_LOCAL" -eq 1 ]; then
     OPENCODE_SKILLS="$INSTALL_SKILLS_DIR"
@@ -711,7 +711,7 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   echo "  opencode skills: $OPENCODE_SKILLS"
 fi
 
-# 6. Install for Kiro CLI (copy from .agents/skills, rewrite paths)
+# 7. Install for Kiro CLI (copy from .agents/skills, rewrite paths)
 if [ "$INSTALL_KIRO" -eq 1 ]; then
   KIRO_SKILLS="$HOME/.kiro/skills"
   AGENTS_DIR="$SOURCE_GSTACK_DIR/.agents/skills"
@@ -767,7 +767,7 @@ if [ "$INSTALL_KIRO" -eq 1 ]; then
   fi
 fi
 
-# 6b. Install for Factory Droid
+# 7b. Install for Factory Droid
 if [ "$INSTALL_FACTORY" -eq 1 ]; then
   mkdir -p "$FACTORY_SKILLS"
   create_factory_runtime_root "$SOURCE_GSTACK_DIR" "$FACTORY_GSTACK"
@@ -777,14 +777,14 @@ if [ "$INSTALL_FACTORY" -eq 1 ]; then
   echo "  factory skills: $FACTORY_SKILLS"
 fi
 
-# 7. Create .agents/ sidecar symlinks for the real Codex skill target.
+# 8. Create .agents/ sidecar symlinks for the real Codex skill target.
 # The root Codex skill ends up pointing at $SOURCE_GSTACK_DIR/.agents/skills/gstack,
 # so the runtime assets must live there for both global and repo-local installs.
 if [ "$INSTALL_CODEX" -eq 1 ]; then
   create_agents_sidecar "$SOURCE_GSTACK_DIR"
 fi
 
-# 8. First-time welcome + legacy cleanup
+# 9. First-time welcome + legacy cleanup
 if [ ! -f "$HOME/.gstack/.welcome-seen" ]; then
   echo "  Welcome! Run /gstack-upgrade anytime to stay current."
   touch "$HOME/.gstack/.welcome-seen"

--- a/setup
+++ b/setup
@@ -21,6 +21,8 @@ CODEX_SKILLS="$HOME/.codex/skills"
 CODEX_GSTACK="$CODEX_SKILLS/gstack"
 FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
+OPENCODE_SKILLS="$HOME/.config/opencode/skills"
+OPENCODE_GSTACK="$OPENCODE_SKILLS/gstack"
 
 IS_WINDOWS=0
 case "$(uname -s)" in
@@ -34,7 +36,7 @@ SKILL_PREFIX=1
 SKILL_PREFIX_FLAG=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, opencode, kiro, factory, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -44,8 +46,8 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|auto) ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, or auto)" >&2; exit 1 ;;
+  claude|codex|opencode|kiro|factory|auto) ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, opencode, kiro, factory, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -102,21 +104,25 @@ fi
 # For auto: detect which agents are installed
 INSTALL_CLAUDE=0
 INSTALL_CODEX=0
+INSTALL_OPENCODE=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
+  command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
   INSTALL_CLAUDE=1
 elif [ "$HOST" = "codex" ]; then
   INSTALL_CODEX=1
+elif [ "$HOST" = "opencode" ]; then
+  INSTALL_OPENCODE=1
 elif [ "$HOST" = "kiro" ]; then
   INSTALL_KIRO=1
 elif [ "$HOST" = "factory" ]; then
@@ -220,6 +226,16 @@ if [ "$INSTALL_FACTORY" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
     cd "$SOURCE_GSTACK_DIR"
     bun install --frozen-lockfile 2>/dev/null || bun install
     bun run gen:skill-docs --host factory
+  )
+fi
+
+# 1d. Generate .opencode/ OpenCode skill docs
+if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  echo "Generating .opencode/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun install --frozen-lockfile 2>/dev/null || bun install
+    bun run gen:skill-docs --host opencode
   )
 fi
 
@@ -550,12 +566,86 @@ link_factory_skill_dirs() {
   fi
 }
 
+link_opencode_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local opencode_dir="$gstack_dir/.opencode/skills"
+  local linked=()
+
+  if [ ! -d "$opencode_dir" ]; then
+    echo "  Generating .opencode/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host opencode )
+  fi
+
+  if [ ! -d "$opencode_dir" ]; then
+    echo "  warning: .opencode/skills/ generation failed — run 'bun run gen:skill-docs --host opencode' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$opencode_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+create_opencode_runtime_root() {
+  local gstack_dir="$1"
+  local opencode_gstack="$2"
+  local opencode_dir="$gstack_dir/.opencode/skills"
+
+  if [ -L "$opencode_gstack" ]; then
+    rm -f "$opencode_gstack"
+  elif [ -d "$opencode_gstack" ] && [ "$opencode_gstack" != "$gstack_dir" ]; then
+    rm -rf "$opencode_gstack"
+  fi
+
+  mkdir -p "$opencode_gstack" "$opencode_gstack/browse" "$opencode_gstack/gstack-upgrade" "$opencode_gstack/review"
+
+  if [ -f "$opencode_dir/gstack/SKILL.md" ]; then
+    ln -snf "$opencode_dir/gstack/SKILL.md" "$opencode_gstack/SKILL.md"
+  fi
+  if [ -d "$gstack_dir/bin" ]; then
+    ln -snf "$gstack_dir/bin" "$opencode_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    ln -snf "$gstack_dir/browse/dist" "$opencode_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    ln -snf "$gstack_dir/browse/bin" "$opencode_gstack/browse/bin"
+  fi
+  if [ -f "$opencode_dir/gstack-upgrade/SKILL.md" ]; then
+    ln -snf "$opencode_dir/gstack-upgrade/SKILL.md" "$opencode_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      ln -snf "$gstack_dir/review/$f" "$opencode_gstack/review/$f"
+    fi
+  done
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    ln -snf "$gstack_dir/ETHOS.md" "$opencode_gstack/ETHOS.md"
+  fi
+}
+
 # 4. Install for Claude (default)
 SKILLS_BASENAME="$(basename "$INSTALL_SKILLS_DIR")"
 SKILLS_PARENT_BASENAME="$(basename "$(dirname "$INSTALL_SKILLS_DIR")")"
 CODEX_REPO_LOCAL=0
+OPENCODE_REPO_LOCAL=0
 if [ "$SKILLS_BASENAME" = "skills" ] && [ "$SKILLS_PARENT_BASENAME" = ".agents" ]; then
   CODEX_REPO_LOCAL=1
+fi
+if [ "$SKILLS_BASENAME" = "skills" ] && [ "$SKILLS_PARENT_BASENAME" = ".opencode" ]; then
+  OPENCODE_REPO_LOCAL=1
 fi
 
 if [ "$INSTALL_CLAUDE" -eq 1 ]; then
@@ -603,6 +693,22 @@ if [ "$INSTALL_CODEX" -eq 1 ]; then
   echo "gstack ready (codex)."
   echo "  browse: $BROWSE_BIN"
   echo "  codex skills: $CODEX_SKILLS"
+fi
+
+# 6. Install for Kiro CLI (copy from .agents/skills, rewrite paths)
+if [ "$INSTALL_OPENCODE" -eq 1 ]; then
+  if [ "$OPENCODE_REPO_LOCAL" -eq 1 ]; then
+    OPENCODE_SKILLS="$INSTALL_SKILLS_DIR"
+    OPENCODE_GSTACK="$INSTALL_GSTACK_DIR"
+  fi
+  mkdir -p "$OPENCODE_SKILLS"
+  if [ "$OPENCODE_REPO_LOCAL" -eq 0 ]; then
+    create_opencode_runtime_root "$SOURCE_GSTACK_DIR" "$OPENCODE_GSTACK"
+  fi
+  link_opencode_skill_dirs "$SOURCE_GSTACK_DIR" "$OPENCODE_SKILLS"
+  echo "gstack ready (opencode)."
+  echo "  browse: $BROWSE_BIN"
+  echo "  opencode skills: $OPENCODE_SKILLS"
 fi
 
 # 6. Install for Kiro CLI (copy from .agents/skills, rewrite paths)

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1877,19 +1877,104 @@ describe('Factory generation (--host factory)', () => {
   });
 });
 
+describe('OpenCode generation (--host opencode)', () => {
+  const OPENCODE_DIR = path.join(ROOT, '.opencode', 'skills');
+
+  Bun.spawnSync(['bun', 'run', 'scripts/gen-skill-docs.ts', '--host', 'opencode'], {
+    cwd: ROOT, stdout: 'pipe', stderr: 'pipe',
+  });
+
+  const OPENCODE_SKILLS = (() => {
+    const skills: Array<{ dir: string; opencodeName: string }> = [];
+    const isSymlinkLoop = (name: string): boolean => {
+      const opencodeSkillDir = path.join(ROOT, '.opencode', 'skills', name);
+      try { return fs.realpathSync(opencodeSkillDir) === fs.realpathSync(ROOT); }
+      catch { return false; }
+    };
+    if (fs.existsSync(path.join(ROOT, 'SKILL.md.tmpl'))) {
+      if (!isSymlinkLoop('gstack')) skills.push({ dir: '.', opencodeName: 'gstack' });
+    }
+    for (const entry of fs.readdirSync(ROOT, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+      if (entry.name === 'codex') continue;
+      if (!fs.existsSync(path.join(ROOT, entry.name, 'SKILL.md.tmpl'))) continue;
+      const opencodeName = entry.name.startsWith('gstack-') ? entry.name : `gstack-${entry.name}`;
+      if (isSymlinkLoop(opencodeName)) continue;
+      skills.push({ dir: entry.name, opencodeName });
+    }
+    return skills;
+  })();
+
+  test('--host opencode generates correct output paths', () => {
+    for (const skill of OPENCODE_SKILLS) {
+      const skillMd = path.join(OPENCODE_DIR, skill.opencodeName, 'SKILL.md');
+      expect(fs.existsSync(skillMd)).toBe(true);
+    }
+  });
+
+  test('OpenCode frontmatter has name + description + compatibility', () => {
+    for (const skill of OPENCODE_SKILLS) {
+      const content = fs.readFileSync(path.join(OPENCODE_DIR, skill.opencodeName, 'SKILL.md'), 'utf-8');
+      const fmEnd = content.indexOf('\n---', 4);
+      const frontmatter = content.slice(4, fmEnd);
+      expect(frontmatter).toContain('name:');
+      expect(frontmatter).toContain('description:');
+      expect(frontmatter).toContain('compatibility: opencode');
+      expect(frontmatter).not.toContain('allowed-tools:');
+      expect(frontmatter).not.toContain('version:');
+      expect(frontmatter).not.toContain('hooks:');
+    }
+  });
+
+  test('OpenCode output strips Claude skill paths and metadata sidecars', () => {
+    for (const skill of OPENCODE_SKILLS) {
+      const content = fs.readFileSync(path.join(OPENCODE_DIR, skill.opencodeName, 'SKILL.md'), 'utf-8');
+      expect(content).not.toContain('.claude/skills');
+      const yamlPath = path.join(OPENCODE_DIR, skill.opencodeName, 'agents', 'openai.yaml');
+      expect(fs.existsSync(yamlPath)).toBe(false);
+    }
+  });
+
+  test('OpenCode preamble uses .opencode local path and ~/.config/opencode global path', () => {
+    const content = fs.readFileSync(path.join(OPENCODE_DIR, 'gstack-review', 'SKILL.md'), 'utf-8');
+    expect(content).toContain('GSTACK_ROOT=');
+    expect(content).toContain('$HOME/.config/opencode/skills/gstack');
+    expect(content).toContain('$_ROOT/.opencode/skills/gstack');
+    expect(content).toContain('$GSTACK_BIN/gstack-config');
+  });
+
+  test('/codex skill excluded from OpenCode output', () => {
+    expect(fs.existsSync(path.join(OPENCODE_DIR, 'gstack-codex', 'SKILL.md'))).toBe(false);
+    expect(fs.existsSync(path.join(OPENCODE_DIR, 'gstack-codex'))).toBe(false);
+  });
+
+  test('--host opencode --dry-run freshness', () => {
+    const result = Bun.spawnSync(['bun', 'run', 'scripts/gen-skill-docs.ts', '--host', 'opencode', '--dry-run'], {
+      cwd: ROOT, stdout: 'pipe', stderr: 'pipe',
+    });
+    expect(result.exitCode).toBe(0);
+    const output = result.stdout.toString();
+    for (const skill of OPENCODE_SKILLS) {
+      expect(output).toContain(`FRESH: .opencode/skills/${skill.opencodeName}/SKILL.md`);
+    }
+    expect(output).not.toContain('STALE');
+  });
+});
+
 // ─── --host all tests ────────────────────────────────────────
 
 describe('--host all', () => {
-  test('--host all generates for claude, codex, and factory', () => {
+  test('--host all generates for claude, codex, factory, and opencode', () => {
     const result = Bun.spawnSync(['bun', 'run', 'scripts/gen-skill-docs.ts', '--host', 'all', '--dry-run'], {
       cwd: ROOT, stdout: 'pipe', stderr: 'pipe',
     });
     expect(result.exitCode).toBe(0);
     const output = result.stdout.toString();
-    // All three hosts should appear in output
+    // All four hosts should appear in output
     expect(output).toContain('FRESH: SKILL.md');           // claude
     expect(output).toContain('FRESH: .agents/skills/');     // codex
     expect(output).toContain('FRESH: .factory/skills/');    // factory
+    expect(output).toContain('FRESH: .opencode/skills/');   // opencode
   });
 });
 
@@ -1969,14 +2054,15 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('ln -snf "gstack/$dir_name"');
   });
 
-  test('setup supports --host auto|claude|codex|kiro', () => {
+  test('setup supports --host auto|claude|codex|opencode|kiro', () => {
     expect(setupContent).toContain('--host');
-    expect(setupContent).toContain('claude|codex|kiro|factory|auto');
+    expect(setupContent).toContain('claude|codex|opencode|kiro|factory|auto');
   });
 
-  test('auto mode detects claude, codex, and kiro binaries', () => {
+  test('auto mode detects claude, codex, opencode, and kiro binaries', () => {
     expect(setupContent).toContain('command -v claude');
     expect(setupContent).toContain('command -v codex');
+    expect(setupContent).toContain('command -v opencode');
     expect(setupContent).toContain('command -v kiro-cli');
   });
 
@@ -2003,6 +2089,14 @@ describe('setup script validation', () => {
     expect(setupContent).toContain('kiro-cli');
     expect(setupContent).toContain('KIRO_SKILLS=');
     expect(setupContent).toContain('~/.kiro/skills/gstack');
+  });
+
+  test('setup supports --host opencode with dedicated install section', () => {
+    expect(setupContent).toContain('INSTALL_OPENCODE=');
+    expect(setupContent).toContain('OPENCODE_SKILLS=');
+    expect(setupContent).toContain('create_opencode_runtime_root');
+    expect(setupContent).toContain('link_opencode_skill_dirs');
+    expect(setupContent).toContain('$HOME/.config/opencode/skills');
   });
 
   test('create_agents_sidecar links runtime assets', () => {


### PR DESCRIPTION
## Summary
- add an `opencode` host to `gen:skill-docs` and generate dedicated `.opencode/skills/...` outputs
- add `./setup --host opencode` with repo-local `.opencode/skills/` installs and global `~/.config/opencode/skills/` installs
- document the OpenCode install flow and add regression coverage for generation, setup, and `--host all`

## Root cause
Issue #648 was not blocked on a new skill format. The missing piece was first-class host plumbing: gstack only generated/install-targeted Claude, Codex, Kiro, and Factory paths, so OpenCode users had no dedicated generator output, runtime root, or setup path even though the skill content itself was already compatible.

## User impact
OpenCode users can now install gstack with a single host-specific command instead of relying on Codex-oriented paths or manual directory conventions.

## Validation
- `bun test test/gen-skill-docs.test.ts`

Closes #648.
