### PR TITLE
feat: add GitHub Copilot CLI as a supported host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ bin/gstack-global-discover
 .opencode/
 .slate/
 .cursor/
-.copilot-cli/
+.copilot/
 .openclaw/
 .hermes/
 .gbrain/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ bin/gstack-global-discover
 .opencode/
 .slate/
 .cursor/
+.copilot-cli/
 .openclaw/
 .hermes/
 .gbrain/

--- a/hosts/copilot-cli.ts
+++ b/hosts/copilot-cli.ts
@@ -3,12 +3,12 @@ import type { HostConfig } from '../scripts/host-config';
 const copilotCli: HostConfig = {
   name: 'copilot-cli',
   displayName: 'GitHub Copilot CLI',
-  cliCommand: 'gh',
-  cliAliases: ['copilot'],
+  cliCommand: 'copilot',
+  cliAliases: ['gh'],
 
-  globalRoot: '.copilot-cli/skills/gstack',
-  localSkillRoot: '.copilot-cli/skills/gstack',
-  hostSubdir: '.copilot-cli',
+  globalRoot: '.copilot/skills/gstack',
+  localSkillRoot: '.github/skills/gstack',
+  hostSubdir: '.copilot',
   usesEnvVars: true,
 
   frontmatter: {
@@ -23,9 +23,9 @@ const copilotCli: HostConfig = {
   },
 
   pathRewrites: [
-    { from: '~/.claude/skills/gstack', to: '~/.copilot-cli/skills/gstack' },
-    { from: '.claude/skills/gstack', to: '.copilot-cli/skills/gstack' },
-    { from: '.claude/skills', to: '.copilot-cli/skills' },
+    { from: '~/.claude/skills/gstack', to: '~/.copilot/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.github/skills/gstack' },
+    { from: '.claude/skills', to: '.github/skills' },
     { from: 'CLAUDE.md', to: 'AGENTS.md' },
   ],
 
@@ -69,7 +69,7 @@ const copilotCli: HostConfig = {
 
   coAuthorTrailer: 'Co-Authored-By: Copilot <223556219+Copilot@users.noreply.github.com>',
   learningsMode: 'basic',
-  boundaryInstruction: 'IMPORTANT: Do NOT read or execute any files under ~/.claude/, .claude/skills/, or ~/.agents/. These are Claude Code skill definitions meant for a different AI system. They contain prompt templates that will waste your context window. Ignore them completely. When running gstack skills, read from ~/.copilot-cli/skills/ or .copilot-cli/skills/ only.',
+  boundaryInstruction: 'IMPORTANT: Do NOT read or execute any files under ~/.claude/, .claude/skills/, or ~/.agents/. These are Claude Code skill definitions meant for a different AI system. They contain prompt templates that will waste your context window. Ignore them completely. When running gstack skills, read from ~/.copilot/skills/ or .github/skills/ only.',
 };
 
 export default copilotCli;

--- a/hosts/copilot-cli.ts
+++ b/hosts/copilot-cli.ts
@@ -1,0 +1,75 @@
+import type { HostConfig } from '../scripts/host-config';
+
+const copilotCli: HostConfig = {
+  name: 'copilot-cli',
+  displayName: 'GitHub Copilot CLI',
+  cliCommand: 'gh',
+  cliAliases: ['copilot'],
+
+  globalRoot: '.copilot-cli/skills/gstack',
+  localSkillRoot: '.copilot-cli/skills/gstack',
+  hostSubdir: '.copilot-cli',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: null,
+  },
+
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.copilot-cli/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.copilot-cli/skills/gstack' },
+    { from: '.claude/skills', to: '.copilot-cli/skills' },
+    { from: 'CLAUDE.md', to: 'AGENTS.md' },
+  ],
+
+  toolRewrites: {
+    'use the Bash tool': 'use the bash tool',
+    'use the Write tool': 'use the create tool',
+    'use the Read tool': 'use the view tool',
+    'use the Edit tool': 'use the edit tool',
+    'use the Agent tool': 'use the task tool',
+    'use the Grep tool': 'use the grep tool',
+    'use the Glob tool': 'use the glob tool',
+    'the Bash tool': 'the bash tool',
+    'the Read tool': 'the view tool',
+    'the Write tool': 'the create tool',
+    'the Edit tool': 'the edit tool',
+    'the Agent tool': 'the task tool',
+    'via the Agent tool': 'via the task tool',
+    'via Agent tool': 'via the task tool',
+    'AskUserQuestion': 'ask_user',
+    'WebSearch': 'web_fetch',
+  },
+
+  suppressedResolvers: [
+    'CODEX_SECOND_OPINION',
+    'CODEX_PLAN_REVIEW',
+    'GBRAIN_CONTEXT_LOAD',
+    'GBRAIN_SAVE_RESULTS',
+  ],
+
+  runtimeRoot: {
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalFiles: {
+      'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  coAuthorTrailer: 'Co-Authored-By: Copilot <223556219+Copilot@users.noreply.github.com>',
+  learningsMode: 'basic',
+  boundaryInstruction: 'IMPORTANT: Do NOT read or execute any files under ~/.claude/, .claude/skills/, or ~/.agents/. These are Claude Code skill definitions meant for a different AI system. They contain prompt templates that will waste your context window. Ignore them completely. When running gstack skills, read from ~/.copilot-cli/skills/ or .copilot-cli/skills/ only.',
+};
+
+export default copilotCli;

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,10 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import copilotCli from './copilot-cli';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, copilotCli];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, copilotCli };

