### PR TITLE
fix: add LEARNINGS_SEARCH + LEARNINGS_LOG to /codex skill

### DIFF
--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -537,6 +537,44 @@ If `NOT_FOUND`: stop and tell the user:
 
 ---
 
+## Prior Learnings
+
+Search for relevant learnings from previous sessions:
+
+```bash
+_CROSS_PROJ=$(~/.claude/skills/gstack/bin/gstack-config get cross_project_learnings 2>/dev/null || echo "unset")
+echo "CROSS_PROJECT: $_CROSS_PROJ"
+if [ "$_CROSS_PROJ" = "true" ]; then
+  ~/.claude/skills/gstack/bin/gstack-learnings-search --limit 10 --cross-project 2>/dev/null || true
+else
+  ~/.claude/skills/gstack/bin/gstack-learnings-search --limit 10 2>/dev/null || true
+fi
+```
+
+If `CROSS_PROJECT` is `unset` (first time): Use AskUserQuestion:
+
+> gstack can search learnings from your other projects on this machine to find
+> patterns that might apply here. This stays local (no data leaves your machine).
+> Recommended for solo developers. Skip if you work on multiple client codebases
+> where cross-contamination would be a concern.
+
+Options:
+- A) Enable cross-project learnings (recommended)
+- B) Keep learnings project-scoped only
+
+If A: run `~/.claude/skills/gstack/bin/gstack-config set cross_project_learnings true`
+If B: run `~/.claude/skills/gstack/bin/gstack-config set cross_project_learnings false`
+
+Then re-run the search with the appropriate flag.
+
+If learnings are found, incorporate them into your analysis. When a review finding
+matches a past learning, display:
+
+**"Prior learning applied: [key] (confidence N/10, from [date])"**
+
+This makes the compounding visible. The user should see that gstack is getting
+smarter on their codebase over time.
+
 ## Step 1: Detect mode
 
 Parse the user's input to determine which mode to run:
@@ -977,6 +1015,31 @@ If token count is not available, display: `Tokens: unknown`
 - **Session resume failure:** If resume fails, delete the session file and start fresh.
 
 ---
+
+## Capture Learnings
+
+If you discovered a non-obvious pattern, pitfall, or architectural insight during
+this session, log it for future sessions:
+
+```bash
+~/.claude/skills/gstack/bin/gstack-learnings-log '{"skill":"codex","type":"TYPE","key":"SHORT_KEY","insight":"DESCRIPTION","confidence":N,"source":"SOURCE","files":["path/to/relevant/file"]}'
+```
+
+**Types:** `pattern` (reusable approach), `pitfall` (what NOT to do), `preference`
+(user stated), `architecture` (structural decision), `tool` (library/framework insight),
+`operational` (project environment/CLI/workflow knowledge).
+
+**Sources:** `observed` (you found this in the code), `user-stated` (user told you),
+`inferred` (AI deduction), `cross-model` (both Claude and Codex agree).
+
+**Confidence:** 1-10. Be honest. An observed pattern you verified in the code is 8-9.
+An inference you're not sure about is 4-5. A user preference they explicitly stated is 10.
+
+**files:** Include the specific file paths this learning references. This enables
+staleness detection: if those files are later deleted, the learning can be flagged.
+
+**Only log genuine discoveries.** Don't log obvious things. Don't log things the user
+already knows. A good test: would this insight save time in a future session? If yes, log it.
 
 ## Important Rules
 

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -43,6 +43,8 @@ If `NOT_FOUND`: stop and tell the user:
 
 ---
 
+{{LEARNINGS_SEARCH}}
+
 ## Step 1: Detect mode
 
 Parse the user's input to determine which mode to run:
@@ -418,6 +420,8 @@ If token count is not available, display: `Tokens: unknown`
 - **Session resume failure:** If resume fails, delete the session file and start fresh.
 
 ---
+
+{{LEARNINGS_LOG}}
 
 ## Important Rules
 


### PR DESCRIPTION
## Summary

The `/codex` skill was the last major skill missing the gstack institutional memory integration. This adds `{{LEARNINGS_SEARCH}}` before mode detection and `{{LEARNINGS_LOG}}` at the end.

## Why it matters

In **consult mode** (`/codex <question>`), prior learnings about project architecture and known quirks can significantly improve what Codex produces. Without them, Codex starts cold on every invocation.

In **review mode** (`/codex review`), surfacing "this codebase has a recurring pattern of X" gives Codex useful context to focus its review on areas that have historically had problems.

The learnings system is one of gstack's most unique features — it's what makes the tools get smarter over time on a specific project. This PR ensures `/codex` participates in that loop.

## Test plan

- [x] `bun run gen:skill-docs` generates `codex/SKILL.md` without errors
- [x] Static skill validation passes
- [ ] Run `/codex consult "how does auth work here"` and verify learnings are surfaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)