### PR TITLE
feat: integrate code health trends into /retro metrics

### DIFF
--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -625,7 +625,11 @@ git log origin/<default> --since="<window>" --oneline --grep="test(qa):" --grep=
 # 12. gstack skill usage telemetry (if available)
 cat ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
-# 12. Test files changed in window
+# 13. Code health history (if available)
+eval "$(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)" 2>/dev/null || true
+cat ~/.gstack/projects/${SLUG:-unknown}/health-history.jsonl 2>/dev/null | tail -20 || true
+
+# 14. Test files changed in window
 git log origin/<default> --since="<window>" --format="" --name-only | grep -E '\.(test|spec)\.' | sort -u | wc -l
 ```
 
@@ -648,6 +652,7 @@ Calculate and present these metrics in a summary table:
 | Detected sessions | N |
 | Avg LOC/session-hour | N |
 | Greptile signal | N% (Y catches, Z FPs) |
+| Code Health | X.X/10 (↑/↓ ±Y.Y) · Details if change |
 | Test Health | N total tests · M added this period · K regression tests |
 
 Then show a **per-author leaderboard** immediately below:
@@ -698,6 +703,38 @@ If moments exist, list them:
 ```
 
 If the JSONL file doesn't exist or has no entries in the window, skip the Eureka Moments row.
+
+**Code Health (if history exists):** Read health-history.jsonl (fetched in Step 1, command 13). Filter entries by `ts` field within the retro window. Use `branch` field to match the current branch.
+
+- **If no entries exist in the window or file doesn't exist:** Skip the Code Health metric row.
+- **If 1 entry exists in the window:** Show "Code Health | X.X/10 · First measurement this period"
+- **If 2+ entries exist:**
+  - Current score = last entry in the window
+  - Prior score = last entry BEFORE the retro window (could be from prior period)
+  - Delta = current.score - prior.score
+  - Trend = if delta ≥ 0 then "↑" else "↓"
+  - Status = if delta > 0.5 then "IMPROVING", if delta < -0.5 then "DECLINING", else "STABLE"
+
+Include in the metrics table:
+```
+| Code Health | X.X/10 (↑ +Y.Y) STABLE |
+```
+
+**If regression detected (current.score < prior.score by more than 0.5):**
+Show a second detail line listing which categories declined:
+```
+| | Lint -2 (8→6, 12 new warnings), Tests -1 (10→9) |
+```
+
+For each category that declined, show the previous and current scores and cite the specific issue count if available.
+
+**If data shows improvement (current.score > prior.score by more than 0.5):**
+Show a detail line highlighting which categories improved:
+```
+| | Lint +2 (6→8), Shell clean (+1) |
+```
+
+**Important:** Only show the detail line if the total score changed by >0.5 points. If the score is stable (within ±0.5), omit the detail line. Frame regressions objectively — this is data, not blame.
 
 ### Step 3: Commit Time Distribution
 

--- a/retro/SKILL.md.tmpl
+++ b/retro/SKILL.md.tmpl
@@ -113,7 +113,11 @@ git log origin/<default> --since="<window>" --oneline --grep="test(qa):" --grep=
 # 12. gstack skill usage telemetry (if available)
 cat ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
-# 12. Test files changed in window
+# 13. Code health history (if available)
+eval "$(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)" 2>/dev/null || true
+cat ~/.gstack/projects/${SLUG:-unknown}/health-history.jsonl 2>/dev/null | tail -20 || true
+
+# 14. Test files changed in window
 git log origin/<default> --since="<window>" --format="" --name-only | grep -E '\.(test|spec)\.' | sort -u | wc -l
 ```
 
@@ -136,6 +140,7 @@ Calculate and present these metrics in a summary table:
 | Detected sessions | N |
 | Avg LOC/session-hour | N |
 | Greptile signal | N% (Y catches, Z FPs) |
+| Code Health | X.X/10 (↑/↓ ±Y.Y) · Details if change |
 | Test Health | N total tests · M added this period · K regression tests |
 
 Then show a **per-author leaderboard** immediately below:
@@ -186,6 +191,38 @@ If moments exist, list them:
 ```
 
 If the JSONL file doesn't exist or has no entries in the window, skip the Eureka Moments row.
