### PR TITLE
fix: make Codex browse runtime work on Windows

### DIFF
--- a/browse/bin/find-browse
+++ b/browse/bin/find-browse
@@ -5,15 +5,25 @@ DIR="$(cd "$(dirname "$0")/.." && pwd)/dist"
 if test -x "$DIR/find-browse"; then
   exec "$DIR/find-browse" "$@"
 fi
+if test -x "$DIR/find-browse.exe"; then
+  exec "$DIR/find-browse.exe" "$@"
+fi
 # Fallback: basic discovery with priority chain
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if test "$(uname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')" = "mingw64_nt" || \
+   test "$(uname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')" = "mingw32_nt" || \
+   test "$(uname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')" = "msys_nt"; then
+  BROWSE_BIN="browse.exe"
+else
+  BROWSE_BIN="browse"
+fi
 for MARKER in .codex .agents .claude; do
-  if [ -n "$ROOT" ] && test -x "$ROOT/$MARKER/skills/gstack/browse/dist/browse"; then
-    echo "$ROOT/$MARKER/skills/gstack/browse/dist/browse"
+  if [ -n "$ROOT" ] && test -x "$ROOT/$MARKER/skills/gstack/browse/dist/$BROWSE_BIN"; then
+    echo "$ROOT/$MARKER/skills/gstack/browse/dist/$BROWSE_BIN"
     exit 0
   fi
-  if test -x "$HOME/$MARKER/skills/gstack/browse/dist/browse"; then
-    echo "$HOME/$MARKER/skills/gstack/browse/dist/browse"
+  if test -x "$HOME/$MARKER/skills/gstack/browse/dist/$BROWSE_BIN"; then
+    echo "$HOME/$MARKER/skills/gstack/browse/dist/$BROWSE_BIN"
     exit 0
   fi
 done

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -49,7 +49,7 @@ export function resolveServerScript(
   );
 }
 
-const SERVER_SCRIPT = resolveServerScript();
+const SERVER_SCRIPT = IS_WINDOWS ? null : resolveServerScript();
 
 /**
  * On Windows, resolve the Node.js-compatible server bundle.
@@ -240,7 +240,7 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'] });
   } else {
     // macOS/Linux: Bun.spawn + unref works correctly
-    proc = Bun.spawn(['bun', 'run', SERVER_SCRIPT], {
+    proc = Bun.spawn(['bun', 'run', SERVER_SCRIPT!], {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env, BROWSE_STATE_FILE: config.stateFile, ...extraEnv },
     });

--- a/browse/src/find-browse.ts
+++ b/browse/src/find-browse.ts
@@ -9,6 +9,8 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
+const BROWSE_BIN = process.platform === 'win32' ? 'browse.exe' : 'browse';
+
 // ─── Binary Discovery ───────────────────────────────────────────
 
 function getGitRoot(): string | null {
@@ -32,14 +34,14 @@ export function locateBinary(): string | null {
   // Workspace-local takes priority (for development)
   if (root) {
     for (const m of markers) {
-      const local = join(root, m, 'skills', 'gstack', 'browse', 'dist', 'browse');
+      const local = join(root, m, 'skills', 'gstack', 'browse', 'dist', BROWSE_BIN);
       if (existsSync(local)) return local;
     }
   }
 
   // Global fallback
   for (const m of markers) {
-    const global = join(home, m, 'skills', 'gstack', 'browse', 'dist', 'browse');
+    const global = join(home, m, 'skills', 'gstack', 'browse', 'dist', BROWSE_BIN);
     if (existsSync(global)) return global;
   }
 

--- a/browse/test/config.test.ts
+++ b/browse/test/config.test.ts
@@ -195,6 +195,11 @@ describe('resolveServerScript', () => {
     expect(() => resolveServerScript({}, '/nonexistent/$bunfs', '/nonexistent/browse'))
       .toThrow('Cannot find server.ts');
   });
+
+  test('Windows startup does not eagerly resolve server.ts at module load', () => {
+    const src = require('fs').readFileSync(require('path').join(__dirname, '../src/cli.ts'), 'utf-8');
+    expect(src).toContain('const SERVER_SCRIPT = IS_WINDOWS ? null : resolveServerScript();');
+  });
 });
 
 describe('resolveNodeServerScript', () => {

--- a/browse/test/find-browse.test.ts
+++ b/browse/test/find-browse.test.ts
@@ -42,6 +42,11 @@ describe('locateBinary', () => {
     expect(agentsIdx).toBeLessThan(claudeIdx);
   });
 
+  test('Windows discovery uses .exe browse binaries', () => {
+    const src = require('fs').readFileSync(require('path').join(__dirname, '../src/find-browse.ts'), 'utf-8');
+    expect(src).toContain("process.platform === 'win32' ? 'browse.exe' : 'browse'");
+  });
+
   test('function signature accepts no arguments', () => {
     // locateBinary should be callable with no arguments
     expect(typeof locateBinary).toBe('function');

--- a/setup
+++ b/setup
@@ -484,6 +484,9 @@ create_codex_runtime_root() {
   if [ -d "$gstack_dir/bin" ]; then
     ln -snf "$gstack_dir/bin" "$codex_gstack/bin"
   fi
+  if [ -d "$gstack_dir/node_modules" ]; then
+    ln -snf "$gstack_dir/node_modules" "$codex_gstack/node_modules"
+  fi
   if [ -d "$gstack_dir/browse/dist" ]; then
     ln -snf "$gstack_dir/browse/dist" "$codex_gstack/browse/dist"
   fi

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2060,6 +2060,7 @@ describe('setup script validation', () => {
     const fnEnd = setupContent.indexOf('}', setupContent.indexOf('done', setupContent.indexOf('review/', fnStart)));
     const fnBody = setupContent.slice(fnStart, fnEnd);
     expect(fnBody).toContain('gstack/SKILL.md');
+    expect(fnBody).toContain('node_modules');
     expect(fnBody).toContain('browse/dist');
     expect(fnBody).toContain('browse/bin');
     expect(fnBody).toContain('gstack-upgrade/SKILL.md');


### PR DESCRIPTION
## Summary
- avoid eagerly resolving `server.ts` on Windows when the Node bundle path is used
- expose `node_modules` in the Codex runtime root so the Windows Node bundle can resolve runtime deps
- teach `find-browse` to locate `browse.exe` / `find-browse.exe` on Windows
- add regression coverage for the Windows-specific runtime and binary discovery paths

## Repro
1. On Windows, run the documented global Codex install flow:
   - `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack`
   - `cd ~/gstack && ./setup --host codex`
2. Run `~/.codex/skills/gstack/browse/dist/browse status`
3. Before this patch, the install could fail early because:
   - `cli.ts` resolves `server.ts` eagerly even on Windows
   - the Codex runtime root exposes `browse/dist` but not `node_modules`
   - `find-browse` only looks for `browse`, not `browse.exe`

## Fix
- make `SERVER_SCRIPT` lazy on Windows so the Node path does not require `browse/src/server.ts`
- link `node_modules` into `~/.codex/skills/gstack` so `server-node.mjs` can resolve `playwright` / `diff`
- prefer `.exe` binaries in the Windows locator / shim paths

## Validation
- `bun test browse/test/config.test.ts browse/test/find-browse.test.ts`
- smoke-tested a minimal Codex runtime root on Windows: startup now reaches Playwright launch instead of failing on missing `server.ts` / `server-node.mjs` path resolution