### PR TITLE
fix(browse): externalize @ngrok/ngrok in Node server build (bun 1.3.11+)

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -20,7 +20,8 @@ bun build "$SRC_DIR/server.ts" \
   --external playwright \
   --external playwright-core \
   --external diff \
-  --external "bun:sqlite"
+  --external "bun:sqlite" \
+  --external "@ngrok/ngrok"
 
 # Step 2: Post-process
 # Replace import.meta.dir with a resolvable reference


### PR DESCRIPTION
## What's broken

On bun **1.3.11** (and likely later), running `./setup` fails at the Node server bundle step with:

```
Building Node-compatible server bundle...
error: cannot write multiple output files without an output directory
```

This blocks any fresh install on a current bun.

## Root cause

`browse/scripts/build-node-server.sh` runs:

```bash
bun build "$SRC_DIR/server.ts" \
  --target=node \
  --outfile "$DIST_DIR/server-node.mjs" \
  --external playwright \
  --external playwright-core \
  --external diff \
  --external "bun:sqlite"
```

On bun 1.3.11, `@ngrok/ngrok` (transitively required from `browse/src/`) drags in its native `.node` binaries as bundled output assets:

```
  server.js                             0.34 MB  (entry point)
  ngrok.darwin-universal-js9zx1ck.node  19.40 MB  (asset)
  ngrok.darwin-arm64-8jkcjhvc.node       9.0  MB  (asset)
```

bun now treats those `.node` files as additional output files and `--outfile` cannot write multiple files — hence the error. Earlier bun versions apparently left them alone at this bundler stage, which is why this used to work.

## Fix

One-line change: add `--external "@ngrok/ngrok"` to the externals list, matching the pattern already used for `playwright`, `playwright-core`, `diff`, and `bun:sqlite`. ngrok stays a runtime `require`, the native binaries remain inside `node_modules/@ngrok/ngrok/`, and the build collapses back to a single `server-node.mjs` output.

No behavior change — ngrok is still loaded the same way at runtime; we're just telling the bundler to leave it alone, consistent with how the other native/runtime deps are already handled.

## Verification

```bash
bun --version
# 1.3.11

cd ~/.claude/skills/gstack
bash browse/scripts/build-node-server.sh
# Building Node-compatible server bundle...
# Bundled 23 modules in 11ms
#
#   server-node.mjs  0.31 MB  (entry point)
#
# Node server bundle ready: .../browse/dist/server-node.mjs
```

Full `./setup` completes cleanly after the fix — all skills link, binaries compile, Node-compatible server bundle produced as expected.

## Scope

One line added in `browse/scripts/build-node-server.sh`. No other files touched. No API or runtime changes.