### PR TITLE
fix: clarify telemetry consent text — repo names stored locally, not transmitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ gstack includes **opt-in** usage telemetry to help improve the project. Here's e
 - **Default is off.** Nothing is sent anywhere unless you explicitly say yes.
 - **On first run,** gstack asks if you want to share anonymous usage data. You can say no.
 - **What's sent (if you opt in):** skill name, duration, success/fail, gstack version, OS. That's it.
-- **What's never sent:** code, file paths, repo names, branch names, prompts, or any user-generated content.
+- **What's never transmitted:** code, file paths, repo names, branch names, prompts, or any user-generated content. Your repo name and branch are stored locally in `~/.gstack/analytics/` for session tracking but never leave your machine.
 - **Change anytime:** `gstack-config set telemetry off` disables everything instantly.
 
 Data is stored in [Supabase](https://supabase.com) (open source Firebase alternative). The schema is in [`supabase/migrations/`](supabase/migrations/) — you can verify exactly what's collected. The Supabase publishable key in the repo is a public key (like a Firebase API key) — row-level security policies deny all direct access. Telemetry flows through validated edge functions that enforce schema checks, event type allowlists, and field length limits.

--- a/scripts/resolvers/preamble/generate-telemetry-prompt.ts
+++ b/scripts/resolvers/preamble/generate-telemetry-prompt.ts
@@ -6,7 +6,7 @@ ask the user about telemetry. Use AskUserQuestion:
 
 > Help gstack get better! Community mode shares usage data (which skills you use, how long
 > they take, crash info) with a stable device ID so we can track trends and fix bugs faster.
-> No code, file paths, or repo names are ever sent.
+> No code, file paths, or repo names are ever transmitted. Your repo name and branch are stored locally in `~/.gstack/analytics/` for session tracking but never leave your machine.
 > Change anytime with \`gstack-config set telemetry off\`.
 
 Options:


### PR DESCRIPTION
## Summary
- Clarify telemetry consent text to specify repo names are stored locally in `~/.gstack/analytics/` but never transmitted
- Updates both `generate-telemetry-prompt.ts` (used in skill preambles) and README.md privacy section

## Issue
Fixes #1080 — Telemetry consent text says 'no repo names ever sent' but omits that they're recorded locally.

## Test plan
- [ ] Verify README.md privacy section reflects updated language
- [ ] Skill preambles regenerated via `bun run gen:skill-docs` reflect updated language