### PR TITLE
feat: add CodeRabbit CLI as adversarial review pass

### DIFF
--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -1295,10 +1295,13 @@ DIFF_INS=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ insertion'
 DIFF_DEL=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
 DIFF_TOTAL=$((DIFF_INS + DIFF_DEL))
 which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+which coderabbit 2>/dev/null && echo "CODERABBIT_AVAILABLE" || echo "CODERABBIT_NOT_AVAILABLE"
 # Legacy opt-out — only gates Codex passes, Claude always runs
 OLD_CFG=$(~/.claude/skills/gstack/bin/gstack-config get codex_reviews 2>/dev/null || true)
 echo "DIFF_SIZE: $DIFF_TOTAL"
 echo "OLD_CFG: ${OLD_CFG:-not_set}"
+# Detect commit state for CodeRabbit flag selection
+git diff --quiet && git diff --cached --quiet && echo "CHANGES_COMMITTED" || echo "CHANGES_UNCOMMITTED"
 ```
 
 If `OLD_CFG` is `disabled`: skip Codex passes only. Claude adversarial subagent still runs (it's free and fast). Jump to the "Claude adversarial subagent" section.
@@ -1348,6 +1351,39 @@ If Codex is NOT available: "Codex CLI not found — running Claude adversarial o
 
 ---
 
+### CodeRabbit review (always runs when available)
+
+If `CODERABBIT_AVAILABLE`: run CodeRabbit CLI review. The flag depends on whether changes are committed or uncommitted at the time this step runs.
+
+**If `CHANGES_UNCOMMITTED`** (Step 5.7 runs before Step 6 commits):
+
+```bash
+coderabbit review --prompt-only -t uncommitted 2>&1
+```
+
+`--prompt-only` outputs the review as plain text (no interactive mode). `-t uncommitted` scopes the review to unstaged/staged changes only.
+
+**If `CHANGES_COMMITTED`** (re-running after Step 6, or all changes already committed):
+
+```bash
+coderabbit review --base <base> 2>&1
+```
+
+This reviews committed changes against the base branch. CodeRabbit may take 1-3 minutes for large diffs. Set the Bash tool's `timeout` parameter to `300000` (5 minutes).
+
+Present findings under a `CODERABBIT SAYS:` header. This is informational — it never blocks shipping. FIXABLE findings flow into the Fix-First pipeline alongside Claude and Codex findings.
+
+**Error handling:** All errors are non-blocking.
+- **Auth failure:** If output contains "auth", "login", "unauthorized", or "API key": "CodeRabbit authentication failed. Run \`coderabbit auth login\` to authenticate."
+- **Timeout:** "CodeRabbit timed out after 5 minutes."
+- **Empty response:** "CodeRabbit returned no findings."
+
+If CodeRabbit is NOT available: "CodeRabbit CLI not found — skipping. Install: `npm install -g coderabbit`"
+
+**Parallelism:** CodeRabbit can run in parallel with the Claude adversarial subagent and Codex adversarial challenge. Launch all three simultaneously when possible.
+
+---
+
 ### Codex structured review (large diffs only, 200+ lines)
 
 If `DIFF_TOTAL >= 200` AND Codex is available AND `OLD_CFG` is NOT `disabled`:
@@ -1386,7 +1422,7 @@ After all passes complete, persist:
 ```bash
 ~/.claude/skills/gstack/bin/gstack-review-log '{"skill":"adversarial-review","timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","status":"STATUS","source":"SOURCE","tier":"always","gate":"GATE","commit":"'"$(git rev-parse --short HEAD)"'"}'
 ```
-Substitute: STATUS = "clean" if no findings across ALL passes, "issues_found" if any pass found issues. SOURCE = "both" if Codex ran, "claude" if only Claude subagent ran. GATE = the Codex structured review gate result ("pass"/"fail"), "skipped" if diff < 200, or "informational" if Codex was unavailable. If all passes failed, do NOT persist.
+Substitute: STATUS = "clean" if no findings across ALL passes, "issues_found" if any pass found issues. SOURCE = comma-separated list of tools that ran (e.g., "claude,codex,coderabbit" or "claude,coderabbit" or "claude"). GATE = the Codex structured review gate result ("pass"/"fail"), "skipped" if diff < 200, or "informational" if Codex was unavailable. If all passes failed, do NOT persist.
 
 ---
 
@@ -1401,7 +1437,8 @@ ADVERSARIAL REVIEW SYNTHESIS (always-on, N lines):
   Unique to Claude structured review: [from earlier step]
   Unique to Claude adversarial: [from subagent]
   Unique to Codex: [from codex adversarial or code review, if ran]
-  Models used: Claude structured ✓  Claude adversarial ✓/✗  Codex ✓/✗
+  Unique to CodeRabbit: [from coderabbit review, if ran]
+  Models used: Claude structured ✓  Claude adversarial ✓/✗  Codex ✓/✗  CodeRabbit ✓/✗
 ════════════════════════════════════════════════════════════
 ```
 

