### PR TITLE
Remove redundant chmod -R on /tmp + avoid body buffering for response size

### DIFF
--- a/.github/docker/Dockerfile.ci
+++ b/.github/docker/Dockerfile.ci
@@ -59,5 +59,4 @@ RUN useradd -m -s /bin/bash runner \
     && chmod -R a+rX /opt/node_modules_cache \
     && mkdir -p /home/runner/.gstack && chown -R runner:runner /home/runner/.gstack \
     && chmod 1777 /tmp \
-    && mkdir -p /home/runner/.bun && chown -R runner:runner /home/runner/.bun \
-    && chmod -R 1777 /tmp
+    && mkdir -p /home/runner/.bun && chown -R runner:runner /home/runner/.bun

--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -1140,14 +1140,14 @@ export class BrowserManager {
       }
     });
 
-    // Capture response sizes via response finished
+    // Capture response sizes via content-length header (#711)
+    // Avoids buffering entire response body (videos, images, downloads)
     page.on('requestfinished', async (req) => {
       try {
         const res = await req.response();
         if (res) {
           const url = req.url();
-          const body = await res.body().catch(() => null);
-          const size = body ? body.length : 0;
+          const size = parseInt(res.headers()['content-length'] || '0', 10);
           for (let i = networkBuffer.length - 1; i >= 0; i--) {
             const entry = networkBuffer.get(i);
             if (entry && entry.url === url && !entry.size) {


### PR DESCRIPTION
## Summary

### #709 — Docker: chmod -R 1777 /tmp sets sticky bit on files

Line 61 of Dockerfile.ci correctly does `chmod 1777 /tmp`. Line 63 redundantly does `chmod -R 1777 /tmp`, recursively applying the sticky bit to all files inside /tmp (meaningless on Linux files, confusing).

**Fix:** Remove the redundant line 63.

### #711 — Performance: res.body() buffers entire response for size

The `requestfinished` handler called `await res.body()` on every completed request to measure `body.length`. For large assets (videos, images, downloads), this buffers the entire response into memory unnecessarily.

**Fix:** Read `content-length` header instead — zero memory allocation, same metric quality. Falls back to 0 for chunked/missing headers (acceptable for a size metric).

## Test Plan

- [x] browser-manager unit tests pass (2/2)
- [x] Dockerfile syntax verified

Fixes #709, fixes #711