### PR TITLE
docs(privacy): disclose hourly GitHub VERSION fetch in update-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ gstack includes **opt-in** usage telemetry to help improve the project. Here's e
 - **What's sent (if you opt in):** skill name, duration, success/fail, gstack version, OS. That's it.
 - **What's never sent:** code, file paths, repo names, branch names, prompts, or any user-generated content.
 - **Change anytime:** `gstack-config set telemetry off` disables everything instantly.
+- **Update checks:** Once per hour, gstack fetches the current version number from `raw.githubusercontent.com` to check for upgrades. This is a plain GET request — no auth, no payload — but it does reach GitHub's servers regardless of your telemetry setting. Set `update_check: false` in `~/.gstack/config.yaml` to disable it entirely.
 
 Data is stored in [Supabase](https://supabase.com) (open source Firebase alternative). The schema is in [`supabase/migrations/`](supabase/migrations/) — you can verify exactly what's collected. The Supabase publishable key in the repo is a public key (like a Firebase API key) — row-level security policies deny all direct access. Telemetry flows through validated edge functions that enforce schema checks, event type allowlists, and field length limits.
 


### PR DESCRIPTION
## Summary

- Adds one bullet to the `## Privacy & Telemetry` section of `README.md` disclosing the hourly GET request that `gstack-update-check` makes to `raw.githubusercontent.com`.
- Points to the existing `update_check: false` escape hatch that already silences it.

## Why

Every gstack skill preamble calls `gstack-update-check`, which on cache miss (~once per hour) fetches:

```
GET https://raw.githubusercontent.com/garrytan/gstack/main/VERSION
```

This fires regardless of the user's `telemetry` setting — including when `telemetry: off` is set. The Privacy & Telemetry section of the README covered opt-in telemetry (Supabase) but was silent on this always-on network call.

The call is harmless by design (no auth, no payload, just a version string). The gap is that a user who reads the privacy section and sets `telemetry: off` expecting zero outbound activity would still be surprised by it. The fix documents what happens and how to disable it.

No code change — `update_check: false` already exists in `gstack-config` and already silences the call. This PR just makes users aware of it.

Fixes #1081