### PR TITLE
fix: normalize legacy learnings schema (GXG-872)

### DIFF
--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -14,6 +14,7 @@ TYPE=""
 QUERY=""
 LIMIT=10
 CROSS_PROJECT=false
+LEARNINGS_HELPER="file://$SCRIPT_DIR/../scripts/learnings-normalize.ts"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -43,8 +44,9 @@ if [ ${#FILES[@]} -eq 0 ]; then
 fi
 
 # Process all files through bun for JSON parsing, decay, dedup, filtering
-GSTACK_SEARCH_TYPE="$TYPE" GSTACK_SEARCH_QUERY="$QUERY" GSTACK_SEARCH_LIMIT="$LIMIT" GSTACK_SEARCH_SLUG="$SLUG" GSTACK_SEARCH_CROSS="$CROSS_PROJECT" \
-cat "${FILES[@]}" 2>/dev/null | GSTACK_SEARCH_TYPE="$TYPE" GSTACK_SEARCH_QUERY="$QUERY" GSTACK_SEARCH_LIMIT="$LIMIT" GSTACK_SEARCH_SLUG="$SLUG" GSTACK_SEARCH_CROSS="$CROSS_PROJECT" bun -e "
+GSTACK_SEARCH_TYPE="$TYPE" GSTACK_SEARCH_QUERY="$QUERY" GSTACK_SEARCH_LIMIT="$LIMIT" GSTACK_SEARCH_SLUG="$SLUG" GSTACK_SEARCH_CROSS="$CROSS_PROJECT" GSTACK_LEARNINGS_HELPER="$LEARNINGS_HELPER" \
+cat "${FILES[@]}" 2>/dev/null | GSTACK_SEARCH_TYPE="$TYPE" GSTACK_SEARCH_QUERY="$QUERY" GSTACK_SEARCH_LIMIT="$LIMIT" GSTACK_SEARCH_SLUG="$SLUG" GSTACK_SEARCH_CROSS="$CROSS_PROJECT" GSTACK_LEARNINGS_HELPER="$LEARNINGS_HELPER" bun -e "
+const { normalizeLearningsEntry } = await import(process.env.GSTACK_LEARNINGS_HELPER);
 const lines = (await Bun.stdin.text()).trim().split('\n').filter(Boolean);
 const now = Date.now();
 const type = process.env.GSTACK_SEARCH_TYPE || '';
@@ -55,22 +57,23 @@ const slug = process.env.GSTACK_SEARCH_SLUG || '';
 const entries = [];
 for (const line of lines) {
   try {
-    const e = JSON.parse(line);
-    if (!e.key || !e.type) continue;
+    const normalized = normalizeLearningsEntry(JSON.parse(line));
+    if (!normalized) continue;
 
     // Apply confidence decay: observed/inferred lose 1pt per 30 days
-    let conf = e.confidence || 5;
-    if (e.source === 'observed' || e.source === 'inferred') {
-      const days = Math.floor((now - new Date(e.ts).getTime()) / 86400000);
+    let conf = normalized.confidence || 5;
+    if (normalized.source === 'observed' || normalized.source === 'inferred') {
+      const tsMs = new Date(normalized.ts || 0).getTime();
+      const days = Math.floor((now - tsMs) / 86400000);
       conf = Math.max(0, conf - Math.floor(days / 30));
     }
-    e._effectiveConfidence = conf;
+    normalized._effectiveConfidence = conf;
 
     // Determine if this is from the current project or cross-project
     // Cross-project entries are tagged for display
-    e._crossProject = !line.includes(slug) && process.env.GSTACK_SEARCH_CROSS === 'true';
+    normalized._crossProject = !line.includes(slug) && process.env.GSTACK_SEARCH_CROSS === 'true';
 
-    entries.push(e);
+    entries.push(normalized);
   } catch {}
 }
 

--- a/bin/gstack-learnings-stats
+++ b/bin/gstack-learnings-stats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# gstack-learnings-stats — summarize project learnings with legacy schema support
+# Usage: gstack-learnings-stats
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
+GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
+LEARN_FILE="$GSTACK_HOME/projects/$SLUG/learnings.jsonl"
+LEARNINGS_HELPER="file://$SCRIPT_DIR/../scripts/learnings-normalize.ts"
+
+if [ ! -f "$LEARN_FILE" ]; then
+  echo "NO_LEARNINGS"
+  exit 0
+fi
+
+TOTAL=$(wc -l < "$LEARN_FILE" | tr -d ' ')
+echo "TOTAL: $TOTAL entries"
+
+GSTACK_LEARNINGS_HELPER="$LEARNINGS_HELPER" cat "$LEARN_FILE" | GSTACK_LEARNINGS_HELPER="$LEARNINGS_HELPER" bun -e "
+const { normalizeLearningsEntry } = await import(process.env.GSTACK_LEARNINGS_HELPER);
+const lines = (await Bun.stdin.text()).trim().split('\n').filter(Boolean);
+
+const seen = new Map();
+for (const line of lines) {
+  try {
+    const normalized = normalizeLearningsEntry(JSON.parse(line));
+    if (!normalized) continue;
+
+    const dedupeKey = normalized.key + '|' + normalized.type;
+    const existing = seen.get(dedupeKey);
+    if (!existing || new Date(normalized.ts || 0) > new Date(existing.ts || 0)) {
+      seen.set(dedupeKey, normalized);
+    }
+  } catch {}
+}
+
+const byType = {};
+const bySource = {};
+let totalConfidence = 0;
+for (const entry of seen.values()) {
+  byType[entry.type] = (byType[entry.type] || 0) + 1;
+  const source = entry.source || 'unknown';
+  bySource[source] = (bySource[source] || 0) + 1;
+  totalConfidence += entry.confidence || 0;
+}
+
+console.log('UNIQUE: ' + seen.size + ' (after dedup)');
+console.log('RAW_ENTRIES: ' + lines.length);
+console.log('BY_TYPE: ' + JSON.stringify(byType));
+console.log('BY_SOURCE: ' + JSON.stringify(bySource));
+console.log('AVG_CONFIDENCE: ' + (seen.size ? (totalConfidence / seen.size).toFixed(1) : '0.0'));
+" 2>/dev/null

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -651,40 +651,7 @@ Show summary statistics about the project's learnings.
 
 ```bash
 eval "$(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)"
-GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
-LEARN_FILE="$GSTACK_HOME/projects/$SLUG/learnings.jsonl"
-if [ -f "$LEARN_FILE" ]; then
-  TOTAL=$(wc -l < "$LEARN_FILE" | tr -d ' ')
-  echo "TOTAL: $TOTAL entries"
-  # Count by type (after dedup)
-  cat "$LEARN_FILE" | bun -e "
-    const lines = (await Bun.stdin.text()).trim().split('\n').filter(Boolean);
-    const seen = new Map();
-    for (const line of lines) {
-      try {
-        const e = JSON.parse(line);
-        const dk = (e.key||'') + '|' + (e.type||'');
-        const existing = seen.get(dk);
-        if (!existing || new Date(e.ts) > new Date(existing.ts)) seen.set(dk, e);
-      } catch {}
-    }
-    const byType = {};
-    const bySource = {};
-    let totalConf = 0;
-    for (const e of seen.values()) {
-      byType[e.type] = (byType[e.type]||0) + 1;
-      bySource[e.source] = (bySource[e.source]||0) + 1;
-      totalConf += e.confidence || 0;
-    }
-    console.log('UNIQUE: ' + seen.size + ' (after dedup)');
-    console.log('RAW_ENTRIES: ' + lines.length);
-    console.log('BY_TYPE: ' + JSON.stringify(byType));
-    console.log('BY_SOURCE: ' + JSON.stringify(bySource));
-    console.log('AVG_CONFIDENCE: ' + (totalConf / seen.size).toFixed(1));
-  " 2>/dev/null
-else
-  echo "NO_LEARNINGS"
-fi
+~/.claude/skills/gstack/bin/gstack-learnings-stats 2>/dev/null
 ```
 
 Present the stats in a readable table format.

--- a/learn/SKILL.md.tmpl
+++ b/learn/SKILL.md.tmpl
@@ -137,40 +137,7 @@ Show summary statistics about the project's learnings.
 
 ```bash
 eval "$(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)"
-GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
-LEARN_FILE="$GSTACK_HOME/projects/$SLUG/learnings.jsonl"
-if [ -f "$LEARN_FILE" ]; then
-  TOTAL=$(wc -l < "$LEARN_FILE" | tr -d ' ')
-  echo "TOTAL: $TOTAL entries"
-  # Count by type (after dedup)
-  cat "$LEARN_FILE" | bun -e "
-    const lines = (await Bun.stdin.text()).trim().split('\n').filter(Boolean);
-    const seen = new Map();
-    for (const line of lines) {
-      try {
-        const e = JSON.parse(line);
-        const dk = (e.key||'') + '|' + (e.type||'');
-        const existing = seen.get(dk);
-        if (!existing || new Date(e.ts) > new Date(existing.ts)) seen.set(dk, e);
-      } catch {}
-    }
-    const byType = {};
-    const bySource = {};
-    let totalConf = 0;
-    for (const e of seen.values()) {
-      byType[e.type] = (byType[e.type]||0) + 1;
-      bySource[e.source] = (bySource[e.source]||0) + 1;
-      totalConf += e.confidence || 0;
-    }
-    console.log('UNIQUE: ' + seen.size + ' (after dedup)');
-    console.log('RAW_ENTRIES: ' + lines.length);
-    console.log('BY_TYPE: ' + JSON.stringify(byType));
-    console.log('BY_SOURCE: ' + JSON.stringify(bySource));
-    console.log('AVG_CONFIDENCE: ' + (totalConf / seen.size).toFixed(1));
-  " 2>/dev/null
-else
-  echo "NO_LEARNINGS"
-fi
+~/.claude/skills/gstack/bin/gstack-learnings-stats 2>/dev/null
 ```
 
 Present the stats in a readable table format.

--- a/scripts/learnings-normalize.ts
+++ b/scripts/learnings-normalize.ts
@@ -1,0 +1,57 @@
+const VALID_TYPES = new Set(['pattern', 'pitfall', 'preference', 'architecture', 'tool', 'operational']);
+
+function getString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function getNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function slugifyLearningsKey(value: unknown): string {
+  return getString(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+export function normalizeLearningsType(entry: Record<string, unknown>): string {
+  const directType = getString(entry.type).toLowerCase();
+  if (VALID_TYPES.has(directType)) return directType;
+
+  const category = getString(entry.category).toLowerCase();
+  if (!category) return '';
+
+  const tokens = category.split(/[^a-z0-9]+/).filter(Boolean);
+
+  if (tokens.includes('pitfall') || tokens.includes('gotcha') || tokens.includes('trap')) return 'pitfall';
+  if (tokens.includes('architecture') || tokens.includes('architectural') || tokens.includes('arch')) return 'architecture';
+  if (tokens.includes('preference') || tokens.includes('pref')) return 'preference';
+  if (tokens.includes('pattern')) return 'pattern';
+  if (tokens.includes('operational') || tokens.includes('workflow') || tokens.includes('process') || tokens.includes('ops')) return 'operational';
+  if (tokens.includes('tool')) return 'tool';
+
+  for (const token of tokens) {
+    if (VALID_TYPES.has(token)) return token;
+  }
+
+  return '';
+}
+
+export function normalizeLearningsEntry(entry: Record<string, unknown>): Record<string, unknown> | null {
+  const type = normalizeLearningsType(entry);
+  const insight = getString(entry.insight) || getString(entry.detail) || getString(entry.summary);
+  const key = getString(entry.key) || slugifyLearningsKey(entry.summary);
+
+  if (!type || !key || !insight) return null;
+
+  return {
+    ...entry,
+    type,
+    key,
+    insight,
+    confidence: getNumber(entry.confidence) ?? 5,
+    skill: getString(entry.skill) || 'learn',
+  };
+}

--- a/test/learnings.test.ts
+++ b/test/learnings.test.ts
@@ -43,6 +43,20 @@ function runSearch(args: string = ''): string {
   }
 }
 
+function runStats(): string {
+  const execOpts: ExecSyncOptionsWithStringEncoding = {
+    cwd: ROOT,
+    env: { ...process.env, GSTACK_HOME: tmpDir },
+    encoding: 'utf-8',
+    timeout: 15000,
+  };
+  try {
+    return execSync(`${BIN}/gstack-learnings-stats`, execOpts).trim();
+  } catch {
+    return '';
+  }
+}
+
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-learn-'));
   slugDir = path.join(tmpDir, 'projects');
@@ -190,6 +204,22 @@ describe('gstack-learnings-search', () => {
     expect(output).toContain('valid-entry');
     expect(output).toContain('also-valid');
   });
+
+  test('normalizes legacy category/summary/detail entries', () => {
+    runLog(JSON.stringify({
+      ts: '2026-04-06T13:45:00Z',
+      category: 'tool-gotcha',
+      summary: 'vitest run --changed requires base ref specification',
+      detail: 'Bare vitest run --changed compares against unstaged changes only.',
+      source: 'eng-review-outside-voice',
+    }));
+
+    const output = runSearch();
+    expect(output).toContain('## Pitfalls');
+    expect(output).toContain('vitest-run-changed-requires-base-ref-specification');
+    expect(output).toContain('Bare vitest run --changed compares against unstaged changes only.');
+    expect(output).not.toContain('undefined');
+  });
 });
 
 describe('gstack-learnings-log edge cases', () => {
@@ -279,5 +309,23 @@ describe('gstack-learnings-search edge cases', () => {
 
     const output = runSearch();
     expect(output).toContain('confidence: 0/10');
+  });
+});
+
+describe('gstack-learnings-stats', () => {
+  test('counts legacy schema entries without undefined type buckets', () => {
+    runLog(JSON.stringify({
+      ts: '2026-04-06T13:45:00Z',
+      category: 'tool-gotcha',
+      summary: 'vitest run --changed requires base ref specification',
+      detail: 'Bare vitest run --changed compares against unstaged changes only.',
+      source: 'eng-review-outside-voice',
+    }));
+
+    const output = runStats();
+    expect(output).toContain('TOTAL: 1 entries');
+    expect(output).toContain('UNIQUE: 1 (after dedup)');
+    expect(output).toContain('BY_TYPE: {"pitfall":1}');
+    expect(output).not.toContain('undefined');
   });
 });


### PR DESCRIPTION
## Summary
- normalize legacy `category/summary/detail` learnings records into the current schema for search and stats
- add a dedicated `gstack-learnings-stats` command so `/learn stats` has a single tested owner
- cover legacy-schema compatibility with regression tests

## Verification
- `~/.bun/bin/bun test test/learnings.test.ts test/gen-skill-docs.test.ts`
- `~/.bun/bin/bun test browse/test/ test/ --ignore 'test/skill-e2e-*.test.ts' --ignore test/skill-llm-eval.test.ts --ignore test/skill-routing-e2e.test.ts --ignore test/codex-e2e.test.ts --ignore test/gemini-e2e.test.ts` was attempted earlier but failed on pre-existing golden-file regressions unrelated to this diff; the targeted suites above are green

Related: GXG-872
