### PR TITLE
fix: normalize ssh URL remotes in global discovery

### DIFF
--- a/bin/gstack-global-discover.ts
+++ b/bin/gstack-global-discover.ts
@@ -124,8 +124,18 @@ function windowToDate(window: string): Date {
 export function normalizeRemoteUrl(url: string): string {
   let normalized = url.trim();
 
-  // SSH → HTTPS: git@github.com:user/repo → https://github.com/user/repo
-  const sshMatch = normalized.match(/^(?:ssh:\/\/)?git@([^:]+):(.+)$/);
+  // SSH URL → HTTPS: ssh://git@github.com/user/repo → https://github.com/user/repo
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol === "ssh:" && parsed.username === "git" && parsed.pathname.length > 1) {
+      normalized = `https://${parsed.host}${parsed.pathname}`;
+    }
+  } catch {
+    // Not a URL-style remote; try scp-style below.
+  }
+
+  // SCP-style SSH → HTTPS: git@github.com:user/repo → https://github.com/user/repo
+  const sshMatch = normalized.match(/^git@([^:]+):(.+)$/);
   if (sshMatch) {
     normalized = `https://${sshMatch[1]}/${sshMatch[2]}`;
   }

--- a/test/global-discover.test.ts
+++ b/test/global-discover.test.ts
@@ -30,6 +30,12 @@ describe("gstack-global-discover", () => {
       );
     });
 
+    test("converts URL-style SSH to HTTPS", () => {
+      expect(normalizeRemoteUrl("ssh://git@github.com/user/repo.git")).toBe(
+        "https://github.com/user/repo"
+      );
+    });
+
     test("converts SSH without .git to HTTPS", () => {
       expect(normalizeRemoteUrl("git@github.com:user/repo")).toBe(
         "https://github.com/user/repo"
@@ -44,9 +50,11 @@ describe("gstack-global-discover", () => {
 
     test("SSH and HTTPS for same repo normalize to same URL", () => {
       const ssh = normalizeRemoteUrl("git@github.com:garrytan/gstack.git");
+      const sshUrl = normalizeRemoteUrl("ssh://git@github.com/garrytan/gstack.git");
       const https = normalizeRemoteUrl("https://github.com/garrytan/gstack.git");
       const httpsNoDotGit = normalizeRemoteUrl("https://github.com/garrytan/gstack");
       expect(ssh).toBe(https);
+      expect(sshUrl).toBe(https);
       expect(https).toBe(httpsNoDotGit);
     });
 
@@ -58,6 +66,12 @@ describe("gstack-global-discover", () => {
 
     test("handles GitLab SSH URLs", () => {
       expect(normalizeRemoteUrl("git@gitlab.com:org/project.git")).toBe(
+        "https://gitlab.com/org/project"
+      );
+    });
+
+    test("handles GitLab URL-style SSH URLs", () => {
+      expect(normalizeRemoteUrl("ssh://git@gitlab.com/org/project.git")).toBe(
         "https://gitlab.com/org/project"
       );
     });


### PR DESCRIPTION
## Summary

- Normalize `ssh://git@host/owner/repo.git` remotes to the same HTTPS canonical form as scp-style SSH remotes
- Keep existing scp-style SSH normalization behavior intact
- Add regression coverage for GitHub and GitLab URL-style SSH remotes, plus cross-format deduplication

Fixes #975

## Testing

- `PATH=/tmp/gstack-bun/node_modules/.bin:$PATH bun test test/global-discover.test.ts`
- `PATH=/tmp/gstack-bun/node_modules/.bin:$PATH bun -e "import { normalizeRemoteUrl } from './bin/gstack-global-discover.ts'; console.log(normalizeRemoteUrl('git@github.com:garrytan/gstack.git')); console.log(normalizeRemoteUrl('ssh://git@github.com/garrytan/gstack.git')); console.log(normalizeRemoteUrl('https://github.com/garrytan/gstack.git'));"`