--- a/scripts/resolvers/review.ts
+++ b/scripts/resolvers/review.ts
@@ -426,10 +426,13 @@ DIFF_INS=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ insertion'
 DIFF_DEL=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
 DIFF_TOTAL=$((DIFF_INS + DIFF_DEL))
 which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+which coderabbit 2>/dev/null && echo "CODERABBIT_AVAILABLE" || echo "CODERABBIT_NOT_AVAILABLE"
 # Legacy opt-out — only gates Codex passes, Claude always runs
 OLD_CFG=$(~/.claude/skills/gstack/bin/gstack-config get codex_reviews 2>/dev/null || true)
 echo "DIFF_SIZE: $DIFF_TOTAL"
 echo "OLD_CFG: \${OLD_CFG:-not_set}"
+# Detect commit state for CodeRabbit flag selection
+git diff --quiet && git diff --cached --quiet && echo "CHANGES_COMMITTED" || echo "CHANGES_UNCOMMITTED"
 \`\`\`
 
 If \`OLD_CFG\` is \`disabled\`: skip Codex passes only. Claude adversarial subagent still runs (it's free and fast). Jump to the "Claude adversarial subagent" section.
@@ -479,6 +482,39 @@ If Codex is NOT available: "Codex CLI not found — running Claude adversarial o
 
 ---
 
+### CodeRabbit review (always runs when available)
+
+If \`CODERABBIT_AVAILABLE\`: run CodeRabbit CLI review. The flag depends on whether changes are committed or uncommitted at the time this step runs.
+
+**If \`CHANGES_UNCOMMITTED\`** (Step ${stepNum} runs before Step 6 commits):
+
+\`\`\`bash
+coderabbit review --prompt-only -t uncommitted 2>&1
+\`\`\`
+
+\`--prompt-only\` outputs the review as plain text (no interactive mode). \`-t uncommitted\` scopes the review to unstaged/staged changes only.
+
+**If \`CHANGES_COMMITTED\`** (re-running after Step 6, or all changes already committed):
+
+\`\`\`bash
+coderabbit review --base <base> 2>&1
+\`\`\`
+
+This reviews committed changes against the base branch. CodeRabbit may take 1-3 minutes for large diffs. Set the Bash tool's \`timeout\` parameter to \`300000\` (5 minutes).
+
+Present findings under a \`CODERABBIT SAYS:\` header. This is informational — it never blocks shipping. FIXABLE findings flow into the Fix-First pipeline alongside Claude and Codex findings.
+
+**Error handling:** All errors are non-blocking.
+- **Auth failure:** If output contains "auth", "login", "unauthorized", or "API key": "CodeRabbit authentication failed. Run \\\`coderabbit auth login\\\` to authenticate."
+- **Timeout:** "CodeRabbit timed out after 5 minutes."
+- **Empty response:** "CodeRabbit returned no findings."
+
+If CodeRabbit is NOT available: "CodeRabbit CLI not found — skipping. Install: \`npm install -g coderabbit\`"
+
+**Parallelism:** CodeRabbit can run in parallel with the Claude adversarial subagent and Codex adversarial challenge. Launch all three simultaneously when possible.
+
+---
+
 ### Codex structured review (large diffs only, 200+ lines)
 
 If \`DIFF_TOTAL >= 200\` AND Codex is available AND \`OLD_CFG\` is NOT \`disabled\`:
@@ -517,7 +553,7 @@ After all passes complete, persist:
 \`\`\`bash
 ~/.claude/skills/gstack/bin/gstack-review-log '{"skill":"adversarial-review","timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","status":"STATUS","source":"SOURCE","tier":"always","gate":"GATE","commit":"'"$(git rev-parse --short HEAD)"'"}'
 \`\`\`
-Substitute: STATUS = "clean" if no findings across ALL passes, "issues_found" if any pass found issues. SOURCE = "both" if Codex ran, "claude" if only Claude subagent ran. GATE = the Codex structured review gate result ("pass"/"fail"), "skipped" if diff < 200, or "informational" if Codex was unavailable. If all passes failed, do NOT persist.
+Substitute: STATUS = "clean" if no findings across ALL passes, "issues_found" if any pass found issues. SOURCE = comma-separated list of tools that ran (e.g., "claude,codex,coderabbit" or "claude,coderabbit" or "claude"). GATE = the Codex structured review gate result ("pass"/"fail"), "skipped" if diff < 200, or "informational" if Codex was unavailable. If all passes failed, do NOT persist.
 
 ---
 
@@ -532,7 +568,8 @@ ADVERSARIAL REVIEW SYNTHESIS (always-on, N lines):
   Unique to Claude structured review: [from earlier step]
   Unique to Claude adversarial: [from subagent]
   Unique to Codex: [from codex adversarial or code review, if ran]
-  Models used: Claude structured ✓  Claude adversarial ✓/✗  Codex ✓/✗
+  Unique to CodeRabbit: [from coderabbit review, if ran]
+  Models used: Claude structured ✓  Claude adversarial ✓/✗  Codex ✓/✗  CodeRabbit ✓/✗
 ════════════════════════════════════════════════════════════
 \`\`\`
 

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -2029,10 +2029,13 @@ DIFF_INS=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ insertion'
 DIFF_DEL=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
 DIFF_TOTAL=$((DIFF_INS + DIFF_DEL))
 which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+which coderabbit 2>/dev/null && echo "CODERABBIT_AVAILABLE" || echo "CODERABBIT_NOT_AVAILABLE"
 # Legacy opt-out — only gates Codex passes, Claude always runs
 OLD_CFG=$(~/.claude/skills/gstack/bin/gstack-config get codex_reviews 2>/dev/null || true)
 echo "DIFF_SIZE: $DIFF_TOTAL"
 echo "OLD_CFG: ${OLD_CFG:-not_set}"
+# Detect commit state for CodeRabbit flag selection
+git diff --quiet && git diff --cached --quiet && echo "CHANGES_COMMITTED" || echo "CHANGES_UNCOMMITTED"
 ```
 
 If `OLD_CFG` is `disabled`: skip Codex passes only. Claude adversarial subagent still runs (it's free and fast). Jump to the "Claude adversarial subagent" section.
@@ -2082,6 +2085,39 @@ If Codex is NOT available: "Codex CLI not found — running Claude adversarial o
 
 ---
 
+### CodeRabbit review (always runs when available)
+
+If `CODERABBIT_AVAILABLE`: run CodeRabbit CLI review. The flag depends on whether changes are committed or uncommitted at the time this step runs.
+
+**If `CHANGES_UNCOMMITTED`** (Step 3.8 runs before Step 6 commits):
+
+```bash
+coderabbit review --prompt-only -t uncommitted 2>&1
+```
+
+`--prompt-only` outputs the review as plain text (no interactive mode). `-t uncommitted` scopes the review to unstaged/staged changes only.
+
+**If `CHANGES_COMMITTED`** (re-running after Step 6, or all changes already committed):
+
+```bash
+coderabbit review --base <base> 2>&1
+```
+
+This reviews committed changes against the base branch. CodeRabbit may take 1-3 minutes for large diffs. Set the Bash tool's `timeout` parameter to `300000` (5 minutes).
+
+Present findings under a `CODERABBIT SAYS:` header. This is informational — it never blocks shipping. FIXABLE findings flow into the Fix-First pipeline alongside Claude and Codex findings.
+
+**Error handling:** All errors are non-blocking.
+- **Auth failure:** If output contains "auth", "login", "unauthorized", or "API key": "CodeRabbit authentication failed. Run \`coderabbit auth login\` to authenticate."
+- **Timeout:** "CodeRabbit timed out after 5 minutes."
+- **Empty response:** "CodeRabbit returned no findings."
+
+If CodeRabbit is NOT available: "CodeRabbit CLI not found — skipping. Install: `npm install -g coderabbit`"
+
+**Parallelism:** CodeRabbit can run in parallel with the Claude adversarial subagent and Codex adversarial challenge. Launch all three simultaneously when possible.
+
+---
+
 ### Codex structured review (large diffs only, 200+ lines)
 
 If `DIFF_TOTAL >= 200` AND Codex is available AND `OLD_CFG` is NOT `disabled`:
@@ -2120,7 +2156,7 @@ After all passes complete, persist:
 ```bash
 ~/.claude/skills/gstack/bin/gstack-review-log '{"skill":"adversarial-review","timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","status":"STATUS","source":"SOURCE","tier":"always","gate":"GATE","commit":"'"$(git rev-parse --short HEAD)"'"}'
 ```
-Substitute: STATUS = "clean" if no findings across ALL passes, "issues_found" if any pass found issues. SOURCE = "both" if Codex ran, "claude" if only Claude subagent ran. GATE = the Codex structured review gate result ("pass"/"fail"), "skipped" if diff < 200, or "informational" if Codex was unavailable. If all passes failed, do NOT persist.
+Substitute: STATUS = "clean" if no findings across ALL passes, "issues_found" if any pass found issues. SOURCE = comma-separated list of tools that ran (e.g., "claude,codex,coderabbit" or "claude,coderabbit" or "claude"). GATE = the Codex structured review gate result ("pass"/"fail"), "skipped" if diff < 200, or "informational" if Codex was unavailable. If all passes failed, do NOT persist.
 
 ---
 
@@ -2135,7 +2171,8 @@ ADVERSARIAL REVIEW SYNTHESIS (always-on, N lines):
   Unique to Claude structured review: [from earlier step]
   Unique to Claude adversarial: [from subagent]
   Unique to Codex: [from codex adversarial or code review, if ran]
-  Models used: Claude structured ✓  Claude adversarial ✓/✗  Codex ✓/✗
+  Unique to CodeRabbit: [from coderabbit review, if ran]
+  Models used: Claude structured ✓  Claude adversarial ✓/✗  Codex ✓/✗  CodeRabbit ✓/✗
 ════════════════════════════════════════════════════════════
 ```
 

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -86,6 +86,14 @@ fi
 _ROUTING_DECLINED=$(~/.claude/skills/gstack/bin/gstack-config get routing_declined 2>/dev/null || echo "false")
 echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
+# Vendoring deprecation: detect if CWD has a vendored gstack copy
+_VENDORED="no"
+if [ -d ".claude/skills/gstack" ] && [ ! -L ".claude/skills/gstack" ]; then
+  if [ -f ".claude/skills/gstack/VERSION" ] || [ -d ".claude/skills/gstack/.git" ]; then
+    _VENDORED="yes"
+  fi
+fi
+echo "VENDORED_GSTACK: $_VENDORED"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```
@@ -213,6 +221,38 @@ If B: run `~/.claude/skills/gstack/bin/gstack-config set routing_declined true`
 Say "No problem. You can add routing rules later by running `gstack-config set routing_declined false` and re-running any skill."
 
 This only happens once per project. If `HAS_ROUTING` is `yes` or `ROUTING_DECLINED` is `true`, skip this entirely.
+
+If `VENDORED_GSTACK` is `yes`: This project has a vendored copy of gstack at
+`.claude/skills/gstack/`. Vendoring is deprecated. We will not keep vendored copies
+up to date, so this project's gstack will fall behind.
+
+Use AskUserQuestion (one-time per project, check for `~/.gstack/.vendoring-warned-$SLUG` marker):
+
+> This project has gstack vendored in `.claude/skills/gstack/`. Vendoring is deprecated.
+> We won't keep this copy up to date, so you'll fall behind on new features and fixes.
+>
+> Want to migrate to team mode? It takes about 30 seconds.
+
+Options:
+- A) Yes, migrate to team mode now
+- B) No, I'll handle it myself
+
+If A:
+1. Run `git rm -r .claude/skills/gstack/`
+2. Run `echo '.claude/skills/gstack/' >> .gitignore`
+3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
+4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
+5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+
+If B: say "OK, you're on your own to keep the vendored copy up to date."
+
+Always run (regardless of choice):
+```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)" 2>/dev/null || true
+touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
+```
+
+This only happens once per project. If the marker file exists, skip entirely.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
 AI orchestrator (e.g., OpenClaw). In spawned sessions:
