### PR TITLE
fix: surface non-EEXIST errors in acquireServerLock instead of masking them

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -289,7 +289,12 @@ function acquireServerLock(): (() => void) | null {
     fs.writeSync(fd, `${process.pid}\n`);
     fs.closeSync(fd);
     return () => { safeUnlink(lockPath); };
-  } catch {
+  } catch (err: any) {
+    if (err?.code !== 'EEXIST') {
+      // Unexpected error — surface it rather than masking as phantom lock contention
+      console.error(`[browse] acquireServerLock: unexpected ${err?.code || ''} opening ${lockPath}: ${err?.message}`);
+      return null;
+    }
     // Lock already held — check if the holder is still alive
     try {
       const holderPid = parseInt(fs.readFileSync(lockPath, 'utf8').trim(), 10);
@@ -299,7 +304,8 @@ function acquireServerLock(): (() => void) | null {
       // Stale lock — remove and retry
       fs.unlinkSync(lockPath);
       return acquireServerLock();
-    } catch {
+    } catch (err: any) {
+      console.error(`[browse] acquireServerLock: stale-lock read failed: ${err?.message}`);
       return null;
     }
   }


### PR DESCRIPTION
## Summary

The bare `catch {}` on `fs.openSync(lockPath, 'wx')` silently swallowed all errors other than `EEXIST` (permissions, disk full, Bun fs regressions). This made real filesystem failures look like phantom lock contention, hiding the root cause for ~30 minutes.

Now only `EEXIST` takes the holder-PID path; everything else logs via `console.error` with error code and message before returning `null`. The inner catch on the holder-PID read gets the same treatment.

## Root cause

When `EEXIST` is NOT the error (e.g., `EPERM`, `ENOSPC`), execution fell through to `readFileSync(lockPath)` — which either succeeded (stale lock) or threw — and returned `null`. The caller then printed "Another instance is starting the server, waiting..." which was completely misleading.

## Test plan

- [ ] `bun test` passes (Tier 1 static validation)
- [ ] Manual: trigger a non-EEXIST fs error on the lock path and verify a diagnostic message is printed instead of phantom lock contention

Fixes #1084

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>