### PR TITLE
feat: add yc_promo config flag to opt out of YC pitch

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -107,6 +107,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -116,6 +116,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -109,6 +109,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -109,6 +109,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/bin/gstack-config
+++ b/bin/gstack-config
@@ -59,6 +59,11 @@ CONFIG_HEADER='# gstack configuration — edit freely, changes take effect on ne
 #                           # Unknown values default to "default" with a warning.
 #                           # See docs/designs/PLAN_TUNING_V1.md for rationale.
 #
+# ─── Promotional ─────────────────────────────────────────────────────
+# yc_promo: true            # false = skip YC pitch + founder resources in /office-hours
+#                           # The pitch and resources still exist in the template,
+#                           # but are skipped at runtime when this is false.
+#
 # ─── Advanced ────────────────────────────────────────────────────────
 # codex_reviews: enabled    # disabled = skip Codex adversarial reviews in /ship
 # gstack_contributor: false # true = file field reports when gstack misbehaves
@@ -82,6 +87,7 @@ lookup_default() {
     codex_reviews) echo "enabled" ;;
     gstack_contributor) echo "false" ;;
     skip_eng_review) echo "false" ;;
+    yc_promo) echo "true" ;;
     cross_project_learnings) echo "" ;; # intentionally empty → unset triggers first-time prompt
     *) echo "" ;;
   esac
@@ -141,7 +147,7 @@ case "${1:-}" in
     echo ""
     echo "# ─── Active values (including defaults for unset keys) ───"
     for KEY in proactive routing_declined telemetry auto_upgrade update_check \
-               skill_prefix checkpoint_mode checkpoint_push codex_reviews \
+               skill_prefix checkpoint_mode checkpoint_push yc_promo codex_reviews \
                gstack_contributor skip_eng_review; do
       VALUE=$(grep -E "^${KEY}:" "$CONFIG_FILE" 2>/dev/null | tail -1 | awk '{print $2}' | tr -d '[:space:]' || true)
       SOURCE="default"
@@ -156,7 +162,7 @@ case "${1:-}" in
   defaults)
     echo "# gstack-config defaults"
     for KEY in proactive routing_declined telemetry auto_upgrade update_check \
-               skill_prefix checkpoint_mode checkpoint_push codex_reviews \
+               skill_prefix checkpoint_mode checkpoint_push yc_promo codex_reviews \
                gstack_contributor skip_eng_review; do
       printf '  %-24s %s\n' "$KEY:" "$(lookup_default "$KEY")"
     done

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -108,6 +108,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/browse/test/gstack-config.test.ts
+++ b/browse/test/gstack-config.test.ts
@@ -193,4 +193,27 @@ describe('gstack-config', () => {
     const { stdout } = run(['get', 'routing_declined']);
     expect(stdout).toBe('false');
   });
+
+  // ─── yc_promo ─────────────────────────────────────────────
+  test('yc_promo defaults to true', () => {
+    const { stdout } = run(['get', 'yc_promo']);
+    expect(stdout).toBe('true');
+  });
+
+  test('yc_promo can be set to false and read back', () => {
+    run(['set', 'yc_promo', 'false']);
+    const { stdout } = run(['get', 'yc_promo']);
+    expect(stdout).toBe('false');
+  });
+
+  test('yc_promo appears in list output', () => {
+    const { stdout } = run(['list']);
+    expect(stdout).toContain('yc_promo');
+  });
+
+  test('yc_promo appears in defaults output', () => {
+    const { stdout } = run(['defaults']);
+    expect(stdout).toContain('yc_promo');
+    expect(stdout).toContain('true');
+  });
 });

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -108,6 +108,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -110,6 +110,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -112,6 +112,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -112,6 +112,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -113,6 +113,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -113,6 +113,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -115,6 +115,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -113,6 +113,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -110,6 +110,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -113,6 +113,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -110,6 +110,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -110,6 +110,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -127,6 +127,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -107,6 +107,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -110,6 +110,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -108,6 +108,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -118,6 +118,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```
@@ -1833,6 +1836,12 @@ One more thing.
 
 **Beat 3: Garry's Personal Plea**
 
+If `YC_PROMO` is `false` (from preamble output), skip Beat 3 entirely and proceed
+to the next section (welcome_back / regular / inner_circle tier handling, or end).
+Do not mention YC, do not show the plea, do not show the apply link.
+
+_(To stop seeing this section in future sessions: `gstack-config set yc_promo false`)_
+
 Use the founder signal count from Phase 4.5 to select the right sub-tier.
 
 - **Top tier** (3+ signals AND named a specific user, revenue, or demand evidence):
@@ -1943,6 +1952,8 @@ Then proceed to Founder Resources below.
 ---
 
 ### Founder Resources (all tiers)
+
+If `YC_PROMO` is `false` (from preamble output), skip the Founder Resources section entirely.
 
 Share 2-3 resources from the pool below. For repeat users, resources compound by matching
 to accumulated session context, not just this session's category.

--- a/office-hours/SKILL.md.tmpl
+++ b/office-hours/SKILL.md.tmpl
@@ -670,6 +670,12 @@ One more thing.
 
 **Beat 3: Garry's Personal Plea**
 
+If `YC_PROMO` is `false` (from preamble output), skip Beat 3 entirely and proceed
+to the next section (welcome_back / regular / inner_circle tier handling, or end).
+Do not mention YC, do not show the plea, do not show the apply link.
+
+_(To stop seeing this section in future sessions: `gstack-config set yc_promo false`)_
+
 Use the founder signal count from Phase 4.5 to select the right sub-tier.
 
 - **Top tier** (3+ signals AND named a specific user, revenue, or demand evidence):
@@ -780,6 +786,8 @@ Then proceed to Founder Resources below.
 ---
 
 ### Founder Resources (all tiers)
+
+If `YC_PROMO` is `false` (from preamble output), skip the Founder Resources section entirely.
 
 Share 2-3 resources from the pool below. For repeat users, resources compound by matching
 to accumulated session context, not just this session's category.

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -107,6 +107,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -108,6 +108,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -114,6 +114,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -111,6 +111,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -115,6 +115,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -113,6 +113,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -121,6 +121,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -109,6 +109,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -115,6 +115,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -108,6 +108,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -112,6 +112,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/scripts/resolvers/preamble/generate-preamble-bash.ts
+++ b/scripts/resolvers/preamble/generate-preamble-bash.ts
@@ -99,6 +99,9 @@ _CHECKPOINT_MODE=$(${ctx.paths.binDir}/gstack-config get checkpoint_mode 2>/dev/
 _CHECKPOINT_PUSH=$(${ctx.paths.binDir}/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(${ctx.paths.binDir}/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true${ctx.host === 'gbrain' || ctx.host === 'hermes' ? `
 # GBrain health check (gbrain/hermes host only)

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -105,6 +105,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -111,6 +111,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -113,6 +113,9 @@ _CHECKPOINT_MODE=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_mode
 _CHECKPOINT_PUSH=$(~/.claude/skills/gstack/bin/gstack-config get checkpoint_push 2>/dev/null || echo "false")
 echo "CHECKPOINT_MODE: $_CHECKPOINT_MODE"
 echo "CHECKPOINT_PUSH: $_CHECKPOINT_PUSH"
