### PR TITLE
docs: add gstack Studio — a desktop GUI for gstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,10 @@ I open sourced how I build software. You can fork it and make it your own.
 > Come work at YC — [ycombinator.com/software](https://ycombinator.com/software)
 > Extremely competitive salary and equity. San Francisco, Dogpatch District.
 
+## Desktop GUI
+
+If you'd rather not memorise slash commands, [gstack Studio](https://github.com/arunrajiah/gstack-studio) is an open-source desktop companion (macOS / Windows / Linux) built on top of this repo. It gives you a visual Sprint Board for all 23 agents, one-click daemon management, a live log stream, and a Browse Console — no CLI required.
+
 ## Docs
 
 | Doc | What it covers |


### PR DESCRIPTION
Hey Garry — been using gstack for a few weeks and wanted to scratch my own itch. I kept forgetting which slash command did what and had to `cat` SKILL.md files to remind myself.

So I built **gstack Studio** — a small Electron app that wraps gstack in a GUI. It's not trying to replace the CLI workflow, it's more of a reference panel you keep open while working in Claude Code.

What it does:
- Sprint Board with all 23 agents organised by phase — click any card to copy the slash command
- Start / Stop / Restart the browse daemon without touching the terminal
- Live log stream so you can see what the daemon is doing
- Browse Console for sending browser automation commands
- Per-project learnings viewer (reads from `~/.gstack/projects/*/learnings.jsonl`)

macOS, Windows, Linux. MIT license. No changes to gstack itself — it just reads the SKILL.md files and talks to the browse daemon over HTTP.

Repo: https://github.com/arunrajiah/gstack-studio

Happy to adjust the wording or move this section wherever makes more sense. Just thought other gstack users might find it useful.