### PR TITLE
fix: CDPATH breaks all bin/ scripts — cd stdout corrupts path variables

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -11,7 +11,7 @@
 #        bin/dev-teardown    # clean up
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." >/dev/null 2>&1 && pwd)"
 
 # 1. Copy .env from main worktree (if we're a worktree and don't have one)
 if [ ! -f "$REPO_ROOT/.env" ]; then

--- a/bin/dev-teardown
+++ b/bin/dev-teardown
@@ -2,7 +2,7 @@
 # Remove local dev skill symlinks. Restores global gstack as the active install.
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." >/dev/null 2>&1 && pwd)"
 
 removed=()
 

--- a/bin/gstack-community-dashboard
+++ b/bin/gstack-community-dashboard
@@ -10,7 +10,7 @@
 #   GSTACK_SUPABASE_ANON_KEY      — override Supabase anon key
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null 2>&1 && pwd)}"
 
 # Source Supabase config if not overridden by env
 if [ -z "${GSTACK_SUPABASE_URL:-}" ] && [ -f "$GSTACK_DIR/supabase/config.sh" ]; then

--- a/bin/gstack-extension
+++ b/bin/gstack-extension
@@ -6,8 +6,8 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)"
 
 # Find the extension directory
 EXT_DIR=""

--- a/bin/gstack-learnings-log
+++ b/bin/gstack-learnings-log
@@ -5,7 +5,7 @@
 # Append-only storage. Duplicates (same key+type) are resolved at read time
 # by gstack-learnings-search ("latest winner" per key+type).
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -6,7 +6,7 @@
 # resolves duplicates (latest winner per key+type), and outputs formatted text.
 # Exit 0 silently if no learnings file exists.
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 

--- a/bin/gstack-platform-detect
+++ b/bin/gstack-platform-detect
@@ -4,8 +4,8 @@ set -euo pipefail
 # gstack-platform-detect: show which AI coding agents are installed and gstack status
 # Config-driven: reads host definitions from hosts/*.ts via host-config-export.ts
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-GSTACK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+GSTACK_DIR="$(cd "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)"
 
 printf "%-16s %-10s %-40s %s\n" "Agent" "Version" "Skill Path" "gstack"
 printf "%-16s %-10s %-40s %s\n" "-----" "-------" "----------" "------"

--- a/bin/gstack-relink
+++ b/bin/gstack-relink
@@ -10,7 +10,7 @@
 #   GSTACK_SKILLS_DIR  — override target skills directory
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 GSTACK_CONFIG="${SCRIPT_DIR}/gstack-config"
 
 # Detect install dir
@@ -19,7 +19,7 @@ if [ -z "$INSTALL_DIR" ]; then
   if [ -d "$HOME/.claude/skills/gstack" ]; then
     INSTALL_DIR="$HOME/.claude/skills/gstack"
   elif [ -d "${SCRIPT_DIR}/.." ] && [ -f "${SCRIPT_DIR}/../setup" ]; then
-    INSTALL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+    INSTALL_DIR="$(cd "${SCRIPT_DIR}/.." >/dev/null 2>&1 && pwd)"
   fi
 fi
 

--- a/bin/gstack-repo-mode
+++ b/bin/gstack-repo-mode
@@ -11,7 +11,7 @@
 # Cache:    ~/.gstack/projects/$SLUG/repo-mode.json (7-day TTL)
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 # Compute SLUG directly (avoid eval of gstack-slug — branch names can contain shell metacharacters)
 REMOTE_URL=$(git remote get-url origin 2>/dev/null || true)
 if [ -z "$REMOTE_URL" ]; then

--- a/bin/gstack-review-log
+++ b/bin/gstack-review-log
@@ -2,7 +2,7 @@
 # gstack-review-log — atomically log a review result
 # Usage: gstack-review-log '{"skill":"...","timestamp":"...","status":"..."}'
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-review-read
+++ b/bin/gstack-review-read
@@ -2,7 +2,7 @@
 # gstack-review-read — read review log and config for dashboard
 # Usage: gstack-review-read
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 cat "$GSTACK_HOME/projects/$SLUG/$BRANCH-reviews.jsonl" 2>/dev/null || echo "NO_REVIEWS"

