### PR TITLE
Fix CDPATH breaking all bin/ scripts + fragile JSON stripping via sed

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -11,7 +11,7 @@
 #        bin/dev-teardown    # clean up
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
 
 # 1. Copy .env from main worktree (if we're a worktree and don't have one)
 if [ ! -f "$REPO_ROOT/.env" ]; then

--- a/bin/dev-teardown
+++ b/bin/dev-teardown
@@ -2,7 +2,7 @@
 # Remove local dev skill symlinks. Restores global gstack as the active install.
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
 
 removed=()
 

--- a/bin/gstack-community-dashboard
+++ b/bin/gstack-community-dashboard
@@ -10,7 +10,7 @@
 #   GSTACK_SUPABASE_ANON_KEY      — override Supabase anon key
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(CDPATH= cd "$(dirname "$0")/.." && pwd)}"
 
 # Source Supabase config if not overridden by env
 if [ -z "${GSTACK_SUPABASE_URL:-}" ] && [ -f "$GSTACK_DIR/supabase/config.sh" ]; then

--- a/bin/gstack-extension
+++ b/bin/gstack-extension
@@ -6,7 +6,7 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Find the extension directory

--- a/bin/gstack-learnings-log
+++ b/bin/gstack-learnings-log
@@ -5,7 +5,7 @@
 # Append-only storage. Duplicates (same key+type) are resolved at read time
 # by gstack-learnings-search ("latest winner" per key+type).
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -6,7 +6,7 @@
 # resolves duplicates (latest winner per key+type), and outputs formatted text.
 # Exit 0 silently if no learnings file exists.
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 

--- a/bin/gstack-platform-detect
+++ b/bin/gstack-platform-detect
@@ -4,7 +4,7 @@ set -euo pipefail
 # gstack-platform-detect: show which AI coding agents are installed and gstack status
 # Config-driven: reads host definitions from hosts/*.ts via host-config-export.ts
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 GSTACK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 printf "%-16s %-10s %-40s %s\n" "Agent" "Version" "Skill Path" "gstack"

--- a/bin/gstack-relink
+++ b/bin/gstack-relink
@@ -10,7 +10,7 @@
 #   GSTACK_SKILLS_DIR  — override target skills directory
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 GSTACK_CONFIG="${SCRIPT_DIR}/gstack-config"
 
 # Detect install dir

--- a/bin/gstack-repo-mode
+++ b/bin/gstack-repo-mode
@@ -11,7 +11,7 @@
 # Cache:    ~/.gstack/projects/$SLUG/repo-mode.json (7-day TTL)
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 # Compute SLUG directly (avoid eval of gstack-slug — branch names can contain shell metacharacters)
 REMOTE_URL=$(git remote get-url origin 2>/dev/null || true)
 if [ -z "$REMOTE_URL" ]; then

--- a/bin/gstack-review-log
+++ b/bin/gstack-review-log
@@ -2,7 +2,7 @@
 # gstack-review-log — atomically log a review result
 # Usage: gstack-review-log '{"skill":"...","timestamp":"...","status":"..."}'
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-review-read
+++ b/bin/gstack-review-read
@@ -2,7 +2,7 @@
 # gstack-review-read — read review log and config for dashboard
 # Usage: gstack-review-read
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 cat "$GSTACK_HOME/projects/$SLUG/$BRANCH-reviews.jsonl" 2>/dev/null || echo "NO_REVIEWS"

