### PR TITLE
Fix invalid YAML in openclaw skill metadata

### DIFF
--- a/openclaw/skills/gstack-openclaw-ceo-review/SKILL.md
+++ b/openclaw/skills/gstack-openclaw-ceo-review/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: gstack-openclaw-ceo-review
-description: CEO/founder-mode plan review. Rethink the problem, find the 10-star product, challenge premises, expand scope when it creates a better product. Four modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). Use when asked to review a plan, challenge this, CEO review, poke holes, think bigger, or expand scope.
+description: |
+  CEO/founder-mode plan review. Rethink the problem, find the 10-star product,
+  challenge premises, expand scope when it creates a better product. Four
+  modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope +
+  cherry-pick), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to
+  essentials). Use when asked to review a plan, challenge this, CEO review,
+  poke holes, think bigger, or expand scope.
 version: 1.0.0
 metadata: { "openclaw": { "emoji": "👑" } }
 ---

--- a/openclaw/skills/gstack-openclaw-investigate/SKILL.md
+++ b/openclaw/skills/gstack-openclaw-investigate/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: gstack-openclaw-investigate
-description: Systematic debugging with root cause investigation. Four phases: investigate, analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when asked to debug, fix a bug, investigate an error, or root cause analysis. Proactively use when user reports errors, stack traces, unexpected behavior, or says something stopped working.
+description: |
+  Systematic debugging with root cause investigation. Four phases:
+  investigate, analyze, hypothesize, implement. Iron Law: no fixes without
+  root cause. Use when asked to debug, fix a bug, investigate an error, or
+  root cause analysis. Proactively use when user reports errors,
+  stack traces, unexpected behavior, or says something stopped working.
 version: 1.0.0
 metadata: { "openclaw": { "emoji": "🔍" } }
 ---

--- a/openclaw/skills/gstack-openclaw-office-hours/SKILL.md
+++ b/openclaw/skills/gstack-openclaw-office-hours/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: gstack-openclaw-office-hours
-description: Product interrogation with six forcing questions. Two modes: startup diagnostic (demand reality, status quo, desperate specificity, narrowest wedge, observation, future-fit) and builder brainstorm. Use when asked to brainstorm, "is this worth building", "I have an idea", "office hours", or "help me think through this". Proactively use when user describes a new product idea or wants to think through design decisions before any code is written.
+description: |
+  Product interrogation with six forcing questions. Two modes: startup
+  diagnostic (demand reality, status quo, desperate specificity, narrowest
+  wedge, observation, future-fit) and builder brainstorm. Use when asked to
+  brainstorm, "is this worth building", "I have an idea", "office hours", or
+  "help me think through this". Proactively use when user describes a new
+  product idea or wants to think through design decisions before any code is
+  written.
 version: 1.0.0
 metadata: { "openclaw": { "emoji": "🎯" } }
 ---


### PR DESCRIPTION
## What changed

This fixes invalid YAML front matter in three OpenClaw skill files:

- `openclaw/skills/gstack-openclaw-investigate/SKILL.md`
- `openclaw/skills/gstack-openclaw-office-hours/SKILL.md`
- `openclaw/skills/gstack-openclaw-ceo-review/SKILL.md`

Each `description:` field is converted from a single plain scalar to a block scalar (`description: |`), preserving the original text while making the front matter parseable.

## Why

These skills were being skipped during load because their `description:` values contained unquoted `: ` sequences, which YAML interprets as mapping separators.

## Impact

The three OpenClaw skills can now be loaded normally instead of being rejected as invalid `SKILL.md` files.

## Root cause

The front matter used unquoted one-line YAML scalars for long descriptions that included colon-space sequences.

## Validation

- Parsed the three updated front matter blocks with Ruby `YAML.safe_load`
- Parsed every `openclaw/skills/*/SKILL.md` front matter block to confirm the directory returns `ALL_OK`
