### PR TITLE
fix: support documented generic setup hosts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,7 +289,9 @@ See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md) for the full guide. Short ver
 4. Run `bun run gen:skill-docs --host myhost`
 5. Run `bun test` (parameterized tests auto-cover it)
 
-Zero generator, setup, or tooling code changes needed.
+Zero generator changes needed. Setup is automatic for hosts that opt into the
+generic symlink-generated installer; hosts with bespoke install flows may still
+need a targeted setup branch.
 
 ### Adding a new skill
 

--- a/docs/ADDING_A_HOST.md
+++ b/docs/ADDING_A_HOST.md
@@ -3,7 +3,9 @@
 gstack uses a declarative host config system. Each supported AI coding agent
 (Claude, Codex, Factory, Kiro, OpenCode, Slate, Cursor, OpenClaw) is defined
 as a typed TypeScript config object. Adding a new host means creating one file
-and re-exporting it. Zero code changes to the generator, setup, or tooling.
+and re-exporting it. Generator and most tooling changes are automatic; simple
+symlink-generated hosts that opt into the generic setup strategy also work with
+setup automatically.
 
 ## How it works
 
@@ -29,7 +31,8 @@ Each config file exports a `HostConfig` object that tells the generator:
 - What assets to symlink at install time
 
 The generator, setup script, platform-detect, uninstall, health checks, worktree
-copy, and tests all read from these configs. None of them have per-host code.
+copy, and tests all read from these configs. Some hosts still keep bespoke setup
+branches where the install flow differs materially (for example Claude or Kiro).
 
 ## Step-by-step: add a new host
 

