### PR TITLE
fix(browse): disable parent-process watchdog in headed mode

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -826,12 +826,12 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
         BROWSE_HEADED: '1',
         BROWSE_PORT: '34567',
         BROWSE_SIDEBAR_CHAT: '1',
+        // Headed mode: disable parent-process watchdog. The CLI process exits
+        // immediately after printing status, so the watchdog would kill the
+        // server ~15s later. In headed mode the user owns the visible browser
+        // window — it should stay alive until explicitly disconnected.
+        BROWSE_PARENT_PID: '0',
       };
-      // If parent explicitly set BROWSE_PARENT_PID=0 (pair-agent disabling
-      // self-termination), pass it through so startServer doesn't override it.
-      if (process.env.BROWSE_PARENT_PID === '0') {
-        serverEnv.BROWSE_PARENT_PID = '0';
-      }
       const newState = await startServer(serverEnv);
 
       // Print connected status


### PR DESCRIPTION
## Problem

`connect` starts a headed Chromium server, prints status, and exits. The server's parent-process watchdog (`server.ts:761-769`, polling every 15s) detects the CLI process is gone and calls `shutdown()`, killing the visible browser window the user is looking at.

The `connect` handler at `cli.ts:825-834` set `BROWSE_PARENT_PID` to `process.pid` by default. It only passed `'0'` through when the env var was *already* set externally (the `if (process.env.BROWSE_PARENT_PID === '0')` branch), which only happens in pair-agent scenarios. Normal `/open-gstack-browser` usage always inherited the CLI's own PID.

### Repro

```bash
# From Claude Code or any shell
$B connect
# Browser opens, "Connected to real Chrome" prints
# Wait ~15 seconds
$B status
# Mode: launched (not headed) — server died and respawned headless
# Browser window is gone
```

## Why this matters

Every user who runs `/open-gstack-browser` or `$B connect` sees their browser window disappear ~15 seconds after launch. The workaround (`BROWSE_PARENT_PID=0 $B connect`) is non-obvious and undocumented for this use case.

## Change

Set `BROWSE_PARENT_PID: '0'` unconditionally in the `connect` handler's `serverEnv`. Removes the conditional that only passed it through from the external env.

The safety nets for headed mode are already solid:
- `browser.on('disconnected')` → `process.exit(2)` when user closes the window (`browser-manager.ts:472-476`)
- SIGTERM/SIGINT handlers call `shutdown()` (`server.ts:1228-1229`)
- `disconnect` command for programmatic teardown
- Idle timeout is already skipped in headed mode (`server.ts:746`)

## Verified

- macOS (Apple Silicon, Darwin 25.3.0): headed browser stays alive 20+ seconds (previously died at ~15s)
- `goto` and `snapshot` work after 20s+ delay
- Closing browser window still terminates the server (exit 2 via `disconnected` event)
- Headless mode unaffected (watchdog still active via `startServer` default path at `cli.ts:229`)

## Related

PR #1012 fixes the same class of bug on the headless path. This PR fixes the headed path. They are complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)