### PR TITLE
feat(design): support OPENAI_BASE_URL for API calls

### DIFF
--- a/design/prototype.ts
+++ b/design/prototype.ts
@@ -8,6 +8,7 @@
 
 import fs from "fs";
 import path from "path";
+import { openaiUrl } from "./src/auth";
 
 const API_KEY = process.env.OPENAI_API_KEY;
 
@@ -44,7 +45,7 @@ async function generateMockup(brief: { name: string; prompt: string }) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 120_000); // 2 min timeout
 
-  const response = await fetch("https://api.openai.com/v1/responses", {
+  const response = await fetch(openaiUrl("responses"), {
     method: "POST",
     headers: {
       "Authorization": `Bearer ${API_KEY}`,

--- a/design/src/auth.ts
+++ b/design/src/auth.ts
@@ -16,6 +16,8 @@
 import fs from "fs";
 import path from "path";
 
+const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
+
 type ApiKeySource = "config" | "env";
 
 export interface ApiKeyResolution {
@@ -97,6 +99,17 @@ export function resolveApiKeyInfo(): ApiKeyResolution | null {
 
 export function resolveApiKey(): string | null {
   return resolveApiKeyInfo()?.key ?? null;
+}
+
+export function resolveOpenAIBaseUrl(): string {
+  const configuredBaseUrl = process.env.OPENAI_BASE_URL?.trim();
+  if (!configuredBaseUrl) return DEFAULT_OPENAI_BASE_URL;
+  return configuredBaseUrl.replace(/\/+$/, "");
+}
+
+export function openaiUrl(endpoint: string): string {
+  const normalizedEndpoint = endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
+  return `${resolveOpenAIBaseUrl()}${normalizedEndpoint}`;
 }
 
 export function describeApiKeySource(resolution: ApiKeyResolution): string {

--- a/design/src/check.ts
+++ b/design/src/check.ts
@@ -4,7 +4,7 @@
  */
 
 import fs from "fs";
-import { requireApiKey } from "./auth";
+import { openaiUrl, requireApiKey } from "./auth";
 
 export interface CheckResult {
   pass: boolean;
@@ -22,7 +22,7 @@ export async function checkMockup(imagePath: string, brief: string): Promise<Che
   const timeout = setTimeout(() => controller.abort(), 60_000);
 
   try {
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    const response = await fetch(openaiUrl("chat/completions"), {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${apiKey}`,

--- a/design/src/design-to-code.ts
+++ b/design/src/design-to-code.ts
@@ -5,7 +5,7 @@
  */
 
 import fs from "fs";
-import { requireApiKey } from "./auth";
+import { openaiUrl, requireApiKey } from "./auth";
 import { readDesignConstraints } from "./memory";
 
 export interface DesignToCodeResult {
@@ -37,7 +37,7 @@ export async function generateDesignToCodePrompt(
       ? `\n\nExisting DESIGN.md (use these as constraints):\n${designConstraints}`
       : "";
 
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    const response = await fetch(openaiUrl("chat/completions"), {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${apiKey}`,

--- a/design/src/diff.ts
+++ b/design/src/diff.ts
@@ -5,7 +5,7 @@
  */
 
 import fs from "fs";
-import { requireApiKey } from "./auth";
+import { openaiUrl, requireApiKey } from "./auth";
 
 export interface DiffResult {
   differences: { area: string; description: string; severity: string }[];
@@ -28,7 +28,7 @@ export async function diffMockups(
   const timeout = setTimeout(() => controller.abort(), 60_000);
 
   try {
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    const response = await fetch(openaiUrl("chat/completions"), {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${apiKey}`,

--- a/design/src/evolve.ts
+++ b/design/src/evolve.ts
@@ -7,7 +7,7 @@
 
 import fs from "fs";
 import path from "path";
-import { requireApiKey } from "./auth";
+import { openaiUrl, requireApiKey } from "./auth";
 
 export interface EvolveOptions {
   screenshot: string;  // Path to current site screenshot
@@ -55,7 +55,7 @@ export async function evolve(options: EvolveOptions): Promise<void> {
   const timeout = setTimeout(() => controller.abort(), 240_000);
 
   try {
-    const response = await fetch("https://api.openai.com/v1/responses", {
+    const response = await fetch(openaiUrl("responses"), {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${apiKey}`,
@@ -113,7 +113,7 @@ async function analyzeScreenshot(apiKey: string, imageBase64: string): Promise<s
   const timeout = setTimeout(() => controller.abort(), 30_000);
 
   try {
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    const response = await fetch(openaiUrl("chat/completions"), {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${apiKey}`,

--- a/design/src/generate.ts
+++ b/design/src/generate.ts
@@ -4,7 +4,7 @@
 
 import fs from "fs";
 import path from "path";
-import { requireApiKey } from "./auth";
+import { openaiUrl, requireApiKey } from "./auth";
 import { parseBrief } from "./brief";
 import { createSession, sessionPath } from "./session";
 import { checkMockup } from "./check";
@@ -40,7 +40,7 @@ async function callImageGeneration(
   const timeout = setTimeout(() => controller.abort(), 240_000);
 
   try {
-    const response = await fetch("https://api.openai.com/v1/responses", {
+    const response = await fetch(openaiUrl("responses"), {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${apiKey}`,

--- a/design/src/iterate.ts
+++ b/design/src/iterate.ts
@@ -8,7 +8,7 @@
 
 import fs from "fs";
 import path from "path";
-import { requireApiKey } from "./auth";
+import { openaiUrl, requireApiKey } from "./auth";
 import { readSession, updateSession } from "./session";
 
 export interface IterateOptions {
@@ -85,7 +85,7 @@ async function callWithThreading(
   const timeout = setTimeout(() => controller.abort(), 240_000);
 
   try {
-    const response = await fetch("https://api.openai.com/v1/responses", {
+    const response = await fetch(openaiUrl("responses"), {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${apiKey}`,
@@ -133,7 +133,7 @@ async function callFresh(
   const timeout = setTimeout(() => controller.abort(), 240_000);
 
   try {
-    const response = await fetch("https://api.openai.com/v1/responses", {
+    const response = await fetch(openaiUrl("responses"), {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${apiKey}`,

--- a/design/src/memory.ts
+++ b/design/src/memory.ts
@@ -13,7 +13,7 @@
 
 import fs from "fs";
 import path from "path";
-import { requireApiKey } from "./auth";
+import { openaiUrl, requireApiKey } from "./auth";
 
 export interface ExtractedDesign {
   colors: { name: string; hex: string; usage: string }[];
@@ -34,7 +34,7 @@ export async function extractDesignLanguage(imagePath: string): Promise<Extracte
   const timeout = setTimeout(() => controller.abort(), 60_000);
 
   try {
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    const response = await fetch(openaiUrl("chat/completions"), {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${apiKey}`,

--- a/design/src/variants.ts
+++ b/design/src/variants.ts
@@ -6,7 +6,7 @@
 
 import fs from "fs";
 import path from "path";
-import { requireApiKey } from "./auth";
+import { openaiUrl, requireApiKey } from "./auth";
 import { parseBrief } from "./brief";
 
 export interface VariantsOptions {
@@ -61,7 +61,7 @@ export async function generateVariant(
     const timeout = setTimeout(() => controller.abort(), 240_000);
 
     try {
-      const response = await fetchFn("https://api.openai.com/v1/responses", {
+      const response = await fetchFn(openaiUrl("responses"), {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${apiKey}`,

--- a/design/test/auth.test.ts
+++ b/design/test/auth.test.ts
@@ -13,6 +13,7 @@ import * as os from "os";
 import * as path from "path";
 import {
   describeApiKeySource,
+  openaiUrl,
   requireApiKey,
   resolveApiKey,
   resolveApiKeyInfo,
@@ -23,8 +24,17 @@ let tmpDir: string;
 let tmpHome: string;
 let originalHome: string | undefined;
 let originalKey: string | undefined;
+let originalBaseUrl: string | undefined;
 let originalNodeEnv: string | undefined;
 let originalCwd: string;
+
+function listTypeScriptFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) return listTypeScriptFiles(entryPath);
+    return entry.isFile() && entry.name.endsWith(".ts") ? [entryPath] : [];
+  });
+}
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gstack-design-auth-"));
@@ -33,11 +43,13 @@ beforeEach(() => {
 
   originalHome = process.env.HOME;
   originalKey = process.env.OPENAI_API_KEY;
+  originalBaseUrl = process.env.OPENAI_BASE_URL;
   originalNodeEnv = process.env.NODE_ENV;
   originalCwd = process.cwd();
 
   process.env.HOME = tmpHome;
   delete process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_BASE_URL;
   delete process.env.NODE_ENV;
   process.chdir(tmpDir);
 });
@@ -48,6 +60,8 @@ afterEach(() => {
   else process.env.HOME = originalHome;
   if (originalKey === undefined) delete process.env.OPENAI_API_KEY;
   else process.env.OPENAI_API_KEY = originalKey;
+  if (originalBaseUrl === undefined) delete process.env.OPENAI_BASE_URL;
+  else process.env.OPENAI_BASE_URL = originalBaseUrl;
   if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
   else process.env.NODE_ENV = originalNodeEnv;
   fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -108,6 +122,47 @@ describe("resolveApiKeyInfo", () => {
     expect(resolution?.key).toBe("sk-shell");
     expect(resolution?.envFile).toBeUndefined();
     expect(resolution?.warning).toBeUndefined();
+  });
+});
+
+describe("openaiUrl", () => {
+  test("uses the OpenAI v1 endpoint by default", () => {
+    expect(openaiUrl("responses")).toBe("https://api.openai.com/v1/responses");
+    expect(openaiUrl("/chat/completions")).toBe(
+      "https://api.openai.com/v1/chat/completions",
+    );
+  });
+
+  test("uses a trimmed OPENAI_BASE_URL without duplicate slashes", () => {
+    process.env.OPENAI_BASE_URL = "  https://gateway.example/openai/v1///  ";
+
+    expect(openaiUrl("/responses")).toBe(
+      "https://gateway.example/openai/v1/responses",
+    );
+  });
+
+  test("falls back to OpenAI when OPENAI_BASE_URL is blank", () => {
+    process.env.OPENAI_BASE_URL = "   ";
+
+    expect(openaiUrl("responses")).toBe("https://api.openai.com/v1/responses");
+  });
+
+  test("routes every design OpenAI request through the URL resolver", () => {
+    const designDir = path.resolve(import.meta.dir, "..");
+    const authPath = path.join(designDir, "src", "auth.ts");
+    const sourceFiles = [
+      path.join(designDir, "prototype.ts"),
+      ...listTypeScriptFiles(path.join(designDir, "src")),
+    ];
+    const hardcodedCallSites = sourceFiles
+      .filter((filePath) => filePath !== authPath)
+      .filter((filePath) =>
+        fs.readFileSync(filePath, "utf-8").includes("https://api.openai.com/v1"),
+      )
+      .map((filePath) => path.relative(designDir, filePath))
+      .sort();
+
+    expect(hardcodedCallSites).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a central `openaiUrl()` resolver that honors `OPENAI_BASE_URL`, trims whitespace/trailing slashes, and defaults to `https://api.openai.com/v1`
- route every current design OpenAI API call through the resolver, including `design/prototype.ts`
- add regression coverage for default/custom/blank base URLs and for future hardcoded design API call sites

## Why
Some environments route OpenAI requests through an internal or compatible API gateway. The design tools previously hardcoded the public OpenAI endpoint at each call site.

## Validation
- `bun test design/test/auth.test.ts design/test/daemon.test.ts design/test/gallery.test.ts design/test/serve.test.ts` — 67 passed, 0 failed
- `bun build` for all nine changed API-call entry points — succeeded
- `git diff --check` — clean

The broader local design suite also contains environment-dependent tests: Playwright Chromium is not installed, daemon-discovery assumes a parent/child PID shape that differs under the local Bun runtime, and one existing HTTP-date retry assertion is timing-sensitive. None of those paths are changed here.
