### PR TITLE
fix: gstack-upgrade uses ff-only merge before the hard reset

### DIFF
--- a/gstack-upgrade/SKILL.md.tmpl
+++ b/gstack-upgrade/SKILL.md.tmpl
@@ -125,9 +125,16 @@ Use the install type and directory detected in Step 2:
 **For git installs** (global-git, local-git):
 ```bash
 cd "$INSTALL_DIR"
-STASH_OUTPUT=$(git stash 2>&1)
+STASH_OUTPUT=$(git stash push --include-untracked -m "pre-upgrade-$(date +%Y-%m-%d)" 2>&1)
 git fetch origin
-git reset --hard origin/main
+# Try fast-forward first. Safer than reset --hard and passes through guard
+# hooks (Claude Code PreToolUse, pre-commit wrappers) that block destructive
+# ops. Falls back to reset for divergent history — no-op when the working
+# tree is clean and there are no local commits, which is the expected state
+# for a global install.
+if ! git merge --ff-only origin/main 2>/dev/null; then
+  git reset --hard origin/main
+fi
 ./setup
 ```
 If `$STASH_OUTPUT` contains "Saved working directory", warn the user: "Note: local changes were stashed. Run `git stash pop` in the skill directory to restore them."


### PR DESCRIPTION
## Problem

`gstack-upgrade` calls `git reset --hard origin/main` as its advance-HEAD step. This trips destructive-command blockers: Claude Code PreToolUse hooks, pre-commit wrappers, `/careful`, `/guard`, and similar safety tools commonly flag the hard reset as destructive.

Hit this today on Windows 11 with `auto_upgrade: true` and a Claude Code guard hook that blocks destructive git operations. Upgrade aborted mid-flow; had to manually work around the block.

## Fix

Try `git merge --ff-only origin/main` first. Falls back to the old behavior if fast-forward fails (divergent history, local commits on the skills repo).

Also switches `git stash` to `git stash push --include-untracked -m "pre-upgrade-<date>"` so untracked build artifacts (`.bak/`, compiled `.exe` binaries from prior runs) don't block the merge, and the stash is self-describing for anyone inspecting it later.

## Why this is safe

- **Clean global install with no local commits:** `merge --ff-only` succeeds, identical end state to the hard reset, no destructive flag ever fires.
- **Divergent history** (user committed locally to the skills repo): falls back to the old behavior, same as before.
- **Dirty working tree:** handled by the `git stash push --include-untracked` above.

No behavior change for the success path, just a less destructive primary command.

## Testing

Ran on Windows 11 with a Claude Code PreToolUse guard that blocks destructive git operations. Upgraded from v0.16.2.0 to v0.18.1.0 cleanly via the ff-only path. Setup regenerated customizations as expected.

## Note

This PR only touches `gstack-upgrade/SKILL.md.tmpl`. The generated `gstack-upgrade/SKILL.md` will pick up the change on the next `bun run gen:skill-docs` or CI regen, so maintainer can regen as part of merge or leave it to the next templated build.
