### PR TITLE
fix(browse): server persists across Claude Code Bash calls

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -759,12 +759,18 @@ const idleCheckInterval = setInterval(() => {
 // and self-terminate if it is gone.
 const BROWSE_PARENT_PID = parseInt(process.env.BROWSE_PARENT_PID || '0', 10);
 if (BROWSE_PARENT_PID > 0) {
+  let parentGone = false;
   setInterval(() => {
     try {
       process.kill(BROWSE_PARENT_PID, 0); // signal 0 = existence check only, no signal sent
     } catch {
-      console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited, shutting down`);
-      shutdown();
+      // Parent exited. Don't shutdown — the server should persist across
+      // Bash calls (e.g. Claude Code sandbox kills the parent shell).
+      // The idle timeout (30 min) handles eventual cleanup instead.
+      if (!parentGone) {
+        parentGone = true;
+        console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited (server stays alive, idle timeout will clean up)`);
+      }
     }
   }, 15_000);
 }
@@ -1225,8 +1231,13 @@ async function shutdown() {
 }
 
 // Handle signals
-process.on('SIGTERM', shutdown);
+// SIGINT (Ctrl+C): user intentionally stopping → shutdown
 process.on('SIGINT', shutdown);
+// SIGTERM: may come from sandbox killing parent → ignore and let idle timeout handle cleanup.
+// Explicit shutdown is available via the /stop command or SIGINT.
+process.on('SIGTERM', () => {
+  console.log('[browse] Received SIGTERM (ignoring — use /stop or Ctrl+C for intentional shutdown)');
+});
 // Windows: taskkill /F bypasses SIGTERM, but 'exit' fires for some shutdown paths.
 // Defense-in-depth — primary cleanup is the CLI's stale-state detection via health check.
 if (process.platform === 'win32') {


### PR DESCRIPTION
## Problem

The browse server dies between Bash tool invocations in Claude Code. Every new `$B` command starts a fresh server, losing all cookies, page state, and navigation. This makes multi-step QA testing impossible.

**Root cause:** Two mechanisms kill the server when the parent Bash shell exits:

1. **SIGTERM from sandbox**: Claude Code's Bash tool sends SIGTERM to all child processes when a command completes. The server's SIGTERM handler called `shutdown()`.

2. **Parent PID watchdog**: The server polls `BROWSE_PARENT_PID` every 15s. When the parent shell dies, the watchdog called `shutdown()`.

## Fix

- **SIGTERM**: log and ignore instead of `shutdown()`. Explicit shutdown still available via `/stop` or SIGINT.
- **Parent watchdog**: log once and continue instead of `shutdown()`. Idle timeout (30 min) handles cleanup.

## What doesn't change

- `/stop` command and SIGINT still work for intentional shutdown
- Windows behavior unchanged
- Idle timeout still cleans up abandoned servers
- State file lifecycle unchanged

## Repro (before fix)

```bash
# Call 1
$B goto http://localhost:3000/login
$B fill '#email' 'test@test.com'

# Call 2 (new Bash invocation)
$B url    # → "about:blank" (server restarted, state lost)
```

## After fix

```bash
# Call 2 reconnects to existing server
$B url    # → "http://localhost:3000/login" (state preserved)
```

Verified across 5+ separate Bash calls maintaining cookies, form fields, and navigation.