### PR TITLE
fix: externalize @ngrok/ngrok in Node-compatible server bundle

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -20,7 +20,8 @@ bun build "$SRC_DIR/server.ts" \
   --external playwright \
   --external playwright-core \
   --external diff \
-  --external "bun:sqlite"
+  --external "bun:sqlite" \
+  --external "@ngrok/ngrok"
 
 # Step 2: Post-process
 # Replace import.meta.dir with a resolvable reference


### PR DESCRIPTION
## Summary

`browse/scripts/build-node-server.sh` fails on a clean checkout with:

```
Building Node-compatible server bundle...
error: cannot write multiple output files without an output directory
```

Root cause: `@ngrok/ngrok` ships ~29 MB of prebuilt native `.node` assets (`darwin-arm64` + `darwin-universal`). When bun bundles `server.ts`, it tries to emit those as additional output files, which is incompatible with `--outfile` (single-file mode).

## Fix

Add `--external "@ngrok/ngrok"` to the `bun build` invocation. `@ngrok/ngrok` is loaded via dynamic `import()` at runtime in `browse/src/server.ts` (lines 1561, 2341), so it should not be bundled — mirroring how `playwright`, `playwright-core`, `diff`, and `bun:sqlite` are already handled.

One-line change:

```diff
   --external "bun:sqlite" \
+  --external "@ngrok/ngrok"
```

## Reproduction

```bash
$ bash browse/scripts/build-node-server.sh
Building Node-compatible server bundle...
error: cannot write multiple output files without an output directory
```

To confirm what bun wants to emit, run the same command with `--outdir` instead of `--outfile`:

```
Bundled 27 modules in 76ms
  server.js                             0.34 MB   (entry point)
  ngrok.darwin-universal-js9zx1ck.node  19.40 MB  (asset)
  ngrok.darwin-arm64-8jkcjhvc.node      9.0 MB    (asset)
```

## After fix

```
$ bash browse/scripts/build-node-server.sh
Building Node-compatible server bundle...
Bundled 24 modules in 9ms
  server-node.mjs  0.32 MB  (entry point)
Node server bundle ready: browse/dist/server-node.mjs
```

Full `./setup` also completes cleanly (`gstack ready (claude).`) with no bundle error.

## Test plan

- [x] Reproduce error on clean main checkout (macOS, bun 1.3.12)
- [x] Apply fix, rerun `bash browse/scripts/build-node-server.sh` — succeeds
- [x] `./setup` end-to-end — `gstack ready (claude).`, no bundle error
- [x] Confirm `@ngrok/ngrok` is only referenced via dynamic `await import('@ngrok/ngrok')`, so externalizing does not break static analysis
- [ ] CI eval suite (maintainer to verify — I don't have ANTHROPIC_API_KEY for this repo)

## Notes

- Discovered while installing gstack on macOS. Setup still completes because this is a Windows-compatibility subcommand (per the script header comment), but the error noise during install is confusing for new users.
- Change is surgical (1 line). Safe on Windows as well — `@ngrok/ngrok` is always a runtime dependency regardless of platform.