### PR TITLE
fix: use os.tmpdir() instead of hardcoded /tmp in cookie-import-browser

### DIFF
--- a/browse/src/cookie-import-browser.ts
+++ b/browse/src/cookie-import-browser.ts
@@ -386,7 +386,7 @@ function openDb(dbPath: string, browserName: string): Database {
 }
 
 function openDbFromCopy(dbPath: string, browserName: string): Database {
-  const tmpPath = `/tmp/browse-cookies-${browserName.toLowerCase()}-${crypto.randomUUID()}.db`;
+  const tmpPath = path.join(os.tmpdir(), `browse-cookies-${browserName.toLowerCase()}-${crypto.randomUUID()}.db`);
   try {
     fs.copyFileSync(dbPath, tmpPath);
     // Also copy WAL and SHM if they exist (for consistent reads)


### PR DESCRIPTION
One-liner. \`/tmp\` doesn't exist on Windows. \`os\` was already imported in the file, just wasn't used here.

Before: \`\`\`\`/tmp/browse-cookies-${browser}-${uuid}.db\`\`\`\`
After: \`os.tmpdir()\` resolves to \`%TEMP%\` on Windows, \`/tmp\` on Unix.

Closes #708.

---
*sent from [mStack](https://github.com/Gonzih)*