### PR TITLE
fix(browse): replace wildcard CORS with localhost origin on sidebar endpoints

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -1087,12 +1087,12 @@ async function start() {
           const tabs = await browserManager.getTabListWithTitles();
           return new Response(JSON.stringify({ tabs }), {
             status: 200,
-            headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+            headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': `http://127.0.0.1:${port}` },
           });
         } catch (err: any) {
           return new Response(JSON.stringify({ tabs: [], error: err.message }), {
             status: 200,
-            headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+            headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': `http://127.0.0.1:${port}` },
           });
         }
       }
@@ -1111,7 +1111,7 @@ async function start() {
           browserManager.switchTab(tabId);
           return new Response(JSON.stringify({ ok: true, activeTab: tabId }), {
             status: 200,
-            headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+            headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': `http://127.0.0.1:${port}` },
           });
         } catch (err: any) {
           return new Response(JSON.stringify({ error: err.message }), { status: 400, headers: { 'Content-Type': 'application/json' } });
@@ -1133,7 +1133,7 @@ async function start() {
         const tabAgentStatus = tabId !== null ? getTabAgentStatus(tabId) : agentStatus;
         return new Response(JSON.stringify({ entries, total: chatNextId, agentStatus: tabAgentStatus, activeTabId: activeTab }), {
           status: 200,
-          headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+          headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': `http://127.0.0.1:${port}` },
         });
       }
 

--- a/browse/test/server-auth.test.ts
+++ b/browse/test/server-auth.test.ts
@@ -62,4 +62,28 @@ describe('Server auth security', () => {
     // Should not have wildcard CORS for the SSE stream
     expect(streamBlock).not.toContain("Access-Control-Allow-Origin': '*'");
   });
+
+  // Test 7: /sidebar-tabs has no wildcard CORS header
+  test('/sidebar-tabs has no wildcard CORS header', () => {
+    const block = sliceBetween(SERVER_SRC, "url.pathname === '/sidebar-tabs'", "url.pathname === '/sidebar-tabs/switch'");
+    expect(block).not.toContain("'*'");
+  });
+
+  // Test 8: /sidebar-tabs/switch has no wildcard CORS header
+  test('/sidebar-tabs/switch has no wildcard CORS header', () => {
+    const block = sliceBetween(SERVER_SRC, "url.pathname === '/sidebar-tabs/switch'", "url.pathname === '/sidebar-chat'");
+    expect(block).not.toContain("'*'");
+  });
+
+  // Test 9: /sidebar-chat has no wildcard CORS header
+  test('/sidebar-chat has no wildcard CORS header', () => {
+    const block = sliceBetween(SERVER_SRC, "url.pathname === '/sidebar-chat'", "url.pathname === '/sidebar-command'");
+    expect(block).not.toContain("'*'");
+  });
+
+  // Test 10: no wildcard CORS anywhere in server.ts
+  test('no wildcard Access-Control-Allow-Origin in entire server source', () => {
+    expect(SERVER_SRC).not.toContain("Access-Control-Allow-Origin': '*'");
+    expect(SERVER_SRC).not.toContain('Access-Control-Allow-Origin": "*"');
+  });
 });


### PR DESCRIPTION
## Summary

Sidebar endpoints (`/sidebar-tabs`, `/sidebar-tabs/switch`, `/sidebar-chat`) respond with `Access-Control-Allow-Origin: *`. This allows any cross-origin website to read chat history, tab data, and agent status from the local browse server via fetch().

Replace with `http://127.0.0.1:{port}` so only same-origin requests from the extension are accepted.

## What changed

4 occurrences of wildcard CORS replaced with the actual localhost origin in browse/src/server.ts.

4 regression tests added to browse/test/server-auth.test.ts:
- /sidebar-tabs has no wildcard CORS
- /sidebar-tabs/switch has no wildcard CORS
- /sidebar-chat has no wildcard CORS
- No wildcard CORS anywhere in server source

## Test results

10/10 server-auth tests pass (6 existing + 4 new).