### PR TITLE
fix: avoid printing partial Render API key in setup-deploy

### DIFF
--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -856,7 +856,14 @@ Ask the user to confirm the production URL. Some Fly apps use custom domains.
 If `render.yaml` detected:
 
 1. Extract service name and type from render.yaml
-2. Check for Render API key: `echo $RENDER_API_KEY | head -c 4` (don't expose the full key)
+2. Check for Render API key:
+```bash
+if [ -n "${RENDER_API_KEY:-}" ]; then
+  echo "RENDER_API_KEY: set"
+else
+  echo "RENDER_API_KEY: not set"
+fi
+```
 3. Infer URL: `https://{service-name}.onrender.com`
 4. Render deploys automatically on push to the connected branch — no deploy workflow needed
 5. Set health check: the inferred URL

--- a/setup-deploy/SKILL.md.tmpl
+++ b/setup-deploy/SKILL.md.tmpl
@@ -99,7 +99,14 @@ Ask the user to confirm the production URL. Some Fly apps use custom domains.
 If `render.yaml` detected:
 
 1. Extract service name and type from render.yaml
-2. Check for Render API key: `echo $RENDER_API_KEY | head -c 4` (don't expose the full key)
+2. Check for Render API key:
+```bash
+if [ -n "${RENDER_API_KEY:-}" ]; then
+  echo "RENDER_API_KEY: set"
+else
+  echo "RENDER_API_KEY: not set"
+fi
+```
 3. Infer URL: `https://{service-name}.onrender.com`
 4. Render deploys automatically on push to the connected branch — no deploy workflow needed
 5. Set health check: the inferred URL


### PR DESCRIPTION
## Summary

The previous instruction in `/setup-deploy` used `echo $RENDER_API_KEY | head -c 4` to check for the Render API key's presence. This still leaked 4 bytes of the secret into terminal scrollback, screen recordings, and screenshots.

Replace with a simple presence check that confirms whether the variable is set, without exposing any bytes.

## Test plan

- [ ] Run `/setup-deploy` on a project with `render.yaml`
- [ ] Verify the Render API key presence check shows only "set" / "not set"
- [ ] Confirm no bytes of the key appear in terminal scrollback

Fixes #1078

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>