### PR TITLE
 feat: add support for Gemini CLI host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin/gstack-global-discover
 .slate/
 .cursor/
 .openclaw/
+.gemini/
 .context/
 extension/.auth.json
 .gstack-worktrees/

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Or target a specific agent with `./setup --host <name>`:
 | Agent | Flag | Skills install to |
 |-------|------|-------------------|
 | OpenAI Codex CLI | `--host codex` | `~/.codex/skills/gstack-*/` |
+| Gemini CLI | `--host gemini` | `~/.gemini/skills/gstack-*/` |
 | OpenCode | `--host opencode` | `~/.config/opencode/skills/gstack-*/` |
 | Cursor | `--host cursor` | `~/.cursor/skills/gstack-*/` |
 | Factory Droid | `--host factory` | `~/.factory/skills/gstack-*/` |

--- a/bin/gstack-relink
+++ b/bin/gstack-relink
@@ -18,6 +18,8 @@ INSTALL_DIR="${GSTACK_INSTALL_DIR:-}"
 if [ -z "$INSTALL_DIR" ]; then
   if [ -d "$HOME/.claude/skills/gstack" ]; then
     INSTALL_DIR="$HOME/.claude/skills/gstack"
+  elif [ -d "$HOME/.gemini/skills/gstack" ]; then
+    INSTALL_DIR="$HOME/.gemini/skills/gstack"
   elif [ -d "${SCRIPT_DIR}/.." ] && [ -f "${SCRIPT_DIR}/../setup" ]; then
     INSTALL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
   fi
@@ -52,14 +54,14 @@ for skill_dir in "$INSTALL_DIR"/*/; do
   [ -d "$skill_dir" ] || continue
   skill=$(basename "$skill_dir")
   # Skip non-skill directories
-  case "$skill" in bin|browse|design|docs|extension|lib|node_modules|scripts|test|.git|.github) continue ;; esac
+  case "$skill" in bin | browse | design | docs | extension | lib | node_modules | scripts | test | .git | .github) continue ;; esac
   [ -f "$skill_dir/SKILL.md" ] || continue
 
   if [ "$PREFIX" = "true" ]; then
     # Don't double-prefix directories already named gstack-*
     case "$skill" in
-      gstack-*) link_name="$skill" ;;
-      *)        link_name="gstack-$skill" ;;
+    gstack-*) link_name="$skill" ;;
+    *) link_name="gstack-$skill" ;;
     esac
     # Remove old flat entry if it exists (and isn't the same as the new link)
     [ "$link_name" != "$skill" ] && _cleanup_skill_entry "$SKILLS_DIR/$skill"
@@ -67,8 +69,8 @@ for skill_dir in "$INSTALL_DIR"/*/; do
     link_name="$skill"
     # Don't remove gstack-* dirs that are their real name (e.g., gstack-upgrade)
     case "$skill" in
-      gstack-*) ;; # Already the real name, no old prefixed link to clean
-      *)        _cleanup_skill_entry "$SKILLS_DIR/gstack-$skill" ;;
+    gstack-*) ;; # Already the real name, no old prefixed link to clean
+    *) _cleanup_skill_entry "$SKILLS_DIR/gstack-$skill" ;;
     esac
   fi
   target="$SKILLS_DIR/$link_name"

--- a/bin/gstack-uninstall
+++ b/bin/gstack-uninstall
@@ -10,14 +10,17 @@
 #   ~/.claude/skills/gstack       — global Claude skill install (git clone or vendored)
 #   ~/.claude/skills/{skill}      — per-skill symlinks created by setup
 #   ~/.codex/skills/gstack*       — Codex skill install + per-skill symlinks
+#   ~/.gemini/skills/gstack*      — Gemini CLI skill install + per-skill symlinks
 #   ~/.factory/skills/gstack*     — Factory Droid skill install + per-skill symlinks
 #   ~/.kiro/skills/gstack*        — Kiro skill install + per-skill symlinks
 #   ~/.gstack/                    — global state (config, analytics, sessions, projects,
 #                                   repos, installation-id, browse error logs)
 #   .claude/skills/gstack*        — project-local skill install (--local installs)
+#   .gemini/skills/gstack*        — project-local skill install (Gemini CLI)
 #   .gstack/                      — per-project browse state (in current git repo)
 #   .gstack-worktrees/            — per-project test worktrees (in current git repo)
