### PR TITLE
fix: normalize line endings in template reads for cross-platform generator

### DIFF
--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -422,7 +422,12 @@ function processExternalHost(
 }
 
 function processTemplate(tmplPath: string, host: Host = 'claude'): { outputPath: string; content: string; symlinkLoop?: boolean } {
-  const tmplContent = fs.readFileSync(tmplPath, 'utf-8');
+  // Normalize to LF at the entry point. Templates may have CRLF on disk when
+  // checked out on Windows with core.autocrlf=true. Downstream regexes
+  // (processVoiceTriggers, transformFrontmatter) hardcode \n, so without
+  // normalization they silently no-op on CRLF — producing different output
+  // than CI (Linux, LF) and breaking the Skill Docs Freshness check.
+  const tmplContent = fs.readFileSync(tmplPath, 'utf-8').replace(/\r\n/g, '\n');
   const relTmplPath = path.relative(ROOT, tmplPath);
   let outputPath = tmplPath.replace(/\.tmpl$/, '');
 


### PR DESCRIPTION
## Summary

The skill-doc generator silently produces wrong output on Windows
because regex patterns that process frontmatter hardcode \n line
endings. Git's default `core.autocrlf=true` on Windows gives
contributors CRLF in checked-out .tmpl files, so these regexes
skip their work — producing output that diverges from CI's Linux
regen.

## Affected code paths

`scripts/gen-skill-docs.ts`:

- `processVoiceTriggers()` line 174:
  `/^voice-triggers:\n(?:\s+-\s+"[^"]*"\n?)*/m`
- `transformFrontmatter()` line 232: same regex, different call site
- `transformFrontmatter()` line 234:
  `new RegExp(\`^\${field}:\s*.*\n\`, 'm')`
- `extractVoiceTriggers()` line 145: `content.indexOf('---\n')`
  (returns -1 on CRLF → voice-triggers extraction yields empty →
  downstream fold silently skipped)

Every one of these breaks on CRLF input.

## Evidence

Discovered while iterating on #1050. My Windows machine kept
generating files with `voice-triggers:` as a YAML list; CI kept
generating the same files with voice-triggers folded into the
description string. Running \`git config core.autocrlf input\` and
resetting to LF content made local regen byte-identical to CI.

## Fix

One line in \`processTemplate()\`:

\`\`\`diff
-  const tmplContent = fs.readFileSync(tmplPath, 'utf-8');
+  const tmplContent = fs.readFileSync(tmplPath, 'utf-8').replace(/\r\n/g, '\n');
\`\`\`

Normalize to LF at the entry point. Every downstream regex then sees
canonical LF content regardless of how git checked out the file.

Scope: minimal. No behavioral change for Linux/macOS contributors.
Windows contributors (with default git settings) will stop seeing
phantom STALE output from CI's freshness check.

## Alternative considered

Updating each regex individually (\`\n\` → \`\r?\n\`) would also work
but requires four separate edits and every future contributor has to
remember the same rule. Normalizing at the boundary is one change
and structurally prevents the class of bug.

## Test plan

- [ ] On Windows with \`core.autocrlf=true\`, run \`gen:skill-docs --host all\`,
      confirm \`--dry-run\` reports 0 STALE
- [ ] On Linux, run \`gen:skill-docs --host all\`, confirm output byte-identical
      to pre-fix output (normalization is no-op on already-LF content)
- [ ] Existing test suite in \`test/gen-skill-docs.test.ts\` still passes

Generated with [Claude Code](https://claude.com/claude-code)