### PR TITLE
feat: /mingle — find collaborators without leaving your terminal

### DIFF
--- a/mingle/SKILL.md.tmpl
+++ b/mingle/SKILL.md.tmpl
@@ -1,0 +1,116 @@
+---
+name: mingle
+version: 0.1.0
+description: |
+  Find collaborators, co-founders, early users, and domain experts without leaving
+  your terminal. Describe what you're building and what kind of person would help,
+  then get matched with relevant people and request introductions.
+  Use when asked to "find people", "find a co-founder", "find collaborators",
+  "network", "mingle", "who's working on X", or "I need someone who".
+voice-triggers:
+  - "find me people"
+  - "I need a co-founder"
+  - "who else is building"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - AskUserQuestion
+
+---
+
+{{PREAMBLE}}
+
+# /mingle — Find collaborators without leaving your terminal
+
+You are a networking agent. Your job is to help the user find the right
+people for what they're building — co-founders, early users, designers,
+domain experts, security researchers, anyone who could help.
+
+## MCP Server
+
+This skill requires the Mingle MCP server. Check if it's configured:
+
+```bash
+grep -q "mingle" ~/.claude.json 2>/dev/null && echo "MINGLE_MCP: configured" || echo "MINGLE_MCP: not_configured"
+```
+
+If `not_configured`, tell the user to add this to their Claude Code MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "mingle": {
+      "type": "url",
+      "url": "https://mcp.aeoess.com/sse"
+    }
+  }
+}
+```
+
+No API key needed. Public network.
+
+## Workflow
+
+### Step 1: Understand what they need
+
+Ask the user two things:
+1. **What are you building?** — one sentence is enough
+2. **What kind of person would help most right now?**
+
+Don't overthink this. "Building a calendar app, need a designer" is plenty.
+
+### Step 2: Publish their intent
+
+Use the `publish_intent_card` MCP tool with their description and needs.
+Tell them their card is live and other builders can now find them.
+
+### Step 3: Search for matches
+
+Use the `search_matches` MCP tool. Present results as a short list:
+- **Name** and what they're building
+- **Why they match** — what they offer that the user needs
+- Keep it to 3-5 results. Quality over quantity.
+
+### Step 4: Request introductions
+
+If the user wants to connect with someone, use `request_intro` with
+a brief context message about why they want to connect. The other
+person decides whether to accept.
+
+### Step 5: Check incoming intros
+
+Use `get_digest` to check if anyone has reached out to the user.
+Show pending introductions and help them respond using `respond_to_intro`.
+
+### Step 6: Clean up
+
+If the user wants to stop being discoverable, use `remove_intent_card`.
+
+## Tone
+
+Direct and efficient. This is a terminal tool for builders, not a
+social media experience. No small talk about networking strategy.
+Find the right people fast.
+
+## Available MCP tools
+
+| Tool | What it does |
+|------|-------------|
+| `publish_intent_card` | Put yourself on the network with what you're building and what you need |
+| `search_matches` | Find people relevant to your project |
+| `request_intro` | Reach out to a match with context |
+| `respond_to_intro` | Accept or decline an incoming introduction |
+| `get_digest` | Check what's new — matches, intros, responses |
+| `remove_intent_card` | Take yourself off the network |
+| `rate_connection` | Rate a connection you made (helps improve matching) |
+
+## Session end
+
+Summarize what happened:
+- Card published (yes/no)
+- Matches found (count)
+- Intros sent / received
+- Next steps
+
+Save a brief log to `~/.gstack/mingle/session-$(date +%Y%m%d-%H%M%S).md`.


### PR DESCRIPTION
## What

A `/mingle` skill that lets developers find collaborators, co-founders, early users, and domain experts without leaving the terminal.

## Why

gstack covers the full build lifecycle from idea to deployment. The one thing it doesn't cover: finding people. A co-founder, a first customer, a designer who gets it, a security researcher to break your stuff.

Right now that means leaving the terminal for LinkedIn, Twitter DMs, cold emails, Discord. This skill keeps you in the flow.

## How it works

```
You: /mingle
Claude: What are you building and what kind of person would help most?
You: Building a local-first calendar app. Need a designer who's done mobile.
Claude: [Searches the Mingle network]
       Found 3 relevant people:
       1. @sarah — designer, shipped 2 iOS apps, looking for a technical co-founder
       2. @james — full-stack, built a calendar tool, looking for design collaborators
       3. @priya — mobile designer, exploring side projects

       Want to request an intro to any of them?
You: Intro to sarah
Claude: Done. Sarah will see your project description and decide whether to connect.
```

## Implementation

Wraps the [Mingle](https://aeoess.com/mingle.html) intent-matching network via MCP. The user adds the MCP server URL to their Claude Code config (no API key, public network). The skill calls 7 MCP tools: `publish_intent_card`, `search_matches`, `request_intro`, `respond_to_intro`, `get_digest`, `remove_intent_card`, `rate_connection`.

Same pattern as other gstack skills — structured conversation that produces a real outcome (introductions, not just advice).

## Files

- `mingle/SKILL.md.tmpl` — skill template (SKILL.md needs generation via `bun run gen:skill-docs`)
