### PR TITLE
fix(browse): `stop` hangs 5s + emits 'Unable to connect' after a goto

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -423,8 +423,32 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
       console.error('[browse] Command timed out after 30s');
       process.exit(1);
     }
-    // Connection error — server may have crashed
-    if (err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET' || err.message?.includes('fetch failed')) {
+    // Connection error — server may have crashed, or the user just asked
+    // it to shut down. Bun's fetch emits `code: 'ConnectionRefused'` /
+    // `'ConnectionReset'` (PascalCase) — Node uses `'ECONNREFUSED'` /
+    // `'ECONNRESET'`. We match both so this code path doesn't change
+    // behavior depending on which runtime executes the binary.
+    const isConnError =
+      err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET' ||
+      err.code === 'ConnectionRefused' || err.code === 'ConnectionReset' ||
+      err.message?.includes('fetch failed') ||
+      err.message?.includes('Unable to connect');
+    if (isConnError) {
+      // Special case: 'stop' shut the server down on purpose. The HTTP listener
+      // closed mid-response (or before we even reached it), so the fetch sees
+      // ConnectionRefused/Reset — but that IS the success signal for stop.
+      // Don't trigger the auto-restart path here, or we'll spawn a fresh
+      // server and emit the misleading "Unable to connect" error after a
+      // 5-second hang. Best-effort cleanup of the recorded pid in case the
+      // server's shutdown() didn't get to it, then exit clean.
+      if (command === 'stop') {
+        const oldState = readState();
+        if (oldState && oldState.pid && isProcessAlive(oldState.pid)) {
+          await killServer(oldState.pid);
+        }
+        process.stdout.write('Server stopped\n');
+        return;
+      }
       if (retries >= 1) throw new Error('[browse] Server crashed twice in a row — aborting');
       console.error('[browse] Server connection lost. Restarting...');
       // Kill the old server to avoid orphaned chromium processes


### PR DESCRIPTION
## Bug

```
$ ./browse/dist/browse goto https://example.com
[browse] Starting server...
Navigated to https://example.com (200)

$ ./browse/dist/browse stop
[browse] Unable to connect. Is the computer able to access the url?
# 5.1s wall time, exit 1
```

The `stop` command hangs ~5 seconds, prints a misleading network error, and exits non-zero — even though the server actually does shut down.

## Root cause (two issues compounded)

1. **`sendCommand`'s connection-error catch missed Bun's runtime error code.** Bun's `fetch()` against a closed port returns `err.code === 'ConnectionRefused'` (PascalCase) and `err.message === 'Unable to connect. Is the computer able to access the url?'`. The existing check only matches `'ECONNREFUSED'` / `'ECONNRESET'` / `'fetch failed'` (Node-style). So the catch falls through to `throw err`, which bubbles to `main()`'s top-level handler, which dumps the raw Bun message verbatim. (Reproduced in 5 lines: `try { await fetch('http://127.0.0.1:1') } catch (e) { console.log(e.code) }` → `ConnectionRefused`.)

2. **Even with that fixed, `stop` shouldn't auto-restart.** The reconnect-and-retry path would spawn a fresh server only to immediately kill it. The user explicitly asked the server to shut down — a connection drop on `stop` IS the success signal.

## Fix

`browse/src/cli.ts` — broaden the `isConnError` check to recognize Bun's PascalCase codes and the `'Unable to connect'` message string, plus a `command === 'stop'` short-circuit that prints "Server stopped" and exits 0 instead of restarting.

```diff
- if (err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET' || err.message?.includes('fetch failed')) {
+ const isConnError =
+   err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET' ||
+   err.code === 'ConnectionRefused' || err.code === 'ConnectionReset' ||
+   err.message?.includes('fetch failed') ||
+   err.message?.includes('Unable to connect');
+ if (isConnError) {
+   if (command === 'stop') {
+     // best-effort kill + exit clean
+     return;
+   }
    // ... existing restart-and-retry logic unchanged ...
```

Test suite already grep's for `'Unable to connect'` (test/skill-e2e.test.ts:167, test/helpers/e2e-helpers.ts:222), so it knows about this Bun-side error string.

## Verification

After applying the patch:

```
$ ./browse/dist/browse goto https://example.com
[browse] Starting server...
Navigated to https://example.com (200)

$ ./browse/dist/browse stop
Server stopped
# exit 0

$ ./browse/dist/browse stop   # second stop, no daemon to kill
[browse] Starting server...
Server stopped
# exit 0  (5.9s — could be optimized further by skipping the spawn entirely if no live pid; left for a follow-up)
```

Both calls now succeed cleanly.

## How this surfaced

Cross-tool browser-CLI benchmarks against ghax (https://github.com/kepptic/ghax) — every gstack-browse iteration showed the teardown step failing with a 5+ s hang and the misleading message, even though all the real automation commands (goto/text/eval/screenshot/snapshot) succeeded. Made gstack-browse look ~5× worse on cold-start total than it really is. Full benchmark report: https://github.com/kepptic/ghax/blob/main/docs/BENCHMARK.md

## Possible follow-up (not in this PR)

The "second stop with no live daemon" path could short-circuit `ensureServer()` entirely when `command === 'stop'` and the recorded pid is dead — saves the ~5 s spawn cost. Left for a separate PR since it changes more code paths.