@@ -1989,10 +2029,13 @@ DIFF_INS=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ insertion'
 DIFF_DEL=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
 DIFF_TOTAL=$((DIFF_INS + DIFF_DEL))
 which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+which coderabbit 2>/dev/null && echo "CODERABBIT_AVAILABLE" || echo "CODERABBIT_NOT_AVAILABLE"
 # Legacy opt-out — only gates Codex passes, Claude always runs
 OLD_CFG=$(~/.claude/skills/gstack/bin/gstack-config get codex_reviews 2>/dev/null || true)
 echo "DIFF_SIZE: $DIFF_TOTAL"
 echo "OLD_CFG: ${OLD_CFG:-not_set}"
+# Detect commit state for CodeRabbit flag selection
+git diff --quiet && git diff --cached --quiet && echo "CHANGES_COMMITTED" || echo "CHANGES_UNCOMMITTED"
 ```
 
 If `OLD_CFG` is `disabled`: skip Codex passes only. Claude adversarial subagent still runs (it's free and fast). Jump to the "Claude adversarial subagent" section.
@@ -2042,6 +2085,39 @@ If Codex is NOT available: "Codex CLI not found — running Claude adversarial o
 
 ---
 
+### CodeRabbit review (always runs when available)
+
+If `CODERABBIT_AVAILABLE`: run CodeRabbit CLI review. The flag depends on whether changes are committed or uncommitted at the time this step runs.
+
+**If `CHANGES_UNCOMMITTED`** (Step 3.8 runs before Step 6 commits):
+
+```bash
+coderabbit review --prompt-only -t uncommitted 2>&1
+```
+
+`--prompt-only` outputs the review as plain text (no interactive mode). `-t uncommitted` scopes the review to unstaged/staged changes only.
+
+**If `CHANGES_COMMITTED`** (re-running after Step 6, or all changes already committed):
+
+```bash
+coderabbit review --base <base> 2>&1
+```
+
+This reviews committed changes against the base branch. CodeRabbit may take 1-3 minutes for large diffs. Set the Bash tool's `timeout` parameter to `300000` (5 minutes).
+
+Present findings under a `CODERABBIT SAYS:` header. This is informational — it never blocks shipping. FIXABLE findings flow into the Fix-First pipeline alongside Claude and Codex findings.
+
+**Error handling:** All errors are non-blocking.
+- **Auth failure:** If output contains "auth", "login", "unauthorized", or "API key": "CodeRabbit authentication failed. Run \`coderabbit auth login\` to authenticate."
+- **Timeout:** "CodeRabbit timed out after 5 minutes."
+- **Empty response:** "CodeRabbit returned no findings."
+
+If CodeRabbit is NOT available: "CodeRabbit CLI not found — skipping. Install: `npm install -g coderabbit`"
+
+**Parallelism:** CodeRabbit can run in parallel with the Claude adversarial subagent and Codex adversarial challenge. Launch all three simultaneously when possible.
+
+---
+
 ### Codex structured review (large diffs only, 200+ lines)
 
 If `DIFF_TOTAL >= 200` AND Codex is available AND `OLD_CFG` is NOT `disabled`:
@@ -2080,7 +2156,7 @@ After all passes complete, persist:
 ```bash
 ~/.claude/skills/gstack/bin/gstack-review-log '{"skill":"adversarial-review","timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","status":"STATUS","source":"SOURCE","tier":"always","gate":"GATE","commit":"'"$(git rev-parse --short HEAD)"'"}'
 ```
-Substitute: STATUS = "clean" if no findings across ALL passes, "issues_found" if any pass found issues. SOURCE = "both" if Codex ran, "claude" if only Claude subagent ran. GATE = the Codex structured review gate result ("pass"/"fail"), "skipped" if diff < 200, or "informational" if Codex was unavailable. If all passes failed, do NOT persist.
+Substitute: STATUS = "clean" if no findings across ALL passes, "issues_found" if any pass found issues. SOURCE = comma-separated list of tools that ran (e.g., "claude,codex,coderabbit" or "claude,coderabbit" or "claude"). GATE = the Codex structured review gate result ("pass"/"fail"), "skipped" if diff < 200, or "informational" if Codex was unavailable. If all passes failed, do NOT persist.
 
 ---
 
@@ -2095,7 +2171,8 @@ ADVERSARIAL REVIEW SYNTHESIS (always-on, N lines):
   Unique to Claude structured review: [from earlier step]
   Unique to Claude adversarial: [from subagent]
   Unique to Codex: [from codex adversarial or code review, if ran]
-  Models used: Claude structured ✓  Claude adversarial ✓/✗  Codex ✓/✗
+  Unique to CodeRabbit: [from coderabbit review, if ran]
+  Models used: Claude structured ✓  Claude adversarial ✓/✗  Codex ✓/✗  CodeRabbit ✓/✗
 ════════════════════════════════════════════════════════════
 ```
 

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -80,6 +80,14 @@ fi
 _ROUTING_DECLINED=$($GSTACK_BIN/gstack-config get routing_declined 2>/dev/null || echo "false")
 echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