--- a/setup
+++ b/setup
@@ -24,6 +24,8 @@ FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
 OPENCODE_SKILLS="$HOME/.config/opencode/skills"
 OPENCODE_GSTACK="$OPENCODE_SKILLS/gstack"
+COPILOT_SKILLS="$HOME/.copilot/skills"
+COPILOT_GSTACK="$COPILOT_SKILLS/gstack"
 
 IS_WINDOWS=0
 case "$(uname -s)" in
@@ -43,7 +45,7 @@ TEAM_MODE=0
 NO_TEAM_MODE=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, copilot-cli, copilot, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -56,7 +58,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|opencode|auto) ;;
+  claude|copilot-cli|copilot|codex|kiro|factory|opencode|auto) ;;
   openclaw)
     echo ""
     echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
@@ -91,7 +93,7 @@ case "$HOST" in
     echo "GBrain setup and brain skills ship from the GBrain repo."
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, copilot-cli, copilot, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -155,18 +157,22 @@ INSTALL_CODEX=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
 INSTALL_OPENCODE=0
+INSTALL_COPILOT_CLI=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
   command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
+  command -v copilot >/dev/null 2>&1 && INSTALL_COPILOT_CLI=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ] && [ "$INSTALL_COPILOT_CLI" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
   INSTALL_CLAUDE=1
+elif [ "$HOST" = "copilot-cli" ] || [ "$HOST" = "copilot" ]; then
+  INSTALL_COPILOT_CLI=1
 elif [ "$HOST" = "codex" ]; then
   INSTALL_CODEX=1
 elif [ "$HOST" = "kiro" ]; then
@@ -284,6 +290,16 @@ if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
     cd "$SOURCE_GSTACK_DIR"
     bun install --frozen-lockfile 2>/dev/null || bun install
     bun run gen:skill-docs --host opencode
+  )
+fi
+
+# 1e. Generate .copilot/ Copilot CLI skill docs
+if [ "$INSTALL_COPILOT_CLI" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .copilot/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun install --frozen-lockfile 2>/dev/null || bun install
+    bun run gen:skill-docs --host copilot-cli
   )
 fi
 
@@ -729,6 +745,92 @@ link_opencode_skill_dirs() {
   fi
 }
 
