### PR TITLE
fix: reset per-tab agent state in killAgent()

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -651,6 +651,17 @@ function killAgent(targetTabId?: number | null): void {
   agentStartTime = null;
   currentMessage = null;
   agentStatus = 'idle';
+  // Also reset the per-tab state — killAgent resets the global but the tab-level
+  // status gates spawnClaude, so without this every subsequent message is queued
+  // instead of dispatched.
+  const resetTabId = targetTabId ?? agentTabId ?? null;
+  if (resetTabId !== null && tabAgents.has(resetTabId)) {
+    const ts = tabAgents.get(resetTabId)!;
+    ts.status = 'idle';
+    ts.startTime = null;
+    ts.currentMessage = null;
+    ts.queue = [];
+  }
 }
 
 // Agent health check — detect hung processes


### PR DESCRIPTION
## Summary

`killAgent()` resets the legacy global `agentStatus = 'idle'` but leaves the per-tab entry in `tabAgents` with `status: 'processing'`.

The `POST /sidebar-command` handler checks per-tab status (not the global) to decide whether to call `spawnClaude()` or queue the message. After a kill, the tab is permanently stuck — the sidebar looks idle but silently queues every new message in memory instead of dispatching it. Only fix was a server restart.

## Root cause

The per-tab `tabAgents` Map was introduced alongside the cancel-file work in #664, but `killAgent()` was only updated to write the cancel file — the per-tab state reset was missed.

## Fix

Reset the `TabAgentState` entry in `tabAgents` inside `killAgent()`, alongside the existing legacy global resets.

## Repro

1. Send a message before the sidebar agent process is running
2. Server marks the tab `'processing'`, agent never responds
3. Hit Kill — global resets to idle, per-tab stays `'processing'`
4. Every subsequent message is queued in-memory, never dispatched
5. Sidebar appears functional but never responds

## Test

After the fix: kill an in-progress agent, send a new message, confirm `agent_start` appears in the chat buffer and a new entry is appended to `sidebar-agent-queue.jsonl`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)