### PR TITLE
fix: freeze boundary check silently blocks edits through symlinks

### DIFF
--- a/freeze/SKILL.md
+++ b/freeze/SKILL.md
@@ -46,9 +46,9 @@ Ask the user which directory to restrict edits to. Use AskUserQuestion:
 
 Once the user provides a directory path:
 
-1. Resolve it to an absolute path:
+1. Resolve it to an absolute path (including symlinks):
 ```bash
-FREEZE_DIR=$(cd "<user-provided-path>" 2>/dev/null && pwd)
+FREEZE_DIR=$(cd "<user-provided-path>" 2>/dev/null && pwd -P)
 echo "$FREEZE_DIR"
 ```
 

--- a/freeze/SKILL.md.tmpl
+++ b/freeze/SKILL.md.tmpl
@@ -45,9 +45,9 @@ Ask the user which directory to restrict edits to. Use AskUserQuestion:
 
 Once the user provides a directory path:
 
-1. Resolve it to an absolute path:
+1. Resolve it to an absolute path (including symlinks):
 ```bash
-FREEZE_DIR=$(cd "<user-provided-path>" 2>/dev/null && pwd)
+FREEZE_DIR=$(cd "<user-provided-path>" 2>/dev/null && pwd -P)
 echo "$FREEZE_DIR"
 ```
 

--- a/freeze/bin/check-freeze.sh
+++ b/freeze/bin/check-freeze.sh
@@ -52,11 +52,26 @@ esac
 FILE_PATH=$(printf '%s' "$FILE_PATH" | sed 's|/\+|/|g;s|/$||')
 
 # Resolve symlinks and .. sequences (POSIX-portable, works on macOS)
+# For directories (like FREEZE_DIR), cd into them and use pwd -P.
+# For files, resolve the parent directory and append the basename.
 _resolve_path() {
+  local _input="$1"
+
+  # If it's a directory, cd into it and resolve with pwd -P
+  if [ -d "$_input" ]; then
+    cd "$_input" 2>/dev/null && pwd -P && return 0
+  fi
+
+  # For non-directories or if cd failed, resolve component-by-component
   local _dir _base
-  _dir="$(dirname "$1")"
-  _base="$(basename "$1")"
-  _dir="$(cd "$_dir" 2>/dev/null && pwd -P || printf '%s' "$_dir")"
+  _dir="$(dirname "$_input")"
+  _base="$(basename "$_input")"
+
+  # If the parent directory exists and is accessible, resolve it
+  if [ -d "$_dir" ]; then
+    _dir="$(cd "$_dir" 2>/dev/null && pwd -P || printf '%s' "$_dir")"
+  fi
+
   printf '%s/%s' "$_dir" "$_base"
 }
 FILE_PATH=$(_resolve_path "$FILE_PATH")


### PR DESCRIPTION
## What
The `/freeze` skill's boundary check silently blocks legitimate edits when symlinks are involved. When a user sets the freeze boundary to a symlinked directory (e.g., `/home/user/project_link` → `/home/user/real_project`), attempting to edit a file accessed via the real path gets blocked with no warning.

## Why
Two root causes:
1. **Skill saves symlink paths unresolved:** Used `pwd` instead of `pwd -P`
2. **Hook doesn't fully resolve symlinks:** `_resolve_path()` left symlinks in final path component unresolved

## How
- **Commit 1:** Improved `_resolve_path()` in `freeze/bin/check-freeze.sh` to resolve symlinks by cd'ing into directories
- **Commit 2:** Changed `pwd` to `pwd -P` in skill, updated docs

## Testing
Verified: symlinked freeze boundaries now allow edits via the real path

## Notes
- Two-commit approach for clarity
- Backwards compatible; no breaking changes
- Defensive fix works with both old and new configs
