### PR TITLE
Fix cookie-import path validation bypass + hardcoded /tmp

### DIFF
--- a/browse/src/cookie-import-browser.ts
+++ b/browse/src/cookie-import-browser.ts
@@ -386,7 +386,8 @@ function openDb(dbPath: string, browserName: string): Database {
 }
 
 function openDbFromCopy(dbPath: string, browserName: string): Database {
-  const tmpPath = `/tmp/browse-cookies-${browserName.toLowerCase()}-${crypto.randomUUID()}.db`;
+  // Use os.tmpdir() instead of hardcoded /tmp for cross-platform support (#708)
+  const tmpPath = path.join(os.tmpdir(), `browse-cookies-${browserName.toLowerCase()}-${crypto.randomUUID()}.db`);
   try {
     fs.copyFileSync(dbPath, tmpPath);
     // Also copy WAL and SHM if they exist (for consistent reads)

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -455,16 +455,17 @@ export async function handleWriteCommand(
     case 'cookie-import': {
       const filePath = args[0];
       if (!filePath) throw new Error('Usage: browse cookie-import <json-file>');
-      // Path validation — prevent reading arbitrary files
-      if (path.isAbsolute(filePath)) {
-        const safeDirs = [TEMP_DIR, process.cwd()];
-        const resolved = path.resolve(filePath);
-        if (!safeDirs.some(dir => isPathWithin(resolved, dir))) {
-          throw new Error(`Path must be within: ${safeDirs.join(', ')}`);
-        }
+      // Path validation — resolve to absolute and check against safe dirs.
+      // Fixes #707: relative paths previously bypassed the safe directory check.
+      // Mirrors validateOutputPath() — resolves symlinks (e.g., macOS /tmp → /private/tmp).
+      const resolved = path.resolve(filePath);
+      let resolvedReal = resolved;
+      try { resolvedReal = fs.realpathSync(resolved); } catch {
+        // File may not exist yet — resolve parent dir instead
+        try { resolvedReal = path.join(fs.realpathSync(path.dirname(resolved)), path.basename(resolved)); } catch {}
       }
-      if (path.normalize(filePath).includes('..')) {
-        throw new Error('Path traversal sequences (..) are not allowed');
+      if (!SAFE_DIRECTORIES.some(dir => isPathWithin(resolvedReal, dir))) {
+        throw new Error(`Path must be within: ${SAFE_DIRECTORIES.join(', ')}`);
       }
       if (!fs.existsSync(filePath)) throw new Error(`File not found: ${filePath}`);
       const raw = fs.readFileSync(filePath, 'utf-8');

--- a/browse/test/commands.test.ts
+++ b/browse/test/commands.test.ts
@@ -1805,7 +1805,8 @@ describe('Path traversal prevention', () => {
       await handleWriteCommand('cookie-import', ['../../etc/shadow'], bm);
       expect(true).toBe(false);
     } catch (err: any) {
-      expect(err.message).toContain('Path traversal');
+      // Traversal blocked by safe-directory check (#707) or explicit .. check
+      expect(err.message).toMatch(/Path must be within|Path traversal/);
     }
   });
 


### PR DESCRIPTION
## Summary

Two security/portability fixes in the browse cookie-import command.

### #707 — Path validation bypass via relative paths

**Before:** Relative paths like `../../etc/shadow` bypassed the safe-directory check because `path.isAbsolute()` gated the entire validation block. Only the `..` pattern check ran for relative paths, but a relative path without `..` (e.g., `sensitive-file.json` in an unexpected cwd) passed through completely.

**After:** Always `path.resolve()` to absolute, then resolve symlinks (matching `validateOutputPath()`), then check against `SAFE_DIRECTORIES`. No separate code paths for relative vs absolute.

### #708 — Hardcoded `/tmp` in cookie-import-browser.ts

**Before:** `openDbFromCopy()` hardcoded `/tmp/browse-cookies-...`. On Windows, `/tmp` may not exist.

**After:** Uses `path.join(os.tmpdir(), ...)`. The `os` module was already imported.

## Test Plan

- [x] All 224 browse tests pass (`bun test browse/test/`)
- [x] Path validation tests: 29 pass
- [x] Cookie import tests: 22 pass
- [x] Traversal test updated to accept both error messages

Fixes #707, fixes #708