### PR TITLE
feat: reviewer discipline gate for free-tier private repos (ship + land-and-deploy)

### DIFF
--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -1035,6 +1035,46 @@ and tell the user: "I found and fixed a few issues during the review. The fixes 
 
 **If review is CURRENT:** Skip this sub-step entirely — no question asked.
 
+### 3.5a-ter: GitHub PR review approval check (HARD GATE)
+
+**This is a hard gate — it blocks merge if a human reviewer was requested but hasn't approved.** Local AI reviews (3.5a) are not a substitute for human approval when a reviewer is assigned.
+
+Query the PR's review state:
+
+```bash
+gh pr view --json reviewDecision,reviewRequests,latestReviews
+```
+
+Parse the output:
+- `reviewDecision`: `APPROVED` / `CHANGES_REQUESTED` / `REVIEW_REQUIRED` / `null`
+- `reviewRequests`: list of pending reviewers (haven't responded yet)
+- `latestReviews`: list of reviews submitted (each has a `state` and `author`)
+
+**Gate logic:**
+
+| Condition | Action |
+|-----------|--------|
+| `reviewDecision == "APPROVED"` | PASS — continue |
+| `reviewDecision == "CHANGES_REQUESTED"` | **BLOCKER** — list the reviewer who requested changes, the file/line they commented on if available, and refuse to merge |
+| `reviewDecision == "REVIEW_REQUIRED"` AND `reviewRequests` is non-empty | **BLOCKER** — "PR has {N} pending reviewer(s): {list}. Cannot merge until at least one approves." |
+| `reviewDecision == null` AND `reviewRequests` is empty AND `latestReviews` is empty AND repo has other collaborators | **WARNING** — "No reviewers requested. This repo has other collaborators — consider requesting review before merge." Not a hard blocker because it may be a solo-authored fix in a multi-person repo. |
+| `reviewDecision == null` AND repo has no other collaborators | PASS — solo repo, no review possible |
+
+**How to fetch collaborators for the "solo repo" check:**
+
+```bash
+_SELF=$(gh api user --jq .login 2>/dev/null)
+_OTHER_COLLABS=$(gh api repos/:owner/:repo/collaborators --jq "[.[] | select(.login != \"$_SELF\") | .login] | length" 2>/dev/null || echo "0")
+```
+
+If `_OTHER_COLLABS > 0`, treat missing reviews as a warning/blocker per the table above. If `_OTHER_COLLABS == 0`, treat as solo repo and pass.
+
+**If BLOCKER:** Include the reviewDecision status in the readiness report under a new `GITHUB REVIEW` section (see 3.5e) and recommend option B (hold off). Do NOT let the user override with option C for this specific blocker — review bypass requires a different, explicit override.
+
+**Explicit override for the GitHub review blocker:** Only if the user types `/land-and-deploy --override-review` (or answers an explicit `AskUserQuestion` with a dedicated "I am the reviewer and I approve this" option) can this blocker be bypassed. Default is refuse.
+
+**Why this matters:** Free GitHub plans on private repos have no branch protection, so discipline is the only gate. Without this check, `/land-and-deploy` would happily merge PRs that the assigned reviewer never saw. That is the exact failure mode this sub-step exists to prevent.
+
 ### 3.5b: Test results
 
 **Free tests — run them now:**
@@ -1126,11 +1166,17 @@ Build the full readiness report:
 ║  PR: #NNN — title                                        ║
 ║  Branch: feature → main                                  ║
 ║                                                          ║
-║  REVIEWS                                                 ║
+║  REVIEWS (local AI)                                      ║
 ║  ├─ Eng Review:    CURRENT / STALE (N commits) / —       ║
 ║  ├─ CEO Review:    CURRENT / — (optional)                ║
 ║  ├─ Design Review: CURRENT / — (optional)                ║
 ║  └─ Codex Review:  CURRENT / — (optional)                ║
+║                                                          ║
+║  GITHUB REVIEW (human)                                   ║
+║  ├─ Decision:      APPROVED / CHANGES_REQUESTED /        ║
+║  │                 REVIEW_REQUIRED / none (solo repo)    ║
+║  ├─ Approvers:     @user1 / —                            ║
+║  └─ Pending:       @user2 / —                            ║
 ║                                                          ║
 ║  TESTS                                                   ║
 ║  ├─ Free tests:    PASS / FAIL (blocker)                 ║
@@ -1149,7 +1195,8 @@ Build the full readiness report:
 ╚══════════════════════════════════════════════════════════╝
 ```
 
-If there are BLOCKERS (failing free tests): list them and recommend B.
+If there are BLOCKERS (failing free tests, OR `reviewDecision == "CHANGES_REQUESTED"`, OR pending required reviewers from 3.5a-ter): list them and recommend B.
+**If the blocker is "GitHub PR review not approved", option C is NOT available.** The user must either get the approval on GitHub or explicitly pass `--override-review` to `/land-and-deploy`. Do not present option C for this blocker.
 If there are WARNINGS but no blockers: list each warning and recommend A if
 warnings are minor, or B if warnings are significant.
 If everything is green: recommend A.
@@ -1575,6 +1622,7 @@ Then suggest relevant follow-ups:
 
 - **Never force push.** Use `gh pr merge` which is safe.
 - **Never skip CI.** If checks are failing, stop and explain why.
+- **Never merge a PR without approved human review when a reviewer was assigned.** Step 3.5a-ter is a HARD GATE — if `reviewDecision != "APPROVED"` and the PR has reviewers or the repo has other collaborators, refuse to merge. The only override is an explicit `--override-review` flag or an explicit AskUserQuestion bypass. Do not treat local AI reviews (eng-review, codex-review) as a substitute for human PR approval. On free GitHub plans with no branch protection, this discipline is the only thing preventing unreviewed merges to main.
 - **Narrate the journey.** The user should always know: what just happened, what's happening now, and what's about to happen next. No silent gaps between steps.
 - **Auto-detect everything.** PR number, merge method, deploy strategy, project type, merge queues, staging environments. Only ask when information genuinely can't be inferred.
 - **Poll with backoff.** Don't hammer GitHub API. 30-second intervals for CI/deploy, with reasonable timeouts.

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -2453,26 +2453,67 @@ you missed it.>
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
+**Reviewer resolution (before creating the PR):**
+
+Check for a configured reviewer in this priority order:
+1. `CLAUDE.md` has a line matching `Default reviewer:\s*@?(\w+)` — use that username.
+2. `CLAUDE.md` has a line matching `Reviewers?:\s*@?(\w+(?:,\s*@?\w+)*)` — use that list.
+3. Otherwise: `gh api repos/:owner/:repo/collaborators --jq "[.[] | select(.login != \"$(gh api user --jq .login)\") | .login] | join(\",\")" 2>/dev/null` — auto-detect non-self collaborators.
+4. If none of the above return anything, skip reviewer assignment (solo repo, no reviewers available).
+
+Store the result in a variable, e.g. `_REVIEWERS`.
+
 **If GitHub:**
 
 ```bash
-gh pr create --base <base> --title "<type>: <summary>" --body "$(cat <<'EOF'
+# Create PR with reviewer if resolved
+if [ -n "$_REVIEWERS" ]; then
+  gh pr create --base <base> --reviewer "$_REVIEWERS" --title "<type>: <summary>" --body "$(cat <<'EOF'
 <PR body from above>
 EOF
 )"
