### PR TITLE
Support configurable default viewport via BROWSE_VIEWPORT

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -823,7 +823,7 @@ Refs are invalidated on navigation — run `snapshot` again after `goto`.
 | `diff <url1> <url2>` | Text diff between pages |
 | `pdf [path]` | Save as PDF |
 | `prettyscreenshot [--scroll-to sel|text] [--cleanup] [--hide sel...] [--width px] [path]` | Clean screenshot with optional cleanup, scroll positioning, and element hiding |
-| `responsive [prefix]` | Screenshots at mobile (375x812), tablet (768x1024), desktop (1280x720). Saves as {prefix}-mobile.png etc. |
+| `responsive [prefix]` | Screenshots at mobile (375x812), tablet (768x1024), desktop (default viewport, or BROWSE_VIEWPORT). Saves as {prefix}-mobile.png etc. |
 | `screenshot [--viewport] [--clip x,y,w,h] [selector|@ref] [path]` | Save screenshot (supports element crop via CSS/@ref, --clip region, --viewport) |
 
 ### Snapshot

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -715,7 +715,7 @@ $B prettyscreenshot --cleanup --scroll-to ".pricing" --width 1440 ~/Desktop/hero
 | `diff <url1> <url2>` | Text diff between pages |
 | `pdf [path]` | Save as PDF |
 | `prettyscreenshot [--scroll-to sel|text] [--cleanup] [--hide sel...] [--width px] [path]` | Clean screenshot with optional cleanup, scroll positioning, and element hiding |
-| `responsive [prefix]` | Screenshots at mobile (375x812), tablet (768x1024), desktop (1280x720). Saves as {prefix}-mobile.png etc. |
+| `responsive [prefix]` | Screenshots at mobile (375x812), tablet (768x1024), desktop (default viewport, or BROWSE_VIEWPORT). Saves as {prefix}-mobile.png etc. |
 | `screenshot [--viewport] [--clip x,y,w,h] [selector|@ref] [path]` | Save screenshot (supports element crop via CSS/@ref, --clip region, --viewport) |
 
 ### Snapshot

--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -25,6 +25,23 @@ export type { RefEntry };
 // Re-export TabSession for consumers
 export { TabSession };
 
