### PR TITLE
fix(codex): add AskUserQuestion→request_user_input tool rewrite

### DIFF
--- a/hosts/codex.ts
+++ b/hosts/codex.ts
@@ -31,6 +31,10 @@ const codex: HostConfig = {
     { from: '.claude/skills', to: '.agents/skills' },
   ],
 
+  toolRewrites: {
+    'AskUserQuestion': 'request_user_input',
+  },
+
   suppressedResolvers: [
     'DESIGN_OUTSIDE_VOICES',  // design.ts:485 — Codex can't invoke itself
     'ADVERSARIAL_STEP',       // review.ts:408 — Codex can't invoke itself


### PR DESCRIPTION
## Summary

Issue #1066 — Codex skills that call `AskUserQuestion` silently fail in Default mode because:

1. Codex strips `AskUserQuestion` from the tool schema in Default mode
2. Its equivalent (`request_user_input`) only works in Plan mode
3. The codex host config had no `toolRewrites` entry to handle this

The `HostConfig` interface already supports `toolRewrites` — `gbrain`, `openclaw`, `factory`, and `hermes` all use it. The `codex.ts` host config was simply missing it.

## Fix

Added `toolRewrites: { 'AskUserQuestion': 'request_user_input' }` to `hosts/codex.ts`. When `gen-skill-docs.ts` applies rewrites at Codex skill generation time, any prompt text referencing `AskUserQuestion` gets replaced with Codex's equivalent.

## What this fixes

- Skills like `/codex` (which calls `AskUserQuestion` unconditionally at `codex/SKILL.md.tmpl:102-114`) now rewrite the tool name to `request_user_input` in generated Codex skills
- Other skills that reference `AskUserQuestion` in their prompt bodies will also be rewritten

## What this doesn't fix (out of scope)

A complete fix would also need the Plan-mode gate in the preamble (Option 4 in #1066), which requires Codex-side `default_mode_request_user_input` feature flag changes outside gstack's control. This PR handles the text rewrite that gstack controls.

## Test plan

- [ ] Verify `hosts/codex.ts` has `toolRewrites: { 'AskUserQuestion': 'request_user_input' }`
- [ ] Run `bun run gen:skill-docs --host codex` and check generated skill for rewritten tool reference
- [ ] Verify Codex Default mode no longer tries to call non-existent `AskUserQuestion` tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)