+
+**Code Health (if history exists):** Read health-history.jsonl (fetched in Step 1, command 13). Filter entries by `ts` field within the retro window. Use `branch` field to match the current branch.
+
+- **If no entries exist in the window or file doesn't exist:** Skip the Code Health metric row.
+- **If 1 entry exists in the window:** Show "Code Health | X.X/10 · First measurement this period"
+- **If 2+ entries exist:**
+  - Current score = last entry in the window
+  - Prior score = last entry BEFORE the retro window (could be from prior period)
+  - Delta = current.score - prior.score
+  - Trend = if delta ≥ 0 then "↑" else "↓"
+  - Status = if delta > 0.5 then "IMPROVING", if delta < -0.5 then "DECLINING", else "STABLE"
+
+Include in the metrics table:
+```
+| Code Health | X.X/10 (↑ +Y.Y) STABLE |
+```
+
+**If regression detected (current.score < prior.score by more than 0.5):**
+Show a second detail line listing which categories declined:
+```
+| | Lint -2 (8→6, 12 new warnings), Tests -1 (10→9) |
+```
+
+For each category that declined, show the previous and current scores and cite the specific issue count if available.
+
+**If data shows improvement (current.score > prior.score by more than 0.5):**
+Show a detail line highlighting which categories improved:
+```
+| | Lint +2 (6→8), Shell clean (+1) |
+```
+
+**Important:** Only show the detail line if the total score changed by >0.5 points. If the score is stable (within ±0.5), omit the detail line. Frame regressions objectively — this is data, not blame.
 
 ### Step 3: Commit Time Distribution
 


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2>
<p>This PR adds a <strong>Code Health</strong> metric row to the <code>/retro</code> retrospective that displays code quality trends from the <code>/health</code> skill. Users now see quality scores alongside commit velocity, revealing when a sprint shipped fast but degraded code health.</p>
<h3>Metric Display</h3>
<p>The metric shows:</p>
<ul>
<li><strong>Current health score</strong> (0-10 composite score from <code>/health</code> skill)</li>
<li><strong>Trend</strong> (↑/↓) comparing current vs. prior run</li>
<li><strong>Status</strong> (IMPROVING/STABLE/DECLINING) based on &gt;0.5 point threshold</li>
<li><strong>Regression details</strong> when categories decline (e.g., "Lint -2 (8→6, 12 new warnings), Tests -1 (10→9)")</li>
</ul>
<hr>
<h2>Problem</h2>
<p>The design document (<a href="https://claude.ai/chat/docs/designs/SELF_LEARNING_V0.md">SESSION_INTELLIGENCE.md</a>) established that <code>/health</code> should write structured code quality data to <code>health-history.jsonl</code> and <code>/retro</code> should consume it for trend analysis. However, <code>/retro</code> was computing "Test Health" from raw test file counts instead of reading the persistent health history, so the infrastructure was incomplete.</p>
<h3>What's Fixed</h3>
<p>A team shipping 500 LOC with +23 type errors, +15 lint warnings, and -2 broken tests now sees this in <code>/retro</code>:</p>
<pre><code>| Code Health | 6.8/10 (↓ -1.2 from 3d ago) [REGRESSION] |
|             | Lint -2 (8→6), Tests -1 (10→9)           |
</code></pre>
<p>Previously they'd only see the commit count and have to run <code>/health</code> separately to discover the quality regression. Quality regressions are now surfaced in the narrative where velocity is discussed.</p>
<hr>
<h2>Implementation</h2>
<h3>Step 1: Data Collection</h3>
<p>Added <code>health-history.jsonl</code> fetch in Step 1 (command 13) using the existing slug infrastructure.</p>
<h3>Step 2: Metric Computation</h3>
<p>Added a new "Code Health (if history exists)" subsection that:</p>
<ul>
<li>Filters health history entries by <code>ts</code> (retro window) and <code>branch</code> (current branch)</li>
<li>Computes current score, prior score, and delta (current - prior)</li>
<li>Determines status:
<ul>
<li><code>&gt;0.5</code> delta → <strong>IMPROVING</strong></li>
<li><code>&lt;-0.5</code> delta → <strong>DECLINING</strong></li>
<li>Otherwise → <strong>STABLE</strong></li>
</ul>
</li>
<li>Generates a detail line only if change exceeds ±0.5 threshold</li>
<li>Lists which categories declined/improved with specific score transitions</li>
</ul>
<h3>Metrics Table Output</h3>
<p>The table now includes one row displaying the health score and trend:</p>

Scenario | Output
-- | --
Stable health | \| Code Health \| 8.2/10 (↑ +0.3) STABLE \|
Improvement | \| Code Health \| 8.5/10 (↑ +0.8) IMPROVING \| Lint clean (+2) \|
Regression | \| Code Health \| 7.1/10 (↓ -1.0) DECLINING \| Lint -2, Tests -1 \|


<p><strong>Graceful fallback:</strong> If no prior data or first run of <code>/health</code>, the row is skipped gracefully.</p>
<hr>
<h2>Testing</h2>
<ul>
<li>[x] Run <code>/health</code> to generate <code>~/.gstack/projects/$SLUG/health-history.jsonl</code></li>
<li>[x] Run <code>/retro</code> — verify new "Code Health" row appears in metrics table</li>
<li>[x] Make a change that introduces lint warnings</li>
<li>[x] Run <code>/health</code> again</li>
<li>[x] Run <code>/retro</code> — verify Code Health row shows the delta and status change</li>
<li>[x] Verify metric is skipped gracefully when <code>health-history.jsonl</code> doesn't exist</li>
<li>[x] Verify detail lines only appear when delta &gt;0.5 points</li>
</ul>
<hr>
<h2>Notes for Reviewers</h2>
<ul>
<li><strong>Purely additive</strong> — no existing metric or logic was changed</li>
<li><strong>Consistent pattern</strong> — follows the same pattern as existing optional metrics (Greptile, Backlog, Eureka)</li>
<li><strong>No new dependencies</strong> — uses existing infrastructure (<code>gstack-slug</code>, JSONL filtering)</li>
<li><strong>Branch-aware</strong> — respects branch filtering via the <code>branch</code> field in <code>health-history.jsonl</code> so <code>/retro</code> on feature branches shows correct trends</li>
<li><strong>Reduced noise</strong> — detail lines only appear when delta &gt;0.5 to reduce noise for stable codebases</li>
<li><strong>Objective framing</strong> — regressions are framed objectively ("Lint -2") without blame language</li>
</ul></body></html>