### PR TITLE
fix(browse): honor BROWSE_PARENT_PID=0 in headless spawn path

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -210,12 +210,16 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
 
   let proc: any = null;
 
+  // Honor BROWSE_PARENT_PID=0 from env (disables parent-death self-termination).
+  // Needed when the caller is a short-lived subshell (e.g. Claude Code Bash tool)
+  // so the server persists across invocations. Otherwise default to CLI's PID.
+  const parentPid = process.env.BROWSE_PARENT_PID === '0' ? '0' : String(process.pid);
   if (IS_WINDOWS && NODE_SERVER_SCRIPT) {
     // Windows: Bun.spawn() + proc.unref() doesn't truly detach on Windows —
     // when the CLI exits, the server dies with it. Use Node's child_process.spawn
     // with { detached: true } instead, which is the gold standard for Windows
     // process independence. Credit: PR #191 by @fqueiro.
-    const extraEnvStr = JSON.stringify({ BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: String(process.pid), ...(extraEnv || {}) });
+    const extraEnvStr = JSON.stringify({ BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: parentPid, ...(extraEnv || {}) });
     const launcherCode =
       `const{spawn}=require('child_process');` +
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
@@ -226,7 +230,7 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     // macOS/Linux: Bun.spawn + unref works correctly
     proc = Bun.spawn(['bun', 'run', SERVER_SCRIPT], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: String(process.pid), ...extraEnv },
+      env: { ...process.env, BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: parentPid, ...extraEnv },
     });
     proc.unref();
   }


### PR DESCRIPTION
## Problem

When callers set `BROWSE_PARENT_PID=0` in their env, the headless server spawn ignored it. `cli.ts:229` hardcoded `String(process.pid)` for the server's `BROWSE_PARENT_PID` env, overriding anything the caller had set.

The HEADED path at `cli.ts:832` already honors `BROWSE_PARENT_PID=0` for pair-agent scenarios. This PR extends the same escape hatch to the headless path.

## Why this matters

Short-lived-parent callers (Claude Code Bash tool, non-interactive shells, CI runners) can't keep the browse server alive across invocations, because each invocation is a fresh subshell that becomes `BROWSE_PARENT_PID`. When the subshell exits (immediately after the command returns), the server's 15s parent-death watcher detects the parent is gone and calls `shutdown()`.

### Repro on Linux

```bash
# From a non-interactive bash subshell (e.g. `bash -c '...'`):
$B goto https://example.com
# Wait 20 seconds (past the 15s watcher interval)
$B status
# URL is about:blank — server died and respawned with no page loaded
```

Orphan chromium processes accumulate (~60MB each) as each killed server leaves its chromium behind.

### After fix

```bash
export BROWSE_PARENT_PID=0
$B goto https://example.com
sleep 20
$B status
# URL still https://example.com/ — server persisted
```

## Change

Three lines in `cli.ts` above the platform dispatch:

```ts
const parentPid = process.env.BROWSE_PARENT_PID === '0' ? '0' : String(process.pid);
```

Then use `parentPid` in both the Windows and macOS/Linux spawn paths instead of hardcoding `String(process.pid)`.

## Verified

- Linux VPS (Ubuntu 24.04, kernel 6.8): server persisted 20+ seconds across 5+ short-subshell calls. No regression observed in normal long-shell usage (PID check still happens, watcher still runs when env var is unset/non-zero).
- Behavior with `BROWSE_PARENT_PID` unset or `> 0`: unchanged (existing logic).

## Notes

Discovered during a Claude Code session where `$B` kept producing orphan chromium processes because each Bash tool call is a fresh subshell with a short-lived PID. The fix brings parity between HEADED and HEADLESS paths — the escape hatch already existed in one, just not the other.