--- a/hosts/claude.ts
+++ b/hosts/claude.ts
@@ -36,6 +36,7 @@ const claude: HostConfig = {
   install: {
     prefixable: true,
     linkingStrategy: 'real-dir-symlink',
+    setupStrategy: 'bespoke',
   },
 
   coAuthorTrailer: 'Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>',

--- a/hosts/codex.ts
+++ b/hosts/codex.ts
@@ -42,7 +42,7 @@ const codex: HostConfig = {
   runtimeRoot: {
     globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
-      'review': ['checklist.md', 'TODOS-format.md'],
+      'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
     },
   },
   sidecar: {
@@ -53,6 +53,7 @@ const codex: HostConfig = {
   install: {
     prefixable: false,
     linkingStrategy: 'symlink-generated',
+    setupStrategy: 'bespoke',
   },
 
   coAuthorTrailer: 'Co-Authored-By: OpenAI Codex <noreply@openai.com>',

--- a/hosts/cursor.ts
+++ b/hosts/cursor.ts
@@ -25,19 +25,22 @@ const cursor: HostConfig = {
   pathRewrites: [
     { from: '~/.claude/skills/gstack', to: '~/.cursor/skills/gstack' },
     { from: '.claude/skills/gstack', to: '.cursor/skills/gstack' },
+    { from: '.claude/skills/review', to: '.cursor/skills/gstack/review' },
     { from: '.claude/skills', to: '.cursor/skills' },
   ],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'design/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
-      'review': ['checklist.md', 'TODOS-format.md'],
+      'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
+      'review/specialists': ['api-contract.md', 'data-migration.md', 'maintainability.md', 'performance.md', 'red-team.md', 'security.md', 'testing.md'],
     },
   },
 
   install: {
     prefixable: false,
     linkingStrategy: 'symlink-generated',
+    setupStrategy: 'generic',
   },
 
   learningsMode: 'basic',

--- a/hosts/factory.ts
+++ b/hosts/factory.ts
@@ -46,13 +46,14 @@ const factory: HostConfig = {
   runtimeRoot: {
     globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
-      'review': ['checklist.md', 'TODOS-format.md'],
+      'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
     },
   },
 
   install: {
     prefixable: false,
     linkingStrategy: 'symlink-generated',
+    setupStrategy: 'bespoke',
   },
 
   coAuthorTrailer: 'Co-Authored-By: Factory Droid <droid@users.noreply.github.com>',

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -29,6 +29,14 @@ export type Host = (typeof ALL_HOST_CONFIGS)[number]['name'];
 /** All host names as a string array (for CLI arg validation, etc.). */
 export const ALL_HOST_NAMES: string[] = ALL_HOST_CONFIGS.map(c => c.name);
 
+/** Hosts supported by setup's generic install path. */
+export function getGenericSetupHosts(): HostConfig[] {
+  return ALL_HOST_CONFIGS.filter(c => c.install.setupStrategy === 'generic');
+}
+
+/** Generic-setup host names as a string array. */
+export const GENERIC_SETUP_HOST_NAMES: string[] = getGenericSetupHosts().map(c => c.name);
+
 /** Get a host config by name. Throws if not found. */
 export function getHostConfig(name: string): HostConfig {
   const config = HOST_CONFIG_MAP[name];

--- a/hosts/kiro.ts
+++ b/hosts/kiro.ts
@@ -33,13 +33,14 @@ const kiro: HostConfig = {
   runtimeRoot: {
     globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
-      'review': ['checklist.md', 'TODOS-format.md'],
+      'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
     },
   },
 
   install: {
     prefixable: false,
     linkingStrategy: 'symlink-generated',
+    setupStrategy: 'bespoke',
   },
 
   learningsMode: 'basic',

--- a/hosts/openclaw.ts
+++ b/hosts/openclaw.ts
@@ -65,6 +65,7 @@ const openclaw: HostConfig = {
   install: {
     prefixable: false,
     linkingStrategy: 'symlink-generated',
+    setupStrategy: 'bespoke',
   },
 
   coAuthorTrailer: 'Co-Authored-By: OpenClaw Agent <agent@openclaw.ai>',

--- a/hosts/opencode.ts
+++ b/hosts/opencode.ts
@@ -25,19 +25,22 @@ const opencode: HostConfig = {
   pathRewrites: [
     { from: '~/.claude/skills/gstack', to: '~/.config/opencode/skills/gstack' },
     { from: '.claude/skills/gstack', to: '.opencode/skills/gstack' },
+    { from: '.claude/skills/review', to: '.opencode/skills/gstack/review' },
     { from: '.claude/skills', to: '.opencode/skills' },
   ],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'design/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
-      'review': ['checklist.md', 'TODOS-format.md'],
+      'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
+      'review/specialists': ['api-contract.md', 'data-migration.md', 'maintainability.md', 'performance.md', 'red-team.md', 'security.md', 'testing.md'],
     },
   },
 
   install: {
     prefixable: false,
     linkingStrategy: 'symlink-generated',
+    setupStrategy: 'generic',
   },
 
   learningsMode: 'basic',

--- a/hosts/slate.ts
+++ b/hosts/slate.ts
@@ -25,19 +25,22 @@ const slate: HostConfig = {
   pathRewrites: [
     { from: '~/.claude/skills/gstack', to: '~/.slate/skills/gstack' },
     { from: '.claude/skills/gstack', to: '.slate/skills/gstack' },
+    { from: '.claude/skills/review', to: '.slate/skills/gstack/review' },
     { from: '.claude/skills', to: '.slate/skills' },
   ],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'design/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
-      'review': ['checklist.md', 'TODOS-format.md'],
+      'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
+      'review/specialists': ['api-contract.md', 'data-migration.md', 'maintainability.md', 'performance.md', 'red-team.md', 'security.md', 'testing.md'],
     },
   },
 
   install: {
     prefixable: false,
     linkingStrategy: 'symlink-generated',
+    setupStrategy: 'generic',
   },
 
   learningsMode: 'basic',

--- a/scripts/host-config-export.ts
+++ b/scripts/host-config-export.ts
@@ -6,14 +6,17 @@
  *
  * Commands:
  *   list                    Print all host names, one per line
+ *   generic-setup-hosts     Print hosts supported by setup's generic install path
  *   get <host> <field>      Print a single config field value
  *   detect                  Print names of hosts whose CLI binary is on PATH
+ *   detect-generic-setup-hosts
+ *                           Print generic-setup hosts whose CLI binary is on PATH
  *   validate                Validate all configs, exit 1 on error
  *
  * All output is shell-safe (single-quoted values, no eval needed).
  */
 
-import { ALL_HOST_CONFIGS, getHostConfig, ALL_HOST_NAMES } from '../hosts/index';
+import { ALL_HOST_CONFIGS, getHostConfig, ALL_HOST_NAMES, getGenericSetupHosts } from '../hosts/index';
 import { validateAllConfigs } from './host-config';
 import { execSync } from 'child_process';
 
@@ -36,6 +39,12 @@ switch (command) {
   case 'list':
     for (const name of ALL_HOST_NAMES) {
       console.log(name);
+    }
+    break;
+
+  case 'generic-setup-hosts':
+    for (const config of getGenericSetupHosts()) {
+      console.log(config.name);
     }
     break;
 
@@ -67,6 +76,22 @@ switch (command) {
 
   case 'detect': {
     for (const config of ALL_HOST_CONFIGS) {
+      const commands = [config.cliCommand, ...(config.cliAliases || [])];
+      for (const cmd of commands) {
+        try {
+          execSync(`command -v ${shellEscape(cmd)}`, { stdio: 'pipe' });
+          console.log(config.name);
+          break;  // Found this host, move to next
+        } catch {
+          // Binary not found, try next alias
+        }
+      }
+    }
+    break;
+  }
+
+  case 'detect-generic-setup-hosts': {
+    for (const config of getGenericSetupHosts()) {
       const commands = [config.cliCommand, ...(config.cliAliases || [])];
       for (const cmd of commands) {
         try {
@@ -114,6 +139,6 @@ switch (command) {
   }
 
   default:
-    console.error('Usage: host-config-export.ts <list|get|detect|validate|symlinks> [args]');
+    console.error('Usage: host-config-export.ts <list|generic-setup-hosts|get|detect|detect-generic-setup-hosts|validate|symlinks> [args]');
     process.exit(1);
 }

--- a/scripts/host-config.ts
+++ b/scripts/host-config.ts
@@ -95,6 +95,8 @@ export interface HostConfig {
     prefixable: boolean;
     /** How skills are linked into the host dir. */
     linkingStrategy: 'real-dir-symlink' | 'symlink-generated';
+    /** Whether setup can use the generic installer or needs a bespoke branch. */
+    setupStrategy?: 'generic' | 'bespoke';
   };
 
   // --- Host-Specific Behavioral Config ---
@@ -150,6 +152,9 @@ export function validateHostConfig(config: HostConfig): string[] {
   }
   if (!['real-dir-symlink', 'symlink-generated'].includes(config.install.linkingStrategy)) {
     errors.push(`install.linkingStrategy must be 'real-dir-symlink' or 'symlink-generated'`);
+  }
+  if (config.install.setupStrategy && !['generic', 'bespoke'].includes(config.install.setupStrategy)) {
+    errors.push(`install.setupStrategy must be 'generic' or 'bespoke' when provided`);
   }
 
   return errors;

--- a/setup
+++ b/setup
@@ -32,6 +32,38 @@ esac
 QUIET=0
 log() { [ "$QUIET" -eq 0 ] && echo "$@" || true; }
 
+# ─── Host config helpers ─────────────────────────────────────
+HOST_CONFIG_EXPORT="$SOURCE_GSTACK_DIR/scripts/host-config-export.ts"
+
+run_host_config_export() {
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun run "$HOST_CONFIG_EXPORT" "$@"
+  )
+}
+
+GENERIC_SETUP_HOSTS=()
+load_generic_setup_hosts() {
+  mapfile -t GENERIC_SETUP_HOSTS < <(run_host_config_export generic-setup-hosts)
+}
+
+is_generic_setup_host() {
+  local host="$1"
+  local candidate
+  for candidate in "${GENERIC_SETUP_HOSTS[@]}"; do
+    [ "$candidate" = "$host" ] && return 0
+  done
+  return 1
+}
+
+load_generic_setup_hosts
+
+HOST_EXPECTED_VALUES="claude, codex, kiro, factory"
+for generic_host in "${GENERIC_SETUP_HOSTS[@]}"; do
+  HOST_EXPECTED_VALUES="$HOST_EXPECTED_VALUES, $generic_host"
+done
+HOST_EXPECTED_VALUES="$HOST_EXPECTED_VALUES, openclaw, or auto"
+
 # ─── Parse flags ──────────────────────────────────────────────
 HOST="claude"
 LOCAL_INSTALL=0
@@ -41,7 +73,7 @@ TEAM_MODE=0
 NO_TEAM_MODE=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected $HOST_EXPECTED_VALUES)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -67,7 +99,11 @@ case "$HOST" in
     echo "  3. See docs/OPENCLAW.md for the full architecture"
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, openclaw, or auto)" >&2; exit 1 ;;
+  *)
+    if ! is_generic_setup_host "$HOST"; then
+      echo "Unknown --host value: $HOST (expected $HOST_EXPECTED_VALUES)" >&2
+      exit 1
+    fi ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -130,13 +166,28 @@ INSTALL_CLAUDE=0
 INSTALL_CODEX=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
+INSTALL_GENERIC_HOSTS=()
+
+add_generic_install_host() {
+  local host="$1"
+  local existing
+  for existing in "${INSTALL_GENERIC_HOSTS[@]}"; do
+    [ "$existing" = "$host" ] && return 0
+  done
+  INSTALL_GENERIC_HOSTS+=("$host")
+}
+
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
+  mapfile -t detected_generic_hosts < <(run_host_config_export detect-generic-setup-hosts)
+  for detected_host in "${detected_generic_hosts[@]}"; do
+    add_generic_install_host "$detected_host"
+  done
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "${#INSTALL_GENERIC_HOSTS[@]}" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
@@ -147,6 +198,8 @@ elif [ "$HOST" = "kiro" ]; then
   INSTALL_KIRO=1
 elif [ "$HOST" = "factory" ]; then
   INSTALL_FACTORY=1
+elif is_generic_setup_host "$HOST"; then
+  add_generic_install_host "$HOST"
 fi
 
 migrate_direct_codex_install() {
@@ -170,6 +223,8 @@ migrate_direct_codex_install() {
   INSTALL_GSTACK_DIR="$migrated_dir"
   INSTALL_SKILLS_DIR="$(dirname "$INSTALL_GSTACK_DIR")"
   BROWSE_BIN="$SOURCE_GSTACK_DIR/browse/dist/browse"
+  HOST_CONFIG_EXPORT="$SOURCE_GSTACK_DIR/scripts/host-config-export.ts"
+  GSTACK_CONFIG="$SOURCE_GSTACK_DIR/bin/gstack-config"
 }
 
 if [ "$INSTALL_CODEX" -eq 1 ]; then
@@ -602,6 +657,105 @@ link_factory_skill_dirs() {
   fi
 }
 
+ensure_generated_host_skills() {
+  local host="$1"
+  local local_skill_root="$2"
+  local generated_root="$SOURCE_GSTACK_DIR/$local_skill_root"
+
+  log "Generating .$host/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun install --frozen-lockfile 2>/dev/null || bun install
+    bun run gen:skill-docs --host "$host"
+  )
+
+  if [ ! -d "$generated_root" ]; then
+    echo "  warning: $local_skill_root generation failed — run 'bun run gen:skill-docs --host $host' manually" >&2
+    return 1
+  fi
+}
+
+create_generic_runtime_root() {
+  local host="$1"
+  local gstack_dir="$2"
+  local host_gstack="$3"
+  local generated_root="$4"
+  local asset
+
+  if [ -L "$host_gstack" ]; then
+    rm -f "$host_gstack"
+  elif [ -d "$host_gstack" ] && [ "$host_gstack" != "$gstack_dir" ]; then
+    rm -rf "$host_gstack"
+  fi
+
+  mkdir -p "$host_gstack"
+
+  if [ -f "$generated_root/SKILL.md" ]; then
+    ln -snf "$generated_root/SKILL.md" "$host_gstack/SKILL.md"
+  fi
+
+  while IFS= read -r asset; do
+    [ -n "$asset" ] || continue
+    local src="$gstack_dir/$asset"
+    local dst="$host_gstack/$asset"
+    if [ -d "$src" ] || [ -f "$src" ]; then
+      mkdir -p "$(dirname "$dst")"
+      ln -snf "$src" "$dst"
+    fi
+  done < <(run_host_config_export symlinks "$host")
+}
+
+link_generated_skill_dirs() {
+  local generated_parent="$1"
+  local skills_dir="$2"
+  local linked=()
+
+  for skill_dir in "$generated_parent"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      local skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      local target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+install_generic_host() {
+  local host="$1"
+  local global_root
+  local local_skill_root
+  local host_skills
+  local host_gstack
+  local generated_root
+  local generated_parent
+  local host_repo_local=0
+
+  global_root="$(run_host_config_export get "$host" globalRoot)"
+  local_skill_root="$(run_host_config_export get "$host" localSkillRoot)"
+  host_skills="$HOME/$(dirname "$global_root")"
+  host_gstack="$HOME/$global_root"
+  generated_root="$SOURCE_GSTACK_DIR/$local_skill_root"
+  generated_parent="$(dirname "$generated_root")"
+
+  ensure_generated_host_skills "$host" "$local_skill_root" || return 1
+  mkdir -p "$host_skills"
+  [ "$SOURCE_GSTACK_DIR" = "$host_gstack" ] && host_repo_local=1
+  if [ "$host_repo_local" -eq 0 ]; then
+    create_generic_runtime_root "$host" "$SOURCE_GSTACK_DIR" "$host_gstack" "$generated_root"
+  fi
+  link_generated_skill_dirs "$generated_parent" "$host_skills"
+
+  log "gstack ready ($host)."
+  log "  browse: $BROWSE_BIN"
+  log "  $host skills: $host_skills"
+}
+
 # 4. Install for Claude (default)
 SKILLS_BASENAME="$(basename "$INSTALL_SKILLS_DIR")"
 SKILLS_PARENT_BASENAME="$(basename "$(dirname "$INSTALL_SKILLS_DIR")")"
@@ -762,6 +916,13 @@ if [ "$INSTALL_FACTORY" -eq 1 ]; then
   echo "gstack ready (factory)."
   echo "  browse: $BROWSE_BIN"
   echo "  factory skills: $FACTORY_SKILLS"
+fi
+
+# 6c. Install for generic symlink-generated hosts (OpenCode, Cursor, Slate, etc.)
+if [ "${#INSTALL_GENERIC_HOSTS[@]}" -gt 0 ]; then
+  for generic_host in "${INSTALL_GENERIC_HOSTS[@]}"; do
+    install_generic_host "$generic_host"
+  done
 fi
 
 # 7. Create .agents/ sidecar symlinks for the real Codex skill target.

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2115,15 +2115,19 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('rm -f "$target"');
   });
 
-  test('setup supports --host auto|claude|codex|kiro', () => {
+  test('setup supports documented generic hosts in addition to legacy hosts', () => {
     expect(setupContent).toContain('--host');
     expect(setupContent).toContain('claude|codex|kiro|factory|auto');
+    expect(setupContent).toContain('generic-setup-hosts');
+    expect(setupContent).toContain('HOST_EXPECTED_VALUES');
+    expect(setupContent).toContain('is_generic_setup_host');
   });
 
-  test('auto mode detects claude, codex, and kiro binaries', () => {
+  test('auto mode detects legacy binaries plus generic setup hosts', () => {
     expect(setupContent).toContain('command -v claude');
     expect(setupContent).toContain('command -v codex');
     expect(setupContent).toContain('command -v kiro-cli');
+    expect(setupContent).toContain('detect-generic-setup-hosts');
   });
 
   // T1: Sidecar skip guard — prevents .agents/skills/gstack from being linked as a skill
@@ -2149,6 +2153,13 @@ describe('setup script validation', () => {
     expect(setupContent).toContain('kiro-cli');
     expect(setupContent).toContain('KIRO_SKILLS=');
     expect(setupContent).toContain('~/.kiro/skills/gstack');
+  });
+
+  test('generic setup hosts use exported config-driven install helpers', () => {
+    expect(setupContent).toContain('install_generic_host()');
+    expect(setupContent).toContain('run_host_config_export get "$host" globalRoot');
+    expect(setupContent).toContain('run_host_config_export symlinks "$host"');
+    expect(setupContent).toContain('INSTALL_GENERIC_HOSTS');
   });
 
   test('create_agents_sidecar links runtime assets', () => {

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -14,6 +14,8 @@ import {
   getHostConfig,
   resolveHostArg,
   getExternalHosts,
+  getGenericSetupHosts,
+  GENERIC_SETUP_HOST_NAMES,
   claude,
   codex,
   factory,
@@ -26,6 +28,63 @@ import {
 import { HOST_PATHS } from '../scripts/resolvers/types';
 
 const ROOT = path.resolve(import.meta.dir, '..');
+
+function walkFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath));
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function exportedRuntimeAssets(config: HostConfig): Set<string> {
+  const assets = new Set<string>(config.runtimeRoot.globalSymlinks);
+  for (const [dir, files] of Object.entries(config.runtimeRoot.globalFiles ?? {})) {
+    for (const file of files) {
+      assets.add(`${dir}/${file}`);
+    }
+  }
+  return assets;
+}
+
+function collectGeneratedRuntimeReferences(config: HostConfig): Set<string> {
+  const skillsRoot = path.join(ROOT, config.hostSubdir, 'skills');
+  const references = new Set<string>();
+  const patterns = [
+    new RegExp(`${escapeRegex(`${config.hostSubdir}/skills/gstack/`)}(review/[A-Za-z0-9_./-]+|design/dist/[A-Za-z0-9_./-]+)`, 'g'),
+    /\$GSTACK_ROOT\/(review\/[A-Za-z0-9_./-]+|design\/dist\/[A-Za-z0-9_./-]+)/g,
+  ];
+
+  for (const file of walkFiles(skillsRoot)) {
+    if (!file.endsWith('.md')) continue;
+    const content = fs.readFileSync(file, 'utf-8');
+    for (const pattern of patterns) {
+      for (const match of content.matchAll(pattern)) {
+        references.add(match[1]);
+      }
+    }
+  }
+
+  return references;
+}
+
+function isCoveredByExport(requiredAsset: string, exportedAssets: Set<string>): boolean {
+  for (const exported of exportedAssets) {
+    if (requiredAsset === exported || requiredAsset.startsWith(`${exported}/`)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 // ─── hosts/index.ts ─────────────────────────────────────────
 
@@ -84,6 +143,20 @@ describe('hosts/index.ts', () => {
     const external = getExternalHosts();
     expect(external.find(c => c.name === 'claude')).toBeUndefined();
     expect(external.length).toBe(ALL_HOST_CONFIGS.length - 1);
+  });
+
+  test('generic setup hosts match the documented compatibility hosts', () => {
+    expect(GENERIC_SETUP_HOST_NAMES).toEqual(['opencode', 'slate', 'cursor']);
+    expect(getGenericSetupHosts().map(c => c.name)).toEqual(GENERIC_SETUP_HOST_NAMES);
+  });
+
+  test('generic setup hosts export the runtime assets their generated skills reference', () => {
+    for (const config of getGenericSetupHosts()) {
+      const exported = exportedRuntimeAssets(config);
+      const referenced = collectGeneratedRuntimeReferences(config);
+      const missing = [...referenced].filter(asset => !isCoveredByExport(asset, exported));
+      expect(missing).toEqual([]);
+    }
   });
 
   test('every host has a unique name', () => {
@@ -191,6 +264,12 @@ describe('validateHostConfig', () => {
     const c = makeValid();
     (c.install as any).linkingStrategy = 'invalid';
     expect(validateHostConfig(c).some(e => e.includes('linkingStrategy'))).toBe(true);
+  });
+
+  test('invalid setupStrategy is caught', () => {
+    const c = makeValid();
+    (c.install as any).setupStrategy = 'invalid';
+    expect(validateHostConfig(c).some(e => e.includes('setupStrategy'))).toBe(true);
   });
 
   test('paths with $ and ~ are valid', () => {
@@ -311,6 +390,13 @@ describe('host-config-export.ts CLI', () => {
     expect(names).toEqual(ALL_HOST_NAMES);
   });
 
+  test('generic-setup-hosts prints setup-compatible host names', () => {
+    const { stdout, exitCode } = run('generic-setup-hosts');
+    expect(exitCode).toBe(0);
+    const names = stdout.split('\n');
+    expect(names).toEqual(GENERIC_SETUP_HOST_NAMES);
+  });
+
   test('get returns string field', () => {
     const { stdout, exitCode } = run('get', 'codex', 'globalRoot');
     expect(exitCode).toBe(0);
@@ -364,6 +450,11 @@ describe('host-config-export.ts CLI', () => {
     expect(exitCode).toBe(0);
     // claude binary should be on PATH in this environment
     expect(stdout).toContain('claude');
+  });
+
+  test('detect-generic-setup-hosts exits cleanly', () => {
+    const { exitCode } = run('detect-generic-setup-hosts');
+    expect(exitCode).toBe(0);
   });
 
   test('unknown command exits 1', () => {


### PR DESCRIPTION
## Summary
This finishes setup support for the documented generic hosts that already exist in the host registry but were still rejected by ./setup.

Before this change:
- README.md documented ./setup --host opencode, ./setup --host cursor, and ./setup --host slate
- setup still rejected those values at argument parsing time
- the host registry already contained hosts/opencode.ts, hosts/cursor.ts, and hosts/slate.ts

## Root cause
setup still had a hardcoded host allowlist and install flow, while host registration had already moved into the declarative host config system.

## What changed
- added a generic setup path driven by host config export data
- accepted config-declared generic hosts in setup --host ...
- added auto-detection for generic setup hosts
- made generic host skill generation refresh on setup runs instead of only when the output directory is missing
- made generic-host eligibility explicit via install.setupStrategy
- fixed OpenCode/Cursor/Slate runtime asset exports so the generated skills and installed runtime root agree:
  - design/dist
  - review/design-checklist.md
  - review/greptile-triage.md
  - review/specialists/*.md
- added the missing .claude/skills/review -> .host/skills/gstack/review path rewrite for OpenCode/Cursor/Slate
- tightened docs so they describe the generic installer accurately
- added tests that assert generic hosts export the runtime assets their generated skills actually reference

## Verification
Passed:
- bun test test/host-config.test.ts --test-name-pattern 'hosts/index.ts|validateHostConfig|validateAllConfigs|HOST_PATHS derivation from configs|host-config-export.ts CLI|host config correctness'
- bun test test/gen-skill-docs.test.ts --test-name-pattern 'setup script validation|Parameterized host smoke tests|--host all'
- bun run gen:skill-docs --host all --dry-run
- bun run skill:check

Manual smoke:
- ./setup --host opencode -q
- this no longer fails on Unknown --host value: opencode
- it now proceeds into the existing setup flow and stops later in the pre-existing browser/bootstrap path with:
  - error: cannot write multiple output files without an output directory
  - gstack setup failed: Playwright Chromium could not be launched

## Notes
I also confirmed that stale golden baselines in the current checkout are unrelated to this change, so I kept this PR focused on the setup/host-config gap only.