### PR TITLE
fix: use content-length header to avoid buffering responses (#711)

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -1022,8 +1022,8 @@ export class BrowserManager {
         const res = await req.response();
         if (res) {
           const url = req.url();
-          const body = await res.body().catch(() => null);
-          const size = body ? body.length : 0;
+          const cl = await res.headerValue('content-length');
+          const size = cl != null ? parseInt(cl, 10) : (await res.body().catch(() => null))?.length ?? 0;
           for (let i = networkBuffer.length - 1; i >= 0; i--) {
             const entry = networkBuffer.get(i);
             if (entry && entry.url === url && !entry.size) {


### PR DESCRIPTION
## Summary
- `requestfinished` handler now reads the `content-length` header first
- Only falls back to `res.body()` when the header is absent
- Avoids buffering entire response bodies (images, videos, large payloads) just to record byte length

Fixes #711

## Test plan
- [ ] `bun test` passes
- [ ] `bun run build` succeeds
- [ ] Network buffer still records accurate sizes for responses with content-length header
- [ ] Responses without content-length header still get their size recorded via body fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)