### PR TITLE
fix(cli): respect BROWSE_PARENT_PID=0 in startServer

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -232,7 +232,7 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     // when the CLI exits, the server dies with it. Use Node's child_process.spawn
     // with { detached: true } instead, which is the gold standard for Windows
     // process independence. Credit: PR #191 by @fqueiro.
-    const extraEnvStr = JSON.stringify({ BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: String(process.pid), ...(extraEnv || {}) });
+    const extraEnvStr = JSON.stringify({ BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: process.env.BROWSE_PARENT_PID === '0' ? '0' : String(process.pid), ...(extraEnv || {}) });
     const launcherCode =
       `const{spawn}=require('child_process');` +
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
@@ -243,7 +243,7 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     // macOS/Linux: Bun.spawn + unref works correctly
     proc = Bun.spawn(['bun', 'run', SERVER_SCRIPT], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: String(process.pid), ...extraEnv },
+      env: { ...process.env, BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: process.env.BROWSE_PARENT_PID === '0' ? '0' : String(process.pid), ...extraEnv },
     });
     proc.unref();
   }


### PR DESCRIPTION
## Problem

  When running browse CLI commands from a terminal (not from Claude Code),
  the server dies ~15 seconds after each CLI invocation. This is because
  `startServer()` always sets `BROWSE_PARENT_PID` to the CLI process PID,
  which is short-lived. The server's parent-PID watchdog detects the dead
  parent and shuts down.

  ## Fix

  If `BROWSE_PARENT_PID=0` is already set in the environment, pass `'0'`
  to the server instead of overriding with the CLI's own PID. This disables
  the watchdog, matching the behavior already implemented in the `connect`
  command (line 842-845).

  ## Use Case

  - Running browse from non-Claude-Code agents
  - CI/CD pipelines
  - Terminal debugging sessions
  - Any scenario where the parent process is not long-lived

  ## Changes

  2 lines changed in `browse/src/cli.ts` (Windows + macOS/Linux paths).