+# Vendoring deprecation: detect if CWD has a vendored gstack copy
+_VENDORED="no"
+if [ -d ".agents/skills/gstack" ] && [ ! -L ".agents/skills/gstack" ]; then
+  if [ -f ".agents/skills/gstack/VERSION" ] || [ -d ".agents/skills/gstack/.git" ]; then
+    _VENDORED="yes"
+  fi
+fi
+echo "VENDORED_GSTACK: $_VENDORED"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```
@@ -207,6 +215,38 @@ If B: run `$GSTACK_BIN/gstack-config set routing_declined true`
 Say "No problem. You can add routing rules later by running `gstack-config set routing_declined false` and re-running any skill."
 
 This only happens once per project. If `HAS_ROUTING` is `yes` or `ROUTING_DECLINED` is `true`, skip this entirely.
+
+If `VENDORED_GSTACK` is `yes`: This project has a vendored copy of gstack at
+`.agents/skills/gstack/`. Vendoring is deprecated. We will not keep vendored copies
+up to date, so this project's gstack will fall behind.
+
+Use AskUserQuestion (one-time per project, check for `~/.gstack/.vendoring-warned-$SLUG` marker):
+
+> This project has gstack vendored in `.agents/skills/gstack/`. Vendoring is deprecated.
+> We won't keep this copy up to date, so you'll fall behind on new features and fixes.
+>
+> Want to migrate to team mode? It takes about 30 seconds.
+
+Options:
+- A) Yes, migrate to team mode now
+- B) No, I'll handle it myself
+
+If A:
+1. Run `git rm -r .agents/skills/gstack/`
+2. Run `echo '.agents/skills/gstack/' >> .gitignore`
+3. Run `$GSTACK_BIN/gstack-team-init required` (or `optional`)
+4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
+5. Tell the user: "Done. Each developer now runs: `cd $GSTACK_ROOT && ./setup --team`"
+
+If B: say "OK, you're on your own to keep the vendored copy up to date."
+
+Always run (regardless of choice):
+```bash
+eval "$($GSTACK_BIN/gstack-slug 2>/dev/null)" 2>/dev/null || true
+touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
+```
+
+This only happens once per project. If the marker file exists, skip entirely.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
 AI orchestrator (e.g., OpenClaw). In spawned sessions:

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -82,6 +82,14 @@ fi
 _ROUTING_DECLINED=$($GSTACK_BIN/gstack-config get routing_declined 2>/dev/null || echo "false")
 echo "HAS_ROUTING: $_HAS_ROUTING"
 echo "ROUTING_DECLINED: $_ROUTING_DECLINED"
+# Vendoring deprecation: detect if CWD has a vendored gstack copy
+_VENDORED="no"
+if [ -d ".factory/skills/gstack" ] && [ ! -L ".factory/skills/gstack" ]; then
+  if [ -f ".factory/skills/gstack/VERSION" ] || [ -d ".factory/skills/gstack/.git" ]; then
+    _VENDORED="yes"
+  fi
+fi
+echo "VENDORED_GSTACK: $_VENDORED"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```
@@ -209,6 +217,38 @@ If B: run `$GSTACK_BIN/gstack-config set routing_declined true`
 Say "No problem. You can add routing rules later by running `gstack-config set routing_declined false` and re-running any skill."
 
 This only happens once per project. If `HAS_ROUTING` is `yes` or `ROUTING_DECLINED` is `true`, skip this entirely.
