### PR TITLE
fix(browse): log decrypt failures behind GSTACK_DEBUG in cookie-import

### DIFF
--- a/browse/src/cookie-import-browser.ts
+++ b/browse/src/cookie-import-browser.ts
@@ -279,8 +279,14 @@ export async function importCookies(
         const cookie = toPlaywrightCookie(row, value);
         cookies.push(cookie);
         domainCounts[row.host_key] = (domainCounts[row.host_key] || 0) + 1;
-      } catch {
+      } catch (err: any) {
         failed++;
+        if (process.env.GSTACK_DEBUG === '1' || process.env.DEBUG === '1') {
+          const code = err?.code ? ` [${err.code}]` : '';
+          console.error(
+            `[cookie-import] decrypt failed for ${row.host_key}/${row.name}${code}: ${err?.message ?? String(err)}`
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

The decrypt loop in `importCookies` uses a bare `catch {}` that swallows the error. The `failed` counter is surfaced in CLI output, but users have no visibility into which cookies failed or why, so partial-import bugs like #1057 become hard to diagnose.

Keep the counter, but log per-row detail on stderr when `GSTACK_DEBUG=1` or `DEBUG=1` is set. Output is byte-identical for the default path.

## Changes

`browse/src/cookie-import-browser.ts:282` - replace `catch {}` with a typed catch that logs `host_key/name` plus the error code and message when the debug env var is set. `importCookiesViaCdp` has no parallel bare-catch and is unchanged.

## Testing

- `bun test browse/test/cookie-import-browser.test.ts` - 22 pass, 0 fail
- `bun run build` - clean

The manual repro the reporter describes (`browse cookie-import-browser arc --domain slack.com --profile "Profile 14"`) needs a macOS keychain state that rotated at some point. With `GSTACK_DEBUG=1` set, every decrypt failure in that run will now print a line like:

```
[cookie-import] decrypt failed for .slack.com/d [EACCES]: Keychain entry not found
```

which is enough to distinguish Keychain rotation, v20 App-Bound Encryption, DB corruption, or a per-cookie format edge case.

Closes #1057

This contribution was developed with AI assistance (Codex).
