### PR TITLE
docs: add uninstall instructions to README (#801)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,59 @@ Or target a specific agent with `./setup --host <name>`:
 **Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).
 It's one TypeScript config file, zero code changes.
 
+## Uninstall
+
+### Option 1: Run the uninstall script
+
+If gstack is installed on your machine:
+
+```bash
+~/.claude/skills/gstack/bin/gstack-uninstall
+```
+
+This handles skills, symlinks, global state (`~/.gstack/`), project-local state, browse daemons, and temp files. Use `--keep-state` to preserve config and analytics. Use `--force` to skip confirmation.
+
+### Option 2: Manual removal (no local repo)
+
+If you don't have the repo cloned (e.g. you installed via a Claude Code paste and later deleted the clone):
+
+```bash
+# 1. Stop browse daemons
+pkill -f "gstack.*browse" 2>/dev/null || true
+
+# 2. Remove per-skill symlinks pointing into gstack/
+find ~/.claude/skills -maxdepth 1 -type l 2>/dev/null | while read -r link; do
+  case "$(readlink "$link" 2>/dev/null)" in gstack/*|*/gstack/*) rm -f "$link" ;; esac
+done
+
+# 3. Remove gstack
+rm -rf ~/.claude/skills/gstack
+
+# 4. Remove global state
+rm -rf ~/.gstack
+
+# 5. Remove integrations (skip any you never installed)
+rm -rf ~/.codex/skills/gstack* 2>/dev/null
+rm -rf ~/.factory/skills/gstack* 2>/dev/null
+rm -rf ~/.kiro/skills/gstack* 2>/dev/null
+rm -rf ~/.openclaw/skills/gstack* 2>/dev/null
+
+# 6. Remove temp files
+rm -f /tmp/gstack-* 2>/dev/null
+
+# 7. Per-project cleanup (run from each project root)
+rm -rf .gstack .gstack-worktrees .claude/skills/gstack 2>/dev/null
+rm -rf .agents/skills/gstack* .factory/skills/gstack* 2>/dev/null
+```
+
+### Clean up CLAUDE.md
+
+The uninstall script does not edit CLAUDE.md. In each project where gstack was added, remove the `## gstack` and `## Skill routing` sections.
+
+### Playwright
+
+`~/Library/Caches/ms-playwright/` (macOS) is left in place because other tools may share it. Remove it if nothing else needs it.
+
 ## See it work
 
 ```


### PR DESCRIPTION
## Summary

- Adds an **Uninstall** section to README.md between install instructions and "See it work"
- Covers two paths: the `gstack-uninstall` script for users with a local clone, and step-by-step manual removal for users without one
- Notes CLAUDE.md cleanup (not handled by the script) and Playwright cache

Closes #801

## Context

Issue #801 reports that users who installed gstack via a Claude Code paste (without cloning the repo locally) have no way to find uninstall instructions. The manual removal steps were verified against the actual `bin/gstack-uninstall` script to ensure nothing is missed.

## What the manual steps cover

1. Stop browse daemons
2. Remove per-skill symlinks (`~/.claude/skills/{name} -> gstack/...`)
3. Remove `~/.claude/skills/gstack`
4. Remove `~/.gstack/` (global state)
5. Remove Codex/Factory/Kiro/OpenClaw integrations
6. Clean up `/tmp/gstack-*`
7. Per-project state (`.gstack/`, `.gstack-worktrees/`, `.claude/skills/gstack`, `.agents/skills/gstack*`)