### PR TITLE
fix: remove duplicate chmod -R 1777 /tmp in Dockerfile (#709)

### DIFF
--- a/.github/docker/Dockerfile.ci
+++ b/.github/docker/Dockerfile.ci
@@ -59,5 +59,4 @@ RUN useradd -m -s /bin/bash runner \
     && chmod -R a+rX /opt/node_modules_cache \
     && mkdir -p /home/runner/.gstack && chown -R runner:runner /home/runner/.gstack \
     && chmod 1777 /tmp \
-    && mkdir -p /home/runner/.bun && chown -R runner:runner /home/runner/.bun \
-    && chmod -R 1777 /tmp
+    && mkdir -p /home/runner/.bun && chown -R runner:runner /home/runner/.bun


### PR DESCRIPTION
## Summary
- Removes duplicate `chmod -R 1777 /tmp` on line 63 of `Dockerfile.ci`
- Line 61 already sets `chmod 1777 /tmp` correctly on the directory
- The `-R` flag needlessly applies the sticky bit to files inside `/tmp` (sticky bit only makes sense on directories)

Fixes #709

## Test plan
- [ ] Docker image builds successfully
- [ ] `/tmp` permissions are correct (1777 on directory, no sticky bit on files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)