+/**
+ * Parse BROWSE_VIEWPORT env var ("WIDTHxHEIGHT") into {width, height}.
+ * Falls back to 1280×720 if unset or malformed.
+ */
+export function getDefaultViewport(): { width: number; height: number } {
+  const raw = process.env.BROWSE_VIEWPORT;
+  if (raw) {
+    const match = raw.match(/^(\d+)x(\d+)$/);
+    if (match) {
+      const width = Math.max(320, Math.min(7680, parseInt(match[1], 10)));
+      const height = Math.max(240, Math.min(4320, parseInt(match[2], 10)));
+      return { width, height };
+    }
+  }
+  return { width: 1280, height: 720 };
+}
+
 export interface BrowserState {
   cookies: Cookie[];
   pages: Array<{
@@ -186,7 +203,7 @@ export class BrowserManager {
     });
 
     const contextOptions: BrowserContextOptions = {
-      viewport: { width: 1280, height: 720 },
+      viewport: getDefaultViewport(),
     };
     if (this.customUserAgent) {
       contextOptions.userAgent = this.customUserAgent;
@@ -902,7 +919,7 @@ export class BrowserManager {
 
       // 3. Create new context with updated settings
       const contextOptions: BrowserContextOptions = {
-        viewport: { width: 1280, height: 720 },
+        viewport: getDefaultViewport(),
       };
       if (this.customUserAgent) {
         contextOptions.userAgent = this.customUserAgent;
@@ -925,7 +942,7 @@ export class BrowserManager {
         if (this.context) await this.context.close().catch(() => {});
 
         const contextOptions: BrowserContextOptions = {
-          viewport: { width: 1280, height: 720 },
+          viewport: getDefaultViewport(),
         };
         if (this.customUserAgent) {
           contextOptions.userAgent = this.customUserAgent;

--- a/browse/src/commands.ts
+++ b/browse/src/commands.ts
@@ -103,7 +103,7 @@ export const COMMAND_DESCRIPTIONS: Record<string, { category: string; descriptio
   // Visual
   'screenshot': { category: 'Visual', description: 'Save screenshot (supports element crop via CSS/@ref, --clip region, --viewport)', usage: 'screenshot [--viewport] [--clip x,y,w,h] [selector|@ref] [path]' },
   'pdf':     { category: 'Visual', description: 'Save as PDF', usage: 'pdf [path]' },
-  'responsive': { category: 'Visual', description: 'Screenshots at mobile (375x812), tablet (768x1024), desktop (1280x720). Saves as {prefix}-mobile.png etc.', usage: 'responsive [prefix]' },
+  'responsive': { category: 'Visual', description: 'Screenshots at mobile (375x812), tablet (768x1024), desktop (default viewport, or BROWSE_VIEWPORT). Saves as {prefix}-mobile.png etc.', usage: 'responsive [prefix]' },
   'diff':    { category: 'Visual', description: 'Text diff between pages', usage: 'diff <url1> <url2>' },
   // Tabs
   'tabs':    { category: 'Tabs', description: 'List open tabs' },

--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -2,7 +2,7 @@
  * Meta commands — tabs, server control, screenshots, chain, diff, snapshot
  */
 
-import type { BrowserManager } from './browser-manager';
+import { type BrowserManager, getDefaultViewport } from './browser-manager';
 import { handleSnapshot } from './snapshot';
 import { getCleanText } from './read-commands';
 import { READ_COMMANDS, WRITE_COMMANDS, META_COMMANDS, PAGE_CONTENT_COMMANDS, wrapUntrustedContent } from './commands';
@@ -225,7 +225,7 @@ export async function handleMetaCommand(
       const viewports = [
         { name: 'mobile', width: 375, height: 812 },
         { name: 'tablet', width: 768, height: 1024 },
-        { name: 'desktop', width: 1280, height: 720 },
+        { name: 'desktop', ...getDefaultViewport() },
       ];
       const originalViewport = page.viewportSize();
       const results: string[] = [];

--- a/browse/test/browser-manager-unit.test.ts
+++ b/browse/test/browser-manager-unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 
 // ─── BrowserManager basic unit tests ─────────────────────────────
 
@@ -13,5 +13,47 @@ describe('BrowserManager defaults', () => {
     const { BrowserManager } = await import('../src/browser-manager');
     const bm = new BrowserManager();
     expect(bm.getRefMap()).toEqual([]);
+  });
+});
+
+// ─── getDefaultViewport tests ───────────────────────────────────
+
+describe('getDefaultViewport', () => {
+  let originalViewport: string | undefined;
+
+  beforeEach(() => {
+    originalViewport = process.env.BROWSE_VIEWPORT;
+  });
+
+  afterEach(() => {
+    if (originalViewport === undefined) {
+      delete process.env.BROWSE_VIEWPORT;
+    } else {
+      process.env.BROWSE_VIEWPORT = originalViewport;
+    }
+  });
+
+  it('returns 1280x720 when BROWSE_VIEWPORT is unset', async () => {
+    delete process.env.BROWSE_VIEWPORT;
+    const { getDefaultViewport } = await import('../src/browser-manager');
+    expect(getDefaultViewport()).toEqual({ width: 1280, height: 720 });
+  });
+
+  it('parses valid BROWSE_VIEWPORT', async () => {
+    process.env.BROWSE_VIEWPORT = '1920x1080';
+    const { getDefaultViewport } = await import('../src/browser-manager');
+    expect(getDefaultViewport()).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it('falls back to 1280x720 on malformed input', async () => {
+    process.env.BROWSE_VIEWPORT = 'notaviewport';
+    const { getDefaultViewport } = await import('../src/browser-manager');
+    expect(getDefaultViewport()).toEqual({ width: 1280, height: 720 });
+  });
+
+  it('clamps excessively large dimensions', async () => {
+    process.env.BROWSE_VIEWPORT = '99999x99999';
+    const { getDefaultViewport } = await import('../src/browser-manager');
+    expect(getDefaultViewport()).toEqual({ width: 7680, height: 4320 });
   });
 });


### PR DESCRIPTION
## Summary

The default browse viewport (1280x720) is hardcoded in three places in `browser-manager.ts` plus the responsive desktop preset. This adds a `BROWSE_VIEWPORT` environment variable so users can configure their preferred default without patching source.

- New exported `getDefaultViewport()` function in `browser-manager.ts` reads `BROWSE_VIEWPORT` env var (format: `WIDTHxHEIGHT`)
- Falls back to 1280x720 if unset or malformed
- Dimensions clamped to sane bounds (320-7680 width, 240-4320 height) consistent with existing viewport clamping
- Responsive desktop preset also uses the configured default
- 4 unit tests covering: default fallback, valid parsing, malformed input, bounds clamping

**Usage with gstack-config:**

```bash
gstack-config set browse_viewport 1920x1080
```

Then in a skill preamble:
```bash
export BROWSE_VIEWPORT=$(~/.claude/skills/gstack/bin/gstack-config get browse_viewport 2>/dev/null)
```

**Files changed:**
- `browse/src/browser-manager.ts` — new `getDefaultViewport()`, replaces 3 hardcoded viewports
- `browse/src/meta-commands.ts` — responsive desktop preset uses `getDefaultViewport()`
- `browse/src/commands.ts` — updated responsive description
- `browse/test/browser-manager-unit.test.ts` — 4 new tests
- `browse/SKILL.md`, `SKILL.md` — auto-regenerated from templates

## Test plan

- [x] 4 new unit tests pass (`bun test browse/test/browser-manager-unit.test.ts` — 6/6)
- [x] All 195 browse command tests pass (`bun test browse/test/commands.test.ts` — 195/195)
- [x] All 77 security audit tests pass (`bun test browse/test/security-audit-r2.test.ts` — 77/77)
- [x] Verified: unset `BROWSE_VIEWPORT` → 1280x720 (backward compatible)
- [x] Verified: `BROWSE_VIEWPORT=1728x996` → 1728x996 viewport
- [x] Verified: malformed input → 1280x720 fallback