-#   .agents/skills/gstack*        — Codex/Gemini/Cursor sidecar (in current git repo)
+#   .agents/skills/gstack*        — Codex sidecar (in current git repo)
+#   .gemini/skills/gstack*        — Gemini sidecar (in current git repo)
 #   Running browse daemons        — stopped via SIGTERM before cleanup
 #
 # What is NOT REMOVED:
@@ -64,15 +67,18 @@ if [ "$FORCE" -eq 0 ]; then
   echo "This will remove gstack from your system:"
   { [ -d "$HOME/.claude/skills/gstack" ] || [ -L "$HOME/.claude/skills/gstack" ]; } && echo "  ~/.claude/skills/gstack (+ per-skill symlinks)"
   [ -d "$HOME/.codex/skills" ] && echo "  ~/.codex/skills/gstack*"
+  [ -d "$HOME/.gemini/skills" ] && echo "  ~/.gemini/skills/gstack*"
   [ -d "$HOME/.factory/skills" ] && echo "  ~/.factory/skills/gstack*"
   [ -d "$HOME/.kiro/skills" ] && echo "  ~/.kiro/skills/gstack*"
   [ "$KEEP_STATE" -eq 0 ] && [ -d "$STATE_DIR" ] && echo "  $STATE_DIR"
 
   if [ -n "$_GIT_ROOT" ]; then
     [ -d "$_GIT_ROOT/.claude/skills/gstack" ] && echo "  $_GIT_ROOT/.claude/skills/gstack (project-local)"
+    [ -d "$_GIT_ROOT/.gemini/skills/gstack" ] && echo "  $_GIT_ROOT/.gemini/skills/gstack (project-local)"
     [ -d "$_GIT_ROOT/.gstack" ] && echo "  $_GIT_ROOT/.gstack/ (browse state + reports)"
     [ -d "$_GIT_ROOT/.gstack-worktrees" ] && echo "  $_GIT_ROOT/.gstack-worktrees/"
     [ -d "$_GIT_ROOT/.agents/skills" ] && echo "  $_GIT_ROOT/.agents/skills/gstack*"
+    [ -d "$_GIT_ROOT/.gemini/skills" ] && echo "  $_GIT_ROOT/.gemini/skills/gstack*"
   fi
 
   # Preview running daemons
@@ -171,6 +177,16 @@ if [ -d "$CODEX_SKILLS" ]; then
   done
 fi
 
+# ─── Remove Gemini CLI skills ───────────────────────────────
+GEMINI_SKILLS="$HOME/.gemini/skills"
+if [ -d "$GEMINI_SKILLS" ]; then
+  for _ITEM in "$GEMINI_SKILLS"/gstack*; do
+    [ -e "$_ITEM" ] || [ -L "$_ITEM" ] || continue
+    rm -rf "$_ITEM"
+    REMOVED+=("gemini/$(basename "$_ITEM")")
+  done
+fi
+
 # ─── Remove Factory Droid skills ────────────────────────────
 FACTORY_SKILLS="$HOME/.factory/skills"
 if [ -d "$FACTORY_SKILLS" ]; then
@@ -201,6 +217,18 @@ if [ -n "$_GIT_ROOT" ] && [ -d "$_GIT_ROOT/.agents/skills" ]; then
 
   rmdir "$_GIT_ROOT/.agents/skills" 2>/dev/null || true
   rmdir "$_GIT_ROOT/.agents" 2>/dev/null || true
+fi
+
+# ─── Remove per-project .gemini/ sidecar ─────────────────────
+if [ -n "$_GIT_ROOT" ] && [ -d "$_GIT_ROOT/.gemini/skills" ]; then
+  for _ITEM in "$_GIT_ROOT/.gemini/skills"/gstack*; do
+    [ -e "$_ITEM" ] || [ -L "$_ITEM" ] || continue
+    rm -rf "$_ITEM"
+    REMOVED+=("gemini/$(basename "$_ITEM")")
+  done
+
+  rmdir "$_GIT_ROOT/.gemini/skills" 2>/dev/null || true
+  rmdir "$_GIT_ROOT/.gemini" 2>/dev/null || true
 fi
 
 # ─── Remove per-project .factory/ sidecar ────────────────────

