### PR TITLE
fix: namespace generated Hermes skill names

### DIFF
--- a/hosts/hermes.ts
+++ b/hosts/hermes.ts
@@ -15,6 +15,7 @@ const hermes: HostConfig = {
     mode: 'allowlist',
     keepFields: ['name', 'description'],
     descriptionLimit: null,
+    nameTransform: 'external-skill-name',
   },
 
   generation: {

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -221,7 +221,7 @@ policy:
  * Codex: keeps name + description only, enforces 1024-char limit.
  * Factory: keeps name + description + user-invocable, conditionally adds disable-model-invocation.
  */
-function transformFrontmatter(content: string, host: Host): string {
+function transformFrontmatter(content: string, host: Host, generatedSkillName?: string): string {
   const hostConfig = getHostConfig(host);
   const fm = hostConfig.frontmatter;
 
@@ -245,6 +245,9 @@ function transformFrontmatter(content: string, host: Host): string {
   const frontmatter = content.slice(fmStart + 4, fmEnd);
   const body = content.slice(fmEnd + 4);
   const { name, description } = extractNameAndDescription(content);
+  const emittedName = fm.nameTransform === 'external-skill-name' && generatedSkillName
+    ? generatedSkillName
+    : name;
 
   // Description limit enforcement
   if (fm.descriptionLimit) {
@@ -252,11 +255,11 @@ function transformFrontmatter(content: string, host: Host): string {
     if (description.length > fm.descriptionLimit) {
       if (behavior === 'error') {
         throw new Error(
-          `${hostConfig.displayName} description for "${name}" is ${description.length} chars (max ${fm.descriptionLimit}). ` +
+          `${hostConfig.displayName} description for "${emittedName}" is ${description.length} chars (max ${fm.descriptionLimit}). ` +
           `Compress the description in the .tmpl file.`
         );
       } else if (behavior === 'warn') {
-        console.warn(`WARNING: ${hostConfig.displayName} description for "${name}" exceeds ${fm.descriptionLimit} chars`);
+        console.warn(`WARNING: ${hostConfig.displayName} description for "${emittedName}" exceeds ${fm.descriptionLimit} chars`);
       }
       // 'truncate' — silently proceed
     }
@@ -264,7 +267,7 @@ function transformFrontmatter(content: string, host: Host): string {
 
   // Build frontmatter with allowed fields
   const indentedDesc = description.split('\n').map(l => `  ${l}`).join('\n');
-  let newFm = `---\nname: ${name}\ndescription: |\n${indentedDesc}\n`;
+  let newFm = `---\nname: ${emittedName}\ndescription: |\n${indentedDesc}\n`;
 
   // Add extra fields (host-wide)
   if (fm.extraFields) {
@@ -390,7 +393,7 @@ function processExternalHost(
   const safetyProse = extractHookSafetyProse(tmplContent);
 
   // Transform frontmatter (host-aware)
-  let result = transformFrontmatter(content, host);
+  let result = transformFrontmatter(content, host, name);
 
   // Insert safety advisory at the top of the body (after frontmatter)
   if (safetyProse) {

--- a/scripts/host-config.ts
+++ b/scripts/host-config.ts
@@ -46,6 +46,8 @@ export interface HostConfig {
     descriptionLimit?: number | null;
     /** What to do when description exceeds limit. Default: 'error'. */
     descriptionLimitBehavior?: 'error' | 'truncate' | 'warn';
+    /** Override the emitted frontmatter name for generated skills. */
+    nameTransform?: 'identity' | 'external-skill-name';
     /** Additional frontmatter fields to inject (host-wide). */
     extraFields?: Record<string, unknown>;
     /** Rename fields from template (e.g., { 'voice-triggers': 'triggers' }). */

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1973,6 +1973,24 @@ describe('Parameterized host smoke tests', () => {
         }
       });
 
+      if (hostConfig.name === 'hermes') {
+        test('Hermes frontmatter names are namespaced to match generated skill names', () => {
+          Bun.spawnSync(['bun', 'run', 'scripts/gen-skill-docs.ts', '--host', 'hermes'], {
+            cwd: ROOT, stdout: 'pipe', stderr: 'pipe',
+          });
+
+          const reviewContent = fs.readFileSync(path.join(hostDir, 'gstack-review', 'SKILL.md'), 'utf-8');
+          const qaContent = fs.readFileSync(path.join(hostDir, 'gstack-qa', 'SKILL.md'), 'utf-8');
+          const shipContent = fs.readFileSync(path.join(hostDir, 'gstack-ship', 'SKILL.md'), 'utf-8');
+          const rootContent = fs.readFileSync(path.join(hostDir, 'gstack', 'SKILL.md'), 'utf-8');
+
+          expect(reviewContent).toMatch(/^name:\s*gstack-review$/m);
+          expect(qaContent).toMatch(/^name:\s*gstack-qa$/m);
+          expect(shipContent).toMatch(/^name:\s*gstack-ship$/m);
+          expect(rootContent).toMatch(/^name:\s*gstack$/m);
+        });
+      }
+
       test('--dry-run freshness check passes', () => {
         const result = Bun.spawnSync(
           ['bun', 'run', 'scripts/gen-skill-docs.ts', '--host', hostConfig.name, '--dry-run'],


### PR DESCRIPTION
## Summary
- add host-config support for host-specific emitted skill names
- namespace generated Hermes skill frontmatter names to match their gstack-* directories
- add a regression test covering Hermes skill-name generation

## Problem
Hermes deduplicates skills by frontmatter `name`, not by directory name. Generated Hermes skills were written to namespaced directories like `gstack-review/`, but their frontmatter still used generic names like `review`, causing Hermes to suppress them as duplicates of existing skills.

## Test Plan
- bun test test/gen-skill-docs.test.ts -t "Hermes frontmatter names are namespaced to match generated skill names"
- bun run scripts/gen-skill-docs.ts --host hermes
- verify `hermes skills list` shows `gstack-review`, `gstack-qa`, and `gstack-ship`
