### PR TITLE
Add uninstall link to install section + NO FINDINGS sanity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Open Claude Code and paste this. Claude does the rest.
 
 > Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.
 
+**To uninstall:** `~/.claude/skills/gstack/bin/gstack-uninstall` — or see [Uninstall](#uninstall) for manual steps if you no longer have the repo locally.
+
 ### Step 2: Team mode — auto-update for shared repos (recommended)
 
 Every developer installs globally, updates happen automatically:

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -1054,6 +1054,13 @@ For each specialist's output:
 2. Otherwise, parse each line as a JSON object. Skip lines that are not valid JSON.
 3. Collect all parsed findings into a single list, tagged with their specialist name.
 
+**Sanity check — all specialists returned NO FINDINGS (#839):**
+If EVERY specialist returned "NO FINDINGS" (zero parsed findings from all subagents), pause and verify before proceeding:
+1. Confirm the diff is non-empty: `git diff $(git merge-base HEAD main)..HEAD --stat` should show changed files
+2. Confirm the specialist subagents received the diff (check their output for file paths)
+3. If the diff is non-trivial (>50 lines changed) and all specialists found nothing, warn the user:
+   "All specialists returned NO FINDINGS on a non-trivial diff. This may indicate a configuration issue (wrong branch, empty diff, or skills not reading files). Proceeding with clean result — verify manually if unexpected."
+
 **Fingerprint and deduplicate:**
 For each finding, compute its fingerprint:
 - If `fingerprint` field is present, use it

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -1835,6 +1835,13 @@ For each specialist's output:
 2. Otherwise, parse each line as a JSON object. Skip lines that are not valid JSON.
 3. Collect all parsed findings into a single list, tagged with their specialist name.
 
+**Sanity check — all specialists returned NO FINDINGS (#839):**
+If EVERY specialist returned "NO FINDINGS" (zero parsed findings from all subagents), pause and verify before proceeding:
+1. Confirm the diff is non-empty: `git diff $(git merge-base HEAD main)..HEAD --stat` should show changed files
+2. Confirm the specialist subagents received the diff (check their output for file paths)
+3. If the diff is non-trivial (>50 lines changed) and all specialists found nothing, warn the user:
+   "All specialists returned NO FINDINGS on a non-trivial diff. This may indicate a configuration issue (wrong branch, empty diff, or skills not reading files). Proceeding with clean result — verify manually if unexpected."
+
 **Fingerprint and deduplicate:**
 For each finding, compute its fingerprint:
 - If `fingerprint` field is present, use it


### PR DESCRIPTION
## Summary

### #801 — Add uninstall steps to README

The install section now includes a one-line uninstall reference right after the install command:

> **To uninstall:** `~/.claude/skills/gstack/bin/gstack-uninstall` — or see [Uninstall](#uninstall) for manual steps if you no longer have the repo locally.

The existing Uninstall section (with full manual steps) is already comprehensive — this just makes it discoverable from the install section where new users land.

### #839 — Post-review sanity check when all specialists return NO FINDINGS

Added to both `review/SKILL.md` and `ship/SKILL.md`:

When ALL specialist subagents return "NO FINDINGS", the review now:
1. Verifies the diff is non-empty (`git diff --stat`)
2. Confirms specialists received the diff (checks output for file paths)
3. Warns the user if diff is non-trivial (>50 lines) — may indicate wrong branch, empty diff, or skills not reading files

This catches silent misconfiguration without blocking legitimately clean reviews.

## Test Plan

- [x] README uninstall link renders correctly (anchor to existing section)
- [x] Sanity check logic is consistent between review/SKILL.md and ship/SKILL.md
- [x] Check only triggers when ALL specialists return NO FINDINGS (not when some do)

Fixes #801, fixes #839