--- a/hosts/gemini.ts
+++ b/hosts/gemini.ts
@@ -1,0 +1,46 @@
+import type { HostConfig } from '../scripts/host-config';
+
+const gemini: HostConfig = {
+  name: 'gemini',
+  displayName: 'Gemini CLI',
+  cliCommand: 'gemini',
+  cliAliases: [],
+
+  globalRoot: '.gemini/skills/gstack',
+  localSkillRoot: '.gemini/skills/gstack',
+  hostSubdir: '.gemini',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: null,
+  },
+
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.gemini/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.gemini/skills/gstack' },
+    { from: '.claude/skills', to: '.gemini/skills' },
+  ],
+
+  runtimeRoot: {
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalFiles: {
+      'review': ['checklist.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  learningsMode: 'basic',
+};
+
+export default gemini;

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -14,9 +14,10 @@ import opencode from './opencode';
 import slate from './slate';
 import cursor from './cursor';
 import openclaw from './openclaw';
+import gemini from './gemini';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, gemini];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -63,4 +64,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, gemini };

--- a/setup
+++ b/setup
@@ -20,6 +20,8 @@ INSTALL_SKILLS_DIR="$(dirname "$INSTALL_GSTACK_DIR")"
 BROWSE_BIN="$SOURCE_GSTACK_DIR/browse/dist/browse"
 CODEX_SKILLS="$HOME/.codex/skills"
 CODEX_GSTACK="$CODEX_SKILLS/gstack"
+GEMINI_SKILLS="$HOME/.gemini/skills"
+GEMINI_GSTACK="$GEMINI_SKILLS/gstack"
 FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
 
@@ -41,7 +43,7 @@ TEAM_MODE=0
 NO_TEAM_MODE=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, gemini, kiro, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -54,7 +56,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|auto) ;;
+  claude|codex|gemini|kiro|factory|auto) ;;
   openclaw)
     echo ""
     echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
@@ -67,7 +69,7 @@ case "$HOST" in
     echo "  3. See docs/OPENCLAW.md for the full architecture"
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, openclaw, or auto)" >&2; exit 1 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, gemini, kiro, factory, openclaw, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -128,21 +130,25 @@ fi
 # For auto: detect which agents are installed
 INSTALL_CLAUDE=0
 INSTALL_CODEX=0
+INSTALL_GEMINI=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
+  command -v gemini >/dev/null 2>&1 && INSTALL_GEMINI=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_GEMINI" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
   INSTALL_CLAUDE=1
 elif [ "$HOST" = "codex" ]; then
   INSTALL_CODEX=1
+elif [ "$HOST" = "gemini" ]; then
+  INSTALL_GEMINI=1
 elif [ "$HOST" = "kiro" ]; then
   INSTALL_KIRO=1
 elif [ "$HOST" = "factory" ]; then