--- a/bin/gstack-specialist-stats
+++ b/bin/gstack-specialist-stats
@@ -6,7 +6,7 @@
 # and outputs hit rates. Tags specialists as GATE_CANDIDATE (0 findings in 10+
 # dispatches) or NEVER_GATE (security, data-migration — insurance policy).
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 PROJECT_DIR="$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-telemetry-log
+++ b/bin/gstack-telemetry-log
@@ -17,7 +17,7 @@
 # NOTE: Uses set -uo pipefail (no -e) — telemetry must never exit non-zero
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(CDPATH= cd "$(dirname "$0")/.." && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 ANALYTICS_DIR="$STATE_DIR/analytics"
 JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"

--- a/bin/gstack-telemetry-sync
+++ b/bin/gstack-telemetry-sync
@@ -11,7 +11,7 @@
 #   GSTACK_SUPABASE_URL        — override Supabase project URL
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(CDPATH= cd "$(dirname "$0")/.." && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 ANALYTICS_DIR="$STATE_DIR/analytics"
 JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"
@@ -78,16 +78,15 @@ while IFS= read -r LINE; do
   [ -z "$LINE" ] && continue
   echo "$LINE" | grep -q '^{' || continue
 
-  # Strip local-only fields (keep v, ts, sessions as-is for edge function)
-  CLEAN="$(echo "$LINE" | sed \
-    -e 's/,"_repo_slug":"[^"]*"//g' \
-    -e 's/,"_branch":"[^"]*"//g' \
-    -e 's/,"repo":"[^"]*"//g')"
-
-  # If anonymous tier, strip installation_id
-  if [ "$TIER" = "anonymous" ]; then
-    CLEAN="$(echo "$CLEAN" | sed 's/,"installation_id":"[^"]*"//g; s/,"installation_id":null//g')"
-  fi
+  # Strip local-only fields using proper JSON parsing (#710)
+  # sed-based field stripping breaks on escaped quotes and edge positioning
+  STRIP_FIELDS='_repo_slug,_branch,repo'
+  [ "$TIER" = "anonymous" ] && STRIP_FIELDS="$STRIP_FIELDS,installation_id"
+  CLEAN="$(echo "$LINE" | bun -e "
+    const o = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+    for (const k of '${STRIP_FIELDS}'.split(',')) delete o[k];
+    process.stdout.write(JSON.stringify(o));
+  " 2>/dev/null || echo "$LINE")"
 
   if [ "$FIRST" = "true" ]; then
     FIRST=false

--- a/bin/gstack-timeline-log
+++ b/bin/gstack-timeline-log
@@ -7,7 +7,7 @@
 # Optional: branch, outcome, duration_s, session, ts.
 # Validation failure → skip silently (non-blocking).
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-timeline-read
+++ b/bin/gstack-timeline-read
@@ -6,7 +6,7 @@
 # Reads ~/.gstack/projects/$SLUG/timeline.jsonl, filters, formats.
 # Exit 0 silently if no timeline file exists.
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 

--- a/bin/gstack-uninstall
+++ b/bin/gstack-uninstall
@@ -36,7 +36,7 @@ if [ -z "${HOME:-}" ]; then
   exit 1
 fi
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(CDPATH= cd "$(dirname "$0")/.." && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 _GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 

--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -12,7 +12,7 @@
 #   GSTACK_STATE_DIR    — override ~/.gstack state directory
 set -euo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(CDPATH= cd "$(dirname "$0")/.." && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 CACHE_FILE="$STATE_DIR/last-update-check"
 MARKER_FILE="$STATE_DIR/just-upgraded-from"

--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-GSTACK_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+GSTACK_DIR="$(CDPATH= cd "$(dirname "$0")/../.." && pwd)"
 SRC_DIR="$GSTACK_DIR/browse/src"
 DIST_DIR="$GSTACK_DIR/browse/dist"
 

--- a/scripts/app/gstack-browser
+++ b/scripts/app/gstack-browser
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 
 # Detect mode: .app bundle or dev
 if [ -d "$SCRIPT_DIR/../Resources" ]; then

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 APP_NAME="GStack Browser"
 BUNDLE_ID="com.gstack.browser"

--- a/setup
+++ b/setup
@@ -14,8 +14,8 @@ if ! command -v bun >/dev/null 2>&1; then
   exit 1
 fi
 
-INSTALL_GSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
-SOURCE_GSTACK_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+INSTALL_GSTACK_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+SOURCE_GSTACK_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd -P)"
 INSTALL_SKILLS_DIR="$(dirname "$INSTALL_GSTACK_DIR")"
 BROWSE_BIN="$SOURCE_GSTACK_DIR/browse/dist/browse"
 CODEX_SKILLS="$HOME/.codex/skills"

--- a/supabase/verify-rls.sh
+++ b/supabase/verify-rls.sh
@@ -10,7 +10,7 @@
 #   bash supabase/verify-rls.sh
 set -uo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/config.sh"
 
 URL="$GSTACK_SUPABASE_URL"


### PR DESCRIPTION
## Summary

### #824 — CDPATH breaks all bin/ scripts

Every shell script uses `SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"` to find its location. When `CDPATH` is set (common in power-user dotfiles), `cd` prints the target directory to stdout, prepending garbage to the captured path.

**Fix:** `CDPATH= cd` — unsets CDPATH for the subshell. Standard POSIX fix.

**23 files** across `bin/`, `scripts/`, `browse/scripts/`, `setup`, `supabase/`.

### #710 — Fragile JSON manipulation via sed in telemetry sync

`gstack-telemetry-sync` stripped JSON fields using sed patterns like `s/,"_repo_slug":"[^"]*"//g`. This breaks on:
- Values containing escaped quotes (`\"`)
- Fields in first position (no leading comma)
- Nested objects as values

**Fix:** Replace with `bun -e` JSON.parse/delete/stringify. Falls back to the original line on parse failure. Bun is guaranteed available.

## Test Plan

- [x] CDPATH fix verified: `CDPATH="/usr:/var" SCRIPT_DIR="$(CDPATH= cd ... && pwd)"` returns correct path
- [x] JSON stripping verified: input with `_repo_slug`, `_branch`, `repo` fields correctly stripped
- [x] Fallback on invalid JSON verified: original line preserved

Fixes #824, fixes #710