### PR TITLE
fix(browse): externalize @ngrok/ngrok in node server build

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -20,7 +20,8 @@ bun build "$SRC_DIR/server.ts" \
   --external playwright \
   --external playwright-core \
   --external diff \
-  --external "bun:sqlite"
+  --external "bun:sqlite" \
+  --external "@ngrok/ngrok"
 
 # Step 2: Post-process
 # Replace import.meta.dir with a resolvable reference


### PR DESCRIPTION
## Problem

Running `./setup` (or `browse/scripts/build-node-server.sh` directly) fails with:

```
Building Node-compatible server bundle...
error: cannot write multiple output files without an output directory
```

Reproduced on: bun `1.3.11`, macOS arm64, gstack `0.16.2.0`.

## Root cause

`@ngrok/ngrok` was added (I believe in `0.16.x` for `/pair-agent` tunneling). That package ships two native `.node` binaries as assets:

- `ngrok.darwin-universal-*.node` (~19 MB)
- `ngrok.darwin-arm64-*.node` (~9 MB)

When bun bundles `server.ts`, it statically analyzes `@ngrok/ngrok` (even though the actual import is dynamic via `await import('@ngrok/ngrok')`) and tries to emit those `.node` files as additional outputs next to `server-node.mjs`. Since `--outfile` can only produce a single file, bun aborts with the "cannot write multiple output files without an output directory" error.

## Fix

Add `--external "@ngrok/ngrok"` to the `bun build` command in `browse/scripts/build-node-server.sh`.

This is safe because `@ngrok/ngrok` is already loaded dynamically at runtime in `server.ts`:

```ts
// server.ts:1568
const ngrok = await import('@ngrok/ngrok');
tunnelListener = await ngrok.forward(forwardOpts);
```

At runtime, Node resolves `@ngrok/ngrok` from `node_modules/` just like the other runtime-loaded externals (`playwright`, `playwright-core`, `diff`).

## Verification

```
$ bash browse/scripts/build-node-server.sh
Building Node-compatible server bundle...
Bundled 23 modules in 5ms

  server-node.mjs  0.31 MB  (entry point)

Node server bundle ready: /.../browse/dist/server-node.mjs
```

Both `server-node.mjs` (307 KB) and `bun-polyfill.cjs` are generated correctly.

## Notes

- Tested on macOS arm64. I don't have a Windows box to smoke-test the actual Windows Node runtime, but since ngrok is loaded via dynamic `import()` on an opt-in code path (`/tunnel/start`), externalizing it should not break any eager initialization.
- Only 2 lines changed (one line + continuation backslash).