### PR TITLE
fix(uninstall): clean up per-skill directories with nested SKILL.md symlinks

### DIFF
--- a/bin/gstack-uninstall
+++ b/bin/gstack-uninstall
@@ -131,7 +131,7 @@ fi
 # ─── Remove global Claude skills ────────────────────────────
 CLAUDE_SKILLS="$HOME/.claude/skills"
 if [ -d "$CLAUDE_SKILLS/gstack" ] || [ -L "$CLAUDE_SKILLS/gstack" ]; then
-  # Remove per-skill symlinks that point into gstack/
+  # Remove legacy per-skill symlinks that point into gstack/
   for _LINK in "$CLAUDE_SKILLS"/*; do
     [ -L "$_LINK" ] || continue
     _NAME="$(basename "$_LINK")"
@@ -141,6 +141,22 @@ if [ -d "$CLAUDE_SKILLS/gstack" ] || [ -L "$CLAUDE_SKILLS/gstack" ]; then
       gstack/*|*/gstack/*) rm -f "$_LINK"; REMOVED+=("claude/$_NAME") ;;
     esac
   done
+
+  # Remove per-skill directories whose nested SKILL.md symlinks into gstack/.
+  # setup creates real directories here (not top-level symlinks), with each
+  # SKILL.md linked to gstack/<skill>/SKILL.md. The legacy loop above never
+  # matches these, so they would otherwise be left behind once gstack/ is
+  # removed. See #1132.
+  while IFS= read -r _DIR; do
+    _NAME="$(basename "$_DIR")"
+    [ "$_NAME" = "gstack" ] && continue
+    [ "$_NAME" = "node_modules" ] && continue
+    [ -L "$_DIR/SKILL.md" ] || continue
+    _TARGET="$(readlink "$_DIR/SKILL.md" 2>/dev/null || true)"
+    case "$_TARGET" in
+      gstack/*|*/gstack/*) rm -rf "$_DIR"; REMOVED+=("claude/$_NAME") ;;
+    esac
+  done < <(find "$CLAUDE_SKILLS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null || true)
 
   rm -rf "$CLAUDE_SKILLS/gstack"
   REMOVED+=("~/.claude/skills/gstack")

--- a/test/uninstall.test.ts
+++ b/test/uninstall.test.ts
@@ -161,5 +161,47 @@ describe('gstack-uninstall', () => {
       // Non-gstack should survive
       expect(fs.existsSync(path.join(mockHome, '.claude', 'skills', 'other-tool'))).toBe(true);
     });
+
+    test('current setup layout: real per-skill dirs with nested SKILL.md symlinks are removed (#1132)', () => {
+      // The current setup script (see setup:399-404) creates real directories at the
+      // top level of ~/.claude/skills/ with SKILL.md as a nested symlink into gstack/.
+      // The legacy loop only matched top-level symlinks, so these survived uninstall.
+      fs.mkdirSync(path.join(mockHome, '.claude', 'skills', 'gstack', 'autoplan'), { recursive: true });
+      fs.mkdirSync(path.join(mockHome, '.claude', 'skills', 'gstack', 'canary'), { recursive: true });
+      fs.writeFileSync(path.join(mockHome, '.claude', 'skills', 'gstack', 'autoplan', 'SKILL.md'), 'real');
+      fs.writeFileSync(path.join(mockHome, '.claude', 'skills', 'gstack', 'canary', 'SKILL.md'), 'real');
+
+      // Per-skill directories with nested SKILL.md symlinks
+      fs.mkdirSync(path.join(mockHome, '.claude', 'skills', 'autoplan'), { recursive: true });
+      fs.symlinkSync(
+        path.join(mockHome, '.claude', 'skills', 'gstack', 'autoplan', 'SKILL.md'),
+        path.join(mockHome, '.claude', 'skills', 'autoplan', 'SKILL.md')
+      );
+      fs.mkdirSync(path.join(mockHome, '.claude', 'skills', 'canary'), { recursive: true });
+      fs.symlinkSync(
+        path.join(mockHome, '.claude', 'skills', 'gstack', 'canary', 'SKILL.md'),
+        path.join(mockHome, '.claude', 'skills', 'canary', 'SKILL.md')
+      );
+
+      const result = spawnSync('bash', [UNINSTALL, '--force'], {
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          HOME: mockHome,
+          GSTACK_DIR: path.join(mockHome, '.claude', 'skills', 'gstack'),
+          GSTACK_STATE_DIR: path.join(mockHome, '.gstack'),
+        },
+        cwd: mockGitRoot,
+      });
+
+      expect(result.status).toBe(0);
+
+      // Per-skill directories with nested SKILL.md symlinks into gstack/ should be gone
+      expect(fs.existsSync(path.join(mockHome, '.claude', 'skills', 'autoplan'))).toBe(false);
+      expect(fs.existsSync(path.join(mockHome, '.claude', 'skills', 'canary'))).toBe(false);
+
+      // Non-gstack tool (no SKILL.md symlink) should survive
+      expect(fs.existsSync(path.join(mockHome, '.claude', 'skills', 'other-tool'))).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`gstack-uninstall` left behind per-skill directories that `setup` creates under `~/.claude/skills/`. After `gstack-uninstall --keep-state`, ~30 empty directories holding broken `SKILL.md` symlinks into the removed `gstack/` tree remained. Covers both issue reports: prefix-mode (`gstack-*`) from #896 and default-mode (`browse/`, `ship/`, etc.) from #1132.

## Why this matters

`setup` (lines 399-404) creates each skill as a real directory with a nested `SKILL.md` symlink, regardless of prefix setting:

```
~/.claude/skills/autoplan/              (real dir, default mode)
└── SKILL.md -> ~/.claude/skills/gstack/autoplan/SKILL.md

~/.claude/skills/gstack-autoplan/       (real dir, --prefix mode)
└── SKILL.md -> ~/.claude/skills/gstack/autoplan/SKILL.md
```

The existing uninstall loop only matched top-level symlinks (`[ -L "$_LINK" ]`), so neither layout got cleaned up. The final `rm -rf "$CLAUDE_SKILLS/gstack"` then left the per-skill directories holding broken links.

## Fix

Adds a second pass in the `CLAUDE_SKILLS` block that iterates real directories, checks whether the nested `SKILL.md` is a symlink pointing into `gstack/`, and removes the directory when it does. The legacy top-level-symlink pass is preserved so older installs still clean up.

The symlink-target check matches both default (`browse/`) and prefix (`gstack-browse/`) layouts because setup writes the same nested `SKILL.md` symlink pattern in both. Also safer than the earlier `gstack-*` glob approach, which would have over-removed any unrelated tool whose top-level directory happened to start with `gstack-`.

Scoped to `~/.claude/skills`. The codex/factory/kiro paths use a different install topology and are untouched.

## Test

Added `test('current setup layout...')` in `test/uninstall.test.ts` covering the real-dir-plus-nested-symlink layout. Runs `--force`, asserts per-skill directories are gone, confirms a sibling with no SKILL.md survives.

Local verification on a fake `HOME`:

```
BEFORE:  ~/.claude/skills/{autoplan, ship, gstack, not-gstack}
AFTER:   ~/.claude/skills/{not-gstack}    (autoplan and ship removed; not-gstack preserved)
```

`bun test test/uninstall.test.ts`: 8/8 pass.

Fixes #896, fixes #1132
