### PR TITLE
fix: use jq for JSON field stripping in telemetry sync (#710)

### DIFF
--- a/bin/gstack-telemetry-sync
+++ b/bin/gstack-telemetry-sync
@@ -79,14 +79,20 @@ while IFS= read -r LINE; do
   echo "$LINE" | grep -q '^{' || continue
 
   # Strip local-only fields (keep v, ts, sessions as-is for edge function)
-  CLEAN="$(echo "$LINE" | sed \
-    -e 's/,"_repo_slug":"[^"]*"//g' \
-    -e 's/,"_branch":"[^"]*"//g' \
-    -e 's/,"repo":"[^"]*"//g')"
-
-  # If anonymous tier, strip installation_id
-  if [ "$TIER" = "anonymous" ]; then
-    CLEAN="$(echo "$CLEAN" | sed 's/,"installation_id":"[^"]*"//g; s/,"installation_id":null//g')"
+  if command -v jq >/dev/null 2>&1; then
+    CLEAN="$(echo "$LINE" | jq -c 'del(._repo_slug, ._branch, .repo)')"
+    if [ "$TIER" = "anonymous" ]; then
+      CLEAN="$(echo "$CLEAN" | jq -c 'del(.installation_id)')"
+    fi
+  else
+    # Fallback: sed-based stripping (fragile with escaped quotes/commas in values)
+    CLEAN="$(echo "$LINE" | sed \
+      -e 's/,"_repo_slug":"[^"]*"//g' \
+      -e 's/,"_branch":"[^"]*"//g' \
+      -e 's/,"repo":"[^"]*"//g')"
+    if [ "$TIER" = "anonymous" ]; then
+      CLEAN="$(echo "$CLEAN" | sed 's/,"installation_id":"[^"]*"//g; s/,"installation_id":null//g')"
+    fi
   fi
 
   if [ "$FIRST" = "true" ]; then


### PR DESCRIPTION
## Summary
- Uses `jq -c 'del(...)'` for correct JSON field removal when `jq` is available
- Keeps the existing `sed` regex as a fallback for environments without `jq`
- Prevents silent data corruption when JSON values contain escaped quotes or commas

Fixes #710

## Test plan
- [ ] With `jq` installed: verify telemetry sync strips fields correctly
- [ ] With `jq` absent: verify sed fallback still works for simple JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)