### PR TITLE
docs(telemetry): clarify 'never sent' → 'never transmitted', disclose local JSONL storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ gstack includes **opt-in** usage telemetry to help improve the project. Here's e
 - **Default is off.** Nothing is sent anywhere unless you explicitly say yes.
 - **On first run,** gstack asks if you want to share anonymous usage data. You can say no.
 - **What's sent (if you opt in):** skill name, duration, success/fail, gstack version, OS. That's it.
-- **What's never sent:** code, file paths, repo names, branch names, prompts, or any user-generated content.
+- **What's never transmitted:** code, file paths, repo names, branch names, prompts, or any user-generated content. Repo name and branch are stored locally in `~/.gstack/analytics/` for session tracking but never leave your machine.
 - **Change anytime:** `gstack-config set telemetry off` disables everything instantly.
 
 Data is stored in [Supabase](https://supabase.com) (open source Firebase alternative). The schema is in [`supabase/migrations/`](supabase/migrations/) — you can verify exactly what's collected. The Supabase publishable key in the repo is a public key (like a Firebase API key) — row-level security policies deny all direct access. Telemetry flows through validated edge functions that enforce schema checks, event type allowlists, and field length limits.

--- a/SKILL.md
+++ b/SKILL.md
@@ -187,7 +187,8 @@ ask the user about telemetry. Use AskUserQuestion:
 
 > Help gstack get better! Community mode shares usage data (which skills you use, how long
 > they take, crash info) with a stable device ID so we can track trends and fix bugs faster.
-> No code, file paths, or repo names are ever sent.
+> No code, file paths, or repo names are ever **transmitted**. Repo name and branch are stored
+> locally in `~/.gstack/analytics/` for session tracking but never leave your machine.
 > Change anytime with `gstack-config set telemetry off`.
 
 Options:

--- a/scripts/resolvers/preamble/generate-telemetry-prompt.ts
+++ b/scripts/resolvers/preamble/generate-telemetry-prompt.ts
@@ -6,7 +6,8 @@ ask the user about telemetry. Use AskUserQuestion:
 
 > Help gstack get better! Community mode shares usage data (which skills you use, how long
 > they take, crash info) with a stable device ID so we can track trends and fix bugs faster.
-> No code, file paths, or repo names are ever sent.
+> No code, file paths, or repo names are ever **transmitted**. Repo name and branch are stored
+> locally in \`~/.gstack/analytics/\` for session tracking but never leave your machine.
 > Change anytime with \`gstack-config set telemetry off\`.
 
 Options:


### PR DESCRIPTION
## Summary

- Changes "No code, file paths, or repo names are ever **sent**" → "ever **transmitted**" in the telemetry consent prompt and README privacy section.
- Adds one sentence noting that repo name and branch are stored locally in `~/.gstack/analytics/` but never transmitted.
- Regenerates all `SKILL.md` files via `bun run gen:skill-docs` so the generated consent text stays in sync with the template.

## Why

`gstack-telemetry-log` writes `_repo_slug` and `_branch` into `~/.gstack/analytics/skill-usage.jsonl` on every skill run regardless of telemetry tier — including `telemetry: off`. The sync script strips them before POSTing to Supabase, so the "never sent" claim is technically accurate for remote transmission. But "never sent" reads as "never recorded anywhere," which isn't true.

The fix is a word change (`sent` → `transmitted`) plus one explanatory sentence. No code changes — this is purely a documentation accuracy fix.

## Files changed

| File | Change |
|------|--------|
| `scripts/resolvers/preamble/generate-telemetry-prompt.ts` | Source of truth for the consent text |
| `README.md` | Privacy & Telemetry section |
| All `*/SKILL.md` files | Regenerated from updated template |

Fixes #1080