### PR TITLE
[codex] refresh stale gstack skill installs

### DIFF
--- a/bin/gstack-uninstall
+++ b/bin/gstack-uninstall
@@ -230,8 +230,11 @@ fi
 # ─── Remove SessionStart hook from Claude Code settings ─────
 SETTINGS_HOOK="$(dirname "$0")/gstack-settings-hook"
 SESSION_UPDATE="$(dirname "$0")/gstack-session-update"
+SETTINGS_FILE="${GSTACK_SETTINGS_FILE:-$HOME/.claude/settings.json}"
 if [ -x "$SETTINGS_HOOK" ]; then
-  "$SETTINGS_HOOK" remove "$SESSION_UPDATE" 2>/dev/null && REMOVED+=("SessionStart hook") || true
+  if [ -f "$SETTINGS_FILE" ] && grep -q 'gstack-session-update' "$SETTINGS_FILE" 2>/dev/null; then
+    "$SETTINGS_HOOK" remove "$SESSION_UPDATE" 2>/dev/null && REMOVED+=("SessionStart hook") || true
+  fi
 fi
 
 # ─── Remove global state ────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gstack",
-  "version": "0.15.15.0",
+  "version": "0.15.16.0",
   "description": "Garry's Stack — Claude Code skills + fast headless browser. One repo, one install, entire AI engineering workflow.",
   "license": "MIT",
   "type": "module",

--- a/setup
+++ b/setup
@@ -442,11 +442,16 @@ link_codex_skill_dirs() {
       # symlink that Step 5 already pointed at the repo root.
       [ "$skill_name" = "gstack" ] && continue
       target="$skills_dir/$skill_name"
-      # Create or update symlink
-      if [ -L "$target" ] || [ ! -e "$target" ]; then
-        ln -snf "$skill_dir" "$target"
-        linked+=("$skill_name")
+      # Upgrade stale real directories from prior installs to symlinks.
+      if [ -L "$target" ]; then
+        current_target="$(readlink "$target" 2>/dev/null || true)"
+        [ "$current_target" = "$skill_dir" ] && continue
+        rm -f "$target"
+      elif [ -e "$target" ]; then
+        rm -rf "$target"
       fi
+      ln -snf "$skill_dir" "$target"
+      linked+=("$skill_name")
     fi
   done
   if [ ${#linked[@]} -gt 0 ]; then
@@ -591,10 +596,15 @@ link_factory_skill_dirs() {
       skill_name="$(basename "$skill_dir")"
       [ "$skill_name" = "gstack" ] && continue
       target="$skills_dir/$skill_name"
-      if [ -L "$target" ] || [ ! -e "$target" ]; then
-        ln -snf "$skill_dir" "$target"
-        linked+=("$skill_name")
+      if [ -L "$target" ]; then
+        current_target="$(readlink "$target" 2>/dev/null || true)"
+        [ "$current_target" = "$skill_dir" ] && continue
+        rm -f "$target"
+      elif [ -e "$target" ]; then
+        rm -rf "$target"
       fi
+      ln -snf "$skill_dir" "$target"
+      linked+=("$skill_name")
     fi
   done
   if [ ${#linked[@]} -gt 0 ]; then

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2076,6 +2076,15 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('gstack*');
   });
 
+  test('link_codex_skill_dirs replaces stale real directories from prior installs', () => {
+    const fnStart = setupContent.indexOf('link_codex_skill_dirs()');
+    const fnEnd = setupContent.indexOf('}', setupContent.indexOf('linked[@]}', fnStart));
+    const fnBody = setupContent.slice(fnStart, fnEnd);
+    expect(fnBody).toContain('current_target="$(readlink "$target"');
+    expect(fnBody).toContain('rm -rf "$target"');
+    expect(fnBody).toContain('ln -snf "$skill_dir" "$target"');
+  });
+
   test('link_claude_skill_dirs creates real directories with absolute SKILL.md symlinks', () => {
     // Claude links should be real directories with absolute SKILL.md symlinks
     // to ensure Claude Code discovers them as top-level skills (not nested under gstack/)
@@ -2182,6 +2191,15 @@ describe('setup script validation', () => {
     expect(setupContent).toContain('migrate_direct_codex_install');
     expect(setupContent).toContain('$HOME/.gstack/repos/gstack');
     expect(setupContent).toContain('avoid duplicate skill discovery');
+  });
+
+  test('link_factory_skill_dirs also replaces stale real directories', () => {
+    const fnStart = setupContent.indexOf('link_factory_skill_dirs()');
+    const fnEnd = setupContent.indexOf('}', setupContent.indexOf('linked[@]}', fnStart));
+    const fnBody = setupContent.slice(fnStart, fnEnd);
+    expect(fnBody).toContain('current_target="$(readlink "$target"');
+    expect(fnBody).toContain('rm -rf "$target"');
+    expect(fnBody).toContain('ln -snf "$skill_dir" "$target"');
   });
 
   // --- Symlink prefix tests (PR #503) ---


### PR DESCRIPTION
## What changed

- make `./setup --host codex` replace stale `gstack-*` real directories with fresh symlinks to the generated `.agents/skills/*` entries instead of silently leaving old installs in place
- apply the same stale-directory refresh logic to Factory installs, which used the same linker pattern
- tighten `gstack-uninstall` so it only reports removing the SessionStart hook when that hook actually exists
- align `package.json` with the current `VERSION` so the validation suite passes again

## Why

Running `./setup --host codex` succeeded on a clean machine, but it failed to repair an existing broken/stale install. If `~/.codex/skills/gstack-qa` already existed as a real directory, setup skipped it because `link_codex_skill_dirs()` only updated missing paths or existing symlinks.

That left Codex reading stale SKILL content while setup still printed success.

## Impact

- Codex users now get a self-healing setup path when stale `gstack-*` directories are already present
- Factory gets the same behavior for parity
- uninstall output is less misleading in clean environments
- the repo's version metadata is internally consistent again

## Root cause

`link_codex_skill_dirs()` and `link_factory_skill_dirs()` treated real directories as untouchable, so prior installs that materialized as directories never got converted back to the symlink layout expected by current setup.

## Validation

- reproduced the bug with a temp `HOME` containing a stale `~/.codex/skills/gstack-qa/SKILL.md`
- verified the patched setup now converts that path into a symlink to `.agents/skills/gstack-qa/`
- `bun test test/gen-skill-docs.test.ts test/uninstall.test.ts`
