### PR TITLE
fix: allow Node server bundle sidecar outputs

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -13,36 +13,53 @@ DIST_DIR="$GSTACK_DIR/browse/dist"
 
 echo "Building Node-compatible server bundle..."
 
-# Step 1: Transpile server.ts to a single .mjs bundle (externalize runtime deps)
+TMP_BUILD_DIR="$DIST_DIR/.node-server-build"
+OUT_FILE="$DIST_DIR/server-node.mjs"
+rm -rf "$TMP_BUILD_DIR"
+mkdir -p "$TMP_BUILD_DIR"
+
+# Step 1: Transpile server.ts for Node. Use an outdir instead of --outfile so
+# Bun can emit any native addon sidecar files (for example ngrok *.node)
+# without aborting the build with "cannot write multiple output files".
 bun build "$SRC_DIR/server.ts" \
   --target=node \
-  --outfile "$DIST_DIR/server-node.mjs" \
+  --outdir "$TMP_BUILD_DIR" \
   --external playwright \
   --external playwright-core \
   --external diff \
   --external "bun:sqlite"
 
+BUNDLED_ENTRY=$(find "$TMP_BUILD_DIR" -maxdepth 1 -type f \( -name '*.js' -o -name '*.mjs' -o -name '*.cjs' \) | head -n 1)
+if [ -z "$BUNDLED_ENTRY" ]; then
+  echo "Failed to locate bundled Node server entry in $TMP_BUILD_DIR" >&2
+  exit 1
+fi
+
+mv "$BUNDLED_ENTRY" "$OUT_FILE"
+find "$TMP_BUILD_DIR" -maxdepth 1 -type f -name '*.node' -exec mv {} "$DIST_DIR"/ \;
+rm -rf "$TMP_BUILD_DIR"
+
 # Step 2: Post-process
 # Replace import.meta.dir with a resolvable reference
-perl -pi -e 's/import\.meta\.dir/__browseNodeSrcDir/g' "$DIST_DIR/server-node.mjs"
+perl -pi -e 's/import\.meta\.dir/__browseNodeSrcDir/g' "$OUT_FILE"
 # Stub out bun:sqlite (macOS-only cookie import, not needed on Windows)
-perl -pi -e 's|import { Database } from "bun:sqlite";|const Database = null; // bun:sqlite stubbed on Node|g' "$DIST_DIR/server-node.mjs"
+perl -pi -e 's|import { Database } from "bun:sqlite";|const Database = null; // bun:sqlite stubbed on Node|g' "$OUT_FILE"
 
 # Step 3: Create the final file with polyfill header injected after the first line
 {
-  head -1 "$DIST_DIR/server-node.mjs"
+  head -1 "$OUT_FILE"
   echo '// ── Windows Node.js compatibility (auto-generated) ──'
   echo 'import { fileURLToPath as _ftp } from "node:url";'
   echo 'import { dirname as _dn } from "node:path";'
   echo 'const __browseNodeSrcDir = _dn(_dn(_ftp(import.meta.url))) + "/src";'
   echo '{ const _r = createRequire(import.meta.url); _r("./bun-polyfill.cjs"); }'
   echo '// ── end compatibility ──'
-  tail -n +2 "$DIST_DIR/server-node.mjs"
+  tail -n +2 "$OUT_FILE"
 } > "$DIST_DIR/server-node.tmp.mjs"
 
-mv "$DIST_DIR/server-node.tmp.mjs" "$DIST_DIR/server-node.mjs"
+mv "$DIST_DIR/server-node.tmp.mjs" "$OUT_FILE"
 
 # Step 4: Copy polyfill to dist/
 cp "$SRC_DIR/bun-polyfill.cjs" "$DIST_DIR/bun-polyfill.cjs"
 
-echo "Node server bundle ready: $DIST_DIR/server-node.mjs"
+echo "Node server bundle ready: $OUT_FILE"


### PR DESCRIPTION
## Summary
- switch `browse/scripts/build-node-server.sh` from `bun build --outfile` to a temp `--outdir`
- move the bundled server entry into `browse/dist/server-node.mjs` after the build completes
- preserve any emitted native sidecar files like ngrok's `*.node` addon instead of letting Bun abort the build

## Why
`bun build --outfile` fails as soon as Bun needs to emit more than one file. That now happens cross-platform because the Node-compatible server bundle can pull in native sidecars like `@ngrok/ngrok`'s platform-specific `.node` binary. The current script therefore breaks with:

```text
error: cannot write multiple output files without an output directory
```

Using a temporary outdir keeps the build working on Windows while also fixing the silent macOS/Linux failure path reported in #960.

## Validation
- `bash -n browse/scripts/build-node-server.sh`
- local stub regression: ran the script against a fake `bun build` that emits both `server.js` and `ngrok.linux-x64-gnu.node`, and verified it now produces:
  - `browse/dist/server-node.mjs`
  - `browse/dist/bun-polyfill.cjs`
  - preserved `browse/dist/*.node` sidecar

Closes #960
