### PR TITLE
fix(windows): externalize @ngrok/ngrok in Node server bundle

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -20,7 +20,8 @@ bun build "$SRC_DIR/server.ts" \
   --external playwright \
   --external playwright-core \
   --external diff \
-  --external "bun:sqlite"
+  --external "bun:sqlite" \
+  --external "@ngrok/ngrok"
 
 # Step 2: Post-process
 # Replace import.meta.dir with a resolvable reference


### PR DESCRIPTION
## Summary

The Windows Node-compat server bundle build (`browse/scripts/build-node-server.sh`) has been silently failing since v0.15.12 with:

```
error: cannot write multiple output files without an output directory
```

Root cause: `@ngrok/ngrok` (added in #815 for pair-agent tunneling) pulls in a ~10 MB native `.node` addon as a build asset. `bun build --outfile` refuses any build that emits more than one file, so the script exits 1, leaves the old `server-node.mjs` in place, and the rest of `bun run build` continues. macOS/Linux users don't notice because their `browse` binary runs the server directly under Bun — but on Windows, `browse.exe` spawns `node server-node.mjs` (Bun can't drive Playwright's Chromium on Windows: [oven-sh/bun#4253](https://github.com/oven-sh/bun/issues/4253), [oven-sh/bun#9911](https://github.com/oven-sh/bun/issues/9911)), so a stale bundle is load-bearing.

Net effect on Windows: a current `browse.exe` talks to a v0.15.11-era server over HTTP after `./setup`. Missing features:
- v0.16.0 browser data platform (`media`, `data`, `download`, `scrape`, `archive`, network capture, `GET /file`)
- v0.16.4 cookie origin pinning + command audit log
- v0.17.0 `ux-audit` command + `snapshot -H`/`--heatmap`
- various v0.15.12+ content-security envelopes for `/pair-agent`

## Fix

One-line: externalize `@ngrok/ngrok` alongside the existing `playwright`/`playwright-core`/`diff`/`bun:sqlite` externals. Ngrok is used exclusively via dynamic import in `server.ts`:

```ts
const ngrok = await import('@ngrok/ngrok');   // line 1588 and 2368
```

…so runtime semantics are unchanged — Node resolves it from `node_modules` on first `/pair-agent` tunnel, which is identical to how `playwright` already works. Bundle drops back to a single file.

## Test plan

- [x] `bun install && bash browse/scripts/build-node-server.sh` on a clean clone → builds successfully, emits only `server-node.mjs`
- [x] `node --input-type=module -e "import('./server-node.mjs')"` loads without errors and starts the HTTP listener
- [x] Grep confirms v0.17 features are present in the bundle (`ux-audit`, `heatmap`, content-security envelopes, 21 matches)
- [ ] Full `/pair-agent` tunnel create (not tested — need a paying ngrok account; relying on the fact that `playwright` externalization uses the same mechanism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)