### PR TITLE
Add Antigravity IDE as host #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin/gstack-global-discover
 .slate/
 .cursor/
 .openclaw/
+.antigravity/
 .context/
 extension/.auth.json
 .gstack-worktrees/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,11 +232,11 @@ To add a browse command, add it to `browse/src/commands.ts`. To add a snapshot f
 
 ## Multi-host development
 
-gstack generates SKILL.md files for 8 hosts from one set of `.tmpl` templates.
+gstack generates SKILL.md files for 9 hosts from one set of `.tmpl` templates.
 Each host is a typed config in `hosts/*.ts`. The generator reads these configs
 to produce host-appropriate output (different frontmatter, paths, tool names).
 
-**Supported hosts:** Claude (primary), Codex, Factory, Kiro, OpenCode, Slate, Cursor, OpenClaw.
+**Supported hosts:** Claude (primary), Codex, Factory, Kiro, OpenCode, Slate, Cursor, OpenClaw, Antigravity.
 
 ### Generating for all hosts
 
@@ -245,7 +245,7 @@ to produce host-appropriate output (different frontmatter, paths, tool names).
 bun run gen:skill-docs                    # Claude (default)
 bun run gen:skill-docs --host codex       # Codex
 bun run gen:skill-docs --host opencode    # OpenCode
-bun run gen:skill-docs --host all         # All 8 hosts
+bun run gen:skill-docs --host all         # All 9 hosts
 
 # Or use build, which does all hosts + compiles binaries
 bun run build

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ These are conversational skills. Your OpenClaw agent runs them directly via chat
 
 ### Other AI Agents
 
-gstack works on 8 AI coding agents, not just Claude. Setup auto-detects which
+gstack works on 9 AI coding agents, not just Claude. Setup auto-detects which
 agents you have installed:
 
 ```bash
@@ -128,6 +128,7 @@ Or target a specific agent with `./setup --host <name>`:
 | Factory Droid | `--host factory` | `~/.factory/skills/gstack-*/` |
 | Slate | `--host slate` | `~/.slate/skills/gstack-*/` |
 | Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |
+| Antigravity IDE | `--host antigravity` | `~/.gemini/antigravity/plugins/gstack-*/` |
 
 **Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).
 It's one TypeScript config file, zero code changes.

--- a/docs/ADDING_A_HOST.md
+++ b/docs/ADDING_A_HOST.md
@@ -1,7 +1,7 @@
 # Adding a New Host to gstack
 
 gstack uses a declarative host config system. Each supported AI coding agent
-(Claude, Codex, Factory, Kiro, OpenCode, Slate, Cursor, OpenClaw) is defined
+(Claude, Codex, Factory, Kiro, OpenCode, Slate, Cursor, OpenClaw, Antigravity) is defined
 as a typed TypeScript config object. Adding a new host means creating one file
 and re-exporting it. Zero code changes to the generator, setup, or tooling.
 
@@ -17,6 +17,7 @@ hosts/
 ├── slate.ts         # Slate (Random Labs)
 ├── cursor.ts        # Cursor
 ├── openclaw.ts      # OpenClaw (hybrid: config + adapter)
+└── antigravity.ts   # Antigravity IDE (Google DeepMind)
 └── index.ts         # Registry: imports all, derives Host type
 ```
 

--- a/hosts/antigravity.ts
+++ b/hosts/antigravity.ts
@@ -1,0 +1,63 @@
+import type { HostConfig } from '../scripts/host-config';
+
+const antigravity: HostConfig = {
+  name: 'antigravity',
+  displayName: 'Antigravity IDE',
+  cliCommand: 'antigravity',
+  cliAliases: ['gemini-antigravity'],
+
+  globalRoot: '.gemini/antigravity/plugins/gstack',
+  localSkillRoot: '.agents/skills/gstack',
+  hostSubdir: '.antigravity',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: null,
+  },
+
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],  // Codex skill is a Claude wrapper around codex exec
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '$GSTACK_ROOT' },
+    { from: '.claude/skills/gstack', to: '.agents/skills/gstack' },
+    { from: '.claude/skills/review', to: '.agents/skills/gstack/review' },
+    { from: '.claude/skills', to: '.agents/skills' },
+  ],
+
+  toolRewrites: {
+    'use the Bash tool': 'use the run_command tool',
+    'use the Write tool': 'use the write_to_file tool',
+    'use the Read tool': 'use the view_file tool',
+    'use the Grep tool': 'use the grep_search tool',
+    'use the Glob tool': 'use the list_dir tool',
+    'use the Agent tool': 'use the browser_subagent tool',
+  },
+
+  suppressedResolvers: [
+    'CODEX_PLAN_REVIEW',    // Cross-model invocation — not available
+    'CODEX_SECOND_OPINION', // Cross-model invocation — not available
+    'REVIEW_ARMY',          // Orchestration — Antigravity can't self-spawn
+  ],
+
+  runtimeRoot: {
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalFiles: {
+      'review': ['checklist.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  coAuthorTrailer: 'Co-Authored-By: Antigravity IDE <noreply@deepmind.google.com>',
+  learningsMode: 'basic',
+};
+
+export default antigravity;

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -14,9 +14,10 @@ import opencode from './opencode';
 import slate from './slate';
 import cursor from './cursor';
 import openclaw from './openclaw';
+import antigravity from './antigravity';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, antigravity];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -63,4 +64,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, antigravity };


### PR DESCRIPTION
New HostConfig for Google DeepMind's Antigravity IDE:
- Allowlist frontmatter (name + description only)
- Tool rewrites: Bash→run_command, Read→view_file, Write→write_to_file, etc.
- Path rewrites: ~/.claude/skills/gstack → $GSTACK_ROOT
- Suppressed resolvers: cross-model invocation features

Follows ADDING_A_HOST.md — zero generator/setup/tooling code changes.