### PR TITLE
fix(browse): redact form fields with sensitive names, not just type=password

### DIFF
--- a/browse/src/read-commands.ts
+++ b/browse/src/read-commands.ts
@@ -145,7 +145,10 @@ export async function handleReadCommand(
               id: input.id || undefined,
               placeholder: input.placeholder || undefined,
               required: input.required || undefined,
-              value: input.type === 'password' ? '[redacted]' : (input.value || undefined),
+              value: input.type === 'password'
+                || (input.name && /(^|[_.-])(token|secret|key|password|credential|auth|jwt|session|csrf|sid)($|[_.-])|api.?key/i.test(input.name))
+                || (input.id && /(^|[_.-])(token|secret|key|password|credential|auth|jwt|session|csrf|sid)($|[_.-])|api.?key/i.test(input.id))
+                ? '[redacted]' : (input.value || undefined),
               options: el.tagName === 'SELECT'
                 ? [...(el as HTMLSelectElement).options].map(o => ({ value: o.value, text: o.text }))
                 : undefined,


### PR DESCRIPTION
## What

Add name and id pattern matching to the forms command redaction logic in `browse/src/read-commands.ts`.

## Why

The `$B forms` command only redacted values for `type="password"` inputs. Hidden inputs and text fields with sensitive names were exposed unredacted in the LLM context:

```html
<input type="hidden" name="csrf_token" value="abc123">   <!-- exposed -->
<input type="hidden" name="api_key" value="sk-secret">    <!-- exposed -->
<input type="text" name="session_id" value="sess_xyz">     <!-- exposed -->
```

Cookies and storage already use `SENSITIVE_COOKIE_NAME` pattern matching against names containing `token`, `secret`, `key`, `password`, `credential`, `auth`, `jwt`, `session`, `csrf`, `sid`, and `api_key`. This PR applies the same pattern to form field `name` and `id` attributes.

The regex runs inside `page.evaluate()` (browser context) so it's inlined rather than referencing the Node export.

## Files

- `browse/src/read-commands.ts`: line 148, forms case