### PR TITLE
fix(bin): pass search params via env vars instead of string interpolation

### DIFF
--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -43,13 +43,14 @@ if [ ${#FILES[@]} -eq 0 ]; then
 fi
 
 # Process all files through bun for JSON parsing, decay, dedup, filtering
-cat "${FILES[@]}" 2>/dev/null | bun -e "
+GSTACK_SEARCH_TYPE="$TYPE" GSTACK_SEARCH_QUERY="$QUERY" GSTACK_SEARCH_LIMIT="$LIMIT" GSTACK_SEARCH_SLUG="$SLUG" \
+cat "${FILES[@]}" 2>/dev/null | GSTACK_SEARCH_TYPE="$TYPE" GSTACK_SEARCH_QUERY="$QUERY" GSTACK_SEARCH_LIMIT="$LIMIT" GSTACK_SEARCH_SLUG="$SLUG" bun -e "
 const lines = (await Bun.stdin.text()).trim().split('\n').filter(Boolean);
 const now = Date.now();
-const type = '${TYPE}';
-const query = '${QUERY}'.toLowerCase();
-const limit = ${LIMIT};
-const slug = '${SLUG}';
+const type = process.env.GSTACK_SEARCH_TYPE || '';
+const query = (process.env.GSTACK_SEARCH_QUERY || '').toLowerCase();
+const limit = parseInt(process.env.GSTACK_SEARCH_LIMIT || '10', 10);
+const slug = process.env.GSTACK_SEARCH_SLUG || '';
 
 const entries = [];
 for (const line of lines) {


### PR DESCRIPTION
--query and --type values are interpolated directly into a bun -e JavaScript string (line 49-52 of gstack-learnings-search). A crafted query breaks out of the string literal and executes arbitrary code.

Tested before fix:
  gstack-learnings-search --query "'; require('child_process').execSync('echo RCE > /tmp/poc'); //"
  Result: /tmp/poc created with content "RCE"

Tested after fix: same payload, /tmp/poc not created. Normal queries return results correctly.

Change: replaced shell string interpolation with environment variables (process.env).