--- a/bin/gstack-specialist-stats
+++ b/bin/gstack-specialist-stats
@@ -6,7 +6,7 @@
 # and outputs hit rates. Tags specialists as GATE_CANDIDATE (0 findings in 10+
 # dispatches) or NEVER_GATE (security, data-migration — insurance policy).
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 PROJECT_DIR="$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-telemetry-log
+++ b/bin/gstack-telemetry-log
@@ -17,7 +17,7 @@
 # NOTE: Uses set -uo pipefail (no -e) — telemetry must never exit non-zero
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null 2>&1 && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 ANALYTICS_DIR="$STATE_DIR/analytics"
 JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"

--- a/bin/gstack-telemetry-sync
+++ b/bin/gstack-telemetry-sync
@@ -11,7 +11,7 @@
 #   GSTACK_SUPABASE_URL        — override Supabase project URL
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null 2>&1 && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 ANALYTICS_DIR="$STATE_DIR/analytics"
 JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"

--- a/bin/gstack-timeline-log
+++ b/bin/gstack-timeline-log
@@ -7,7 +7,7 @@
 # Optional: branch, outcome, duration_s, session, ts.
 # Validation failure → skip silently (non-blocking).
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"

--- a/bin/gstack-timeline-read
+++ b/bin/gstack-timeline-read
@@ -6,7 +6,7 @@
 # Reads ~/.gstack/projects/$SLUG/timeline.jsonl, filters, formats.
 # Exit 0 silently if no timeline file exists.
 set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 

--- a/bin/gstack-uninstall
+++ b/bin/gstack-uninstall
@@ -36,7 +36,7 @@ if [ -z "${HOME:-}" ]; then
   exit 1
 fi
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null 2>&1 && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 _GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 

--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -12,7 +12,7 @@
 #   GSTACK_STATE_DIR    — override ~/.gstack state directory
 set -euo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null 2>&1 && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 CACHE_FILE="$STATE_DIR/last-update-check"
 MARKER_FILE="$STATE_DIR/just-upgraded-from"


### PR DESCRIPTION
## Summary

When `CDPATH` is set (common with zsh users, zoxide, custom `.zshrc` navigation), `cd` prints the resolved path to stdout if it resolves through `CDPATH`. This doubles the output of `$(cd ... && pwd)`, corrupting `GSTACK_DIR`, `SCRIPT_DIR`, and every path derived from them.

**Most visible impact:** `gstack-update-check` silently exits — `VERSION_FILE` becomes a two-line string, `[ -f "$VERSION_FILE" ]` fails, and upgrade detection never runs. Users with `CDPATH` set are permanently stuck on their installed version.

**Fix:** redirect `cd` stdout with `>/dev/null 2>&1` in all path-resolution patterns. This is the standard POSIX-safe idiom for `cd` inside command substitution.

**18 files, 21 call sites:**

```
bin/dev-setup                  bin/gstack-relink
bin/dev-teardown               bin/gstack-repo-mode
bin/gstack-community-dashboard bin/gstack-review-log
bin/gstack-extension           bin/gstack-review-read
bin/gstack-learnings-log       bin/gstack-specialist-stats
bin/gstack-learnings-search    bin/gstack-telemetry-log
bin/gstack-platform-detect     bin/gstack-telemetry-sync
bin/gstack-timeline-log        bin/gstack-timeline-read
bin/gstack-uninstall           bin/gstack-update-check
```

**Before (broken):**
```bash
GSTACK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
# With CDPATH=".:/home/user" → GSTACK_DIR="/path\n/path" (two lines)
```

**After (fixed):**
```bash
GSTACK_DIR="$(cd "$(dirname "$0")/.." >/dev/null 2>&1 && pwd)"
# With any CDPATH → GSTACK_DIR="/path" (one line, correct)
```

## Reproduction

```bash
export CDPATH=".:/home/user:/home/user/dev"
~/.claude/skills/gstack/bin/gstack-update-check --force
# No output — silently exits, never checks remote VERSION
```

## Scope

This PR fixes `bin/` scripts only. The same pattern exists in `setup`, `scripts/build-app.sh`, `scripts/app/gstack-browser`, `browse/scripts/build-node-server.sh`, `gstack-upgrade/migrations/v0.15.2.0.sh`, and `supabase/verify-rls.sh` — flagging as a follow-up to keep this PR focused.

## Test plan

- [x] `CDPATH=".:/tmp" bash bin/gstack-update-check --force` — no longer silently exits
- [x] Verified `$(cd path >/dev/null 2>&1 && pwd)` returns single line with `CDPATH` set
- [x] Verified original pattern returns two lines with `CDPATH` set (confirmed the bug)
- [x] `bun test` passes (6 pre-existing failures, 0 new — golden file + version mismatch)

Closes #824

Generated with [Claude Code](https://claude.ai/code)