### PR TITLE
fix(office-hours): output full design doc inline before approval prompt

### DIFF
--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -1775,6 +1775,19 @@ Replace ITERATIONS, FOUND, FIXED, REMAINING, SCORE with actual values from the r
 
 ---
 
+**Before asking for approval, output the full design doc inline.**
+
+Print the complete contents of the design doc as direct assistant text in the
+conversation — do NOT ask the user to open the file, and do NOT rely on a
+`Bash cat` or `Read` tool call to show it. Tool outputs are frequently
+collapsed in the Claude Code UI, which leaves the user approving a document
+they cannot actually see. The one place the full doc is guaranteed to render
+is the assistant message itself.
+
+Format: a short preamble (`Here is the design doc saved to {path} — please
+review before approving:`) followed by the verbatim document body. Then
+proceed to the AskUserQuestion below.
+
 Present the reviewed design doc to the user via AskUserQuestion:
 - A) Approve — mark Status: APPROVED and proceed to handoff
 - B) Revise — specify which sections need changes (loop back to revise those sections)

--- a/office-hours/SKILL.md.tmpl
+++ b/office-hours/SKILL.md.tmpl
@@ -612,6 +612,19 @@ Supersedes: {prior filename — omit this line if first design on this branch}
 
 ---
 
+**Before asking for approval, output the full design doc inline.**
+
+Print the complete contents of the design doc as direct assistant text in the
+conversation — do NOT ask the user to open the file, and do NOT rely on a
+`Bash cat` or `Read` tool call to show it. Tool outputs are frequently
+collapsed in the Claude Code UI, which leaves the user approving a document
+they cannot actually see. The one place the full doc is guaranteed to render
+is the assistant message itself.
+
+Format: a short preamble (`Here is the design doc saved to {path} — please
+review before approving:`) followed by the verbatim document body. Then
+proceed to the AskUserQuestion below.
+
 Present the reviewed design doc to the user via AskUserQuestion:
 - A) Approve — mark Status: APPROVED and proceed to handoff
 - B) Revise — specify which sections need changes (loop back to revise those sections)


### PR DESCRIPTION
Closes #879.

## Problem

When `/office-hours` finishes Phase 5 (Design Doc) and asks the user for approval via `AskUserQuestion`, the user often cannot see the document content. Tool outputs (e.g. `Bash cat`, `Read`) are frequently collapsed in the Claude Code UI, so the design doc the skill just wrote is effectively invisible at the exact moment the user has to approve / revise / start over. The current flow leaves users repeatedly asking "show me the full doc" before they can decide.

## Fix

Add an explicit instruction in the office-hours Phase 5 template, placed immediately after `{{SPEC_REVIEW_LOOP}}` and immediately before the Approve / Revise / Start over `AskUserQuestion`:

> **Before asking for approval, output the full design doc inline.**
>
> Print the complete contents of the design doc as direct assistant text in the conversation — do NOT ask the user to open the file, and do NOT rely on a `Bash cat` or `Read` tool call to show it. Tool outputs are frequently collapsed in the Claude Code UI, which leaves the user approving a document they cannot actually see. The one place the full doc is guaranteed to render is the assistant message itself.
>
> Format: a short preamble (\`Here is the design doc saved to {path} — please review before approving:\`) followed by the verbatim document body. Then proceed to the AskUserQuestion below.

Assistant messages render reliably, so the user can actually read the doc at the moment of approval.

## Scope

- Edit `office-hours/SKILL.md.tmpl` (the source of truth).
- Regenerate `office-hours/SKILL.md` via `bun run gen:skill-docs --host all`.
- No code, no tests, no other skills touched.

## Diff stat

```
 office-hours/SKILL.md      | 13 +++++++++++++
 office-hours/SKILL.md.tmpl | 13 +++++++++++++
 2 files changed, 26 insertions(+)
```

## Test plan

- [x] `bun run gen:skill-docs --host all` completes cleanly and updates `office-hours/SKILL.md` to match the new template text at the Phase 5 approval step.
- [ ] Next `/office-hours` session on a real project — confirm the assistant prints the full design doc inline before the Approve / Revise / Start over question.

Made with [Cursor](https://cursor.com)