### PR TITLE
fix: keep cookie picker alive after cli exits

### DIFF
--- a/browse/src/cookie-picker-routes.ts
+++ b/browse/src/cookie-picker-routes.ts
@@ -40,6 +40,23 @@ export function generatePickerCode(): string {
   return code;
 }
 
+/** Return true while the picker still has a live code or session. */
+export function hasActivePicker(): boolean {
+  const now = Date.now();
+
+  for (const [code, expiry] of pendingCodes) {
+    if (expiry > now) return true;
+    pendingCodes.delete(code);
+  }
+
+  for (const [session, expiry] of validSessions) {
+    if (expiry > now) return true;
+    validSessions.delete(session);
+  }
+
+  return false;
+}
+
 /** Extract session ID from the gstack_picker cookie. */
 function getSessionFromCookie(req: Request): string | null {
   const cookie = req.headers.get('cookie');

--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -763,6 +763,7 @@ if (BROWSE_PARENT_PID > 0) {
     try {
       process.kill(BROWSE_PARENT_PID, 0); // signal 0 = existence check only, no signal sent
     } catch {
+      if (hasActivePicker()) return;
       console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited, shutting down`);
       shutdown();
     }
@@ -770,6 +771,7 @@ if (BROWSE_PARENT_PID > 0) {
 }
 
 // ─── Command Sets (from commands.ts — single source of truth) ───
+import { hasActivePicker } from './cookie-picker-routes';
 import { READ_COMMANDS, WRITE_COMMANDS, META_COMMANDS } from './commands';
 export { READ_COMMANDS, WRITE_COMMANDS, META_COMMANDS };
 

--- a/browse/test/cookie-picker-routes.test.ts
+++ b/browse/test/cookie-picker-routes.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { handleCookiePickerRoute, generatePickerCode } from '../src/cookie-picker-routes';
+import { handleCookiePickerRoute, generatePickerCode, hasActivePicker } from '../src/cookie-picker-routes';
 
 // ─── Mock BrowserManager ──────────────────────────────────────
 
@@ -281,6 +281,57 @@ describe('cookie-picker-routes', () => {
       const res = await handleCookiePickerRoute(url, req, bm, 'test-token');
 
       expect(res.status).toBe(403);
+    });
+  });
+
+  describe('active picker tracking', () => {
+    test('one-time codes keep the picker active until consumed', async () => {
+      const realNow = Date.now;
+      Date.now = () => realNow() + 3_700_000;
+      try {
+        expect(hasActivePicker()).toBe(false); // clears any stale state from prior tests
+      } finally {
+        Date.now = realNow;
+      }
+
+      const { bm } = mockBrowserManager();
+      const code = generatePickerCode();
+      expect(hasActivePicker()).toBe(true);
+
+      const res = await handleCookiePickerRoute(
+        makeUrl(`/cookie-picker?code=${code}`),
+        new Request('http://127.0.0.1:9470', { method: 'GET' }),
+        bm,
+        'test-token',
+      );
+
+      expect(res.status).toBe(302);
+      expect(hasActivePicker()).toBe(true); // session is now active
+    });
+
+    test('picker becomes inactive after an invalid session probe clears expired state', async () => {
+      const { bm } = mockBrowserManager();
+      const session = await getSessionCookie(bm, 'test-token');
+      expect(hasActivePicker()).toBe(true);
+
+      const realNow = Date.now;
+      Date.now = () => realNow() + 3_700_000;
+      try {
+        const res = await handleCookiePickerRoute(
+          makeUrl('/cookie-picker'),
+          new Request('http://127.0.0.1:9470', {
+            method: 'GET',
+            headers: { 'Cookie': `gstack_picker=${session}` },
+          }),
+          bm,
+          'test-token',
+        );
+
+        expect(res.status).toBe(403);
+        expect(hasActivePicker()).toBe(false);
+      } finally {
+        Date.now = realNow;
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Keep the browse server alive while the cookie picker still has an active one-time code or session, so `cookie-import-browser` does not strand the UI with `Failed to fetch` after the launching CLI exits.

## Changes

- add `hasActivePicker()` to track live picker codes and sessions while opportunistically pruning expired entries
- skip parent-PID watchdog shutdowns when the cookie picker still has active state
- add regression tests covering both active-code/session tracking and expiry cleanup

## Testing

- `bun test browse/test/cookie-picker-routes.test.ts`

Fixes garrytan/gstack#985