### PR TITLE
fix(design-html): add missing <title>, meta description, and OG tags to HTML checklist

### DIFF
--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -764,6 +764,9 @@ For framework output, save to:
 - CSS custom properties for design tokens from DESIGN.md / Step 1 extraction
 - Google Fonts via `<link>` tags + `document.fonts.ready` gate before first `prepare()`
 - Semantic HTML5 (`<header>`, `<nav>`, `<main>`, `<section>`, `<footer>`)
+- `<title>` from the H1 or hero heading (50-60 chars)
+- `<meta name="description">` — one-sentence page summary (150-160 chars)
+- Open Graph (`og:title`, `og:description`, `og:type`) + `twitter:card` for social previews
 - Responsive behavior via Pretext relayout (not just media queries)
 - Breakpoint-specific adjustments at 375px, 768px, 1024px, 1440px
 - ARIA attributes, heading hierarchy, focus-visible states

--- a/design-html/SKILL.md.tmpl
+++ b/design-html/SKILL.md.tmpl
@@ -250,6 +250,9 @@ For framework output, save to:
 - CSS custom properties for design tokens from DESIGN.md / Step 1 extraction
 - Google Fonts via `<link>` tags + `document.fonts.ready` gate before first `prepare()`
 - Semantic HTML5 (`<header>`, `<nav>`, `<main>`, `<section>`, `<footer>`)
+- `<title>` from the H1 or hero heading (50-60 chars)
+- `<meta name="description">` — one-sentence page summary (150-160 chars)
+- Open Graph (`og:title`, `og:description`, `og:type`) + `twitter:card` for social previews
 - Responsive behavior via Pretext relayout (not just media queries)
 - Breakpoint-specific adjustments at 375px, 768px, 1024px, 1440px
 - ARIA attributes, heading hierarchy, focus-visible states


### PR DESCRIPTION
## Summary

The "Always include in vanilla HTML" checklist requires semantic HTML5, ARIA
attributes, and dark mode support — but omits `<title>`, `<meta description>`,
and Open Graph tags. Generated pages render correctly but have empty browser
tabs, blank social previews, and no search engine snippet.

This adds three items to the checklist, placed after the existing
"Semantic HTML5" line where they logically belong.

## Changes

- `<title>` derived from H1 or hero heading (50-60 chars)
- `<meta name="description">` — one-sentence page summary (150-160 chars)
- Open Graph (`og:title`, `og:description`, `og:type`) + `twitter:card`

## Verification

- `bun test` — 289 pass (1 pre-existing fail: package.json/VERSION mismatch)
- `--dry-run` freshness check — FRESH across all three hosts (claude, codex, factory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)