### PR TITLE
fix(browse): respect GSTACK_CHROMIUM_PATH in headless mode

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -180,12 +180,15 @@ export class BrowserManager {
       console.log(`[browse] Extensions loaded from: ${extensionsDir}`);
     }
 
+    const executablePath = process.env.GSTACK_CHROMIUM_PATH || undefined;
+
     this.browser = await chromium.launch({
       headless: useHeadless,
       // On Windows, Chromium's sandbox fails when the server is spawned through
       // the Bun→Node process chain (GitHub #276). Disable it — local daemon
       // browsing user-specified URLs has marginal sandbox benefit.
       chromiumSandbox: process.platform !== 'win32',
+      ...(executablePath ? { executablePath } : {}),
       ...(launchArgs.length > 0 ? { args: launchArgs } : {}),
     });
 


### PR DESCRIPTION
## Summary

`GSTACK_CHROMIUM_PATH` is only respected in `launchHeaded()` (`browser-manager.ts:270`) but not in `launch()` (`browser-manager.ts:183`). Skills like `/qa` use headless mode by default, so setting `GSTACK_CHROMIUM_PATH` has no effect when the bundled `chromium_headless_shell` fails on NixOS and other non-FHS distros.

## Changes

Read `GSTACK_CHROMIUM_PATH` in `launch()` and pass it as `executablePath` to `chromium.launch()`, matching the existing pattern in `launchHeaded()`.

`browse/src/browser-manager.ts`: 3 lines added.

## Testing

`bun test` passes (665 pass across skill validation and gen-skill-docs). The change mirrors the existing env var handling in `launchHeaded()` at line 270.

Fixes #906

This contribution was developed with AI assistance (Claude Code).