### PR TITLE
fix: validate saved URLs before navigation in restoreState

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -694,7 +694,15 @@ export class BrowserManager {
       this.wirePageEvents(page);
 
       if (saved.url) {
-        await page.goto(saved.url, { waitUntil: 'domcontentloaded', timeout: 15000 }).catch(() => {});
+        // Validate the saved URL before navigating — the state file is user-writable and
+        // a tampered URL could navigate to cloud metadata endpoints or file:// URIs.
+        try {
+          await validateNavigationUrl(saved.url);
+          await page.goto(saved.url, { waitUntil: 'domcontentloaded', timeout: 15000 }).catch(() => {});
+        } catch {
+          // Invalid URL in saved state — skip navigation, leave blank page
+          console.log(`[browse] restoreState: skipping unsafe URL: ${saved.url}`);
+        }
       }
 
       if (saved.storage) {


### PR DESCRIPTION
## The Bug

\`restoreState()\` in \`browser-manager.ts\` navigates to URLs from the saved state file without validation:

\`\`\`typescript
if (saved.url) {
  await page.goto(saved.url, { ... });  // no validation
}
\`\`\`

The state file (\`~/.gstack/browse.json\`) is user-writable and persists across sessions. A tampered state file could navigate the browser to \`file://\` URIs, cloud metadata endpoints, or \`javascript:\` URIs on the next session start.

Issue #674.

## Fix

Call \`validateNavigationUrl(saved.url)\` before navigation. This function is already imported and used for the \`goto\` command — the same protection should apply to session restoration. Invalid URLs are skipped with a log message, leaving a blank page instead.

---
*sent from [mStack](https://github.com/Gonzih)*