### PR TITLE
fix: headed browser auto-shuts down within 1-2 minutes

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -826,12 +826,13 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
         BROWSE_HEADED: '1',
         BROWSE_PORT: '34567',
         BROWSE_SIDEBAR_CHAT: '1',
+        // Disable parent-process watchdog for headed mode. The CLI process
+        // exits immediately after launching the server (process.exit(0) below),
+        // so the watchdog would detect a dead parent within 15-75s and shut
+        // down the browser. Headed sessions are user-controlled — they should
+        // only close on explicit disconnect, not on parent exit.
+        BROWSE_PARENT_PID: '0',
       };
-      // If parent explicitly set BROWSE_PARENT_PID=0 (pair-agent disabling
-      // self-termination), pass it through so startServer doesn't override it.
-      if (process.env.BROWSE_PARENT_PID === '0') {
-        serverEnv.BROWSE_PARENT_PID = '0';
-      }
       const newState = await startServer(serverEnv);
 
       // Print connected status


### PR DESCRIPTION
## Summary

- The `connect` command (headed browser launch) sets `BROWSE_PARENT_PID` to the CLI process PID, then immediately exits (`process.exit(0)` at cli.ts:905)
- The server's parent-process watchdog (`server.ts:760-769`) polls every 15s, detects the dead parent, and calls `shutdown()` — killing the browser within 15-75 seconds
- This contradicts the server's own design: the idle timer already exempts headed mode with the comment *"Headed mode: the user is looking at the browser. Never auto-die."* (`server.ts:744-745`)
- Fix: always set `BROWSE_PARENT_PID=0` in headed mode `serverEnv`, disabling the watchdog. The previous code only passed through `PID=0` when pair-agent set it, missing the default `connect` case

## Test plan

- [ ] Run `/open-gstack-browser` and verify the browser stays alive for more than 2 minutes without any interaction
- [ ] Verify `$B disconnect` still works (explicit user-initiated shutdown)
- [ ] Verify pair-agent flow still works (already set `BROWSE_PARENT_PID=0`)
- [ ] Verify headless mode still auto-shuts down when parent exits (watchdog unaffected for non-headed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)