### PR TITLE
fix: make all 18 bin/ scripts CDPATH-safe

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -11,7 +11,7 @@
 #        bin/dev-teardown    # clean up
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." >/dev/null && pwd)"
 
 # 1. Copy .env from main worktree (if we're a worktree and don't have one)
 if [ ! -f "$REPO_ROOT/.env" ]; then

--- a/bin/dev-teardown
+++ b/bin/dev-teardown
@@ -2,7 +2,7 @@
 # Remove local dev skill symlinks. Restores global gstack as the active install.
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." >/dev/null && pwd)"
 
 removed=()
 

--- a/bin/gstack-community-dashboard
+++ b/bin/gstack-community-dashboard
@@ -10,7 +10,7 @@
 #   GSTACK_SUPABASE_ANON_KEY      — override Supabase anon key
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 
 # Source Supabase config if not overridden by env
 if [ -z "${GSTACK_SUPABASE_URL:-}" ] && [ -f "$GSTACK_DIR/supabase/config.sh" ]; then

--- a/bin/gstack-extension
+++ b/bin/gstack-extension
@@ -6,7 +6,7 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Find the extension directory

--- a/bin/gstack-learnings-log
+++ b/bin/gstack-learnings-log
@@ -5,7 +5,7 @@
 # Append-only storage. Duplicates (same key+type) are resolved at read time
 # by gstack-learnings-search ("latest winner" per key+type).
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -6,7 +6,7 @@
 # resolves duplicates (latest winner per key+type), and outputs formatted text.
 # Exit 0 silently if no learnings file exists.
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 

--- a/bin/gstack-platform-detect
+++ b/bin/gstack-platform-detect
@@ -4,7 +4,7 @@ set -euo pipefail
 # gstack-platform-detect: show which AI coding agents are installed and gstack status
 # Config-driven: reads host definitions from hosts/*.ts via host-config-export.ts
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null && pwd)"
 GSTACK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 printf "%-16s %-10s %-40s %s\n" "Agent" "Version" "Skill Path" "gstack"

--- a/bin/gstack-relink
+++ b/bin/gstack-relink
@@ -10,7 +10,7 @@
 #   GSTACK_SKILLS_DIR  — override target skills directory
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null && pwd)"
 GSTACK_CONFIG="${SCRIPT_DIR}/gstack-config"
 
 # Detect install dir

--- a/bin/gstack-repo-mode
+++ b/bin/gstack-repo-mode
@@ -11,7 +11,7 @@
 # Cache:    ~/.gstack/projects/$SLUG/repo-mode.json (7-day TTL)
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null && pwd)"
 # Compute SLUG directly (avoid eval of gstack-slug — branch names can contain shell metacharacters)
 REMOTE_URL=$(git remote get-url origin 2>/dev/null || true)
 if [ -z "$REMOTE_URL" ]; then

--- a/bin/gstack-review-log
+++ b/bin/gstack-review-log
@@ -2,7 +2,7 @@
 # gstack-review-log — atomically log a review result
 # Usage: gstack-review-log '{"skill":"...","timestamp":"...","status":"..."}'
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-review-read
+++ b/bin/gstack-review-read
@@ -2,7 +2,7 @@
 # gstack-review-read — read review log and config for dashboard
 # Usage: gstack-review-read
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 cat "$GSTACK_HOME/projects/$SLUG/$BRANCH-reviews.jsonl" 2>/dev/null || echo "NO_REVIEWS"

--- a/bin/gstack-specialist-stats
+++ b/bin/gstack-specialist-stats
@@ -6,7 +6,7 @@
 # and outputs hit rates. Tags specialists as GATE_CANDIDATE (0 findings in 10+
 # dispatches) or NEVER_GATE (security, data-migration — insurance policy).
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 PROJECT_DIR="$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-telemetry-log
+++ b/bin/gstack-telemetry-log
@@ -17,7 +17,7 @@
 # NOTE: Uses set -uo pipefail (no -e) — telemetry must never exit non-zero
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 ANALYTICS_DIR="$STATE_DIR/analytics"
 JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"

--- a/bin/gstack-telemetry-sync
+++ b/bin/gstack-telemetry-sync
@@ -11,7 +11,7 @@
 #   GSTACK_SUPABASE_URL        — override Supabase project URL
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 ANALYTICS_DIR="$STATE_DIR/analytics"
 JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"

--- a/bin/gstack-timeline-log
+++ b/bin/gstack-timeline-log
@@ -7,7 +7,7 @@
 # Optional: branch, outcome, duration_s, session, ts.
 # Validation failure → skip silently (non-blocking).
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-timeline-read
+++ b/bin/gstack-timeline-read
@@ -6,7 +6,7 @@
 # Reads ~/.gstack/projects/$SLUG/timeline.jsonl, filters, formats.
 # Exit 0 silently if no timeline file exists.
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 

--- a/bin/gstack-uninstall
+++ b/bin/gstack-uninstall
@@ -36,7 +36,7 @@ if [ -z "${HOME:-}" ]; then
   exit 1
 fi
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 _GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 

--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -12,7 +12,7 @@
 #   GSTACK_STATE_DIR    — override ~/.gstack state directory
 set -euo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 CACHE_FILE="$STATE_DIR/last-update-check"
 MARKER_FILE="$STATE_DIR/just-upgraded-from"


### PR DESCRIPTION
## Summary

- Suppress `cd` stdout in all 18 affected `bin/` scripts to prevent `CDPATH` from corrupting path resolution
- Uses `>/dev/null` redirect on `cd` in `$(cd ... && pwd)` patterns
- Covers all scripts listed in #824, not just a subset

## Root cause

When `CDPATH` is set (common with zsh users, zoxide, or custom navigation), `cd` prints the resolved path to stdout. This doubles the output of `$(cd ... && pwd)`, corrupting `GSTACK_DIR`, `SCRIPT_DIR`, and `REPO_ROOT` assignments. Most visibly, `gstack-update-check` silently exits because `VERSION_FILE` becomes a two-line string.

## Fix

```bash
# Before (broken with CDPATH):
GSTACK_DIR="$(cd "$(dirname "$0")/.." && pwd)"

# After (works with any CDPATH):
GSTACK_DIR="$(cd "$(dirname "$0")/.." >/dev/null && pwd)"
```

## All 18 scripts fixed

dev-setup, dev-teardown, gstack-community-dashboard, gstack-extension, gstack-learnings-log, gstack-learnings-search, gstack-platform-detect, gstack-relink, gstack-repo-mode, gstack-review-log, gstack-review-read, gstack-specialist-stats, gstack-telemetry-log, gstack-telemetry-sync, gstack-timeline-log, gstack-timeline-read, gstack-uninstall, gstack-update-check.

## Testing

```bash
bash -n bin/dev-setup bin/dev-teardown bin/gstack-community-dashboard \
  bin/gstack-extension bin/gstack-learnings-log bin/gstack-learnings-search \
  bin/gstack-platform-detect bin/gstack-relink bin/gstack-repo-mode \
  bin/gstack-review-log bin/gstack-review-read bin/gstack-specialist-stats \
  bin/gstack-telemetry-log bin/gstack-telemetry-sync bin/gstack-timeline-log \
  bin/gstack-timeline-read bin/gstack-uninstall bin/gstack-update-check
```

All 18 pass syntax check. Fix verified with `CDPATH='.:/tmp'` set.

Note: PR #836 fixes 7 of 18 scripts. This PR covers all 18.

Fixes #824