+create_copilot_runtime_root() {
+  local gstack_dir="$1"
+  local copilot_gstack="$2"
+  local copilot_dir="$gstack_dir/.copilot/skills"
+
+  if [ -L "$copilot_gstack" ]; then
+    rm -f "$copilot_gstack"
+  elif [ -d "$copilot_gstack" ] && [ "$copilot_gstack" != "$gstack_dir" ]; then
+    rm -rf "$copilot_gstack"
+  fi
+
+  mkdir -p "$copilot_gstack" "$copilot_gstack/browse" "$copilot_gstack/design" "$copilot_gstack/gstack-upgrade" "$copilot_gstack/review" "$copilot_gstack/qa" "$copilot_gstack/plan-devex-review"
+
+  if [ -f "$copilot_dir/gstack/SKILL.md" ]; then
+    ln -snf "$copilot_dir/gstack/SKILL.md" "$copilot_gstack/SKILL.md"
+  fi
+  if [ -d "$gstack_dir/bin" ]; then
+    ln -snf "$gstack_dir/bin" "$copilot_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    ln -snf "$gstack_dir/browse/dist" "$copilot_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    ln -snf "$gstack_dir/browse/bin" "$copilot_gstack/browse/bin"
+  fi
+  if [ -d "$gstack_dir/design/dist" ]; then
+    ln -snf "$gstack_dir/design/dist" "$copilot_gstack/design/dist"
+  fi
+  if [ -f "$copilot_dir/gstack-upgrade/SKILL.md" ]; then
+    ln -snf "$copilot_dir/gstack-upgrade/SKILL.md" "$copilot_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      ln -snf "$gstack_dir/review/$f" "$copilot_gstack/review/$f"
+    fi
+  done
+  if [ -d "$gstack_dir/review/specialists" ]; then
+    ln -snf "$gstack_dir/review/specialists" "$copilot_gstack/review/specialists"
+  fi
+  if [ -d "$gstack_dir/qa/templates" ]; then
+    ln -snf "$gstack_dir/qa/templates" "$copilot_gstack/qa/templates"
+  fi
+  if [ -d "$gstack_dir/qa/references" ]; then
+    ln -snf "$gstack_dir/qa/references" "$copilot_gstack/qa/references"
+  fi
+  if [ -f "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" ]; then
+    ln -snf "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" "$copilot_gstack/plan-devex-review/dx-hall-of-fame.md"
+  fi
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    ln -snf "$gstack_dir/ETHOS.md" "$copilot_gstack/ETHOS.md"
+  fi
+}
+
+link_copilot_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local copilot_dir="$gstack_dir/.copilot/skills"
+  local linked=()
+
+  if [ ! -d "$copilot_dir" ]; then
+    echo "  Generating .copilot/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host copilot-cli )
+  fi
+
+  if [ ! -d "$copilot_dir" ]; then
+    echo "  warning: .copilot/skills/ generation failed — run 'bun run gen:skill-docs --host copilot-cli' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$copilot_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+
 # 4. Install for Claude (default)
 SKILLS_BASENAME="$(basename "$INSTALL_SKILLS_DIR")"
 SKILLS_PARENT_BASENAME="$(basename "$(dirname "$INSTALL_SKILLS_DIR")")"
@@ -899,6 +1001,15 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   echo "gstack ready (opencode)."
   echo "  browse: $BROWSE_BIN"
   echo "  opencode skills: $OPENCODE_SKILLS"
+fi
+
+if [ "$INSTALL_COPILOT_CLI" -eq 1 ]; then
+  mkdir -p "$COPILOT_SKILLS"
+  create_copilot_runtime_root "$SOURCE_GSTACK_DIR" "$COPILOT_GSTACK"
+  link_copilot_skill_dirs "$SOURCE_GSTACK_DIR" "$COPILOT_SKILLS"
+  echo "gstack ready (copilot-cli)."
+  echo "  browse: $BROWSE_BIN"
+  echo "  copilot skills: $COPILOT_SKILLS"
 fi
 
 # 7. Create .agents/ sidecar symlinks for the real Codex skill target.

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2115,16 +2115,17 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('rm -f "$target"');
   });
 
