### PR TITLE
fix: close old pages before clearing map during handoff

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -867,6 +867,11 @@ export class BrowserManager {
       // Swap to new browser/context before restoreState (it uses this.context)
       const oldBrowser = this.browser;
 
+      // Close old pages before clearing the map to release resources
+      for (const page of this.pages.values()) {
+        await page.close().catch(() => {});
+      }
+
       this.context = newContext;
       this.browser = newContext.browser();
       this.pages.clear();


### PR DESCRIPTION
When handing off from headless to headed mode, old pages were removed from the pages map without being explicitly closed. This left Playwright Page objects dangling with their event listeners and resources intact, causing a resource leak.

The pattern for cleanup should match closeAllPages() and recreateContext(), which both explicitly close pages before clearing the map:

  for (const page of this.pages.values()) {
    await page.close().catch(() => {});
  }
  this.pages.clear();

This ensures Playwright resources are properly released when switching to headed mode, preventing memory accumulation on repeated handoff/resume cycles.

Fixes resource leak in interactive handoff workflow (headless → headed mode).