### PR TITLE
fix: make bin root detection CDPATH-safe

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -11,7 +11,7 @@
 #        bin/dev-teardown    # clean up
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." >/dev/null && pwd)"
 
 # 1. Copy .env from main worktree (if we're a worktree and don't have one)
 if [ ! -f "$REPO_ROOT/.env" ]; then

--- a/bin/dev-teardown
+++ b/bin/dev-teardown
@@ -2,7 +2,7 @@
 # Remove local dev skill symlinks. Restores global gstack as the active install.
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." >/dev/null && pwd)"
 
 removed=()
 

--- a/bin/gstack-community-dashboard
+++ b/bin/gstack-community-dashboard
@@ -10,7 +10,7 @@
 #   GSTACK_SUPABASE_ANON_KEY      — override Supabase anon key
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 
 # Source Supabase config if not overridden by env
 if [ -z "${GSTACK_SUPABASE_URL:-}" ] && [ -f "$GSTACK_DIR/supabase/config.sh" ]; then

--- a/bin/gstack-telemetry-log
+++ b/bin/gstack-telemetry-log
@@ -17,7 +17,7 @@
 # NOTE: Uses set -uo pipefail (no -e) — telemetry must never exit non-zero
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 ANALYTICS_DIR="$STATE_DIR/analytics"
 JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"

--- a/bin/gstack-telemetry-sync
+++ b/bin/gstack-telemetry-sync
@@ -11,7 +11,7 @@
 #   GSTACK_SUPABASE_URL        — override Supabase project URL
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 ANALYTICS_DIR="$STATE_DIR/analytics"
 JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"

--- a/bin/gstack-uninstall
+++ b/bin/gstack-uninstall
@@ -36,7 +36,7 @@ if [ -z "${HOME:-}" ]; then
   exit 1
 fi
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 _GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 

--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -12,7 +12,7 @@
 #   GSTACK_STATE_DIR    — override ~/.gstack state directory
 set -euo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 CACHE_FILE="$STATE_DIR/last-update-check"
 MARKER_FILE="$STATE_DIR/just-upgraded-from"


### PR DESCRIPTION
## Summary
- make all affected `bin/` scripts suppress `cd` stdout while resolving `GSTACK_DIR`
- prevent `CDPATH` from injecting an extra path line into `$(cd ... && pwd)` command substitutions and corrupting downstream file paths
- cover the most user-visible path (`gstack-update-check`) with a manual reproduction that now succeeds under `CDPATH`

Fixes #824.

## Testing
- `bash -n bin/dev-setup bin/dev-teardown bin/gstack-community-dashboard bin/gstack-telemetry-log bin/gstack-telemetry-sync bin/gstack-uninstall bin/gstack-update-check`
- `tmpdir=$(mktemp -d) && printf '999.0.0\n' > "$tmpdir/VERSION" && export CDPATH='.:/tmp' && export GSTACK_STATE_DIR="$tmpdir/state" && export GSTACK_REMOTE_URL="file://$tmpdir/VERSION" && bin/gstack-update-check --force`