### PR TITLE
fix(browse): externalize @ngrok/ngrok in Windows Node server bundle

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -14,13 +14,16 @@ DIST_DIR="$GSTACK_DIR/browse/dist"
 echo "Building Node-compatible server bundle..."
 
 # Step 1: Transpile server.ts to a single .mjs bundle (externalize runtime deps)
+# Note: @ngrok/ngrok is externalized because it ships a .node native binding;
+# bun >=1.3 refuses --outfile when an asset would be emitted alongside the entry.
 bun build "$SRC_DIR/server.ts" \
   --target=node \
   --outfile "$DIST_DIR/server-node.mjs" \
   --external playwright \
   --external playwright-core \
   --external diff \
-  --external "bun:sqlite"
+  --external "bun:sqlite" \
+  --external "@ngrok/ngrok"
 
 # Step 2: Post-process
 # Replace import.meta.dir with a resolvable reference


### PR DESCRIPTION
## Summary

bun >=1.3 refuses \`--outfile\` when an asset (like \`@ngrok/ngrok\`'s \`.node\` native binding) would be emitted alongside the entry point. The current \`build-node-server.sh\` script bundles \`server.ts\` targeting Node and writes to a single \`--outfile\`, but \`@ngrok/ngrok\` ships a platform-specific \`.node\` file that bun tries to emit alongside the \`.mjs\` bundle.

Result on Windows during \`./setup\`:

\`\`\`
Building Node-compatible server bundle...
error: cannot write multiple output files without an output directory
\`\`\`

The Node-compatible server bundle is the Windows compatibility path (playwright + bun has a longstanding incompatibility — see oven-sh/bun#4253 and #9911), so this error breaks the install for every Windows user. \`./setup\` continues past it (the bun-binary path used on macOS/Linux still completes), but on Windows the \`browse\` server fails to launch later because \`server-node.mjs\` is stale or missing.

## Fix

Add \`--external "@ngrok/ngrok"\` alongside the existing \`playwright\`, \`playwright-core\`, \`diff\`, and \`bun:sqlite\` externals. The package is already required at runtime (not bundled), so this only affects what bun tries to emit during the bundle step. macOS/Linux installs that use the bun-binary path are unaffected.

Inline comment added so the next contributor who looks at the externals list understands why \`@ngrok/ngrok\` is in there with the runtime deps.

## Verification

Local repro on Windows 11, gstack 0.16.4.0, bun 1.3.x:

**Before (current main):**
\`\`\`
Building Node-compatible server bundle...
error: cannot write multiple output files without an output directory
\`\`\`

**After this patch:**
\`\`\`
Building Node-compatible server bundle...
Bundled 25 modules in 23ms
  server-node.mjs  0.32 MB  (entry point)
Node server bundle ready: .../browse/dist/server-node.mjs
\`\`\`

\`server-node.mjs\` is 322 KB after the patch, the same shape as before bun 1.3 changed its multi-output guard.

## Test plan

- [ ] Reviewer runs \`./setup\` on Windows with bun >= 1.3 and confirms no \`cannot write multiple output files\` error
- [ ] Reviewer confirms macOS/Linux \`./setup\` still completes (this script only runs in the Windows compat path, but worth a sanity check)
- [ ] \`browse/dist/server-node.mjs\` is produced and has non-zero size on Windows