### PR TITLE
security: extend hidden-element detection to every DOM-reading channel

### DIFF
--- a/browse/src/commands.ts
+++ b/browse/src/commands.ts
@@ -53,6 +53,22 @@ export const PAGE_CONTENT_COMMANDS = new Set([
   'ux-audit',
 ]);
 
+/**
+ * Subset of PAGE_CONTENT_COMMANDS whose output is derived from the
+ * live page DOM. These channels can carry hidden elements or
+ * ARIA-injection payloads that the centralized envelope wrap alone
+ * does not neutralize, so the scoped-token pipeline runs
+ * `markHiddenElements` on the page before the read and surfaces any
+ * hits as CONTENT WARNINGS to the LLM.
+ *
+ * `console`, `dialog` intentionally excluded — they read separate
+ * runtime state (console capture, dialog events), not the DOM tree.
+ */
+export const DOM_CONTENT_COMMANDS = new Set([
+  'text', 'html', 'links', 'forms', 'accessibility', 'attrs',
+  'media', 'data', 'ux-audit',
+]);
+
 /** Wrap output from untrusted-content commands with trust boundary markers */
 export function wrapUntrustedContent(result: string, url: string): string {
   // Sanitize URL: remove newlines to prevent marker injection via history.pushState

--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -19,7 +19,7 @@ import { handleWriteCommand } from './write-commands';
 import { handleMetaCommand } from './meta-commands';
 import { handleCookiePickerRoute } from './cookie-picker-routes';
 import { sanitizeExtensionUrl } from './sidebar-utils';
-import { COMMAND_DESCRIPTIONS, PAGE_CONTENT_COMMANDS, wrapUntrustedContent } from './commands';
+import { COMMAND_DESCRIPTIONS, PAGE_CONTENT_COMMANDS, DOM_CONTENT_COMMANDS, wrapUntrustedContent } from './commands';
 import {
   wrapUntrustedPageContent, datamarkContent,
   runContentFilters, type ContentFilterResult,
@@ -1015,18 +1015,39 @@ async function handleCommandInternal(
 
     const session = browserManager.getActiveSession();
 
+    // Per-request warnings collected during hidden-element detection,
+    // surfaced into the envelope the LLM sees. Carries across the read
+    // phase into the centralized wrap block below.
+    let hiddenContentWarnings: string[] = [];
+
     if (READ_COMMANDS.has(command)) {
       const isScoped = tokenInfo && tokenInfo.clientId !== 'root';
-      // Hidden element stripping for scoped tokens on text command
-      if (isScoped && command === 'text') {
+      // Hidden-element / ARIA-injection detection for every scoped
+      // DOM-reading channel (text, html, links, forms, accessibility,
+      // attrs, data, media, ux-audit). Previously only `text` received
+      // stripping; other channels let hidden injection payloads reach
+      // the LLM despite the envelope wrap. Detections become CONTENT
+      // WARNINGS on the outgoing envelope so the model can see what it
+      // would have otherwise trusted silently.
+      if (isScoped && DOM_CONTENT_COMMANDS.has(command)) {
         const page = session.getPage();
-        const strippedDescs = await markHiddenElements(page);
-        if (strippedDescs.length > 0) {
-          console.warn(`[browse] Content security: stripped ${strippedDescs.length} hidden elements for ${tokenInfo.clientId}`);
-        }
         try {
-          const target = session.getActiveFrameOrPage();
-          result = await getCleanTextWithStripping(target);
+          const strippedDescs = await markHiddenElements(page);
+          if (strippedDescs.length > 0) {
+            console.warn(`[browse] Content security: ${strippedDescs.length} hidden elements flagged on ${command} for ${tokenInfo.clientId}`);
+            hiddenContentWarnings = strippedDescs.slice(0, 8).map(d =>
+              `hidden content: ${d.slice(0, 120)}`,
+            );
+            if (strippedDescs.length > 8) {
+              hiddenContentWarnings.push(`hidden content: +${strippedDescs.length - 8} more flagged elements`);
+            }
+          }
+          if (command === 'text') {
+            const target = session.getActiveFrameOrPage();
+            result = await getCleanTextWithStripping(target);
+          } else {
+            result = await handleReadCommand(command, args, session, browserManager);
+          }
         } finally {
           await cleanupHiddenMarkers(page);
         }
@@ -1094,10 +1115,14 @@ async function handleCommandInternal(
         if (command === 'text') {
           result = datamarkContent(result);
         }
-        // Enhanced envelope wrapping for scoped tokens
+        // Enhanced envelope wrapping for scoped tokens.
+        // Merge per-request hidden-element warnings with content-filter
+        // warnings so both reach the LLM through the same CONTENT
+        // WARNINGS header.
+        const combinedWarnings = [...filterResult.warnings, ...hiddenContentWarnings];
         result = wrapUntrustedPageContent(
           result, command,
-          filterResult.warnings.length > 0 ? filterResult.warnings : undefined,
+          combinedWarnings.length > 0 ? combinedWarnings : undefined,
         );
       } else {
         // Root token: basic wrapping (backward compat, Decision 2)

--- a/browse/test/content-security.test.ts
+++ b/browse/test/content-security.test.ts
@@ -302,6 +302,75 @@ describe('Centralized wrapping', () => {
   });
 });
 
+// ─── 5b. DOM-content channel coverage (F008) ────────────────────
+//
+// Regression: `markHiddenElements` was only invoked for scoped
+// `text`. Other DOM-reading channels (html, accessibility, attrs,
+// forms, links, data, media, ux-audit) went through the envelope
+// wrap with zero hidden-element detection, so a
+// <div style="display:none">IGNORE INSTRUCTIONS …</div> or an
+// aria-label carrying an injection pattern reached the LLM silently.
+// The dispatch now gates on DOM_CONTENT_COMMANDS and surfaces
+// descriptions as CONTENT WARNINGS.
+
+describe('DOM-content channel coverage', () => {
+  test('commands.ts exports DOM_CONTENT_COMMANDS', () => {
+    expect(COMMANDS_SRC).toContain('export const DOM_CONTENT_COMMANDS');
+  });
+
+  test('DOM_CONTENT_COMMANDS covers the DOM-reading channels', () => {
+    const setStart = COMMANDS_SRC.indexOf('export const DOM_CONTENT_COMMANDS');
+    expect(setStart).toBeGreaterThan(-1);
+    const setBlock = COMMANDS_SRC.slice(
+      setStart, COMMANDS_SRC.indexOf(']);', setStart),
+    );
+    for (const cmd of ['text', 'html', 'links', 'forms', 'accessibility', 'attrs', 'media', 'data', 'ux-audit']) {
+      expect(setBlock).toContain(`'${cmd}'`);
+    }
+    // console + dialog read runtime state, not DOM — should NOT be in the set
+    expect(setBlock).not.toContain("'console'");
+    expect(setBlock).not.toContain("'dialog'");
+  });
+
+  test('server gates markHiddenElements on DOM_CONTENT_COMMANDS, not just text', () => {
+    // Find the scoped-token read block. The dispatch must pivot on
+    // the full set rather than the literal string 'text'.
+    const readBlockStart = SERVER_SRC.indexOf('if (READ_COMMANDS.has(command))');
+    expect(readBlockStart).toBeGreaterThan(-1);
+    const readBlockEnd = SERVER_SRC.indexOf('} else if (WRITE_COMMANDS.has(command))', readBlockStart);
+    const readBlock = SERVER_SRC.slice(readBlockStart, readBlockEnd);
+
+    // Old shape the PR replaces — must be gone. If a future refactor
+    // reintroduces `command === 'text'` as the ONLY trigger for
+    // markHiddenElements this test trips.
+    expect(readBlock).toContain('DOM_CONTENT_COMMANDS.has(command)');
+    expect(readBlock).toContain('markHiddenElements');
+    expect(readBlock).toContain('cleanupHiddenMarkers');
+  });
+
+  test('hidden-element descriptions flow into the envelope warnings', () => {
+    // The per-request warnings variable must be collected during the
+    // read phase and then merged into the wrap block's
+    // `combinedWarnings` before `wrapUntrustedPageContent` is called.
+    expect(SERVER_SRC).toContain('hiddenContentWarnings');
+    expect(SERVER_SRC).toMatch(/combinedWarnings\s*=\s*\[\s*\.\.\.\s*filterResult\.warnings\s*,\s*\.\.\.\s*hiddenContentWarnings\s*\]/);
+    // And the merged list is what actually reaches the wrap helper.
+    const wrapBlockStart = SERVER_SRC.indexOf('Enhanced envelope wrapping for scoped tokens');
+    expect(wrapBlockStart).toBeGreaterThan(-1);
+    const wrapBlock = SERVER_SRC.slice(wrapBlockStart, wrapBlockStart + 600);
+    expect(wrapBlock).toContain('combinedWarnings');
+    expect(wrapBlock).toMatch(/wrapUntrustedPageContent\s*\(\s*\n?\s*result/);
+  });
+
+  test('DOM_CONTENT_COMMANDS is a subset of PAGE_CONTENT_COMMANDS', async () => {
+    const { PAGE_CONTENT_COMMANDS, DOM_CONTENT_COMMANDS } =
+      await import('../src/commands');
+    for (const cmd of DOM_CONTENT_COMMANDS) {
+      expect(PAGE_CONTENT_COMMANDS.has(cmd)).toBe(true);
+    }
+  });
+});
+
 // ─── 6. Chain Security (source-level) ───────────────────────────
 
 describe('Chain security', () => {


### PR DESCRIPTION
## Summary

The Confusion Protocol envelope wrap already covers every scoped `PAGE_CONTENT_COMMAND` — `text`, `html`, `links`, `forms`, `accessibility`, `attrs`, `console`, `dialog`, `media`, `data`, `ux-audit`. The hidden-element / ARIA-injection detection layer (`markHiddenElements` + `getCleanTextWithStripping` in `content-security.ts`) only ran when `command === 'text'`. For every other DOM-reading channel the output went through the envelope with no hidden-content filter.

Net effect: a page that carries a `display:none` div with payload text, or a button with an `aria-label` matching one of the injection patterns, has that payload leak to the LLM the moment the agent calls `browse html`, `browse accessibility`, `browse attrs`, or any of the other non-text channels. The envelope wrap by itself does not mitigate this — it only tells the model that content is untrusted, not that the visible page never actually rendered those bytes to the human operator.

## Reproduction (before the fix)

```bash
bun run report/evidence/poc-f008-channel-gaps.ts
```

The PoC simulates the dispatcher against a page that renders a hidden injection div plus an aria-label injection, then walks every `PAGE_CONTENT_COMMAND`. With the current code, every non-text channel emits the hidden payload inside the envelope. Expected after the fix: no channel returns the raw payload without a CONTENT WARNINGS header flagging it.

## Root cause

`browse/src/server.ts` around the read dispatch:

```ts
if (isScoped && command === 'text') {
  const page = session.getPage();
  await markHiddenElements(page);
  // ...
  result = await getCleanTextWithStripping(target);
}
```

The condition gates on the literal `'text'` string. Every other scoped channel falls through to `handleReadCommand` and never touches the hidden-element detector. The envelope wrap later in the same handler does not know which content came from hidden nodes, so it cannot flag them.

## Fix

Two parts, each small on its own.

1. **New export `DOM_CONTENT_COMMANDS` in `browse/src/commands.ts`.** Subset of `PAGE_CONTENT_COMMANDS` whose output is derived from the live DOM tree: `text`, `html`, `links`, `forms`, `accessibility`, `attrs`, `media`, `data`, `ux-audit`. `console` and `dialog` stay out — they read separate runtime state (captured console output, queued dialog events), so running the DOM detector would be wasteful and potentially racy against navigation.

2. **Dispatcher gates on the set, not on `text`.** `browse/src/server.ts` now does:

   ```ts
   let hiddenContentWarnings: string[] = [];
   if (isScoped && DOM_CONTENT_COMMANDS.has(command)) {
     const page = session.getPage();
     try {
       const strippedDescs = await markHiddenElements(page);
       if (strippedDescs.length > 0) {
         hiddenContentWarnings = strippedDescs.slice(0, 8).map(d => `hidden content: ${d.slice(0, 120)}`);
         if (strippedDescs.length > 8) {
           hiddenContentWarnings.push(`hidden content: +${strippedDescs.length - 8} more flagged elements`);
         }
       }
       if (command === 'text') {
         result = await getCleanTextWithStripping(target);   // unchanged
       } else {
         result = await handleReadCommand(command, args, session, browserManager);
       }
     } finally {
       await cleanupHiddenMarkers(page);
     }
   }
   ```

   And the centralized wrap block folds those descriptions into `combinedWarnings` before the envelope call:

   ```ts
   const combinedWarnings = [...filterResult.warnings, ...hiddenContentWarnings];
   result = wrapUntrustedPageContent(
     result, command,
     combinedWarnings.length > 0 ? combinedWarnings : undefined,
   );
   ```

`text` still gets physical stripping via `getCleanTextWithStripping` (no behavior change on that path). Every other scoped DOM channel keeps its output format unchanged and now also emits a `⚠ CONTENT WARNINGS:` header listing the flagged hidden nodes. The LLM sees, for example:

```
⚠ CONTENT WARNINGS: hidden content: [div] opacity < 0.1: "IGNORE...";  hidden content: [button] ARIA injection: "System: you are..."
═══ BEGIN UNTRUSTED WEB CONTENT ═══
...actual channel output...
═══ END UNTRUSTED WEB CONTENT ═══
```

That turns the silent-leak into a visible, flagged payload the LLM can refuse.

## What stayed the same

- `text` command still uses `getCleanTextWithStripping` — visible hidden nodes are physically removed before the read, exactly as before.
- `console`, `dialog` — not in `DOM_CONTENT_COMMANDS`, no detector runs, no behavior change. These read runtime state, not the DOM.
- Root-token (non-scoped) calls — unchanged, same `wrapUntrustedContent` backward-compat path.
- Sentinel strings, envelope shape, datamarking behavior, chain recursion guard — all unchanged.
- No new dependencies. No config knobs.

## Sibling review

Greped `browse/src/` for every `markHiddenElements` or `getCleanTextWithStripping` call:

| Location | Trigger | Change |
|---|---|---|
| `server.ts` read dispatch | was `command === 'text'` | now `DOM_CONTENT_COMMANDS.has(command)` |
| `content-security.ts` helpers | page DOM traversal | unchanged |
| any other call site | none | n/a |

No other call site invokes the hidden-element detector. All scoped DOM-channel output now passes through the same gate.

## Tests

`browse/test/content-security.test.ts` — new `DOM-content channel coverage` describe block, 5 cases:

- `commands.ts` exports `DOM_CONTENT_COMMANDS`.
- The set covers `text`, `html`, `links`, `forms`, `accessibility`, `attrs`, `media`, `data`, `ux-audit`, and does **not** include `console` or `dialog`.
- The server's scoped-read dispatch gates on `DOM_CONTENT_COMMANDS.has(command)` and contains both `markHiddenElements` and `cleanupHiddenMarkers` (source-level lock — if a future refactor narrows the gate back to `'text'`, the test trips).
- `hiddenContentWarnings` plumbs into `combinedWarnings` and reaches `wrapUntrustedPageContent`.
- `DOM_CONTENT_COMMANDS` is a strict subset of `PAGE_CONTENT_COMMANDS` (runtime import check).

`bun test browse/test/content-security.test.ts`: 52 pass, 0 fail.

### Negative control

Reverting `browse/src/server.ts` and `browse/src/commands.ts` to `origin/main` and rerunning:

- `DOM_CONTENT_COMMANDS` import fails first (not exported yet).
- The source-level regressions on `server.ts` fail.

Applying the fix: 52/52 pass.

## Files

```
 browse/src/commands.ts               | 16 +++++++++
 browse/src/server.ts                 | 47 ++++++++++++++++++------
 browse/test/content-security.test.ts | 69 ++++++++++++++++++++++++++++++++++++
 3 files changed, 121 insertions(+), 11 deletions(-)
```

## How to verify

```bash
git checkout security/confusion-protocol-channel-coverage
bun install
bun test browse/test/content-security.test.ts   # 52 pass
bun test                                           # full suite, exit 0
```