+
+If `VENDORED_GSTACK` is `yes`: This project has a vendored copy of gstack at
+`.factory/skills/gstack/`. Vendoring is deprecated. We will not keep vendored copies
+up to date, so this project's gstack will fall behind.
+
+Use AskUserQuestion (one-time per project, check for `~/.gstack/.vendoring-warned-$SLUG` marker):
+
+> This project has gstack vendored in `.factory/skills/gstack/`. Vendoring is deprecated.
+> We won't keep this copy up to date, so you'll fall behind on new features and fixes.
+>
+> Want to migrate to team mode? It takes about 30 seconds.
+
+Options:
+- A) Yes, migrate to team mode now
+- B) No, I'll handle it myself
+
+If A:
+1. Run `git rm -r .factory/skills/gstack/`
+2. Run `echo '.factory/skills/gstack/' >> .gitignore`
+3. Run `$GSTACK_BIN/gstack-team-init required` (or `optional`)
+4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
+5. Tell the user: "Done. Each developer now runs: `cd $GSTACK_ROOT && ./setup --team`"
+
+If B: say "OK, you're on your own to keep the vendored copy up to date."
+
+Always run (regardless of choice):
+```bash
+eval "$($GSTACK_BIN/gstack-slug 2>/dev/null)" 2>/dev/null || true
+touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
+```
+
+This only happens once per project. If the marker file exists, skip entirely.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
 AI orchestrator (e.g., OpenClaw). In spawned sessions:
