### PR TITLE
fix(build): make git rev-parse graceful when .git is absent

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "browse": "./browse/dist/browse"
   },
   "scripts": {
-    "build": "bun run gen:skill-docs --host all; bun build --compile browse/src/cli.ts --outfile browse/dist/browse && bun build --compile browse/src/find-browse.ts --outfile browse/dist/find-browse && bun build --compile design/src/cli.ts --outfile design/dist/design && bun build --compile bin/gstack-global-discover.ts --outfile bin/gstack-global-discover && bash browse/scripts/build-node-server.sh && git rev-parse HEAD > browse/dist/.version && git rev-parse HEAD > design/dist/.version && chmod +x browse/dist/browse browse/dist/find-browse design/dist/design bin/gstack-global-discover && (rm -f .*.bun-build || true)",
+    "build": "bun run gen:skill-docs --host all; bun build --compile browse/src/cli.ts --outfile browse/dist/browse && bun build --compile browse/src/find-browse.ts --outfile browse/dist/find-browse && bun build --compile design/src/cli.ts --outfile design/dist/design && bun build --compile bin/gstack-global-discover.ts --outfile bin/gstack-global-discover && bash browse/scripts/build-node-server.sh && (git rev-parse HEAD 2>/dev/null || echo unknown) > browse/dist/.version && (git rev-parse HEAD 2>/dev/null || echo unknown) > design/dist/.version && chmod +x browse/dist/browse browse/dist/find-browse design/dist/design bin/gstack-global-discover && (rm -f .*.bun-build || true)",
     "dev:design": "bun run design/src/cli.ts",
     "gen:skill-docs": "bun run scripts/gen-skill-docs.ts",
     "dev": "bun run browse/src/cli.ts",


### PR DESCRIPTION
## Problem

When gstack is consumed via a template engine that vendors the repo **without** the `.git` directory (e.g. [Conductor](https://conductor.melty.sh/)'s gstack project template, or any degit-based workflow), running `bun run build` crashes with:

```
fatal: not a git repository (or any of the parent directories): .git
error: script \"build\" exited with code 128
```

Because in the current `scripts.build`:

```
... && git rev-parse HEAD > browse/dist/.version && git rev-parse HEAD > design/dist/.version && ...
```

`git rev-parse HEAD` returns exit 128 when `.git` is missing, aborting the whole `&&`-chain and bun surfaces it as `script \"build\" exited with code 128`.

## Fix

Fall back to writing `unknown` into the `.version` files when not in a git repo. Inside a normal git checkout, behaviour is unchanged — the HEAD sha is still recorded.

```diff
- git rev-parse HEAD > browse/dist/.version && git rev-parse HEAD > design/dist/.version
+ (git rev-parse HEAD 2>/dev/null || echo unknown) > browse/dist/.version && (git rev-parse HEAD 2>/dev/null || echo unknown) > design/dist/.version
```

## Repro

```bash
# Simulate a template engine that strips .git
cp -r gstack/ /tmp/vendored-gstack/
rm -rf /tmp/vendored-gstack/.git
cd /tmp/vendored-gstack && bun install && bun run build
```

Before: `error: script \"build\" exited with code 128`  
After: build succeeds, `.version` files contain `unknown`.

## Verification

Verified both paths:

| Scenario | Before | After |
|---|---|---|
| Normal git checkout (`.git` present) | sha written, exit 0 | sha written, exit 0 (unchanged) |
| Vendored/degit checkout (no `.git`) | exit 128 | `\"unknown\"` written, exit 0 |

## Affects

- **Conductor** gstack project template (reports \"Failed to create repo: error: script 'build' exited with code 128\" when a user picks the gstack template)
- Any template engine / monorepo vendoring flow that drops `.git`
- CI builds where the repo is extracted from a tarball rather than cloned