### PR TITLE
feat: add opencode support to setup script

### DIFF
--- a/setup
+++ b/setup
@@ -22,6 +22,8 @@ CODEX_SKILLS="$HOME/.codex/skills"
 CODEX_GSTACK="$CODEX_SKILLS/gstack"
 FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
+OPENCODE_SKILLS="$HOME/.config/opencode/skills"
+OPENCODE_GSTACK="$OPENCODE_SKILLS/gstack"
 
 IS_WINDOWS=0
 case "$(uname -s)" in
@@ -54,7 +56,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|auto) ;;
+  claude|codex|kiro|factory|opencode|auto) ;;
   openclaw)
     echo ""
     echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
@@ -67,7 +69,7 @@ case "$HOST" in
     echo "  3. See docs/OPENCLAW.md for the full architecture"
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, openclaw, or auto)" >&2; exit 1 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -130,13 +132,15 @@ INSTALL_CLAUDE=0
 INSTALL_CODEX=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
+INSTALL_OPENCODE=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
+  command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
@@ -147,6 +151,8 @@ elif [ "$HOST" = "kiro" ]; then
   INSTALL_KIRO=1
 elif [ "$HOST" = "factory" ]; then
   INSTALL_FACTORY=1
+elif [ "$HOST" = "opencode" ]; then
+  INSTALL_OPENCODE=1
 fi
 
 migrate_direct_codex_install() {
@@ -246,6 +252,16 @@ if [ "$INSTALL_FACTORY" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
     cd "$SOURCE_GSTACK_DIR"
     bun install --frozen-lockfile 2>/dev/null || bun install
     bun run gen:skill-docs --host factory
+  )
+fi
+
+# 1d. Generate .opencode/ OpenCode skill docs
+if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .opencode/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun install --frozen-lockfile 2>/dev/null || bun install
+    bun run gen:skill-docs --host opencode
   )
 fi
 
@@ -602,6 +618,76 @@ link_factory_skill_dirs() {
   fi
 }
 
+create_opencode_runtime_root() {
+  local gstack_dir="$1"
+  local opencode_gstack="$2"
+  local opencode_dir="$gstack_dir/.opencode/skills"
+
+  if [ -L "$opencode_gstack" ]; then
+    rm -f "$opencode_gstack"
+  elif [ -d "$opencode_gstack" ] && [ "$opencode_gstack" != "$gstack_dir" ]; then
+    rm -rf "$opencode_gstack"
+  fi
+
+  mkdir -p "$opencode_gstack" "$opencode_gstack/browse" "$opencode_gstack/gstack-upgrade" "$opencode_gstack/review"
+
+  if [ -f "$opencode_dir/gstack/SKILL.md" ]; then
+    ln -snf "$opencode_dir/gstack/SKILL.md" "$opencode_gstack/SKILL.md"
+  fi
+  if [ -d "$gstack_dir/bin" ]; then
+    ln -snf "$gstack_dir/bin" "$opencode_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    ln -snf "$gstack_dir/browse/dist" "$opencode_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    ln -snf "$gstack_dir/browse/bin" "$opencode_gstack/browse/bin"
+  fi
+  if [ -f "$opencode_dir/gstack-upgrade/SKILL.md" ]; then
+    ln -snf "$opencode_dir/gstack-upgrade/SKILL.md" "$opencode_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      ln -snf "$gstack_dir/review/$f" "$opencode_gstack/review/$f"
+    fi
+  done
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    ln -snf "$gstack_dir/ETHOS.md" "$opencode_gstack/ETHOS.md"
+  fi
+}
+
+link_opencode_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local opencode_dir="$gstack_dir/.opencode/skills"
+  local linked=()
+
+  if [ ! -d "$opencode_dir" ]; then
+    echo "  Generating .opencode/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host opencode )
+  fi
+
+  if [ ! -d "$opencode_dir" ]; then
+    echo "  warning: .opencode/skills/ generation failed — run 'bun run gen:skill-docs --host opencode' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$opencode_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
 # 4. Install for Claude (default)
 SKILLS_BASENAME="$(basename "$INSTALL_SKILLS_DIR")"
 SKILLS_PARENT_BASENAME="$(basename "$(dirname "$INSTALL_SKILLS_DIR")")"
@@ -762,6 +848,16 @@ if [ "$INSTALL_FACTORY" -eq 1 ]; then
   echo "gstack ready (factory)."
   echo "  browse: $BROWSE_BIN"
   echo "  factory skills: $FACTORY_SKILLS"
+fi
+
+# 6c. Install for OpenCode
+if [ "$INSTALL_OPENCODE" -eq 1 ]; then
+  mkdir -p "$OPENCODE_SKILLS"
+  create_opencode_runtime_root "$SOURCE_GSTACK_DIR" "$OPENCODE_GSTACK"
+  link_opencode_skill_dirs "$SOURCE_GSTACK_DIR" "$OPENCODE_SKILLS"
+  echo "gstack ready (opencode)."
+  echo "  browse: $BROWSE_BIN"
+  echo "  opencode skills: $OPENCODE_SKILLS"
 fi
 
 # 7. Create .agents/ sidecar symlinks for the real Codex skill target.


### PR DESCRIPTION
## Summary

- Adds `--host opencode` support to the `setup` script, mirroring the existing Codex/Kiro/Factory pattern
- Auto-detects OpenCode via `command -v opencode` when using `--host auto`
- Generates skill docs into `.opencode/skills/` via `bun run gen:skill-docs --host opencode`
- Creates runtime root at `~/.config/opencode/skills/gstack/` with symlinks for `bin/`, `browse/dist/`, `browse/bin/`, `gstack-upgrade/`, `review/`, `ETHOS.md`
- Links generated `gstack-*` skills into `~/.config/opencode/skills/`

The `hosts/opencode.ts` config already existed with the correct paths — this just wires it into the install pipeline.

## Test plan

- [ ] `./setup --host opencode` completes without errors
- [ ] `~/.config/opencode/skills/` contains `gstack-*` skill dirs
- [ ] `~/.config/opencode/skills/gstack/bin` symlink resolves correctly
- [ ] `./setup --host auto` detects and installs opencode when `opencode` CLI is in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)