### PR TITLE
fix(make-pdf): resolve browse binary on Windows without BROWSE_BIN

### DIFF
--- a/make-pdf/src/browseClient.ts
+++ b/make-pdf/src/browseClient.ts
@@ -62,13 +62,17 @@ export function resolveBrowseBin(): string {
   const envOverride = process.env.BROWSE_BIN;
   if (envOverride && isExecutable(envOverride)) return envOverride;
 
+  const isWin = process.platform === "win32";
+  const exeSuffix = isWin ? ".exe" : "";
+  const binName = `browse${exeSuffix}`;
+
   // Sibling: look relative to this process's binary
   // (for when make-pdf and browse live next to each other in dist/)
   const selfDir = path.dirname(process.argv[0]);
   const siblingCandidates = [
-    path.resolve(selfDir, "../browse/dist/browse"),
-    path.resolve(selfDir, "../../browse/dist/browse"),
-    path.resolve(selfDir, "../browse"),
+    path.resolve(selfDir, `../browse/dist/${binName}`),
+    path.resolve(selfDir, `../../browse/dist/${binName}`),
+    path.resolve(selfDir, `../${binName}`),
   ];
   for (const candidate of siblingCandidates) {
     if (isExecutable(candidate)) return candidate;
@@ -76,15 +80,18 @@ export function resolveBrowseBin(): string {
 
   // Global install
   const home = os.homedir();
-  const globalPath = path.join(home, ".claude/skills/gstack/browse/dist/browse");
+  const globalPath = path.join(home, ".claude/skills/gstack/browse/dist", binName);
   if (isExecutable(globalPath)) return globalPath;
 
-  // PATH lookup
+  // PATH lookup — Windows uses `where`, Unix uses `which`
+  const lookupCmd = isWin ? "where" : "which";
   try {
-    const which = execFileSync("which", ["browse"], { encoding: "utf8" }).trim();
-    if (which && isExecutable(which)) return which;
+    const out = execFileSync(lookupCmd, [binName], { encoding: "utf8" }).trim();
+    // `where` can return multiple lines; take first
+    const first = out.split(/\r?\n/)[0]?.trim();
+    if (first && isExecutable(first)) return first;
   } catch {
-    // `which` exited non-zero; fall through to error
+    // lookup exited non-zero; fall through to error
   }
 
   throw new BrowseClientError(
@@ -94,24 +101,32 @@ export function resolveBrowseBin(): string {
       "browse binary not found.",
       "",
       "make-pdf needs browse (the gstack Chromium daemon) to render PDFs.",
+      `Platform: ${process.platform} (looking for "${binName}")`,
       "Tried:",
       `  - $BROWSE_BIN (${envOverride || "unset"})`,
       `  - sibling: ${siblingCandidates.join(", ")}`,
       `  - global: ${globalPath}`,
-      "  - PATH: `browse`",
+      `  - PATH: \`${lookupCmd} ${binName}\``,
       "",
       "To fix: run gstack setup from the gstack repo:",
       "  cd ~/.claude/skills/gstack && ./setup",
       "",
       "Or set BROWSE_BIN explicitly:",
-      "  export BROWSE_BIN=/path/to/browse",
+      isWin
+        ? '  setx BROWSE_BIN "C:\\path\\to\\browse.exe"'
+        : "  export BROWSE_BIN=/path/to/browse",
     ].join("\n"),
   );
 }
 
 function isExecutable(p: string): boolean {
   try {
-    fs.accessSync(p, fs.constants.X_OK);
+    // Windows: NTFS has no execute bit. X_OK is unreliable — use F_OK
+    // (file exists) and let the OS decide at execFile time.
+    const mode = process.platform === "win32"
+      ? fs.constants.F_OK
+      : fs.constants.X_OK;
+    fs.accessSync(p, mode);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

`make-pdf/src/browseClient.ts` `resolveBrowseBin()` hardcoded the Unix binary name `browse` and the Unix `which` lookup tool. On Windows the compiled binary is `browse.exe`, so every fallback (sibling paths, global install at `~/.claude/skills/gstack/browse/dist/browse`, PATH lookup) missed — users hit `browse binary not found` unless they set `BROWSE_BIN` manually.

This PR makes every fallback Windows-aware while keeping Unix behavior unchanged.

## Changes

- Branch binary name on `process.platform === "win32"` → append `.exe`.
- Use `where` on Windows, `which` on Unix; parse first line of `where` output (can span multiple PATHEXT hits).
- `isExecutable()` checks `F_OK` on Windows — NTFS has no execute bit and Node's `X_OK` delegates to `AccessCheck`, which false-negatives on `.exe` files depending on ACLs.
- Error message now shows the actual binary name searched and suggests `setx BROWSE_BIN ...` on Windows instead of `export`.

## Verification

Environment: Windows 11 Pro + Git Bash + gstack v1.4.0.0 (main).

**Before patch:** with `BROWSE_BIN` unset, `pdf.exe generate smoke.md out.pdf` fails:
```
$P: browse newtab exited 1: ...
```
Root cause: `fs.accessSync("~/.claude/skills/gstack/browse/dist/browse", X_OK)` throws ENOENT because the actual file is `browse.exe`.

**After patch:** same command succeeds. Binary resolved via the global-install branch. Generated a 51KB single-page PDF end-to-end. Full PDF pipeline validated (cover + TOC + paged.js render + pdftotext QA) in a separate run against `~/.claude/CLAUDE.md` (10 pages, 208KB).

No platform-conditional test added — the change is a pure cross-platform branching patch with the same semantics on macOS/Linux (empty suffix, `which`, `X_OK`).

## Test plan

- [x] Windows: `pdf.exe generate` with `BROWSE_BIN` unset succeeds
- [x] Windows: error message mentions `browse.exe` and `setx` when binary truly missing
- [ ] macOS/Linux: no behavior change (empty suffix, `which`, `X_OK` preserved — request reviewer run existing test suite)

## Context

Discovered while dogfooding `/make-pdf` on Windows the day after the v1.4.0.0 release. Without this fix, the skill is effectively blocked on Windows until users know to run `setx BROWSE_BIN "C:\path\to\browse.exe"` themselves — not documented in `SKILL.md`.