### PR TITLE
fix(open-gstack-browser): disable parent watchdog on connect

### DIFF
--- a/open-gstack-browser/SKILL.md.tmpl
+++ b/open-gstack-browser/SKILL.md.tmpl
@@ -51,8 +51,15 @@ echo "Pre-flight cleanup done"
 ## Step 1: Connect
 
 ```bash
-$B connect
+BROWSE_PARENT_PID=0 $B connect
 ```
+
+**CRITICAL: the `BROWSE_PARENT_PID=0` prefix is required.** When Claude Code spawns
+`$B connect` via a Bash tool call, the bash subprocess exits immediately after
+`connect` returns. The v0.15.15.0+ parent-process watchdog then sees "parent gone"
+and kills the headed Chromium ~15 seconds later — you'll see the window flash up
+and disappear. Setting `BROWSE_PARENT_PID=0` disables the watchdog for this
+session (same trick `/pair-agent` uses, see `cli.ts:847`).
 
 This launches GStack Browser (rebranded Chromium) in headed mode with:
 - A visible window you can watch (not your regular Chrome — it stays untouched)
@@ -67,16 +74,26 @@ directory. It always uses port **34567** so the extension can auto-connect.
 After connecting, print the full output to the user. Confirm you see
 `Mode: headed` in the output.
 
-If the output shows an error or the mode is not `headed`, run `$B status` and
-share the output with the user before proceeding.
+If the output shows an error or the mode is not `headed`, jump to Step 2 for
+verification (do NOT call `$B status` — see the warning in Step 2).
 
 ## Step 2: Verify
 
+**Do NOT use `$B status` for verification.** `status` is not read-only: if no
+server is running (because the watchdog killed it), `status` silently spawns a
+new server in default `launched` (headless) mode and reports `healthy` — masking
+the actual problem. Use `$B focus` instead, which fails loudly if the headed
+window is gone and never auto-spawns anything.
+
 ```bash
-$B status
+$B focus
 ```
 
-Confirm the output shows `Mode: headed`. Read the port from the state file:
+Expected output: `Browser window activated.` If you see `focus requires headed
+mode. Run $B connect first.`, the watchdog killed the session — re-run Step 0
+cleanup and Step 1 connect (making sure to include `BROWSE_PARENT_PID=0`).
+
+Read the port from the state file:
 
 ```bash
 cat "$(git rev-parse --show-toplevel 2>/dev/null)/.gstack/browse.json" 2>/dev/null | grep -o '"port":[0-9]*' | grep -o '[0-9]*'
@@ -138,10 +155,12 @@ If B: Tell the user:
 
 If C:
 
-1. Run `$B status` and show the output
-2. If the server is not healthy, re-run Step 0 cleanup + Step 1 connect
-3. If the server IS healthy but the browser isn't visible, try `$B focus`
-4. If that fails, ask the user what they see (error message, blank screen, etc.)
+1. Run `$B focus` (do NOT use `$B status` — it auto-spawns a headless server if
+   the headed one died, masking the real problem)
+2. If `focus` reports `requires headed mode`, the watchdog killed the session —
+   re-run Step 0 cleanup + Step 1 connect (with `BROWSE_PARENT_PID=0`)
+3. If `focus` reports `Browser window activated` but the user still can't see it,
+   ask what they see (error message, blank screen, window on another display, etc.)
 
 ## Step 4: Demo
 


### PR DESCRIPTION
## Summary

The `open-gstack-browser` skill currently fails its first-run experience inside Claude Code: the headed Chromium window appears for a few seconds then vanishes, and the user has no idea why. Root cause is the v0.15.15.0+ parent-process watchdog killing the browse server because the bash process that spawned `$B connect` has already exited.

## Repro

1. In Claude Code, invoke `/open-gstack-browser` on a clean machine (no prior browse session)
2. The skill runs `$B connect` inside a Bash tool call
3. Chromium launches in headed mode, user starts looking for the extension
4. ~15 seconds later, the window disappears. `$B focus` reports `focus requires headed mode. Run $B connect first.`

Hit this today upgrading from v0.15.15.0 → v0.16.2.0 in a real Claude Code session. Had to reverse-engineer the fix live with the user watching the browser keep disappearing. Not a great first-run.

## Root cause

- `browse/src/server.ts:740-751` implements the parent-process watchdog that exits the server when its recorded parent PID dies.
- `browse/src/cli.ts:235` records the CLI's own PID as `BROWSE_PARENT_PID` when spawning the server.
- When Claude Code runs `$B connect` via a Bash tool call, the bash subprocess is the CLI's parent. Bash exits immediately after `connect` returns (which it does as soon as Chromium finishes launching), so the watchdog sees its parent gone and kills everything ~15s later.
- This is the same issue v0.15.15.1 fixed for pair-agent (see changelog), but open-gstack-browser was never updated to use the same escape hatch.

The escape hatch already exists: `browse/src/cli.ts:847-848` explicitly honors `BROWSE_PARENT_PID=0` from the parent environment as a "disable watchdog" signal. `/pair-agent` uses this in `browse/src/cli.ts:988`.

## Fix

Two tiny updates to `open-gstack-browser/SKILL.md.tmpl`:

1. **Step 1 (Connect):** prefix `$B connect` with `BROWSE_PARENT_PID=0` and add a critical-warning paragraph explaining why, so future skill maintainers don't accidentally remove it.
2. **Step 2 (Verify) + Step 3 Option C (troubleshooting):** swap `$B status` for `$B focus` as the verification command. `$B status` is not read-only — if no server is running, it silently spawns a new one in default `launched` (headless) mode and reports `healthy`, which completely masks the failure this PR is trying to diagnose. `$B focus` fails loudly when the headed window is gone and never auto-spawns anything, so it's a strictly better diagnostic.

Only the template (`SKILL.md.tmpl`) is touched. The generated `SKILL.md` will be regenerated from the template on next `./setup` run.

## Test plan

- [x] Applied the fix locally, re-ran `/open-gstack-browser` from a clean state. Headed Chromium stayed alive past the 15s window, survived a long session, `$B focus` and `$B snapshot -i` worked against the live page.
- [x] Verified `BROWSE_PARENT_PID=0` is the documented escape hatch in `browse/src/cli.ts:847-848`.
- [ ] (For maintainer) Verify the `./setup` regen pipeline produces a SKILL.md that matches the new template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)