### PR TITLE
Add .ainative/ to .gitignore for host output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bin/gstack-global-discover
 .gstack/
 .claude/skills/
 .agents/
+.ainative/
 .factory/
 .kiro/
 .opencode/


### PR DESCRIPTION
## Summary

The AINative Studio host config generates skills into `.ainative/skills/`. This directory was missing from `.gitignore`, causing untracked files after `bun run gen:skill-docs --host ainative`.

All other host output directories are already covered: `.agents/`, `.factory/`, `.kiro/`, `.opencode/`, `.slate/`, `.cursor/`, `.openclaw/`.

## Test Plan

- [x] `git status` clean after generating AINative host skills
- [x] Other host dirs still properly ignored

Refs #840