### PR TITLE
fix(browse): use --outdir for Windows node server build

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -13,14 +13,17 @@ DIST_DIR="$GSTACK_DIR/browse/dist"
 
 echo "Building Node-compatible server bundle..."
 
-# Step 1: Transpile server.ts to a single .mjs bundle (externalize runtime deps)
+# Step 1: Transpile server.ts to a bundle in DIST_DIR (externalize runtime deps).
+# Bun emits the entry as server.js plus any native assets (e.g. ngrok) alongside
+# it, so --outdir is required — --outfile rejects multi-output builds.
 bun build "$SRC_DIR/server.ts" \
   --target=node \
-  --outfile "$DIST_DIR/server-node.mjs" \
+  --outdir "$DIST_DIR" \
   --external playwright \
   --external playwright-core \
   --external diff \
   --external "bun:sqlite"
+mv "$DIST_DIR/server.js" "$DIST_DIR/server-node.mjs"
 
 # Step 2: Post-process
 # Replace import.meta.dir with a resolvable reference


### PR DESCRIPTION
## Problem

On Windows, `bash browse/scripts/build-node-server.sh` fails with:

\`\`\`
error: cannot write multiple output files without an output directory
\`\`\`

because recent \`bun build\` (Bun v1.3.11) emits a native asset (\`ngrok.win32-x64-msvc-*.node\`, ~10 MB) alongside the main server bundle. When bun has multiple outputs, it rejects the \`--outfile\` flag.

The script crashes before producing \`server-node.mjs\`, so \`browse.exe\` can't start on Windows and every \`\$B\` command dies with:

\`\`\`
error: server-node.mjs not found. Run \`bun run build\` to generate the Windows server bundle.
\`\`\`

Every fresh \`./setup\` or \`gstack-upgrade\` on Windows leaves \`/browse\` broken until someone rebuilds by hand.

## Fix

Replace \`--outfile\` with \`--outdir\`, then rename the emitted entry bundle to \`server-node.mjs\` before the existing perl substitutions and polyfill-header injection run. All downstream steps are unchanged.

\`\`\`diff
- --outfile "\$DIST_DIR/server-node.mjs" \
+ --outdir "\$DIST_DIR" \
   --external playwright \
   ...
+mv "\$DIST_DIR/server.js" "\$DIST_DIR/server-node.mjs"
\`\`\`

The ngrok native asset lands in \`dist/\` as a sibling file; \`browse.exe\` doesn't reference it, and it's already covered by the existing \`browse/dist/\` line in \`.gitignore\`, so it won't get committed.

## Verification

Verified end-to-end on Windows 11 / Bun v1.3.11:

1. \`rm -f browse/dist/server-node.mjs browse/dist/bun-polyfill.cjs browse/dist/ngrok*.node\` — reset state
2. \`bash browse/scripts/build-node-server.sh\` — prints \`Node server bundle ready: .../browse/dist/server-node.mjs\`
3. \`head -8 browse/dist/server-node.mjs\` — polyfill header correctly injected (\`createRequire\`, \`fileURLToPath\`, \`dirname\`, \`__browseNodeSrcDir\`, \`createRequire(... "./bun-polyfill.cjs")\`)
4. \`bun run build\` — full pipeline succeeds (all dist binaries compile, \`.version\` written)
5. \`browse goto https://example.com && browse js "document.title"\` → \`Example Domain\` ✓

No changes needed to \`package.json\`, \`setup\`, or any caller — the script is the only thing that had to change.

## Not in scope

- The parallel macOS-only \`scripts/build-app.sh\` line 31 also uses \`bun build --compile --outfile\`, but that's \`--compile\` mode (single standalone binary, no side assets) and not triggered on Windows, so it's unaffected.