### PR TITLE
fix: ad-hoc codesign compiled binaries on Apple Silicon after build

### DIFF
--- a/setup
+++ b/setup
@@ -215,6 +215,23 @@ if [ "$NEEDS_BUILD" -eq 1 ]; then
   if [ ! -f "$SOURCE_GSTACK_DIR/browse/dist/.version" ]; then
     git -C "$SOURCE_GSTACK_DIR" rev-parse HEAD > "$SOURCE_GSTACK_DIR/browse/dist/.version" 2>/dev/null || true
   fi
+
+  # macOS Apple Silicon: ad-hoc codesign compiled binaries.
+  # Bun's --compile can produce a corrupt or linker-only code signature that
+  # macOS kills with SIGKILL (exit 137). The two-step remove+re-sign is
+  # required because a naive `codesign -s - -f` fails when the existing
+  # signature block is corrupt. This is idempotent and costs <1s.
+  # See: https://github.com/garrytan/gstack/issues/997
+  if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+    for _bin in browse/dist/browse browse/dist/find-browse design/dist/design bin/gstack-global-discover; do
+      _bin_path="$SOURCE_GSTACK_DIR/$_bin"
+      [ -f "$_bin_path" ] && [ -x "$_bin_path" ] || continue
+      codesign --remove-signature "$_bin_path" 2>/dev/null || true
+      if ! codesign -s - -f "$_bin_path" 2>/dev/null; then
+        log "warning: codesign failed for $_bin (binary may not run on Apple Silicon)"
+      fi
+    done
+  fi
 fi
 
 if [ ! -x "$BROWSE_BIN" ]; then

--- a/test/setup-codesign.test.ts
+++ b/test/setup-codesign.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from 'bun:test';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const SETUP_SCRIPT = path.join(ROOT, 'setup');
+
+describe('setup: Apple Silicon codesign', () => {
+  test('setup script contains codesign block for Darwin arm64', () => {
+    const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
+    // Verify the codesign guard checks both Darwin and arm64
+    expect(content).toContain('$(uname -s)" = "Darwin"');
+    expect(content).toContain('$(uname -m)" = "arm64"');
+    // Verify remove-then-resign two-step pattern
+    expect(content).toContain('codesign --remove-signature');
+    expect(content).toContain('codesign -s - -f');
+  });
+
+  test('codesign block covers all compiled binaries', () => {
+    const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
+    // Extract the binaries from the codesign for-loop
+    const forMatch = content.match(/for _bin in ([^;]+);/);
+    expect(forMatch).toBeTruthy();
+    const binaries = forMatch![1].trim().split(/\s+/);
+    // All four compiled binaries from `bun run build` must be covered
+    expect(binaries).toContain('browse/dist/browse');
+    expect(binaries).toContain('browse/dist/find-browse');
+    expect(binaries).toContain('design/dist/design');
+    expect(binaries).toContain('bin/gstack-global-discover');
+  });
+
+  test('codesign block is inside the NEEDS_BUILD=1 branch', () => {
+    const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
+    // The codesign block should appear after `bun run build` and before the
+    // `if [ ! -x "$BROWSE_BIN" ]` guard that checks the build succeeded.
+    const buildIdx = content.indexOf('bun run build');
+    const codesignIdx = content.indexOf('codesign --remove-signature');
+    const browseCheckIdx = content.indexOf('gstack setup failed: browse binary missing');
+    expect(buildIdx).toBeGreaterThan(-1);
+    expect(codesignIdx).toBeGreaterThan(buildIdx);
+    expect(browseCheckIdx).toBeGreaterThan(codesignIdx);
+  });
+
+  test('codesign block is idempotent (skips missing binaries)', () => {
+    const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
+    // The loop must guard with a file-existence + executable check before codesigning
+    expect(content).toContain('[ -f "$_bin_path" ] && [ -x "$_bin_path" ] || continue');
+  });
+
+  test('codesign failure is a warning, not a fatal error', () => {
+    const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
+    // On codesign failure, log a warning but don't exit
+    expect(content).toContain('warning: codesign failed for');
+    // Should NOT have `set -e` causing exit on codesign failure
+    // (the `|| true` after --remove-signature and the if-guard around -s - -f handle this)
+    expect(content).toContain('codesign --remove-signature "$_bin_path" 2>/dev/null || true');
+  });
+
+  test('codesign shell snippet is syntactically valid', () => {
+    // Extract the codesign block and validate it parses as bash
+    const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
+    const match = content.match(
+      /# macOS Apple Silicon: ad-hoc codesign[\s\S]*?done\n\s*fi/
+    );
+    expect(match).toBeTruthy();
+    const snippet = match![0];
+    // Wrap in a function to make it a complete script, then syntax-check
+    const testScript = `#!/usr/bin/env bash\nset -e\n_test_fn() {\n${snippet}\n}\n`;
+    const result = spawnSync('bash', ['-n', '-c', testScript], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

On some Apple Silicon machines, `bun build --compile` produces a corrupt or linker-only code signature. macOS kills these binaries with SIGKILL (exit 137, `zsh: killed`) before they execute a single instruction. Every re-run of `./setup` reproduces the same unrunnable binary.

The root cause is well-documented upstream ([Bun #7208](https://github.com/oven-sh/bun/issues/7208), [Go #42684](https://github.com/golang/go/issues/42684)): Apple Silicon requires properly signed executables, and linker-signed-only binaries get killed. A naive `codesign -s - -f` also fails because the existing (broken) signature block prevents re-signing.

## Fix

Add a post-build codesign step to `setup` that runs only on Darwin arm64:

1. **Remove** the corrupt/linker-only signature (`codesign --remove-signature`) — this is required because a direct re-sign fails with "invalid or unsupported format for signature"
2. **Apply** a fresh ad-hoc signature (`codesign -s - -f`)

All four compiled binaries are covered:
- `browse/dist/browse`
- `browse/dist/find-browse`
- `design/dist/design`
- `bin/gstack-global-discover`

## Properties

- **Idempotent**: safe to re-run, skips missing binaries
- **Fast**: <1s total
- **Non-fatal**: codesign failure is a warning, not an error (Intel/CI builds are unaffected)
- **Platform-guarded**: only runs on `Darwin` + `arm64`
- **Bun-recommended**: matches [Bun docs on codesigning standalone executables](https://bun.com/docs/guides/runtime/codesign-macos-executable)

## Tests

Added `test/setup-codesign.test.ts` (6 tests):
- Verifies the codesign block checks both Darwin and arm64
- Verifies all four compiled binaries are covered
- Verifies the block is inside the NEEDS_BUILD=1 branch
- Verifies missing binaries are skipped (idempotent)
- Verifies failure is a warning, not fatal
- Validates the shell snippet syntax

```
bun test test/setup-codesign.test.ts
 6 pass, 0 fail
```

Fixes #997