### PR TITLE
perf: use Content-Length header instead of res.body() for network size

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -1016,14 +1016,28 @@ export class BrowserManager {
       }
     });
 
-    // Capture response sizes via response finished
+    // Capture response sizes via response finished.
+    // Prefer Content-Length header over res.body() — body() buffers the entire
+    // response into memory, which is O(response_size) per request and blocks
+    // the event loop on large payloads (images, JS bundles, API responses).
+    // Content-Length is available immediately from headers with zero I/O cost.
+    // Fall back to body() only when Content-Length is absent (chunked transfer).
     page.on('requestfinished', async (req) => {
       try {
         const res = await req.response();
         if (res) {
           const url = req.url();
-          const body = await res.body().catch(() => null);
-          const size = body ? body.length : 0;
+          let size = 0;
+
+          const contentLength = res.headers()['content-length'];
+          if (contentLength) {
+            size = parseInt(contentLength, 10) || 0;
+          } else {
+            // Chunked or unknown — body() is the only option
+            const body = await res.body().catch(() => null);
+            size = body ? body.length : 0;
+          }
+
           for (let i = networkBuffer.length - 1; i >= 0; i--) {
             const entry = networkBuffer.get(i);
             if (entry && entry.url === url && !entry.size) {


### PR DESCRIPTION
## The Problem

In \`browser-manager.ts\`, the \`requestfinished\` handler calls \`res.body()\` to get the response size:

\`\`\`typescript
const body = await res.body().catch(() => null);
const size = body ? body.length : 0;
\`\`\`

\`res.body()\` in Playwright buffers the **entire response** into a Node \`Buffer\`. For a 2MB JS bundle, that's a 2MB allocation per network request, just to call \`.length\` on it. Under load (SPA with 50+ network requests on page load), this is significant memory pressure and event loop blocking.

Issue #711.

## Fix

Read \`Content-Length\` from response headers first — it's O(1) and already cached by Playwright. Only fall back to \`res.body()\` for chunked transfer encoding where \`Content-Length\` is genuinely absent.

Most HTTP/1.1 and HTTP/2 responses include \`Content-Length\`. The fallback covers streaming/chunked responses where the header is missing by design.

---
*sent from [mStack](https://github.com/Gonzih)*