### PR TITLE
fix(ship): read test command from CLAUDE.md instead of hardcoding Rails+Node commands

### DIFF
--- a/ship/SKILL.md.tmpl
+++ b/ship/SKILL.md.tmpl
@@ -147,19 +147,23 @@ git fetch origin <base> && git merge origin/<base> --no-edit
 
 ## Step 5: Run tests (on merged code)
 
-**Do NOT run `RAILS_ENV=test bin/rails db:migrate`** — `bin/test-lane` already calls
+**Do NOT run `RAILS_ENV=test bin/rails db:migrate`** — test-lane already calls
 `db:test:prepare` internally, which loads the schema into the correct lane database.
 Running bare test migrations without INSTANCE hits an orphan DB and corrupts structure.sql.
 
-Run both test suites in parallel:
+**Read the test command from CLAUDE.md:**
 
 ```bash
-bin/test-lane 2>&1 | tee /tmp/ship_tests.txt &
-npm run test 2>&1 | tee /tmp/ship_vitest.txt &
-wait
+grep -A2 '## Testing' CLAUDE.md 2>/dev/null | head -20
 ```
 
-After both complete, read the output files and check pass/fail.
+If `## Testing` section exists with a run command: use that command.
+If missing: search the project for the appropriate test command (look for package.json test script, Gemfile with rake tasks, pytest configuration, etc.) and use what you find.
+If no test framework found: print "No test framework detected — skipping Step 5." and continue to Step 6.
+
+Run the test command and tee output to /tmp/ship_tests.txt.
+
+After tests complete, read the output and check pass/fail.
 
 **If any test fails:** Do NOT immediately stop. Apply the Test Failure Ownership Triage:
 


### PR DESCRIPTION
## Summary

Issue #1069 — `/ship` Step 5 hardcodes `bin/test-lane` + `npm run test` regardless of detected framework.

Step 4's `TEST_BOOTSTRAP` correctly detects the runtime, but Step 5 ignores it and unconditionally runs both commands. This violates the project's own platform-agnostic design rule in `CLAUDE.md`:

> Skills must NEVER hardcode framework-specific commands, file patterns, or directory structures. Instead:
> 1. **Read CLAUDE.md** for project-specific config (test commands, eval commands, etc.)
> 2. **If missing, AskUserQuestion** — let the user tell you or let gstack search the repo
> 3. **Persist the answer to CLAUDE.md** so we never have to ask again

In a Django project, `bin/test-lane` (Rails-specific) and `npm run test` (Node-specific) both fail silently with non-existent commands. The issue reporter hit this while shipping a Django app.

## Fix

Replaced the hardcoded dual-command block in `ship/SKILL.md.tmpl` Step 5 with a `CLAUDE.md`-first lookup (matching `TEST_COVERAGE_AUDIT_SHIP`'s existing pattern):

```bash
grep -A2 '## Testing' CLAUDE.md 2>/dev/null | head -20
```

- If `## Testing` section exists with a run command: use that command
- If missing: search the project for the appropriate test command
- If no test framework found: print "No test framework detected — skipping Step 5." and continue to Step 6

This ensures the test execution follows the same platform-agnostic pattern that the coverage audit already uses.

## Test plan

- [ ] Verify `ship/SKILL.md.tmpl` no longer contains hardcoded `bin/test-lane` or `npm run test` in Step 5
- [ ] Run `/ship` in a non-Rails, non-Node project — Step 5 should read CLAUDE.md for the test command
- [ ] Run `/ship` in a Rails project — should still find and execute the correct test command
- [ ] Verify the skip message appears when no test framework is detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)