### PR TITLE
security: validate --from-file payload paths for parity with direct paths

### DIFF
--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -8,7 +8,7 @@ import { getCleanText } from './read-commands';
 import { READ_COMMANDS, WRITE_COMMANDS, META_COMMANDS, PAGE_CONTENT_COMMANDS, wrapUntrustedContent, canonicalizeCommand } from './commands';
 import { validateNavigationUrl } from './url-validation';
 import { checkScope, type TokenInfo } from './token-registry';
-import { validateOutputPath, escapeRegExp } from './path-security';
+import { validateOutputPath, validateReadPath, SAFE_DIRECTORIES, escapeRegExp } from './path-security';
 // Re-export for backward compatibility (tests import from meta-commands)
 export { validateOutputPath, escapeRegExp } from './path-security';
 import * as Diff from 'diff';
@@ -134,6 +134,17 @@ function parsePdfArgs(args: string[]): ParsedPdfArgs {
 }
 
 function parsePdfFromFile(payloadPath: string): ParsedPdfArgs {
+  // Parity with load-html --from-file (browse/src/write-commands.ts) and
+  // the direct load-html <file> path: every caller-supplied file path
+  // must pass validateReadPath so the safe-dirs policy can't be skirted
+  // by routing reads through the --from-file shortcut.
+  try {
+    validateReadPath(path.resolve(payloadPath));
+  } catch {
+    throw new Error(
+      `pdf: --from-file ${payloadPath} must be under ${SAFE_DIRECTORIES.join(' or ')} (security policy). Copy the payload into the project tree or /tmp first.`
+    );
+  }
   const raw = fs.readFileSync(payloadPath, 'utf8');
   const json = JSON.parse(raw);
   const out: ParsedPdfArgs = {

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -188,6 +188,19 @@ export async function handleWriteCommand(
         if (args[i] === '--from-file') {
           const payloadPath = args[++i];
           if (!payloadPath) throw new Error('load-html: --from-file requires a path');
+          // Parity with the sibling `load-html <file>` path below (line 249):
+          // that branch runs every `file://` target through validateReadPath
+          // so the safe-dirs policy can't be side-stepped. Same policy must
+          // apply here — otherwise --from-file becomes a read-anywhere escape
+          // hatch for any caller that can pick the payload path (e.g., an
+          // MCP caller issuing load-html with an attacker-influenced path).
+          try {
+            validateReadPath(path.resolve(payloadPath));
+          } catch {
+            throw new Error(
+              `load-html: --from-file ${payloadPath} must be under ${SAFE_DIRECTORIES.join(' or ')} (security policy). Copy the payload into the project tree or /tmp first.`
+            );
+          }
           const raw = fs.readFileSync(payloadPath, 'utf8');
           let json: any;
           try { json = JSON.parse(raw); }

--- a/browse/test/from-file-path-validation.test.ts
+++ b/browse/test/from-file-path-validation.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Source-level guardrail for the --from-file shortcut flags.
+ *
+ * Context: both `load-html <file>` (write-commands.ts) and `pdf <url>`
+ * (meta-commands.ts) support a `--from-file <payload.json>` shortcut that
+ * reads a JSON payload with the inline content (HTML body / PDF options).
+ * The DIRECT `load-html <file>` path runs every caller-supplied file path
+ * through `validateReadPath()` so reads are confined to SAFE_DIRECTORIES.
+ * The `--from-file` paths historically skipped this validation, opening a
+ * parity gap: an MCP caller that can pick the payload path could route
+ * reads through --from-file to bypass the safe-dirs policy.
+ *
+ * This test inspects the source to make sure both --from-file sites call
+ * validateReadPath before fs.readFileSync. Pattern mirrors
+ * postgres-engine.test.ts and pglite-search-timeout.test.ts.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(import.meta.dir, '..', 'src');
+const WRITE_SRC = readFileSync(join(ROOT, 'write-commands.ts'), 'utf-8');
+const META_SRC  = readFileSync(join(ROOT, 'meta-commands.ts'), 'utf-8');
+
+function stripComments(s: string): string {
+  return s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|\s)\/\/[^\n]*/g, '$1');
+}
+
+describe('--from-file path validation parity', () => {
+  test('load-html --from-file validates payload path before reading', () => {
+    const stripped = stripComments(WRITE_SRC);
+    // Grab the --from-file branch body.
+    const idx = stripped.indexOf("'--from-file'");
+    expect(idx).toBeGreaterThan(-1);
+    const fromFileBranch = stripped.slice(idx, idx + 1200);
+
+    // validateReadPath must appear BEFORE the readFileSync in the branch.
+    const vIdx = fromFileBranch.indexOf('validateReadPath');
+    const rIdx = fromFileBranch.indexOf('readFileSync');
+    expect(vIdx).toBeGreaterThan(-1);
+    expect(rIdx).toBeGreaterThan(-1);
+    expect(vIdx).toBeLessThan(rIdx);
+  });
+
+  test('pdf --from-file validates payload path before reading', () => {
+    const stripped = stripComments(META_SRC);
+    const idx = stripped.indexOf('function parsePdfFromFile');
+    expect(idx).toBeGreaterThan(-1);
+    const fnBody = stripped.slice(idx, idx + 1200);
+
+    const vIdx = fnBody.indexOf('validateReadPath');
+    const rIdx = fnBody.indexOf('readFileSync');
+    expect(vIdx).toBeGreaterThan(-1);
+    expect(rIdx).toBeGreaterThan(-1);
+    expect(vIdx).toBeLessThan(rIdx);
+  });
+
+  test('both sites reference SAFE_DIRECTORIES in the error message', () => {
+    // Error shape parity so ops teams / agents see a consistent message.
+    const write = stripComments(WRITE_SRC);
+    const meta = stripComments(META_SRC);
+    // load-html --from-file error
+    expect(write).toMatch(/load-html: --from-file [\s\S]{0,80}SAFE_DIRECTORIES/);
+    // pdf --from-file error
+    expect(meta).toMatch(/pdf: --from-file [\s\S]{0,80}SAFE_DIRECTORIES/);
+  });
+});


### PR DESCRIPTION
## Summary

Both `load-html --from-file <payload.json>` (`browse/src/write-commands.ts`) and
`pdf --from-file <payload.json>` (`browse/src/meta-commands.ts`) read the
payload file straight through `fs.readFileSync()` without any path
validation. The direct `load-html <file>` path next to it (in the same
function, ~60 lines below) runs every caller-supplied path through
`validateReadPath()` so reads stay confined to `SAFE_DIRECTORIES`
(`cwd`, `TEMP_DIR`). The parity gap means `--from-file` is a
read-anywhere escape hatch for any caller that can pick the payload
path.

This PR brings the shortcut flags up to the same policy.

## Root cause (same shape as R3 F002 / F008)

The recent security audits keep finding the same pattern: a defense
exists on the primary path and is missing from a sibling shortcut.

- R3 F002: `validateNavigationUrl` ran on `goto` but not on
  `download` / `scrape` (tracked in #1029).
- R3 F008: `markHiddenElements` ran for `text` but not for 10 other
  DOM-reading commands (tracked in #1032).

Here: `validateReadPath` runs for `load-html <file>` but not for
`load-html --from-file <payload>` or `pdf --from-file <payload>`.
Same class of miss, same class of fix.

## The gap

`browse/src/write-commands.ts` (load-html), before this PR:

```ts
if (args[i] === '--from-file') {
  const payloadPath = args[++i];
  if (!payloadPath) throw new Error('load-html: --from-file requires a path');
  const raw = fs.readFileSync(payloadPath, 'utf8');   // <-- no validateReadPath
  // ...
}
// ... ~60 lines later, the direct-path branch:
const absolutePath = path.resolve(filePath);
try {
  validateReadPath(absolutePath);                     // <-- guarded here
} catch (e: any) { /* actionable error */ }
```

`browse/src/meta-commands.ts` (pdf), before this PR:

```ts
function parsePdfFromFile(payloadPath: string): ParsedPdfArgs {
  const raw = fs.readFileSync(payloadPath, 'utf8');   // <-- no validateReadPath
  const json = JSON.parse(raw);
  // ...
}
```

## Threat model

An attacker-influenced caller (MCP tool call whose arguments come from
agent context that can be prompt-injected) picks an arbitrary
`--from-file` path. Even when the JSON parse later fails on a target
that isn't valid JSON with an `html` / PDF-options field, the file has
already been read into process memory and error shapes can leak
presence/permissions. In tightened deployments where `SAFE_DIRECTORIES`
is the trust boundary between project files and the user's home, the
shortcut flags silently skip that boundary.

Severity is LOW on its own (defense-in-depth for the policy; no direct
content exfil channel on a typical target). Bundling it is cheap.

## Fix

Add `validateReadPath(path.resolve(payloadPath))` before `readFileSync`
in both sites, with a `SAFE_DIRECTORIES`-aware error message that
matches the direct-path branch so operators and agents see a consistent
error shape.

## Test plan

New file: `browse/test/from-file-path-validation.test.ts` (pattern matches
`browse/test/path-validation.test.ts` and `browse/test/content-security.test.ts`).

- [x] Source-level: `validateReadPath` precedes `readFileSync` in the
      `load-html --from-file` branch.
- [x] Source-level: `validateReadPath` precedes `readFileSync` in
      `parsePdfFromFile()`.
- [x] Error-shape parity: both sites reference `SAFE_DIRECTORIES` in the
      thrown error so the UX matches the direct path.
- [x] `bun test -- browse/test/from-file-path-validation.test.ts
      browse/test/path-validation.test.ts browse/test/content-security.test.ts
      browse/test/adversarial-security.test.ts` — 81 pass / 0 fail.

## Risk

- `validateReadPath` is already imported in `write-commands.ts`; the
  `meta-commands.ts` change adds two symbols to an existing import. No
  new dependencies.
- Runtime cost: one `path.resolve` + one `realpathSync` per `--from-file`
  call (same cost as the direct path).
- Backward compatibility: callers that previously passed payload paths
  outside `SAFE_DIRECTORIES` will now see the `Path must be within: ...`
  error with guidance to copy the payload into cwd or `TEMP_DIR`. Same
  behavior the direct `load-html <file>` path has had since
  `path-security.ts` landed.

## Notes

Flagged during an ongoing security parity audit. Happy to rebase on
request or split into two PRs (one per file) if that is easier to
review.