### PR TITLE
fix: quote YAML description values in openclaw skills

### DIFF
--- a/openclaw/skills/gstack-openclaw-ceo-review/SKILL.md
+++ b/openclaw/skills/gstack-openclaw-ceo-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gstack-openclaw-ceo-review
-description: CEO/founder-mode plan review. Rethink the problem, find the 10-star product, challenge premises, expand scope when it creates a better product. Four modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). Use when asked to review a plan, challenge this, CEO review, poke holes, think bigger, or expand scope.
+description: "CEO/founder-mode plan review. Rethink the problem, find the 10-star product, challenge premises, expand scope when it creates a better product. Four modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). Use when asked to review a plan, challenge this, CEO review, poke holes, think bigger, or expand scope."
 version: 1.0.0
 metadata: { "openclaw": { "emoji": "👑" } }
 ---

--- a/openclaw/skills/gstack-openclaw-investigate/SKILL.md
+++ b/openclaw/skills/gstack-openclaw-investigate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gstack-openclaw-investigate
-description: Systematic debugging with root cause investigation. Four phases: investigate, analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when asked to debug, fix a bug, investigate an error, or root cause analysis. Proactively use when user reports errors, stack traces, unexpected behavior, or says something stopped working.
+description: "Systematic debugging with root cause investigation. Four phases: investigate, analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when asked to debug, fix a bug, investigate an error, or root cause analysis. Proactively use when user reports errors, stack traces, unexpected behavior, or says something stopped working."
 version: 1.0.0
 metadata: { "openclaw": { "emoji": "🔍" } }
 ---

--- a/openclaw/skills/gstack-openclaw-office-hours/SKILL.md
+++ b/openclaw/skills/gstack-openclaw-office-hours/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gstack-openclaw-office-hours
-description: Product interrogation with six forcing questions. Two modes: startup diagnostic (demand reality, status quo, desperate specificity, narrowest wedge, observation, future-fit) and builder brainstorm. Use when asked to brainstorm, "is this worth building", "I have an idea", "office hours", or "help me think through this". Proactively use when user describes a new product idea or wants to think through design decisions before any code is written.
+description: "Product interrogation with six forcing questions. Two modes: startup diagnostic (demand reality, status quo, desperate specificity, narrowest wedge, observation, future-fit) and builder brainstorm. Use when asked to brainstorm, is this worth building, I have an idea, office hours, or help me think through this. Proactively use when user describes a new product idea or wants to think through design decisions before any code is written."
 version: 1.0.0
 metadata: { "openclaw": { "emoji": "🎯" } }
 ---


### PR DESCRIPTION
## Summary

Quote `description` values in 3 openclaw skill SKILL.md files. Unquoted colons in the YAML frontmatter caused Claude Code to skip loading these skills with `invalid YAML: mapping values are not allowed in this context`.

## What Changed

- `openclaw/skills/gstack-openclaw-investigate/SKILL.md` — wrapped description in quotes
- `openclaw/skills/gstack-openclaw-office-hours/SKILL.md` — wrapped description in quotes
- `openclaw/skills/gstack-openclaw-ceo-review/SKILL.md` — wrapped description in quotes

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes on all 3 files
- [x] Claude Code no longer shows "Skipped loading" warnings for these skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)