@@ -174,6 +180,33 @@ migrate_direct_codex_install() {
 
 if [ "$INSTALL_CODEX" -eq 1 ]; then
   migrate_direct_codex_install "$SOURCE_GSTACK_DIR" "$CODEX_GSTACK"
+fi
+
+migrate_direct_gemini_install() {
+  local gstack_dir="$1"
+  local gemini_gstack="$2"
+  local migrated_dir="$HOME/.gstack/repos/gstack"
+
+  [ "$gstack_dir" = "$gemini_gstack" ] || return 0
+  [ -L "$gstack_dir" ] && return 0
+
+  mkdir -p "$(dirname "$migrated_dir")"
+  if [ -e "$migrated_dir" ] && [ "$migrated_dir" != "$gstack_dir" ]; then
+    echo "gstack setup failed: direct Gemini install detected at $gstack_dir" >&2
+    echo "A migrated repo already exists at $migrated_dir; move one of them aside and rerun setup." >&2
+    exit 1
+  fi
+
+  log "Migrating direct Gemini install to $migrated_dir to avoid duplicate skill discovery..."
+  mv "$gstack_dir" "$migrated_dir"
+  SOURCE_GSTACK_DIR="$migrated_dir"
+  INSTALL_GSTACK_DIR="$migrated_dir"
+  INSTALL_SKILLS_DIR="$(dirname "$INSTALL_GSTACK_DIR")"
+  BROWSE_BIN="$SOURCE_GSTACK_DIR/browse/dist/browse"
+}
+
+if [ "$INSTALL_GEMINI" -eq 1 ]; then
+  migrate_direct_gemini_install "$SOURCE_GSTACK_DIR" "$GEMINI_GSTACK"
 fi
 
 ensure_playwright_browser() {
@@ -236,6 +269,16 @@ if [ "$NEEDS_AGENTS_GEN" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
     cd "$SOURCE_GSTACK_DIR"
     bun install --frozen-lockfile 2>/dev/null || bun install
     bun run gen:skill-docs --host codex
+  )
+fi
+
+# 1bc. Generate .gemini/ Gemini CLI skill docs
+if [ "$INSTALL_GEMINI" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .gemini/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun install --frozen-lockfile 2>/dev/null || bun install
+    bun run gen:skill-docs --host gemini
   )
 fi
 
@@ -532,6 +575,44 @@ create_codex_runtime_root() {
   fi
 }
 
+create_gemini_runtime_root() {
+  local gstack_dir="$1"
+  local gemini_gstack="$2"
+  local gemini_dir="$gstack_dir/.gemini/skills"
+
+  if [ -L "$gemini_gstack" ]; then
+    rm -f "$gemini_gstack"
+  elif [ -d "$gemini_gstack" ] && [ "$gemini_gstack" != "$gstack_dir" ]; then
+    rm -rf "$gemini_gstack"
+  fi
+
+  mkdir -p "$gemini_gstack" "$gemini_gstack/browse" "$gemini_gstack/gstack-upgrade" "$gemini_gstack/review"
+
+  if [ -f "$gemini_dir/gstack/SKILL.md" ]; then
+    ln -snf "$gemini_dir/gstack/SKILL.md" "$gemini_gstack/SKILL.md"
+  fi
+  if [ -d "$gstack_dir/bin" ]; then
+    ln -snf "$gstack_dir/bin" "$gemini_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    ln -snf "$gstack_dir/browse/dist" "$gemini_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    ln -snf "$gstack_dir/browse/bin" "$gemini_gstack/browse/bin"
+  fi
+  if [ -f "$gemini_dir/gstack-upgrade/SKILL.md" ]; then
+    ln -snf "$gemini_dir/gstack-upgrade/SKILL.md" "$gemini_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      ln -snf "$gstack_dir/review/$f" "$gemini_gstack/review/$f"
+    fi
+  done
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    ln -snf "$gstack_dir/ETHOS.md" "$gemini_gstack/ETHOS.md"
+  fi
+}
+
 create_factory_runtime_root() {
   local gstack_dir="$1"
   local factory_gstack="$2"
@@ -587,6 +668,38 @@ link_factory_skill_dirs() {
   fi
 
   for skill_dir in "$factory_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+link_gemini_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local gemini_dir="$gstack_dir/.gemini/skills"
+  local linked=()
+
+  if [ ! -d "$gemini_dir" ]; then
+    echo "  Generating .gemini/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host gemini )
+  fi
+
+  if [ ! -d "$gemini_dir" ]; then
+    echo "  warning: .gemini/skills/ generation failed — run 'bun run gen:skill-docs --host gemini' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$gemini_dir"/gstack*/; do
     if [ -f "$skill_dir/SKILL.md" ]; then
       skill_name="$(basename "$skill_dir")"
       [ "$skill_name" = "gstack" ] && continue
@@ -696,6 +809,16 @@ if [ "$INSTALL_CODEX" -eq 1 ]; then
   log "gstack ready (codex)."
   log "  browse: $BROWSE_BIN"
   log "  codex skills: $CODEX_SKILLS"
+fi
+
+# 5b. Install for Gemini CLI
+if [ "$INSTALL_GEMINI" -eq 1 ]; then
+  mkdir -p "$GEMINI_SKILLS"
+  create_gemini_runtime_root "$SOURCE_GSTACK_DIR" "$GEMINI_GSTACK"
+  link_gemini_skill_dirs "$SOURCE_GSTACK_DIR" "$GEMINI_SKILLS"
+  log "gstack ready (gemini)."
+  log "  browse: $BROWSE_BIN"
+  log "  gemini skills: $GEMINI_SKILLS"
 fi
 
 # 6. Install for Kiro CLI (copy from .agents/skills, rewrite paths)


### PR DESCRIPTION
 - Create hosts/gemini.ts with global/local skill roots and path rewrites
 - Register gemini in hosts/index.ts registry
 - Update .gitignore to exclude generated .gemini/ directory
 - Add --host gemini support to ./setup script for auto-detection and linking
 - Update gstack-uninstall to clean up global and per-project gemini skills
 - Update gstack-relink to detect installs in ~/.gemini/skills/gstack/
 - Add Gemini CLI to supported hosts table in README.md