### PR TITLE
fix(preamble): resolve CLAUDE.md from git root, not CWD

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -72,9 +72,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"gstack","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -82,8 +84,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -82,9 +82,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"autoplan","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -92,8 +94,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -75,9 +75,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"benchmark","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -85,8 +87,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -74,9 +74,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"browse","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -84,8 +86,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -74,9 +74,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"canary","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -84,8 +86,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/checkpoint/SKILL.md
+++ b/checkpoint/SKILL.md
@@ -77,9 +77,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"checkpoint","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -87,8 +89,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -76,9 +76,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"codex","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -86,8 +88,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -79,9 +79,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"cso","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -89,8 +91,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -79,9 +79,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"design-consultation","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -89,8 +91,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -81,9 +81,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"design-html","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -91,8 +93,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -79,9 +79,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"design-review","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -89,8 +91,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -76,9 +76,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"design-shotgun","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -86,8 +88,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -79,9 +79,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"devex-review","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -89,8 +91,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -76,9 +76,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"document-release","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -86,8 +88,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -76,9 +76,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"health","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -86,8 +88,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -91,9 +91,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"investigate","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -101,8 +103,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -73,9 +73,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"land-and-deploy","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -83,8 +85,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -76,9 +76,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"learn","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -86,8 +88,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -83,9 +83,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"office-hours","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -93,8 +95,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -73,9 +73,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"open-gstack-browser","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -83,8 +85,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -74,9 +74,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"pair-agent","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -84,8 +86,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -79,9 +79,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"plan-ceo-review","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -89,8 +91,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -77,9 +77,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"plan-design-review","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -87,8 +89,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -81,9 +81,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"plan-devex-review","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -91,8 +93,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -79,9 +79,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"plan-eng-review","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -89,8 +91,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -75,9 +75,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"qa-only","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -85,8 +87,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -81,9 +81,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"qa","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -91,8 +93,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -74,9 +74,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"retro","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -84,8 +86,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -77,9 +77,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"review","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -87,8 +89,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/scripts/resolvers/preamble.ts
+++ b/scripts/resolvers/preamble.ts
@@ -81,9 +81,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ${ctx.paths.binDir}/gstack-timeline-log '{"skill":"${ctx.skillName}","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=\${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(${ctx.paths.binDir}/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -91,8 +93,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -71,9 +71,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"setup-browser-cookies","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -81,8 +83,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -77,9 +77,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"setup-deploy","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -87,8 +89,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -78,9 +78,11 @@ else
 fi
 # Session timeline: record skill start (local-only, never sent anywhere)
 ~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"ship","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+# Resolve project root (CWD may be a subdirectory, worktree, or monorepo package)
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
 # Check if CLAUDE.md has routing rules
 _HAS_ROUTING="no"
-if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
+if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md" 2>/dev/null; then
   _HAS_ROUTING="yes"
 fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
@@ -88,8 +90,8 @@ echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
 # Vendoring deprecation: detect if CWD has a vendored gstack copy
 _VENDORED="no"
-if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
-  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+if [ -d "$_ROOT/.claude/skills/gstack" ] && [ ! -L "$_ROOT/.claude/skills/gstack" ]; then
+  if [ -f "$_ROOT/.claude/skills/gstack/VERSION" ] || [ -d "$_ROOT/.claude/skills/gstack/.git" ]; then
     _VENDORED="yes"
   fi
 fi

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1327,7 +1327,7 @@ describe('preamble routing injection', () => {
   const shipContent = fs.readFileSync(path.join(ROOT, 'ship', 'SKILL.md'), 'utf-8');
 
   test('preamble bash checks for routing section in CLAUDE.md', () => {
-    expect(shipContent).toContain('grep -q "## Skill routing" CLAUDE.md');
+    expect(shipContent).toContain('grep -qi "## Skill routing" "$_ROOT/CLAUDE.md"');
     expect(shipContent).toContain('HAS_ROUTING');
   });
 


### PR DESCRIPTION
## Summary

- The preamble's routing-rules check (`[ -f CLAUDE.md ]`) and vendoring check (`[ -d ".claude/skills/gstack" ]`) use CWD-relative paths. When launched from a subdirectory, worktree, or monorepo package, these checks never find the project root files.
- This causes the "Add routing rules to CLAUDE.md?" prompt to fire **every session**, even after the user accepts or declines — because the root CLAUDE.md is never found from `apps/web/` or similar subdirectories.
- Fix: resolve `_ROOT` via `git rev-parse --show-toplevel` (fallback to `pwd`) and use it for both checks. Also makes the routing grep case-insensitive (`-qi`) to prevent duplicate appends when the heading has different casing.

The fix is in `scripts/resolvers/preamble.ts` (single source of truth). All 32 generated SKILL.md files are regenerated.

### What changed

| File | Change |
|------|--------|
| `scripts/resolvers/preamble.ts` | Add `_ROOT` resolution, use `$_ROOT/CLAUDE.md` and `$_ROOT/.claude/skills/gstack` |
| `test/gen-skill-docs.test.ts` | Update assertion to match new grep pattern |
| 32 `*/SKILL.md` files | Regenerated from fixed template |

### Root cause

```bash
# Before (CWD-relative — breaks in subdirectories)
if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md; then

# After (git root-relative — works everywhere)
_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
if [ -f "$_ROOT/CLAUDE.md" ] && grep -qi "## Skill routing" "$_ROOT/CLAUDE.md"; then
```

This aligns with the project's own CLAUDE.md principles:
- "Don't hardcode branch names. Detect dynamically" — same principle applies to paths
- `_ROOT` uses `${_ROOT:-...}` to preserve the value if already set by `runtimeRoot` for hosts that use env vars

## Test plan

- [x] `bun test test/skill-validation.test.ts test/gen-skill-docs.test.ts` — 653 pass, 2 pre-existing failures (binary size + version mismatch), 0 new failures
- [x] Verified 0 remaining `[ -f CLAUDE.md ]` in generated SKILL.md files
- [x] Verified 32/32 SKILL.md files contain `$_ROOT/CLAUDE.md`
- [ ] Manual: launch gstack from a monorepo subdirectory, verify routing prompt does not repeat after declining