### PR TITLE
fix: telemetry-ingest edge function uses service role key instead of anon key

### DIFF
--- a/supabase/functions/telemetry-ingest/index.ts
+++ b/supabase/functions/telemetry-ingest/index.ts
@@ -43,9 +43,15 @@ Deno.serve(async (req) => {
       return new Response(`Batch too large (max ${MAX_BATCH_SIZE})`, { status: 400 });
     }
 
+    // Use the anon key, not the service role key.
+    // The service role key bypasses Row Level Security (RLS) and grants full
+    // unrestricted database access — wildly over-privileged for a public
+    // telemetry endpoint that only needs INSERT on two tables.
+    // The anon key + properly configured RLS INSERT policies is correct.
+    // See: https://supabase.com/docs/guides/database/postgres/row-level-security
     const supabase = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+      Deno.env.get("SUPABASE_ANON_KEY") ?? ""
     );
 
     // Validate and transform events


### PR DESCRIPTION
## The Problem

\`supabase/functions/telemetry-ingest/index.ts\` uses \`SUPABASE_SERVICE_ROLE_KEY\`:

\`\`\`typescript
const supabase = createClient(
  Deno.env.get("SUPABASE_URL") ?? "",
  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""  // ← wrong
);
\`\`\`

The service role key **bypasses all Row Level Security** and has full unrestricted database access including admin operations. This is a public-facing edge function called by every gstack user for telemetry. Using the service role here means any exploit in the JSON parsing or validation logic has full database access as a blast radius.

Issue #675.

## The Fix

Use \`SUPABASE_ANON_KEY\` instead. The RLS INSERT policies for the \`anon\` role are already in place (\`001_telemetry.sql\` + \`002_tighten_rls.sql\`). Anon can INSERT into \`telemetry_events\` and \`installations\` — that's all this function needs.

The service role key should never be on the network path to user-facing endpoints.

---
*sent from [mStack](https://github.com/Gonzih)*