### PR TITLE
fix(browse): externalize @ngrok/ngrok so Node server bundle builds on Windows

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -20,7 +20,8 @@ bun build "$SRC_DIR/server.ts" \
   --external playwright \
   --external playwright-core \
   --external diff \
-  --external "bun:sqlite"
+  --external "bun:sqlite" \
+  --external "@ngrok/ngrok"
 
 # Step 2: Post-process
 # Replace import.meta.dir with a resolvable reference


### PR DESCRIPTION
## Summary

`browse/scripts/build-node-server.sh` fails on a fresh install on Windows with:

```
Building Node-compatible server bundle...
error: cannot write multiple output files without an output directory
```

This breaks the browser-related skills on Windows after `./setup`: `/browse`, `/canary`, `/pair-agent`, `/open-gstack-browser`, `/setup-browser-cookies`, and `/design-review` (all of which rely on `server-node.mjs`).

## Root cause

`browse/src/server.ts` has two `await import('@ngrok/ngrok')` calls (around lines 1588 and 2368). Bun treats these dynamic imports as a code-splitting signal and wants to emit a separate chunk for `@ngrok/ngrok`. Combined with `--outfile` (single-file output, used by the script), bun refuses with the "cannot write multiple output files without an output directory" error.

The other skipped externals in the same `bun build` invocation (`playwright`, `playwright-core`, `diff`, `bun:sqlite`) use exactly the pattern needed here.

## Fix

Add `--external "@ngrok/ngrok"` to the `bun build` invocation. The dynamic import then resolves at runtime via `node_modules/@ngrok/ngrok` instead of being bundled, no chunks emitted, single-file output succeeds.

`@ngrok/ngrok` is already declared in `package.json` (`"^1.7.0"`), so it's reachable at runtime under Node.

## Verification

```
$ bash browse/scripts/build-node-server.sh
Building Node-compatible server bundle...

  Bundled 25 modules in 52ms

  server-node.mjs  0.33 MB  (entry point)

Node server bundle ready: /c/Users/tomas/.claude/skills/gstack/browse/dist/server-node.mjs
```

Confirmed `browse.exe` then launches the bundled server (`[browse] Starting server...` → command list) on:
- Windows 11 Home 26200
- Git Bash 2.53.0.windows.2
- bun 1.3.11
- Node v25.2.1

## Test plan

- [ ] Run `./setup --host claude` on a fresh Windows install — expect no build error.
- [ ] Run a `/browse goto …` command after install — expect server to start and respond.