### PR TITLE
fix: sync package.json version with VERSION file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gstack",
-  "version": "0.15.0.0",
+  "version": "0.15.1.0",
   "description": "Garry's Stack — Claude Code skills + fast headless browser. One repo, one install, entire AI engineering workflow.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Problem

`package.json` shows version `0.15.0.0` but `VERSION` file contains `0.15.1.0`. These are out of sync.

This means `npm show gstack version` (if published), `package.json` version checks, and any tooling that reads `package.json` see the wrong version. Closes #399.

## Fix

Updated `package.json` `"version"` field to match the canonical `VERSION` file: `0.15.1.0`.

## Notes

The `VERSION` file is the source of truth (used by `gstack-update-check`, CHANGELOG headers, etc). `package.json` should always mirror it. The `/ship` skill's idempotency check already guards against double-bumping `VERSION` — but it should also update `package.json` to keep these in sync after each bump.

---
*sent from mStack*