### PR TITLE
fix(browse): add symlink resolution to meta-commands validateOutputPath

### DIFF
--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -15,11 +15,31 @@ import { resolveConfig } from './config';
 import type { Frame } from 'playwright';
 
 // Security: Path validation to prevent path traversal attacks
-const SAFE_DIRECTORIES = [TEMP_DIR, process.cwd()];
+// Must match the hardened version in write-commands.ts (symlink resolution)
+// Resolve safe directories through realpathSync to handle symlinks (e.g., macOS /tmp → /private/tmp)
+const SAFE_DIRECTORIES = [TEMP_DIR, process.cwd()].map(d => {
+  try { return fs.realpathSync(d); } catch { return d; }
+});
 
 export function validateOutputPath(filePath: string): void {
   const resolved = path.resolve(filePath);
-  const isSafe = SAFE_DIRECTORIES.some(dir => isPathWithin(resolved, dir));
+
+  // Resolve real path of the parent directory to catch symlinks.
+  // The file itself may not exist yet (e.g., screenshot output).
+  let dir = path.dirname(resolved);
+  let realDir: string;
+  try {
+    realDir = fs.realpathSync(dir);
+  } catch {
+    try {
+      realDir = fs.realpathSync(path.dirname(dir));
+    } catch {
+      throw new Error(`Path must be within: ${SAFE_DIRECTORIES.join(', ')}`);
+    }
+  }
+
+  const realResolved = path.join(realDir, path.basename(resolved));
+  const isSafe = SAFE_DIRECTORIES.some(dir => isPathWithin(realResolved, dir));
   if (!isSafe) {
     throw new Error(`Path must be within: ${SAFE_DIRECTORIES.join(', ')}`);
   }


### PR DESCRIPTION
The security wave patched validateOutputPath in write-commands.ts with realpathSync symlink resolution, but meta-commands.ts has a separate copy that was not patched. Affects screenshot, pdf, and responsive commands.

Tested before fix:
  ln -s /outside/dir /tmp/escape
  validateOutputPath('/tmp/escape/test.png') -> ACCEPTED

Tested after fix:
  Same symlink -> BLOCKED
  Normal /tmp/test.png -> ACCEPTED
  Relative ./test.png -> ACCEPTED

Change: added realpathSync on parent directory and resolved safe directories, matching the pattern in write-commands.ts.