### PR TITLE
fix(security): add symlink resolution to meta-commands validateOutputPath

### DIFF
--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -19,9 +19,32 @@ const SAFE_DIRECTORIES = [TEMP_DIR, process.cwd()];
 
 export function validateOutputPath(filePath: string): void {
   const resolved = path.resolve(filePath);
+
+  // Lexical containment check: catches obvious traversal (../../../etc/passwd)
   const isSafe = SAFE_DIRECTORIES.some(dir => isPathWithin(resolved, dir));
   if (!isSafe) {
     throw new Error(`Path must be within: ${SAFE_DIRECTORIES.join(', ')}`);
+  }
+
+  // Symlink check: resolve the real path of the nearest existing ancestor
+  // directory and re-validate. Closes the symlink bypass where a symlink
+  // inside /tmp or cwd points outside the safe zone.
+  let dir = path.dirname(resolved);
+  let realDir: string;
+  try {
+    realDir = fs.realpathSync(dir);
+  } catch {
+    try {
+      realDir = fs.realpathSync(path.dirname(dir));
+    } catch {
+      throw new Error(`Path must be within: ${SAFE_DIRECTORIES.join(', ')}`);
+    }
+  }
+
+  const realResolved = path.join(realDir, path.basename(resolved));
+  const isRealSafe = SAFE_DIRECTORIES.some(dir => isPathWithin(realResolved, dir));
+  if (!isRealSafe) {
+    throw new Error(`Path must be within: ${SAFE_DIRECTORIES.join(', ')} (symlink target blocked)`);
   }
 }
 

--- a/browse/test/path-validation.test.ts
+++ b/browse/test/path-validation.test.ts
@@ -33,6 +33,16 @@ describe('validateOutputPath', () => {
   it('blocks path traversal via ..', () => {
     expect(() => validateOutputPath('/tmp/../etc/passwd')).toThrow(/Path must be within/);
   });
+
+  it('blocks symlink inside safe dir pointing outside', () => {
+    const linkPath = join(tmpdir(), 'test-output-symlink-' + Date.now());
+    try {
+      symlinkSync('/etc', linkPath);
+      expect(() => validateOutputPath(join(linkPath, 'passwd'))).toThrow(/Path must be within/);
+    } finally {
+      try { unlinkSync(linkPath); } catch {}
+    }
+  });
 });
 
 describe('validateReadPath', () => {


### PR DESCRIPTION
## Summary

`meta-commands.ts:validateOutputPath` only performed lexical `path.resolve` checking, while `write-commands.ts:validateOutputPath` had a full symlink resolution step added in PR #640 (security audit round 2). A symlink inside `/tmp` pointing outside the safe zone would pass `meta-commands` validation but be blocked by `write-commands`.

This brings `meta-commands.ts:validateOutputPath` to parity with `write-commands.ts:validateOutputPath`.

## The vulnerability

```bash
# Create a symlink inside /tmp pointing to /etc
ln -s /etc /tmp/escape-hatch

# meta-commands validateOutputPath passes: /tmp/escape-hatch/passwd resolves
# lexically to /tmp/escape-hatch/passwd which IS within /tmp
# But the real path is /etc/passwd which is NOT within /tmp
```

Commands using `meta-commands.validateOutputPath` (screenshot, pdf, responsive) would allow writing to paths outside the safe zone via symlinks.

## Fix

Added symlink resolution (identical to the existing `write-commands.ts` implementation):
1. Resolve the real path of the nearest existing ancestor directory via `fs.realpathSync`
2. Re-validate the real path against safe directories
3. Fail closed if resolution fails

## Testing

Added regression test: creates a symlink inside `/tmp` pointing to `/etc`, verifies `validateOutputPath` blocks `join(linkPath, 'passwd')`.

Follows the exact same test pattern as the existing `validateReadPath` symlink test (line 67-75 of `path-validation.test.ts`).

Fixes #707