### PR TITLE
security: suppress /health token when a tunnel is active

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -1339,13 +1339,18 @@ async function start() {
           mode: browserManager.getConnectionMode(),
           uptime: Math.floor((Date.now() - startTime) / 1000),
           tabs: browserManager.getTabCount(),
-          // Auth token for extension bootstrap. Safe: /health is localhost-only.
-          // Previously served unconditionally, but that leaks the token if the
-          // server is tunneled to the internet (ngrok, SSH tunnel).
-          // In headed mode the server is always local, so return token unconditionally
-          // (fixes Playwright Chromium extensions that don't send Origin header).
-          ...(browserManager.getConnectionMode() === 'headed' ||
-              req.headers.get('origin')?.startsWith('chrome-extension://')
+          // Auth token for extension bootstrap. Safe only while the daemon
+          // is reachable from localhost only. Two qualifying shapes:
+          //   1. Same-origin chrome-extension:// caller (MV3 isolation).
+          //   2. Headed mode AND no active tunnel. Playwright's local
+          //      extension bootstrap omits Origin, so we keep that branch,
+          //      but when /tunnel/start (or BROWSE_TUNNEL=1) has exposed
+          //      the daemon via ngrok, /health becomes internet-reachable
+          //      and must not emit AUTH_TOKEN regardless of the browser
+          //      mode. The `pair-agent --client` flow triggers exactly
+          //      this state by default.
+          ...(req.headers.get('origin')?.startsWith('chrome-extension://') ||
+              (browserManager.getConnectionMode() === 'headed' && !tunnelActive)
               ? { token: AUTH_TOKEN } : {}),
           chatEnabled: true,
           agent: {

--- a/browse/test/server-auth.test.ts
+++ b/browse/test/server-auth.test.ts
@@ -31,6 +31,24 @@ describe('Server auth security', () => {
     expect(healthBlock).toContain('chrome-extension://');
   });
 
+  // Test 1a: /health never serves the token while a tunnel is active.
+  //
+  // Regression: the v0.15.13.0 "serve token only to extension / headed"
+  // fix was later refactored with an OR that re-allowed the leak whenever
+  // connection mode is 'headed', even if the daemon was exposed to the
+  // internet via /tunnel/start (pair-agent --client default) or
+  // BROWSE_TUNNEL=1. Gate the headed branch on `!tunnelActive` so that
+  // an internet-reachable daemon cannot hand out AUTH_TOKEN regardless
+  // of mode.
+  test('/health suppresses the token when a tunnel is active', () => {
+    const healthBlock = sliceBetween(SERVER_SRC, "url.pathname === '/health'", "url.pathname === '/connect'");
+    // The headed-mode gate must reference tunnelActive. The ordering
+    // inside the expression is flexible (!tunnelActive && headed ===
+    // headed && !tunnelActive) but the negation + variable must appear.
+    expect(healthBlock).toContain('tunnelActive');
+    expect(healthBlock).toMatch(/!tunnelActive|tunnelActive\s*===\s*false/);
+  });
+
   // Test 1b: /health does not expose sensitive browsing state
   test('/health does not expose currentUrl or currentMessage', () => {
     const healthBlock = sliceBetween(SERVER_SRC, "url.pathname === '/health'", "url.pathname === '/connect'");


### PR DESCRIPTION
## Summary

gstack ships `pair-agent --client foo` as the documented onboarding flow: run it, get a shareable `https://…ngrok-free.app` URL, send it to the other person, they point their agent at it and start driving your local browser. The flow works because the daemon opens an ngrok tunnel via `POST /tunnel/start` and stays in headed mode so you can watch the session.

Same daemon exposes `/health`. That route has an audit history — the v0.15.13.0 wave-3 fix restricted the `AUTH_TOKEN` field to `chrome-extension://` origins so a tunneled instance couldn't leak a bearer that unlocks `/command`, `/read`, `/upload`. Later refactors broadened the gate with an `||`:

```ts
// browse/src/server.ts around line 1347
...(browserManager.getConnectionMode() === 'headed' ||
    req.headers.get('origin')?.startsWith('chrome-extension://')
    ? { token: AUTH_TOKEN } : {}),
```

The comment two lines above reads *"in headed mode the server is always local, so return token unconditionally."* That assumption doesn't hold once `pair-agent` (or `BROWSE_TUNNEL=1`) is the default onboarding flow. Headed **and** tunneled is the explicitly-documented case.

Net effect: any unauthenticated client that knows the tunnel URL can do

```bash
curl https://xxx.ngrok-free.app/health | jq -r .token
```

and receive the root `AUTH_TOKEN`. That token is accepted by `/command` (arbitrary JS in the browser), `/read` (cookies + storage), `/upload` (file write on the server's disk), and everything else guarded by `validateAuth`. One-shot remote browser takeover.

This isn't a 0-day against a local install — it's a live vector against anyone who ran `pair-agent --client` and didn't explicitly stop the tunnel. That's the documented shape of the feature.

## Root cause

The `||` that was added to fix the Playwright-extension-bootstrap case collapsed two very different conditions into one trust boundary:

| Condition | Localhost-only? | Comment |
|---|---|---|
| `Origin: chrome-extension://<id>` | Yes (MV3 isolation) | The real localhost gate — browsers don't forward this header through a tunnel. |
| `connectionMode === 'headed'` | **No, not anymore** | True for `pair-agent`, `BROWSE_HEADED=1`, every interactive session. Orthogonal to whether a tunnel is open. |

The `tunnelActive` flag at `browse/src/server.ts:61` already tracks tunnel state (set by `/tunnel/start`, cleared by `/tunnel/stop` and by the liveness probe at line 1505). The `/health` gate didn't consult it.

## Fix

```ts
// browse/src/server.ts — after
...(req.headers.get('origin')?.startsWith('chrome-extension://') ||
    (browserManager.getConnectionMode() === 'headed' && !tunnelActive)
    ? { token: AUTH_TOKEN } : {}),
```

- Same-origin `chrome-extension://` caller still gets the token. MV3 isolation is the localhost guarantee; the token is already inside the extension's process, emitting it back adds no new surface.
- Headed mode gets the token **only while no tunnel is active**. Local Playwright development keeps working. The moment `pair-agent` / `BROWSE_TUNNEL=1` / any caller hits `POST /tunnel/start`, `tunnelActive` flips to `true` and `/health` stops emitting the token, regardless of mode.
- When the liveness probe at line 1505 clears `tunnelActive` (ngrok died externally), the local-only branch re-opens automatically.

## Reproduction

Before the fix, with the shipped defaults:

```bash
# Terminal 1 — gstack operator
BROWSE_HEADED=1 bun run dev serve --tunnel &
# tunnel URL lands in ~/.gstack/tunnel-url, e.g. https://abc.ngrok-free.app

# Terminal 2 — anywhere on the internet
T=$(curl -s https://abc.ngrok-free.app/health | jq -r .token)
# T is the root AUTH_TOKEN, returned with HTTP 200

curl -H "Authorization: Bearer $T" \
     -X POST https://abc.ngrok-free.app/command \
     -d '{"command":"eval","args":["document.cookie"]}'
# → attacker reads cookies from the victim's active tab
```

After the fix, the same `/health` request returns `{status, mode, uptime, tabs, …}` with no `token` field. `/command` without the token returns 401.

## Sibling review

Grepped every `AUTH_TOKEN` emission in `browse/src/` for the same pattern:

| Location | Reads `AUTH_TOKEN` | Gate | Status |
|---|---|---|---|
| `server.ts:~1347` (`/health`) | emits to body | was: `headed \|\| chrome-extension` | **fixed** |
| `server.ts` elsewhere | used via `validateAuth` (Authorization header compare) | requires client to already have token | unaffected |
| `cli.ts`, `sidebar-agent.ts` | read from local file / environment, not HTTP | local file ACL | unaffected |

No other HTTP surface emits the raw token. The fix is scoped to the one `/health` branch.

## Tests

`browse/test/server-auth.test.ts` — source-level guardrails. Kept DB-free and framework-independent, matching the convention in that file.

### New regression test

```ts
test('/health suppresses the token when a tunnel is active', () => {
  const healthBlock = sliceBetween(SERVER_SRC, "url.pathname === '/health'", "url.pathname === '/connect'");
  expect(healthBlock).toContain('tunnelActive');
  expect(healthBlock).toMatch(/!tunnelActive|tunnelActive\s*===\s*false/);
});
```

If a future refactor drops the `tunnelActive` gate this test turns red before the code reaches a reviewer.

### Negative control

Reverting `browse/src/server.ts` to `origin/main` and rerunning `bun test browse/test/server-auth.test.ts`:

```
37 pass
 1 fail
```

The one failing test is the new one. Applying the fix: 38/38 pass.

### Full suite

```
bun test
# exit 0 — browse + test + skill validation all green
```

(The "FAIL" rows inside the self-tests of the evals framework are expected by those self-tests — they assert that the framework marks simulated failures correctly.)

## What stayed the same

- Chrome extension bootstrap continues to work (same-origin MV3 case).
- Local Playwright-extension dev (headed, no tunnel) continues to receive the token.
- `validateAuth` remains the primary auth path; this PR only closes the one HTTP response that handed the token out unauthenticated.
- No changes to `tunnelActive` lifecycle — the fix reads the existing flag.
- No new dependencies, no API change.

## Files

```
 browse/src/server.ts            | 19 ++++++++++++-------
 browse/test/server-auth.test.ts | 18 ++++++++++++++++++
 2 files changed, 30 insertions(+), 7 deletions(-)
```

## How to verify

```bash
git checkout security/health-token-leak-tunneled-headed
bun install
bun test browse/test/server-auth.test.ts   # 38 pass
bun test                                     # full suite, exit 0
```