+# YC promotional content (office-hours Beat 3 + founder resources)
+_YC_PROMO=$(~/.claude/skills/gstack/bin/gstack-config get yc_promo 2>/dev/null || echo "true")
+echo "YC_PROMO: $_YC_PROMO"
 # Detect spawned session (OpenClaw or other orchestrator)
 [ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
 ```

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -588,6 +588,13 @@ describe('v0.4.1 preamble features', () => {
       expect(content).toContain('NEEDS_CONTEXT');
     });
   }
+
+  for (const skill of skillsWithPreamble) {
+    test(`${skill} preamble reads YC_PROMO config`, () => {
+      const content = fs.readFileSync(path.join(ROOT, skill), 'utf-8');
+      expect(content).toContain('YC_PROMO');
+    });
+  }
 });
 
 // --- Structural tests for new skills ---
@@ -629,9 +636,14 @@ describe('office-hours skill structure', () => {
     expect(content).toContain('Intrapreneurship');
   });
 
-  // YC founder discovery engine
+  // YC founder discovery engine (gated by yc_promo config)
   test('contains YC apply CTA with ref tracking', () => {
     expect(content).toContain('ycombinator.com/apply?ref=gstack');
+  });
+
+  test('YC pitch is gated by YC_PROMO config flag', () => {
+    expect(content).toContain('YC_PROMO');
+    expect(content).toContain('gstack-config set yc_promo false');
   });
 
   test('contains "What I noticed" design doc section', () => {


### PR DESCRIPTION
## Summary

Power users who see the YC application pitch in `/office-hours` repeatedly find it off-putting. This PR adds a `yc_promo` config flag (default: `true`, preserving current behavior) that lets users opt out of Beat 3 (Garry's Personal Plea) and the Founder Resources pool.

When the pitch IS shown, it now includes a self-disable hint:
`gstack-config set yc_promo false`

This is better UX than users forking to remove it. I maintain a fork with a 710-line manifest of transforms just to strip this content. A config flag eliminates the need for that fork entirely.

**What changes:**
- `bin/gstack-config`: new `yc_promo` key (default: `true`) in defaults, header, list/defaults loops
- `scripts/resolvers/preamble/generate-preamble-bash.ts`: reads and echoes `_YC_PROMO`
- `office-hours/SKILL.md.tmpl`: conditional gate on Beat 3 + Founder Resources when `YC_PROMO` is `false`
- Tests: config round-trip, preamble variable presence, conditional gate validation

**What does NOT change:**
- Garry Tan attribution in voice directive stays
- "YC partner energy" tone direction stays
- All other YC references across skills stay
- Default behavior is identical to today

## Test plan

- [x] `bun test browse/test/gstack-config.test.ts` — 4 new yc_promo tests pass
- [x] `bun test test/skill-validation.test.ts` — 342 pass, 0 fail
- [x] `bun run gen:skill-docs` — all SKILL.md files regenerate with YC_PROMO variable
- [x] Manual: `gstack-config set yc_promo false` → run /office-hours → verify no Beat 3
- [x] Manual: `gstack-config set yc_promo true` → run /office-hours → verify Beat 3 + hint