### PR TITLE
fix: check IPv6 AAAA records in DNS rebinding protection (#668)

### DIFF
--- a/browse/src/url-validation.ts
+++ b/browse/src/url-validation.ts
@@ -51,11 +51,13 @@ function isMetadataIp(hostname: string): boolean {
 async function resolvesToBlockedIp(hostname: string): Promise<boolean> {
   try {
     const dns = await import('node:dns');
-    const { resolve4 } = dns.promises;
-    const addresses = await resolve4(hostname);
-    return addresses.some(addr => BLOCKED_METADATA_HOSTS.has(addr));
+    const { resolve4, resolve6 } = dns.promises;
+    const [v4, v6] = await Promise.all([
+      resolve4(hostname).catch(() => [] as string[]),
+      resolve6(hostname).catch(() => [] as string[]),
+    ]);
+    return [...v4, ...v6].some(addr => BLOCKED_METADATA_HOSTS.has(addr));
   } catch {
-    // DNS resolution failed — not a rebinding risk
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- `resolvesToBlockedIp()` now checks both A (IPv4) and AAAA (IPv6) records in parallel
- Each resolution has its own `.catch(() => [])` so a failure in one doesn't skip the other
- Prevents DNS rebinding attacks via IPv6 AAAA records pointing to metadata IPs

Fixes #668

## Test plan
- [ ] `bun test` passes
- [ ] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)