### PR TITLE
fix: chmod 1777 /tmp not chmod -R 1777 /tmp in Dockerfile.ci

### DIFF
--- a/.github/docker/Dockerfile.ci
+++ b/.github/docker/Dockerfile.ci
@@ -58,6 +58,5 @@ RUN mv /workspace/node_modules /opt/node_modules_cache \
 RUN useradd -m -s /bin/bash runner \
     && chmod -R a+rX /opt/node_modules_cache \
     && mkdir -p /home/runner/.gstack && chown -R runner:runner /home/runner/.gstack \
-    && chmod 1777 /tmp \
     && mkdir -p /home/runner/.bun && chown -R runner:runner /home/runner/.bun \
-    && chmod -R 1777 /tmp
+    && chmod 1777 /tmp


### PR DESCRIPTION
## The Bug

\`Dockerfile.ci\` has:

\`\`\`dockerfile
&& chmod 1777 /tmp \      ← correct
&& chmod -R 1777 /tmp     ← wrong + duplicate
\`\`\`

\`chmod -R 1777 /tmp\` recursively sets the sticky bit on every **file** inside \`/tmp\`, not just the directory. The sticky bit on a directory (1777) is well-defined: it prevents users from deleting each other's files. The sticky bit on a file has no defined behavior in modern Linux/POSIX and can confuse tools that inspect permissions (e.g., package managers, installers, security scanners that report "unexpected sticky bit on file").

It also runs twice — the first \`chmod 1777 /tmp\` on the line before is correct. The second with \`-R\` undoes that correctness.

Issue #709.

## Fix

Remove the recursive \`-R\` flag and deduplicate. One \`chmod 1777 /tmp\` is correct.

---
*sent from [mStack](https://github.com/Gonzih)*