### PR TITLE
fix: respect BROWSE_PARENT_PID=0 from environment

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -227,12 +227,17 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
 
   let proc: any = null;
 
+  // Respect BROWSE_PARENT_PID=0 from the environment — callers (e.g. Claude Code,
+  // long-lived CLI wrappers) may need the daemon to outlive the spawning process.
+  // The idle timeout (30min) still handles cleanup for orphaned daemons.
+  const parentPid = process.env.BROWSE_PARENT_PID === '0' ? '0' : String(process.pid);
+
   if (IS_WINDOWS && NODE_SERVER_SCRIPT) {
     // Windows: Bun.spawn() + proc.unref() doesn't truly detach on Windows —
     // when the CLI exits, the server dies with it. Use Node's child_process.spawn
     // with { detached: true } instead, which is the gold standard for Windows
     // process independence. Credit: PR #191 by @fqueiro.
-    const extraEnvStr = JSON.stringify({ BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: String(process.pid), ...(extraEnv || {}) });
+    const extraEnvStr = JSON.stringify({ BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: parentPid, ...(extraEnv || {}) });
     const launcherCode =
       `const{spawn}=require('child_process');` +
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
@@ -243,7 +248,7 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     // macOS/Linux: Bun.spawn + unref works correctly
     proc = Bun.spawn(['bun', 'run', SERVER_SCRIPT], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: String(process.pid), ...extraEnv },
+      env: { ...process.env, BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: parentPid, ...extraEnv },
     });
     proc.unref();
   }


### PR DESCRIPTION
## Problem

`startServer()` always overrides `BROWSE_PARENT_PID` with `process.pid`, ignoring the environment. The parent-PID watchdog then kills the daemon 15 seconds after the spawning CLI process exits.

This is correct for interactive use (one long-lived CLI session), but breaks tools like Claude Code where each bash command is a separate short-lived process. The daemon starts, the CLI exits, and 15 seconds later the daemon self-terminates — losing browser state, cookies, and navigation context.

## Fix

Check for `BROWSE_PARENT_PID=0` in the environment before overriding with `process.pid`. When set to `0`, the watchdog is skipped (the server already handles this case). The 30-minute idle timeout still cleans up orphaned daemons.

This is a 3-line change — extract a `parentPid` variable and use it in both the Windows and macOS/Linux spawn paths.

## Prior art

The `pair-agent` command already uses `BROWSE_PARENT_PID=0` via `extraEnv` (cli.ts:988) for the same reason — the server needs to outlive the spawning process. This PR extends the same pattern to the general spawn path via an environment variable.

## Usage

```bash
export BROWSE_PARENT_PID=0  # in ~/.bashrc or equivalent
browse goto "https://example.com"
# daemon survives after this process exits
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)