### PR TITLE
fix: resolve symlinks in validateOutputPath (#665)

### DIFF
--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -15,11 +15,30 @@ import { resolveConfig } from './config';
 import type { Frame } from 'playwright';
 
 // Security: Path validation to prevent path traversal attacks
-const SAFE_DIRECTORIES = [TEMP_DIR, process.cwd()];
+// Resolve safe directories through realpathSync to handle symlinks (e.g., macOS /tmp → /private/tmp)
+const SAFE_DIRECTORIES = [TEMP_DIR, process.cwd()].map(d => {
+  try { return fs.realpathSync(d); } catch { return d; }
+});
 
 export function validateOutputPath(filePath: string): void {
   const resolved = path.resolve(filePath);
-  const isSafe = SAFE_DIRECTORIES.some(dir => isPathWithin(resolved, dir));
+  // Resolve symlinks — output files may not exist yet, so fall back to parent dir
+  let realPath: string;
+  try {
+    realPath = fs.realpathSync(resolved);
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      try {
+        const dir = fs.realpathSync(path.dirname(resolved));
+        realPath = path.join(dir, path.basename(resolved));
+      } catch {
+        realPath = resolved;
+      }
+    } else {
+      throw new Error(`Cannot resolve real path: ${filePath} (${err.code})`);
+    }
+  }
+  const isSafe = SAFE_DIRECTORIES.some(dir => isPathWithin(realPath, dir));
   if (!isSafe) {
     throw new Error(`Path must be within: ${SAFE_DIRECTORIES.join(', ')}`);
   }


### PR DESCRIPTION
## Summary
- Mirrors the `validateReadPath` symlink-resolution pattern into `validateOutputPath`
- Resolves `SAFE_DIRECTORIES` via `realpathSync` at module load to handle platform symlinks (e.g., macOS `/tmp` → `/private/tmp`)
- Resolves input paths via `realpathSync` with ENOENT fallback for parent directory (output files may not exist yet)

Fixes #665

## Test plan
- [ ] `bun test` passes
- [ ] `bun run build` succeeds
- [ ] Verify symlink under /tmp no longer bypasses output path validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)