@@ -1985,10 +2025,13 @@ DIFF_INS=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ insertion'
 DIFF_DEL=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
 DIFF_TOTAL=$((DIFF_INS + DIFF_DEL))
 which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+which coderabbit 2>/dev/null && echo "CODERABBIT_AVAILABLE" || echo "CODERABBIT_NOT_AVAILABLE"
 # Legacy opt-out — only gates Codex passes, Claude always runs
 OLD_CFG=$($GSTACK_ROOT/bin/gstack-config get codex_reviews 2>/dev/null || true)
 echo "DIFF_SIZE: $DIFF_TOTAL"
 echo "OLD_CFG: ${OLD_CFG:-not_set}"
+# Detect commit state for CodeRabbit flag selection
+git diff --quiet && git diff --cached --quiet && echo "CHANGES_COMMITTED" || echo "CHANGES_UNCOMMITTED"
 ```
 
 If `OLD_CFG` is `disabled`: skip Codex passes only. Claude adversarial subagent still runs (it's free and fast). Jump to the "Claude adversarial subagent" section.
@@ -2038,6 +2081,39 @@ If Codex is NOT available: "Codex CLI not found — running Claude adversarial o
 
 ---
 
+### CodeRabbit review (always runs when available)
+
+If `CODERABBIT_AVAILABLE`: run CodeRabbit CLI review. The flag depends on whether changes are committed or uncommitted at the time this step runs.
+
+**If `CHANGES_UNCOMMITTED`** (Step 3.8 runs before Step 6 commits):
+
+```bash
+coderabbit review --prompt-only -t uncommitted 2>&1
+```
+
+`--prompt-only` outputs the review as plain text (no interactive mode). `-t uncommitted` scopes the review to unstaged/staged changes only.
+
+**If `CHANGES_COMMITTED`** (re-running after Step 6, or all changes already committed):
+
+```bash
+coderabbit review --base <base> 2>&1
+```
+
+This reviews committed changes against the base branch. CodeRabbit may take 1-3 minutes for large diffs. Set the Bash tool's `timeout` parameter to `300000` (5 minutes).
+
+Present findings under a `CODERABBIT SAYS:` header. This is informational — it never blocks shipping. FIXABLE findings flow into the Fix-First pipeline alongside Claude and Codex findings.
+
+**Error handling:** All errors are non-blocking.
+- **Auth failure:** If output contains "auth", "login", "unauthorized", or "API key": "CodeRabbit authentication failed. Run \`coderabbit auth login\` to authenticate."
+- **Timeout:** "CodeRabbit timed out after 5 minutes."
+- **Empty response:** "CodeRabbit returned no findings."
+
+If CodeRabbit is NOT available: "CodeRabbit CLI not found — skipping. Install: `npm install -g coderabbit`"
+
+**Parallelism:** CodeRabbit can run in parallel with the Claude adversarial subagent and Codex adversarial challenge. Launch all three simultaneously when possible.
+
+---
+
 ### Codex structured review (large diffs only, 200+ lines)
 
 If `DIFF_TOTAL >= 200` AND Codex is available AND `OLD_CFG` is NOT `disabled`:
@@ -2076,7 +2152,7 @@ After all passes complete, persist:
 ```bash
 $GSTACK_ROOT/bin/gstack-review-log '{"skill":"adversarial-review","timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","status":"STATUS","source":"SOURCE","tier":"always","gate":"GATE","commit":"'"$(git rev-parse --short HEAD)"'"}'
 ```
-Substitute: STATUS = "clean" if no findings across ALL passes, "issues_found" if any pass found issues. SOURCE = "both" if Codex ran, "claude" if only Claude subagent ran. GATE = the Codex structured review gate result ("pass"/"fail"), "skipped" if diff < 200, or "informational" if Codex was unavailable. If all passes failed, do NOT persist.
+Substitute: STATUS = "clean" if no findings across ALL passes, "issues_found" if any pass found issues. SOURCE = comma-separated list of tools that ran (e.g., "claude,codex,coderabbit" or "claude,coderabbit" or "claude"). GATE = the Codex structured review gate result ("pass"/"fail"), "skipped" if diff < 200, or "informational" if Codex was unavailable. If all passes failed, do NOT persist.
 
 ---
 
@@ -2091,7 +2167,8 @@ ADVERSARIAL REVIEW SYNTHESIS (always-on, N lines):
   Unique to Claude structured review: [from earlier step]
   Unique to Claude adversarial: [from subagent]
   Unique to Codex: [from codex adversarial or code review, if ran]
-  Models used: Claude structured ✓  Claude adversarial ✓/✗  Codex ✓/✗
+  Unique to CodeRabbit: [from coderabbit review, if ran]
+  Models used: Claude structured ✓  Claude adversarial ✓/✗  Codex ✓/✗  CodeRabbit ✓/✗
 ════════════════════════════════════════════════════════════
 ```
 