+else
+  gh pr create --base <base> --title "<type>: <summary>" --body "$(cat <<'EOF'
+<PR body from above>
+EOF
+)"
+fi
 ```
 
 **If GitLab:**
 
 ```bash
-glab mr create -b <base> -t "<type>: <summary>" -d "$(cat <<'EOF'
+# GitLab equivalent: --reviewer flag
+if [ -n "$_REVIEWERS" ]; then
+  glab mr create -b <base> --reviewer "$_REVIEWERS" -t "<type>: <summary>" -d "$(cat <<'EOF'
 <MR body from above>
 EOF
 )"
+else
+  glab mr create -b <base> -t "<type>: <summary>" -d "$(cat <<'EOF'
+<MR body from above>
+EOF
+)"
+fi
 ```
 
 **If neither CLI is available:**
 Print the branch name, remote URL, and instruct the user to create the PR/MR manually via the web UI. Do not stop — the code is pushed and ready.
+
+**Post-creation review gate banner (MANDATORY if `_REVIEWERS` is set):**
+
+After the PR/MR is created, print this banner verbatim and STOP any auto-merge intent:
+
+```
+==================================================================
+  REVIEW REQUESTED from: $_REVIEWERS
+  DO NOT MERGE this PR until a reviewer approves it.
+  Check status: gh pr view <PR#> --json reviewDecision,reviews
+  Merge only when reviewDecision == "APPROVED"
+==================================================================
+```
+
+**Never run `gh pr merge` (or equivalent) in the same /ship invocation when reviewers are set.** /ship's job ends at PR creation. The user runs a separate merge command only after the review is approved. If the user asks /ship to also merge, refuse with: "Review required first. PR #<N> has reviewers assigned. Merge only after reviewDecision is APPROVED."
 
 **Output the PR/MR URL** — then proceed to Step 8.5.
 
@@ -2532,6 +2573,7 @@ This step is automatic — never skip it, never ask for confirmation.
 - **Never skip tests.** If tests fail, stop.
 - **Never skip the pre-landing review.** If checklist.md is unreadable, stop.
 - **Never force push.** Use regular `git push` only.
+- **Never merge without reviewer approval.** If the repo has collaborators or CLAUDE.md specifies a reviewer, /ship creates the PR with `--reviewer` assigned and STOPS. The user runs `gh pr merge` only after `reviewDecision == "APPROVED"`. If asked to merge in the same invocation, refuse and point at the review gate banner from Step 8.
 - **Never ask for trivial confirmations** (e.g., "ready to push?", "create PR?"). DO stop for: version bumps (MINOR/MAJOR), pre-landing review findings (ASK items), and Codex structured review [P1] findings (large diffs only).
 - **Always use the 4-digit version format** from the VERSION file.
 - **Date format in CHANGELOG:** `YYYY-MM-DD`


### PR DESCRIPTION
## Summary

Closes the "private repo + free GitHub plan + no branch protection" loophole where `/ship` happily creates a PR with reviewers assigned and `/land-and-deploy` happily merges it without the human reviewer ever seeing the code. Two coordinated changes — `ship` sets the reviewer + posts a banner, `land-and-deploy` enforces the gate at merge time.

On a paid GitHub plan you'd configure branch protection and the platform would enforce review approval. On a **free private plan** the "Require pull request reviews before merging" toggle isn't available, so there is no platform-level enforcement that the assigned reviewer ever sees the code before it merges. Without this change, `/ship` + `/land-and-deploy` will auto-merge every PR with reviewers set, defeating the whole point of having a reviewer in the first place.

This is a real failure mode I hit on a private repo earlier today. `/ship` created the PR, `/land-and-deploy` was about to merge it, my collaborator never saw it. That's the gap this PR fills.

## What changes

### `ship/SKILL.md` — Step 8 (Create PR/MR)

Adds a **Reviewer resolution** sub-step before `gh pr create` / `glab mr create`. Resolves a reviewer in this priority order:

1. `CLAUDE.md` line matching `Default reviewer: @username`
2. `CLAUDE.md` line matching `Reviewers: @user1, @user2`
3. `gh api repos/:owner/:repo/collaborators` (auto-detect non-self collaborators)
4. None — solo repo, skip reviewer assignment

Result is stored in `$_REVIEWERS`. Both the GitHub and GitLab create-PR blocks now branch on whether `$_REVIEWERS` is set, passing `--reviewer` when available.

After PR creation, if `$_REVIEWERS` is non-empty, `/ship` prints a mandatory banner verbatim and is **explicitly forbidden** from running `gh pr merge` in the same invocation:

```
==================================================================
  REVIEW REQUESTED from: $_REVIEWERS
  DO NOT MERGE this PR until a reviewer approves it.
  Check status: gh pr view <PR#> --json reviewDecision,reviews
  Merge only when reviewDecision == "APPROVED"
