### PR TITLE
fix: pass extraEnv to Windows server launcher

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -232,11 +232,14 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     // when the CLI exits, the server dies with it. Use Node's child_process.spawn
     // with { detached: true } instead, which is the gold standard for Windows
     // process independence. Credit: PR #191 by @fqueiro.
+    const extraEnvEntries = extraEnv ? Object.entries(extraEnv).map(([k, v]) => `${JSON.stringify(k)}:${JSON.stringify(v)}`).join(',') : '';
     const launcherCode =
       `const{spawn}=require('child_process');` +
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
       `{detached:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
-      `{BROWSE_STATE_FILE:${JSON.stringify(config.stateFile)}})}).unref()`;
+      `{BROWSE_STATE_FILE:${JSON.stringify(config.stateFile)}}` +
+      (extraEnvEntries ? `,{${extraEnvEntries}}` : '') +
+      `)}).unref()`;
     Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'] });
   } else {
     // macOS/Linux: Bun.spawn + unref works correctly


### PR DESCRIPTION
## Summary

- **Windows `startServer()` was silently dropping `extraEnv`** (containing `BROWSE_HEADED`, `BROWSE_PORT`, `BROWSE_SIDEBAR_CHAT`), causing `/connect-chrome` to always launch headless on Windows
- The Node launcher code only forwarded `BROWSE_STATE_FILE` to the spawned process; the `extraEnv` parameter was ignored
- Now all extra env vars are serialized into the launcher code string and merged via `Object.assign`

## Root cause

`cli.ts:235-239` — the Windows code path builds a one-liner JS string to spawn the server via `node -e`. The `env` object in that string only included `BROWSE_STATE_FILE`, not the `extraEnv` parameter passed by callers like the `connect` command.

The macOS/Linux path (line 243) correctly passes `...extraEnv` via `Bun.spawn()`.

## Test plan

- [x] Tested on Windows 11 — `/connect-chrome` now opens a visible headed Chromium window
- [ ] Verify macOS/Linux path is unchanged (no code touched)
- [ ] Verify other `extraEnv` consumers work (e.g. `BROWSE_PORT` forwarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)