### PR TITLE
fix(design): restrict session file permissions to owner-only

### DIFF
--- a/design/src/session.ts
+++ b/design/src/session.ts
@@ -49,7 +49,7 @@ export function createSession(
     updatedAt: new Date().toISOString(),
   };
 
-  fs.writeFileSync(sessionPath(id), JSON.stringify(session, null, 2));
+  fs.writeFileSync(sessionPath(id), JSON.stringify(session, null, 2), { mode: 0o600 });
   return session;
 }
 
@@ -75,5 +75,5 @@ export function updateSession(
   session.outputPaths.push(outputPath);
   session.updatedAt = new Date().toISOString();
 
-  fs.writeFileSync(sessionPath(session.id), JSON.stringify(session, null, 2));
+  fs.writeFileSync(sessionPath(session.id), JSON.stringify(session, null, 2), { mode: 0o600 });
 }


### PR DESCRIPTION
## What

Add `{ mode: 0o600 }` to both `writeFileSync` calls in `design/src/session.ts`.

## Why

Design session files are written to `/tmp` without restricted permissions. Default umask (typically 0644) makes them world-readable on shared systems. Sessions contain `originalBrief` and `feedbackHistory` with user design prompts and iteration data.

The rest of the codebase uses `mode: 0o600` for sensitive file writes (16 locations across `browse/src/server.ts`, `browse/src/sidebar-agent.ts`, `browse/src/browser-manager.ts`, `browse/src/cli.ts`, `browse/src/meta-commands.ts`, and `design/src/auth.ts`).

## Files

- `design/src/session.ts`: `createSession()` line 52 and `updateSession()` line 78