==================================================================
```

If the user asks `/ship` to also merge, it refuses with: "Review required first. PR #<N> has reviewers assigned. Merge only after reviewDecision is APPROVED."

### `land-and-deploy/SKILL.md` — new Step 3.5a-ter (HARD GATE)

A new sub-step that runs alongside the existing 3.5a (local AI review check) and 3.5a-bis (inline review offer). It is a **HARD GATE** — local AI reviews are not a substitute for human approval when a reviewer is assigned.

Queries the PR's review state via:

```bash
gh pr view --json reviewDecision,reviewRequests,latestReviews
```

Gate logic:

| reviewDecision     | reviewRequests | Action                |
|--------------------|----------------|-----------------------|
| APPROVED           | -              | PASS                  |
| CHANGES_REQUESTED  | -              | BLOCK (list reviewer) |
| REVIEW_REQUIRED    | non-empty      | BLOCK (list pending)  |
| null               | empty + collab | WARN (collab repo)    |
| null               | empty + solo   | PASS (solo repo)      |

The "solo repo" detection uses `gh api repos/:owner/:repo/collaborators` filtered against the current user's login. If `_OTHER_COLLABS == 0`, treat as solo and pass; otherwise treat missing reviews as a warning/blocker per the table.

The readiness report's REVIEWS section is renamed to **REVIEWS (local AI)** and a new **GITHUB REVIEW (human)** section is added showing decision / approvers / pending.

If the blocker is "GitHub PR review not approved", the standard option C ("override") is intentionally NOT available in the AskUserQuestion. The only override is an explicit `--override-review` flag passed to `/land-and-deploy` or an explicit dedicated AskUserQuestion bypass ("I am the reviewer and I approve this"). Default is refuse.

A reminder is also added to the "Important Rules" section of `land-and-deploy/SKILL.md`:

> **Never merge a PR without approved human review when a reviewer was assigned.** Step 3.5a-ter is a HARD GATE — if reviewDecision != APPROVED and the PR has reviewers or the repo has other collaborators, refuse to merge. The only override is an explicit `--override-review` flag or an explicit AskUserQuestion bypass. Do not treat local AI reviews as a substitute for human PR approval. **On free GitHub plans with no branch protection, this discipline is the only thing preventing unreviewed merges to main.**

## Why a "soft" warn for the unset-decision-with-collaborators case

When `reviewDecision` is `null` (no review submitted yet) but the repo has other collaborators and no reviewers were explicitly requested, the gate is a **warning, not a blocker**. Reasoning: it might be a solo-authored fix in a multi-person repo where review isn't needed for that specific change. Forcing a hard block here would be too aggressive and would break legitimate small fixes. The warning surfaces it in the readiness report so the user can make an explicit call.

## Impact on existing behavior

**Solo repos with no other collaborators:** zero behavior change. Reviewer resolution returns empty, no banner printed, no gate triggered, `/ship` and `/land-and-deploy` work exactly as today.

**Repos with collaborators where no reviewers were ever assigned:** still works, surfaces a one-line warning in the readiness report, doesn't block.

**Repos with collaborators where `/ship` assigned a reviewer:** new behavior — `/ship` prints the banner and stops at PR creation, `/land-and-deploy` blocks merge until `reviewDecision == APPROVED`. This is the intended discipline.

**Existing CLAUDE.md `Default reviewer:` lines:** picked up automatically, no migration needed.

## Test plan

- [x] `/ship` on a solo private repo (no other collaborators) — no reviewer assigned, no banner, `/ship` completes normally
- [x] `/ship` on a multi-collaborator repo — auto-detects non-self collaborator, assigns as reviewer, prints banner, refuses to merge in the same invocation
- [x] `/ship` with `Default reviewer: @username` line in CLAUDE.md — uses configured username over auto-detection
- [x] `/land-and-deploy` on a PR with `reviewDecision=APPROVED` — passes
- [x] `/land-and-deploy` on a PR with `reviewDecision=CHANGES_REQUESTED` — blocks, lists the reviewer who requested changes
- [x] `/land-and-deploy` on a PR with pending reviewers and no decision — blocks, lists pending
- [x] `/land-and-deploy` on a solo repo PR — passes (no collaborators to require review from)
- [x] `/land-and-deploy --override-review` on a blocked PR — passes with override logged

## Notes for review

- The two files work together as a pair, but they're independent enough that you could land just one if you wanted to. The `ship/SKILL.md` change is the smaller, lower-risk one. The `land-and-deploy/SKILL.md` change is where the actual enforcement lives.
- I've been carrying this customization locally across gstack upgrades for several versions (the auto-stash dance was getting silly — 8 stashes deep). Wanted to upstream it instead.
- No CHANGELOG entry added — figured you'd want to phrase it / version it your way.
- Happy to split this into two separate PRs if you'd prefer that for review, or to adjust the wording/structure to match upstream conventions.