### PR TITLE
Add gstack skill documentation and guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,3 +36,9 @@ The active skill lives at `~/.claude/skills/gstack/`. After making changes:
 3. Rebuild: `cd ~/.claude/skills/gstack && bun run build`
 
 Or copy the binary directly: `cp browse/dist/browse ~/.claude/skills/gstack/browse/dist/browse`
+
+## gstack
+
+Use the `/browse` skill from gstack for all web browsing. Never use `mcp__claude-in-chrome__*` tools.
+
+Available skills: `/office-hours`, `/plan-ceo-review`, `/plan-eng-review`, `/plan-design-review`, `/design-consultation`, `/design-shotgun`, `/design-html`, `/review`, `/ship`, `/land-and-deploy`, `/canary`, `/benchmark`, `/browse`, `/connect-chrome`, `/qa`, `/qa-only`, `/design-review`, `/setup-browser-cookies`, `/setup-deploy`, `/retro`, `/investigate`, `/document-release`, `/codex`, `/cso`, `/autoplan`, `/plan-devex-review`, `/devex-review`, `/careful`, `/freeze`, `/guard`, `/unfreeze`, `/gstack-upgrade`, `/learn`


### PR DESCRIPTION
## Summary
Added documentation to CLAUDE.md clarifying the gstack skill system and providing guidance on web browsing tool usage.

## Changes
- Added a new "gstack" section to CLAUDE.md with instructions to use the `/browse` skill for all web browsing tasks
- Documented that `mcp__claude-in-chrome__*` tools should not be used
- Provided a comprehensive list of all available gstack skills for reference

## Details
This documentation update helps users understand the proper way to interact with web browsing capabilities through the gstack skill system, ensuring consistent tool usage across the codebase.

https://claude.ai/code/session_01MmqcYxes4AFU4BEaYnCic2