### PR TITLE
fix: disclose hourly GitHub update check; use REST API for PR edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ gstack includes **opt-in** usage telemetry to help improve the project. Here's e
 - **What's sent (if you opt in):** skill name, duration, success/fail, gstack version, OS. That's it.
 - **What's never sent:** code, file paths, repo names, branch names, prompts, or any user-generated content.
 - **Change anytime:** `gstack-config set telemetry off` disables everything instantly.
+- **Update checks:** Once per hour, gstack fetches the current version number from GitHub to check for updates. This is a plain GET request that reveals your IP to GitHub. Set `update_check: false` to disable it entirely.
 
 Data is stored in [Supabase](https://supabase.com) (open source Firebase alternative). The schema is in [`supabase/migrations/`](supabase/migrations/) — you can verify exactly what's collected. The Supabase publishable key in the repo is a public key (like a Firebase API key) — row-level security policies deny all direct access. Telemetry flows through validated edge functions that enforce schema checks, event type allowlists, and field length limits.
 

--- a/ship/SKILL.md.tmpl
+++ b/ship/SKILL.md.tmpl
@@ -768,9 +768,9 @@ gh pr view --json url,number,state -q 'if .state == "OPEN" then "PR #\(.number):
 glab mr view -F json 2>/dev/null | jq -r 'if .state == "opened" then "MR_EXISTS" else "NO_MR" end' 2>/dev/null || echo "NO_MR"
 ```
 
-If an **open** PR/MR already exists: **update** the PR body using `gh pr edit --body "..."` (GitHub) or `glab mr update -d "..."` (GitLab). Always regenerate the PR body from scratch using this run's fresh results (test output, coverage audit, review findings, adversarial review, TODOS summary, documentation_section from Step 18). Never reuse stale PR body content from a prior run. Print the existing URL and continue to Step 20.
+If an **open** PR/MR already exists: **update** the PR body using `gh api -X PATCH repos/owner/repo/pulls/N -F body=@body.md` (GitHub) or `glab mr update -d "..."` (GitLab). Always regenerate the PR body from scratch using this run's fresh results (test output, coverage audit, review findings, adversarial review, TODOS summary, documentation_section from Step 18). Never reuse stale PR body content from a prior run. Print the existing URL and continue to Step 20.
 
-If no PR/MR exists: create a pull request (GitHub) or merge request (GitLab) using the platform detected in Step 0.
+If no PR/MR exists: create a pull request using `gh api -X POST repos/owner/repo/pulls -F title="$(git log <base>..HEAD --format=%s | head -1)" -F body=@body.md -F head="$(git branch --show-current)" -F base=<base>` (GitHub) or create a merge request (GitLab) using the platform detected in Step 0.
 
 The PR/MR body should contain these sections:
 


### PR DESCRIPTION
## Summary

- Add update check disclosure to README privacy section: explains the hourly GitHub VERSION fetch and update_check:false escape hatch (fixes #1081)
- Replace deprecated gh pr edit with gh api REST calls in /ship Step 19 (fixes #1079)
- Replace gh pr create with REST API equivalent for new PR creation

## Issues

- Fixes #1081 - Undisclosed hourly GitHub network call in every skill preamble
- Fixes #1079 - /ship Step 19: gh pr edit fails on repos with deprecated GraphQL Projects classic fields

## Test plan

- Verify README privacy section mentions update check
- bun run gen:skill-docs regenerates SKILL.md with updated ship template