### PR TITLE
fix: path traversal in design serve /api/reload — arbitrary file read

### DIFF
--- a/design/src/serve.ts
+++ b/design/src/serve.ts
@@ -182,8 +182,20 @@ export async function serve(options: ServeOptions): Promise<void> {
       );
     }
 
+    // Path traversal guard: the reload path must stay within the same directory
+    // as the original HTML file. Arbitrary paths from the POST body would let
+    // any caller read any file on the filesystem via the GET / endpoint.
+    const safeDir = path.resolve(path.dirname(html));
+    const resolvedNew = path.resolve(newHtmlPath);
+    if (!resolvedNew.startsWith(safeDir + path.sep) && resolvedNew !== safeDir) {
+      return Response.json(
+        { error: `Reload path must be within design directory: ${safeDir}` },
+        { status: 403 }
+      );
+    }
+
     // Swap the HTML content
-    htmlContent = fs.readFileSync(newHtmlPath, "utf-8");
+    htmlContent = fs.readFileSync(resolvedNew, "utf-8");
     state = "serving";
 
     console.error(`SERVE_RELOADED: html=${newHtmlPath}`);


### PR DESCRIPTION
## The Bug

\`POST /api/reload\` in \`design/src/serve.ts\` accepts a JSON body with an arbitrary \`html\` path and reads it with no validation:

\`\`\`typescript
const newHtmlPath = body.html;
if (!newHtmlPath || !fs.existsSync(newHtmlPath)) { ... }  // existence check only
htmlContent = fs.readFileSync(newHtmlPath, "utf-8");       // reads anything
\`\`\`

The design server binds to localhost, but the Chrome extension (or any local process) can POST to it. Attack:

\`\`\`
POST /api/reload {"html": "/etc/passwd"}
GET /  → returns contents of /etc/passwd
\`\`\`

Issue #672.

## Fix

Validate that the reload path resolves within the same directory as the original HTML file. Paths outside are rejected with 403. The agent only ever reloads variant files in the same output directory — legitimate use is unaffected.

---
*sent from [mStack](https://github.com/Gonzih)*