-  test('setup supports --host auto|claude|codex|kiro|opencode', () => {
+  test('setup supports --host auto|claude|copilot-cli|codex|kiro|opencode', () => {
     expect(setupContent).toContain('--host');
-    expect(setupContent).toContain('claude|codex|kiro|factory|opencode|auto');
+    expect(setupContent).toContain('claude|copilot-cli|copilot|codex|kiro|factory|opencode|auto');
   });
 
-  test('auto mode detects claude, codex, kiro, and opencode binaries', () => {
+  test('auto mode detects claude, codex, kiro, opencode, and copilot binaries', () => {
     expect(setupContent).toContain('command -v claude');
     expect(setupContent).toContain('command -v codex');
     expect(setupContent).toContain('command -v kiro-cli');
     expect(setupContent).toContain('command -v opencode');
+    expect(setupContent).toContain('command -v copilot');
   });
 
   // T1: Sidecar skip guard — prevents .agents/skills/gstack from being linked as a skill

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -31,7 +31,7 @@ const ROOT = path.resolve(import.meta.dir, '..');
 
 describe('hosts/index.ts', () => {
   test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+    expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {


### PR DESCRIPTION
## Summary

Adds GitHub Copilot CLI as gstack's 11th supported host — with full install support, runtime root creation, and skill linking.

### What's included

- **`hosts/copilot-cli.ts`** — Declarative host config following the pattern in `ADDING_A_HOST.md`
- **`hosts/index.ts`** — Registration in the host registry
- **`setup`** — Full install support: `--host copilot-cli` (or `--host copilot`), auto-detection via `command -v copilot`, `create_copilot_runtime_root()` (symlinks `bin/`, `browse/dist/`, `ETHOS.md`, etc. into `~/.copilot/skills/gstack/`), `link_copilot_skill_dirs()` (links individual skills into `~/.copilot/skills/`)
- **`.gitignore`** — Added `.copilot/` for generated skill docs
- **`test/host-config.test.ts`** — Bumped host count assertion (10→11)
- **`test/gen-skill-docs.test.ts`** — Updated host list and binary detection assertions

### Design decisions

**Tool rewrites** — Copilot CLI uses different tool names than Claude Code:
| Claude Code | Copilot CLI |
|---|---|
| Read | view |
| Write | create |
| Edit | edit |
| Bash | bash |
| Agent | task |
| AskUserQuestion | ask_user |
| WebSearch | web_fetch |
| Grep | grep |
| Glob | glob |

**Path rewrites:**
- `.claude/skills/gstack` → `.copilot/skills/gstack`
- `CLAUDE.md` → `AGENTS.md` (Copilot CLI reads AGENTS.md as custom instructions)

**Suppressed resolvers:**
- `CODEX_SECOND_OPINION`, `CODEX_PLAN_REVIEW` — Codex-specific
- `GBRAIN_CONTEXT_LOAD`, `GBRAIN_SAVE_RESULTS` — Not available

**Kept resolvers:**
- `REVIEW_ARMY`, `ADVERSARIAL_STEP`, `DESIGN_OUTSIDE_VOICES` — these map to Copilot CLI's `task` tool which supports parallel sub-agent dispatch (similar to Claude's Agent tool)

**Detection:** `cliCommand: 'gh'` with alias `'copilot'`. The GitHub CLI (`gh`) hosts the Copilot CLI extension.

**Boundary instruction:** Prevents the agent from reading `.claude/` or `.agents/` directories.

### Verification

```
$ bun run scripts/host-config-export.ts validate
All 11 configs valid

$ bun run gen:skill-docs --host copilot-cli
36 skills generated (0 errors)

$ ./setup --host copilot-cli
gstack ready (copilot-cli).
  browse: .../browse/dist/browse
  copilot skills: ~/.copilot/skills

$ ls ~/.copilot/skills/gstack/
ETHOS.md  SKILL.md  bin -> .../bin  browse/  design/  gstack-upgrade/  plan-devex-review/  qa/  review/

$ bun test
355 pass, 0 fail
```

### Context

I use GitHub Copilot CLI as my primary AI coding agent. gstack's methodology (especially /review, /office-hours, /cso) is exactly what's missing from my workflow. The generated skill docs work as reference documents that the agent reads on demand via its `view` tool.

### TODO (follow-up PRs)

- [ ] Add install section to README.md
- [ ] Test with actual Copilot CLI sessions to refine tool rewrites