### PR DESCRIPTION
## Summary

- Adds CodeRabbit CLI as a third adversarial review voice in `/ship` (Step 3.8) and `/review` (Step 5.7), alongside Claude subagent and Codex
- Auto-detects `coderabbit` CLI availability and commit state (committed vs uncommitted) to select the right flags
- CodeRabbit findings flow into the Fix-First pipeline as FIXABLE/INVESTIGATE, same as Claude and Codex
- Updated review log `SOURCE` field to use comma-separated tool list (e.g., `claude,codex,coderabbit`) instead of `"both"`
- Updated cross-model synthesis to include "Unique to CodeRabbit" section and CodeRabbit in "Models used" line
- All CodeRabbit errors are non-blocking (auth failures, timeouts, empty responses)
- CodeRabbit can run in parallel with Claude subagent and Codex adversarial challenge

## Test plan

- [x] `bun run gen:skill-docs` regenerates correctly
- [x] Golden baseline tests updated and passing (claude, codex, factory ship SKILLs)
- [x] `bun test` passes (72/72 host-config tests, 1127 total)
- [ ] Manual: run `/ship` on a branch with `coderabbit` CLI installed — verify CodeRabbit section appears
- [ ] Manual: run `/ship` without `coderabbit` CLI — verify graceful skip message

Built by Mid0 + Claude Code + CodeRabbit