### PR TITLE
fix: user-friendly error when OpenAI org is not verified

### DIFF
--- a/design/src/generate.ts
+++ b/design/src/generate.ts
@@ -60,7 +60,14 @@ async function callImageGeneration(
 
     if (!response.ok) {
       const error = await response.text();
-      throw new Error(`API error (${response.status}): ${error}`);
+      if (response.status === 403 && error.includes("organization must be verified")) {
+        throw new Error(
+          "OpenAI organization verification required.\n"
+          + "Go to https://platform.openai.com/settings/organization to verify.\n"
+          + "After verification, wait up to 15 minutes for access to propagate.",
+        );
+      }
+      throw new Error(`API error (${response.status}): ${error.slice(0, 200)}`);
     }
 
     const data = await response.json() as any;


### PR DESCRIPTION
When a user's OpenAI org isn't verified, `$D generate` dumps the raw JSON error response — which includes a broken URL (`/settings/organization/general` returns 404). This detects the 403 + "organization must be verified" pattern and shows a clean message with the correct verification URL instead.

Also truncates the generic error fallback to 200 chars, matching `design-to-code.ts`, `iterate.ts`, and `evolve.ts` which already truncate.

### Before / After

![demo](https://vhs.charm.sh/vhs-7fiZtG5aDH8Mlc4ZC0RAYc.gif)

### Changes

- `design/src/generate.ts:61-64`: detect 403 org verification error, throw actionable message
- Truncate raw error to `.slice(0, 200)` on the generic fallback path

### Testing

`bun test` passes. No unit test added — triggering this error path requires an unverified OpenAI org. The E2E design tests run against real API and don't cover error responses.

This contribution was developed with AI assistance (Codex).

Fixes #718