### PR TITLE
docs(SKILL.md): broaden description to match routing rules

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -3,10 +3,15 @@ name: gstack
 preamble-tier: 1
 version: 1.1.0
 description: |
-  Fast headless browser for QA testing and site dogfooding. Navigate pages, interact with
-  elements, verify state, diff before/after, take annotated screenshots, test responsive
-  layouts, forms, uploads, dialogs, and capture bug evidence. Use when asked to open or
-  test a site, verify a deployment, dogfood a user flow, or file a bug with screenshots. (gstack)
+  Virtual AI engineering team for Claude Code — ~30 slash commands covering the full product
+  lifecycle. Use for: ideation (/office-hours, /plan-ceo-review), planning (/autoplan,
+  /plan-eng-review, /plan-design-review), design (/design-consultation, /design-shotgun,
+  /design-html, /design-review), code review (/review, /devex-review), security audit
+  (/cso — OWASP + STRIDE), QA and browser automation (/qa, /qa-only, /browse, /connect-chrome),
+  release (/ship, /land-and-deploy, /canary, /benchmark, /document-release), retros (/retro),
+  investigation and learning (/investigate, /learn, /careful, /guard, /freeze). Invoke whenever
+  the user wants to start, plan, design, build, review, secure, test, ship, or reflect on a
+  project — not just for browser testing. (gstack)
 allowed-tools:
   - Bash
   - Read

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -3,10 +3,15 @@ name: gstack
 preamble-tier: 1
 version: 1.1.0
 description: |
-  Fast headless browser for QA testing and site dogfooding. Navigate pages, interact with
-  elements, verify state, diff before/after, take annotated screenshots, test responsive
-  layouts, forms, uploads, dialogs, and capture bug evidence. Use when asked to open or
-  test a site, verify a deployment, dogfood a user flow, or file a bug with screenshots. (gstack)
+  Virtual AI engineering team for Claude Code — ~30 slash commands covering the full product
+  lifecycle. Use for: ideation (/office-hours, /plan-ceo-review), planning (/autoplan,
+  /plan-eng-review, /plan-design-review), design (/design-consultation, /design-shotgun,
+  /design-html, /design-review), code review (/review, /devex-review), security audit
+  (/cso — OWASP + STRIDE), QA and browser automation (/qa, /qa-only, /browse, /connect-chrome),
+  release (/ship, /land-and-deploy, /canary, /benchmark, /document-release), retros (/retro),
+  investigation and learning (/investigate, /learn, /careful, /guard, /freeze). Invoke whenever
+  the user wants to start, plan, design, build, review, secure, test, ship, or reflect on a
+  project — not just for browser testing. (gstack)
 allowed-tools:
   - Bash
   - Read


### PR DESCRIPTION
## Problem

The `description:` in `SKILL.md.tmpl` only advertises the browser-QA subset of gstack:

> Fast headless browser for QA testing and site dogfooding. Navigate pages, interact with elements, verify state, diff before/after, take annotated screenshots...

But the body of `SKILL.md` contains explicit routing rules for *non-browser* tasks, e.g.:

> - User describes a new idea, asks "is this worth building", wants to brainstorm → invoke `/office-hours`
> - User asks about strategy, scope, ambition, "think bigger" → invoke `/plan-ceo-review`

These routing rules never fire, because the host (Claude Code / Codex / Factory) reads the narrow `description:` at session start, concludes gstack only applies to browser tasks, and **never invokes gstack in the first place** for ideation/planning/review/ship tasks.

## Observed behavior

In a fresh Claude Code session, prompts like:
- "Start a new Python TUI project"
- "Brainstorm a feature idea"
- "Review the diff on this branch"

…do not route into gstack at all. The skill listing only hints at browser testing, so the assistant ignores `/office-hours`, `/autoplan`, `/review`, `/ship`, etc. — even though those are gstack's primary value proposition per the README's quickstart:

> 1. Install gstack
> 2. Run `/office-hours` — describe what you're building
> 3. Run `/plan-ceo-review` on any feature idea
> 4. Run `/review` on any branch with changes
> 5. Run `/qa` on your staging URL

## Fix

Broaden the `description:` to advertise the full slash-command surface, organized by lifecycle phase, so host skill-selection correctly routes non-browser tasks into gstack where the internal routing rules can then delegate to the right subcommand.

## Changes

- `SKILL.md.tmpl` — new description
- `SKILL.md` — regenerated via `bun run gen:skill-docs` (no other files touched)

## Test plan

- [x] `bun run gen:skill-docs` produces no diff after the commit (freshness check passes)
- [x] Only `SKILL.md` + `SKILL.md.tmpl` change — no scope creep across hosts
- [x] Verified in a live Claude Code session: after the edit, the session-start skill listing re-reads `SKILL.md` on file-watch and the new description becomes visible without restarting the session
- [ ] Would be good for a maintainer to confirm a fresh session now routes "start a project" → `/office-hours` as the README quickstart intends

## Why this matters

gstack's README explicitly positions the tool as a "virtual AI engineering team — CEO, designer, eng manager, reviewer, QA lead, security officer, release engineer." The narrow description silently undersells ~95% of that value to every new user on every new session.