### PR TITLE
fix(design): bind server to localhost and validate reload paths

### DIFF
--- a/design/src/serve.ts
+++ b/design/src/serve.ts
@@ -33,19 +33,21 @@
  */
 
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { spawn } from "child_process";
 
 export interface ServeOptions {
   html: string;
   port?: number;
+  hostname?: string; // default '127.0.0.1' — localhost only
   timeout?: number; // seconds, default 600 (10 min)
 }
 
 type ServerState = "serving" | "regenerating" | "done";
 
 export async function serve(options: ServeOptions): Promise<void> {
-  const { html, port = 0, timeout = 600 } = options;
+  const { html, port = 0, hostname = '127.0.0.1', timeout = 600 } = options;
 
   // Validate HTML file exists
   if (!fs.existsSync(html)) {
@@ -59,6 +61,7 @@ export async function serve(options: ServeOptions): Promise<void> {
 
   const server = Bun.serve({
     port,
+    hostname,
     fetch(req) {
       const url = new URL(req.url);
 
@@ -179,6 +182,17 @@ export async function serve(options: ServeOptions): Promise<void> {
       return Response.json(
         { error: `HTML file not found: ${newHtmlPath}` },
         { status: 400 }
+      );
+    }
+
+    // Validate path is within cwd or temp directory
+    const resolved = path.resolve(newHtmlPath);
+    const safeDirs = [process.cwd(), os.tmpdir()];
+    const isSafe = safeDirs.some(dir => resolved.startsWith(dir + path.sep) || resolved === dir);
+    if (!isSafe) {
+      return Response.json(
+        { error: `Path must be within working directory or temp` },
+        { status: 403 }
       );
     }
 


### PR DESCRIPTION
The design comparison board server binds to all interfaces with no authentication. The /api/reload endpoint reads arbitrary files from disk and serves them via GET /.

Tested: started the server, POSTed {"html":"/etc/hosts"} to /api/reload, fetched / and got the file contents. After the fix, the reload returns 403 for paths outside cwd/tmp and the server only listens on 127.0.0.1.

Changes:
- Added hostname to ServeOptions with default '127.0.0.1' (matching browse server pattern at server.ts:1042)
- Added path validation to /api/reload (cwd and tmpdir only)