### PR TITLE
fix(bin): pass settings path and hook command via env vars

### DIFF
--- a/bin/gstack-settings-hook
+++ b/bin/gstack-settings-hook
@@ -26,10 +26,10 @@ fi
 
 case "$ACTION" in
   add)
-    bun -e "
+    GSTACK_SETTINGS_PATH="$SETTINGS_FILE" GSTACK_HOOK_CMD="$HOOK_CMD" bun -e "
       const fs = require('fs');
-      const settingsPath = '$SETTINGS_FILE';
-      const hookCmd = $(printf '%s' "$HOOK_CMD" | bun -e "process.stdout.write(JSON.stringify(require('fs').readFileSync('/dev/stdin','utf8')))");
+      const settingsPath = process.env.GSTACK_SETTINGS_PATH;
+      const hookCmd = process.env.GSTACK_HOOK_CMD;
 
       let settings = {};
       try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch {}
@@ -55,9 +55,9 @@ case "$ACTION" in
     ;;
   remove)
     [ -f "$SETTINGS_FILE" ] || exit 0
-    bun -e "
+    GSTACK_SETTINGS_PATH="$SETTINGS_FILE" bun -e "
       const fs = require('fs');
-      const settingsPath = '$SETTINGS_FILE';
+      const settingsPath = process.env.GSTACK_SETTINGS_PATH;
 
       let settings = {};
       try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch { process.exit(0); }

--- a/bin/gstack-team-init
+++ b/bin/gstack-team-init
@@ -139,9 +139,9 @@ HOOK_EOF
 
   # Add hook to project-level settings.json
   if command -v bun >/dev/null 2>&1; then
-    bun -e "
+    GSTACK_SETTINGS_PATH="$SETTINGS" bun -e "
       const fs = require('fs');
-      const settingsPath = '$SETTINGS';
+      const settingsPath = process.env.GSTACK_SETTINGS_PATH;
 
       let settings = {};
       try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch {}


### PR DESCRIPTION
## What

Replace direct shell variable interpolation inside `bun -e` scripts with
environment variables read via `process.env` in `gstack-team-init` and
`gstack-settings-hook`.

## Why

Same pattern fixed in #819 (gstack-learnings-search): shell variables
interpolated into JavaScript string literals allow paths containing quotes
to break the string context.

A settings path like `/tmp/it's-a-test/settings.json` produces:
```js
const settingsPath = '/tmp/it's-a-test/settings.json';
//                              ^ JS parse error here
```

Environment variables are read as-is by `process.env` without shell
interpretation.

## Files

- `bin/gstack-team-init`: `$SETTINGS` → `process.env.GSTACK_SETTINGS_PATH`
- `bin/gstack-settings-hook`: `$SETTINGS_FILE` → `process.env.GSTACK_SETTINGS_PATH`, `$HOOK_CMD` → `process.env.GSTACK_HOOK_CMD`