### PR TITLE
fix: use relative symlinks for vendored/local installs

### DIFF
--- a/setup
+++ b/setup
@@ -298,6 +298,13 @@ link_claude_skill_dirs() {
   local gstack_dir="$1"
   local skills_dir="$2"
   local linked=()
+  local gstack_basename="$(basename "$gstack_dir")"
+  # Use relative symlinks when gstack is inside skills_dir (vendored/local installs).
+  # Absolute paths break portability — other devs cloning the repo get dangling symlinks.
+  local resolved_parent="$(cd "$gstack_dir/.." 2>/dev/null && pwd -P)"
+  local resolved_skills="$(cd "$skills_dir" 2>/dev/null && pwd -P)"
+  local use_relative=0
+  [ "$resolved_parent" = "$resolved_skills" ] && use_relative=1
   for skill_dir in "$gstack_dir"/*/; do
     if [ -f "$skill_dir/SKILL.md" ]; then
       dir_name="$(basename "$skill_dir")"
@@ -320,12 +327,16 @@ link_claude_skill_dirs() {
       if [ -L "$target" ]; then
         rm -f "$target"
       fi
-      # Create real directory with symlinked SKILL.md (absolute path)
+      # Create real directory with symlinked SKILL.md
       # Use mkdir -p unconditionally (idempotent) to avoid TOCTOU race
       mkdir -p "$target"
       # Validate target isn't a symlink before creating the link
       if [ -L "$target/SKILL.md" ]; then rm "$target/SKILL.md"; fi
-      ln -snf "$gstack_dir/$dir_name/SKILL.md" "$target/SKILL.md"
+      if [ "$use_relative" -eq 1 ]; then
+        ln -snf "../$gstack_basename/$dir_name/SKILL.md" "$target/SKILL.md"
+      else
+        ln -snf "$gstack_dir/$dir_name/SKILL.md" "$target/SKILL.md"
+      fi
       linked+=("$link_name")
     fi
   done


### PR DESCRIPTION
## Problem

`link_claude_skill_dirs()` creates absolute symlinks for SKILL.md files regardless of install type. For vendored installs where gstack lives inside the project's `.claude/skills/`, this bakes in the machine-specific absolute path (e.g., `/Users/alice/myproject/.claude/skills/gstack/qa/SKILL.md`), which:

1. Breaks for other developers cloning the repo (dangling symlinks)
2. Shows churn in `git diff` on every upgrade (relative → absolute conversion)

## Fix

Detect when `gstack_dir` is a direct child of `skills_dir` and use relative paths (`../gstack/qa/SKILL.md`) instead. Absolute paths are still used for global installs where gstack lives outside the skills directory.

The detection uses `pwd -P` to resolve both paths and compares `gstack_dir/..` against `skills_dir` — same approach already used elsewhere in the setup script.

## Testing

Verified on a vendored install:
- Before: `readlink .claude/skills/qa/SKILL.md` → `/Users/hyldmo/.../gstack/qa/SKILL.md`
- After: `readlink .claude/skills/qa/SKILL.md` → `../gstack/qa/SKILL.md`

Global install behavior is unchanged (absolute paths preserved).

Fixes #954