### PR TITLE
fix: skip parent-process watchdog in headed mode

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -705,6 +705,9 @@ const idleCheckInterval = setInterval(() => {
 const BROWSE_PARENT_PID = parseInt(process.env.BROWSE_PARENT_PID || '0', 10);
 if (BROWSE_PARENT_PID > 0) {
   setInterval(() => {
+    // Headed mode: the user is looking at the browser. Don't kill it
+    // just because the CLI command that launched it has exited.
+    if (browserManager.getConnectionMode() === 'headed') return;
     try {
       process.kill(BROWSE_PARENT_PID, 0); // signal 0 = existence check only, no signal sent
     } catch {


### PR DESCRIPTION
## Problem

When using `$B connect` (headed mode), the browse server crashes after ~15 seconds, closing the browser window unexpectedly.

## Root Cause

The Parent-Process Watchdog in `browse/src/server.ts` (line 706-715) polls the parent PID every 15 seconds and shuts down the server when the spawning CLI process exits. This is correct behavior for headless mode, but in headed mode the user has explicitly connected to a visible browser - the server should stay alive regardless of what happens to the CLI command that launched it.

The idle check (line 690-698) already has a headed-mode guard:

```typescript
if (browserManager.getConnectionMode() === 'headed') return;
```

But the parent-process watchdog was missing this same guard.

## Fix

Add a headed-mode check to the parent-process watchdog, matching the existing pattern used in the idle check:

```typescript
if (browserManager.getConnectionMode() === 'headed') return;
```

This skips the parent PID existence check when in headed mode, so the server stays alive until the user explicitly disconnects or closes the browser window.

## Testing

Tested and confirmed working - headed browser no longer closes after 15 seconds when the launching CLI command exits.