### PR TITLE
feat: add Copilot CLI as a host option

### DIFF
--- a/bin/gstack-global-discover.ts
+++ b/bin/gstack-global-discover.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * gstack-global-discover — Discover AI coding sessions across Claude Code, Codex CLI, and Gemini CLI.
+ * gstack-global-discover — Discover AI coding sessions across Claude Code, Codex CLI, Gemini CLI, and GitHub Copilot CLI.
  * Resolves each session's working directory to a git repo, deduplicates by normalized remote URL,
  * and outputs structured JSON to stdout.
  *
@@ -17,7 +17,7 @@ import { homedir } from "os";
 // ── Types ──────────────────────────────────────────────────────────────────
 
 interface Session {
-  tool: "claude_code" | "codex" | "gemini";
+  tool: "claude_code" | "codex" | "gemini" | "copilot";
   cwd: string;
 }
 
@@ -25,7 +25,7 @@ interface Repo {
   name: string;
   remote: string;
   paths: string[];
-  sessions: { claude_code: number; codex: number; gemini: number };
+  sessions: { claude_code: number; codex: number; gemini: number; copilot: number };
 }
 
 interface DiscoveryResult {
@@ -36,6 +36,7 @@ interface DiscoveryResult {
     claude_code: { total_sessions: number; repos: number };
     codex: { total_sessions: number; repos: number };
     gemini: { total_sessions: number; repos: number };
+    copilot: { total_sessions: number; repos: number };
   };
   total_sessions: number;
   total_repos: number;
@@ -290,6 +291,95 @@ function extractCwdFromJsonl(filePath: string): string | null {
   return null;
 }
 
+function extractCopilotCwdFromWorkspace(filePath: string): string | null {
+  try {
+    const text = readFileSync(filePath, { encoding: "utf-8" });
+    const match = text.match(/^cwd:\s*(.+)$/m);
+    if (!match) return null;
+    return match[1].trim().replace(/^['"]|['"]$/g, "");
+  } catch {
+    return null;
+  }
+}
+
+function extractCopilotCwdFromEvents(filePath: string): string | null {
+  try {
+    const fd = openSync(filePath, "r");
+    const buf = Buffer.alloc(16384);
+    const bytesRead = readSync(fd, buf, 0, 16384, 0);
+    closeSync(fd);
+    const lines = buf.toString("utf-8", 0, bytesRead).split("\n").slice(0, 25);
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const obj = JSON.parse(line);
+        const cwd = obj.data?.context?.cwd;
+        if (obj.type === "session.start" && typeof cwd === "string") {
+          return cwd;
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    // File read error
+  }
+  return null;
+}
+
+function scanCopilot(since: Date): Session[] {
+  const sessionsDir = join(homedir(), ".copilot", "session-state");
+  if (!existsSync(sessionsDir)) return [];
+
+  const sessions: Session[] = [];
+
+  let dirs: string[];
+  try {
+    dirs = readdirSync(sessionsDir);
+  } catch {
+    return [];
+  }
+
+  for (const dirName of dirs) {
+    const dirPath = join(sessionsDir, dirName);
+    try {
+      const stat = statSync(dirPath);
+      if (!stat.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    const workspacePath = join(dirPath, "workspace.yaml");
+    const eventsPath = join(dirPath, "events.jsonl");
+
+    const hasRecentWorkspace = existsSync(workspacePath) && (() => {
+      try {
+        return statSync(workspacePath).mtime >= since;
+      } catch {
+        return false;
+      }
+    })();
+    const hasRecentEvents = existsSync(eventsPath) && (() => {
+      try {
+        return statSync(eventsPath).mtime >= since;
+      } catch {
+        return false;
+      }
+    })();
+    if (!hasRecentWorkspace && !hasRecentEvents) continue;
+
+    let cwd = hasRecentWorkspace ? extractCopilotCwdFromWorkspace(workspacePath) : null;
+    if ((!cwd || !existsSync(cwd)) && hasRecentEvents) {
+      cwd = extractCopilotCwdFromEvents(eventsPath);
+    }
+    if (!cwd || !existsSync(cwd)) continue;
+
+    sessions.push({ tool: "copilot", cwd });
+  }
+
+  return sessions;
+}
+
 function scanCodex(since: Date): Session[] {
   const sessionsDir = join(homedir(), ".codex", "sessions");
   if (!existsSync(sessionsDir)) return [];
@@ -496,7 +586,7 @@ async function resolveAndDeduplicate(sessions: Session[]): Promise<Repo[]> {
       }
     }
 
-    const sessionCounts = { claude_code: 0, codex: 0, gemini: 0 };
+    const sessionCounts = { claude_code: 0, codex: 0, gemini: 0, copilot: 0 };
     for (const s of data.sessions) {
       sessionCounts[s.tool]++;
     }
@@ -512,8 +602,8 @@ async function resolveAndDeduplicate(sessions: Session[]): Promise<Repo[]> {
   // Sort by total sessions descending
   repos.sort(
     (a, b) =>
-      b.sessions.claude_code + b.sessions.codex + b.sessions.gemini -
-      (a.sessions.claude_code + a.sessions.codex + a.sessions.gemini)
+      b.sessions.claude_code + b.sessions.codex + b.sessions.gemini + b.sessions.copilot -
+      (a.sessions.claude_code + a.sessions.codex + a.sessions.gemini + a.sessions.copilot)
   );
 
   return repos;
@@ -530,12 +620,13 @@ async function main() {
   const ccSessions = scanClaudeCode(sinceDate);
   const codexSessions = scanCodex(sinceDate);
   const geminiSessions = scanGemini(sinceDate);
+  const copilotSessions = scanCopilot(sinceDate);
 
-  const allSessions = [...ccSessions, ...codexSessions, ...geminiSessions];
+  const allSessions = [...ccSessions, ...codexSessions, ...geminiSessions, ...copilotSessions];
 
   // Summary to stderr
   console.error(
-    `Discovered: ${ccSessions.length} CC sessions, ${codexSessions.length} Codex sessions, ${geminiSessions.length} Gemini sessions`
+    `Discovered: ${ccSessions.length} CC sessions, ${codexSessions.length} Codex sessions, ${geminiSessions.length} Gemini sessions, ${copilotSessions.length} Copilot sessions`
   );
 
   // Deduplicate
@@ -547,6 +638,7 @@ async function main() {
   const ccRepos = new Set(repos.filter((r) => r.sessions.claude_code > 0).map((r) => r.remote)).size;
   const codexRepos = new Set(repos.filter((r) => r.sessions.codex > 0).map((r) => r.remote)).size;
   const geminiRepos = new Set(repos.filter((r) => r.sessions.gemini > 0).map((r) => r.remote)).size;
+  const copilotRepos = new Set(repos.filter((r) => r.sessions.copilot > 0).map((r) => r.remote)).size;
 
   const result: DiscoveryResult = {
     window: since,
@@ -556,6 +648,7 @@ async function main() {
       claude_code: { total_sessions: ccSessions.length, repos: ccRepos },
       codex: { total_sessions: codexSessions.length, repos: codexRepos },
       gemini: { total_sessions: geminiSessions.length, repos: geminiRepos },
+      copilot: { total_sessions: copilotSessions.length, repos: copilotRepos },
     },
     total_sessions: allSessions.length,
     total_repos: repos.length,
@@ -566,15 +659,16 @@ async function main() {
   } else {
     // Summary format
     console.log(`Window: ${since} (since ${startDate})`);
-    console.log(`Sessions: ${allSessions.length} total (CC: ${ccSessions.length}, Codex: ${codexSessions.length}, Gemini: ${geminiSessions.length})`);
+    console.log(`Sessions: ${allSessions.length} total (CC: ${ccSessions.length}, Codex: ${codexSessions.length}, Gemini: ${geminiSessions.length}, Copilot: ${copilotSessions.length})`);
     console.log(`Repos: ${repos.length} unique`);
     console.log("");
     for (const repo of repos) {
-      const total = repo.sessions.claude_code + repo.sessions.codex + repo.sessions.gemini;
+      const total = repo.sessions.claude_code + repo.sessions.codex + repo.sessions.gemini + repo.sessions.copilot;
       const tools = [];
       if (repo.sessions.claude_code > 0) tools.push(`CC:${repo.sessions.claude_code}`);
       if (repo.sessions.codex > 0) tools.push(`Codex:${repo.sessions.codex}`);
       if (repo.sessions.gemini > 0) tools.push(`Gemini:${repo.sessions.gemini}`);
+      if (repo.sessions.copilot > 0) tools.push(`Copilot:${repo.sessions.copilot}`);
       console.log(`  ${repo.name} (${total} sessions) — ${tools.join(", ")}`);
       console.log(`    Remote: ${repo.remote}`);
       console.log(`    Paths: ${repo.paths.join(", ")}`);

--- a/setup
+++ b/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# gstack setup — build browser binary + register skills with Claude Code / Codex
+# gstack setup — build browser binary + register skills with Claude Code / Copilot CLI / Codex
 set -e
 
 if ! command -v bun >/dev/null 2>&1; then
@@ -34,7 +34,7 @@ SKILL_PREFIX=1
 SKILL_PREFIX_FLAG=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, copilot, codex, kiro, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -44,8 +44,8 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|auto) ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, or auto)" >&2; exit 1 ;;
+  claude|copilot|codex|kiro|factory|auto) ;;
+  *) echo "Unknown --host value: $HOST (expected claude, copilot, codex, kiro, factory, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -90,7 +90,7 @@ fi
 # --local: install to .claude/skills/ in the current working directory
 if [ "$LOCAL_INSTALL" -eq 1 ]; then
   if [ "$HOST" = "codex" ]; then
-    echo "Error: --local is only supported for Claude Code (not Codex)." >&2
+    echo "Error: --local is only supported for Claude Code and Copilot CLI (not Codex)." >&2
     exit 1
   fi
   INSTALL_SKILLS_DIR="$(pwd)/.claude/skills"
@@ -101,6 +101,7 @@ fi
 
 # For auto: detect which agents are installed
 INSTALL_CLAUDE=0
+INSTALL_COPILOT=0
 INSTALL_CODEX=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
@@ -109,12 +110,17 @@ if [ "$HOST" = "auto" ]; then
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
+  if [ "$INSTALL_CLAUDE" -eq 0 ]; then
+    command -v copilot >/dev/null 2>&1 && INSTALL_COPILOT=1
+  fi
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_COPILOT" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
   INSTALL_CLAUDE=1
+elif [ "$HOST" = "copilot" ]; then
+  INSTALL_COPILOT=1
 elif [ "$HOST" = "codex" ]; then
   INSTALL_CODEX=1
 elif [ "$HOST" = "kiro" ]; then
@@ -579,6 +585,25 @@ if [ "$INSTALL_CLAUDE" -eq 1 ]; then
     echo "  browse: $BROWSE_BIN"
   else
     echo "gstack ready (claude)."
+    echo "  browse: $BROWSE_BIN"
+    echo "  (skipped skill symlinks — not inside .claude/skills/)"
+  fi
+fi
+
+# 4b. Install for Copilot CLI (GitHub Copilot CLI officially supports .claude/skills and
+# ~/.claude/skills, so it shares the same lowest-friction layout as Claude Code.)
+if [ "$INSTALL_COPILOT" -eq 1 ]; then
+  if [ "$SKILLS_BASENAME" = "skills" ]; then
+    link_claude_skill_dirs "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
+    if [ "$LOCAL_INSTALL" -eq 1 ]; then
+      echo "gstack ready (project-local copilot)."
+      echo "  skills: $INSTALL_SKILLS_DIR"
+    else
+      echo "gstack ready (copilot)."
+    fi
+    echo "  browse: $BROWSE_BIN"
+  else
+    echo "gstack ready (copilot)."
     echo "  browse: $BROWSE_BIN"
     echo "  (skipped skill symlinks — not inside .claude/skills/)"
   fi

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1971,13 +1971,20 @@ describe('setup script validation', () => {
 
   test('setup supports --host auto|claude|codex|kiro', () => {
     expect(setupContent).toContain('--host');
-    expect(setupContent).toContain('claude|codex|kiro|factory|auto');
+    expect(setupContent).toContain('claude|copilot|codex|kiro|factory|auto');
   });
 
-  test('auto mode detects claude, codex, and kiro binaries', () => {
+  test('auto mode detects claude, copilot, codex, and kiro binaries', () => {
     expect(setupContent).toContain('command -v claude');
+    expect(setupContent).toContain('command -v copilot');
     expect(setupContent).toContain('command -v codex');
     expect(setupContent).toContain('command -v kiro-cli');
+  });
+
+  test('Copilot setup reuses the Claude-compatible .claude/skills layout', () => {
+    expect(setupContent).toContain('INSTALL_COPILOT=');
+    expect(setupContent).toContain('GitHub Copilot CLI officially supports .claude/skills');
+    expect(setupContent).toContain('INSTALL_COPILOT" -eq 1');
   });
 
   // T1: Sidecar skip guard — prevents .agents/skills/gstack from being linked as a skill

--- a/test/global-discover.test.ts
+++ b/test/global-discover.test.ts
@@ -151,6 +151,7 @@ describe("gstack-global-discover", () => {
         expect(repo.sessions).toHaveProperty("claude_code");
         expect(repo.sessions).toHaveProperty("codex");
         expect(repo.sessions).toHaveProperty("gemini");
+        expect(repo.sessions).toHaveProperty("copilot");
       }
     });
 
@@ -166,7 +167,8 @@ describe("gstack-global-discover", () => {
       const toolTotal =
         json.tools.claude_code.total_sessions +
         json.tools.codex.total_sessions +
-        json.tools.gemini.total_sessions;
+        json.tools.gemini.total_sessions +
+        json.tools.copilot.total_sessions;
       expect(json.total_sessions).toBe(toolTotal);
     });
 


### PR DESCRIPTION
- setup: add --host copilot (shares .claude/skills layout with Claude Code)
- setup: detect 'copilot' binary in auto mode
- setup: update --local error message to allow copilot
- gstack-global-discover: add scanCopilot() reading ~/.copilot/session-state/
- gstack-global-discover: add copilot to Session, Repo, and DiscoveryResult types
- tests: update to expect copilot in repo.sessions and host checks

Inspired by ridermw:copilot-cli-claude-layout on garrytan/gstack.