### PR TITLE
fix(make-pdf): Windows .exe resolution for browse + pdftotext

### DIFF
--- a/make-pdf/src/browseClient.ts
+++ b/make-pdf/src/browseClient.ts
@@ -100,6 +100,9 @@ export function resolveBrowseBin(): string {
     // non-zero exit; fall through to error
   }
 
+  const setCmd = process.platform === "win32"
+    ? '  setx BROWSE_BIN "C:\\path\\to\\browse.exe"'
+    : "  export BROWSE_BIN=/path/to/browse";
   throw new BrowseClientError(
     /* exitCode */ 127,
     "resolve",
@@ -107,6 +110,7 @@ export function resolveBrowseBin(): string {
       "browse binary not found.",
       "",
       "make-pdf needs browse (the gstack Chromium daemon) to render PDFs.",
+      `Platform: ${process.platform}`,
       "Tried:",
       `  - $BROWSE_BIN (${envOverride || "unset"})`,
       `  - sibling: ${siblingCandidates.join(", ")}`,
@@ -117,7 +121,7 @@ export function resolveBrowseBin(): string {
       "  cd ~/.claude/skills/gstack && ./setup",
       "",
       "Or set BROWSE_BIN explicitly:",
-      "  export BROWSE_BIN=/path/to/browse",
+      setCmd,
     ].join("\n"),
   );
 }

--- a/make-pdf/src/browseClient.ts
+++ b/make-pdf/src/browseClient.ts
@@ -60,7 +60,10 @@ export interface JsOptions {
  */
 export function resolveBrowseBin(): string {
   const envOverride = process.env.BROWSE_BIN;
-  if (envOverride && isExecutable(envOverride)) return envOverride;
+  if (envOverride) {
+    const resolved = findExecutable(envOverride);
+    if (resolved) return resolved;
+  }
 
   // Sibling: look relative to this process's binary
   // (for when make-pdf and browse live next to each other in dist/)
@@ -71,20 +74,30 @@ export function resolveBrowseBin(): string {
     path.resolve(selfDir, "../browse"),
   ];
   for (const candidate of siblingCandidates) {
-    if (isExecutable(candidate)) return candidate;
+    const resolved = findExecutable(candidate);
+    if (resolved) return resolved;
   }
 
   // Global install
   const home = os.homedir();
   const globalPath = path.join(home, ".claude/skills/gstack/browse/dist/browse");
-  if (isExecutable(globalPath)) return globalPath;
+  const globalResolved = findExecutable(globalPath);
+  if (globalResolved) return globalResolved;
 
-  // PATH lookup
+  // PATH lookup — use `where` on Windows (native, always in System32),
+  // `which` on POSIX. Git Bash provides `which` too, but Windows users
+  // running from cmd.exe or PowerShell don't have it.
+  const pathLookupCmd = process.platform === "win32" ? "where" : "which";
   try {
-    const which = execFileSync("which", ["browse"], { encoding: "utf8" }).trim();
-    if (which && isExecutable(which)) return which;
+    const out = execFileSync(pathLookupCmd, ["browse"], { encoding: "utf8" }).trim();
+    // `where` can return multiple matches; take the first.
+    const firstHit = out.split(/\r?\n/)[0]?.trim();
+    if (firstHit) {
+      const resolved = findExecutable(firstHit);
+      if (resolved) return resolved;
+    }
   } catch {
-    // `which` exited non-zero; fall through to error
+    // non-zero exit; fall through to error
   }
 
   throw new BrowseClientError(
@@ -98,7 +111,7 @@ export function resolveBrowseBin(): string {
       `  - $BROWSE_BIN (${envOverride || "unset"})`,
       `  - sibling: ${siblingCandidates.join(", ")}`,
       `  - global: ${globalPath}`,
-      "  - PATH: `browse`",
+      `  - PATH: \`browse\` (via ${pathLookupCmd})`,
       "",
       "To fix: run gstack setup from the gstack repo:",
       "  cd ~/.claude/skills/gstack && ./setup",
@@ -107,6 +120,36 @@ export function resolveBrowseBin(): string {
       "  export BROWSE_BIN=/path/to/browse",
     ].join("\n"),
   );
+}
+
+/**
+ * Resolve a base path to an executable, probing platform-specific extensions.
+ *
+ * On win32, probes `{base}.exe`, `{base}.cmd`, `{base}.bat` in addition to
+ * `{base}` so callers can pass POSIX-style candidate paths and still hit
+ * Windows artifacts (bun --compile emits `.exe`, batch wrappers are common).
+ *
+ * Returns the resolved path or null if nothing is executable.
+ *
+ * Why this exists: on Windows, `fs.constants.X_OK` is degraded to an
+ * existence check (the Node docs are explicit:
+ * https://nodejs.org/api/fs.html#fsaccesspath-mode-callback —
+ * "On Windows, the file system accessibility checks can behave differently.
+ * For example, changing visibility using chmod does not update read and
+ * write permissions... Only the presence of the read-only attribute is
+ * reflected."). So `isExecutable("/path/to/browse")` returns false when
+ * the actual file on disk is `/path/to/browse.exe` — the extension probe
+ * is the only thing that closes the gap.
+ */
+export function findExecutable(base: string): string | null {
+  if (isExecutable(base)) return base;
+  if (process.platform === "win32") {
+    for (const ext of [".exe", ".cmd", ".bat"]) {
+      const withExt = base + ext;
+      if (isExecutable(withExt)) return withExt;
+    }
+  }
+  return null;
 }
 
 function isExecutable(p: string): boolean {

--- a/make-pdf/src/pdftotext.ts
+++ b/make-pdf/src/pdftotext.ts
@@ -84,11 +84,15 @@ export function resolvePdftotext(): PdftotextInfo {
     if (resolved) return describeBinary(resolved);
   }
 
+  const setCmd = process.platform === "win32"
+    ? '  setx PDFTOTEXT_BIN "C:\\path\\to\\pdftotext.exe"'
+    : "  export PDFTOTEXT_BIN=/path/to/pdftotext";
   throw new PdftotextUnavailableError([
     "pdftotext not found.",
     "",
     "make-pdf needs pdftotext to run the copy-paste CI gate.",
     "(Runtime rendering does NOT need it. This only affects tests.)",
+    `Platform: ${process.platform}`,
     "",
     "To install:",
     "  macOS:    brew install poppler",
@@ -98,7 +102,7 @@ export function resolvePdftotext(): PdftotextInfo {
     "            https://github.com/oschwartz10612/poppler-windows)",
     "",
     "Or set PDFTOTEXT_BIN to an explicit path:",
-    "  export PDFTOTEXT_BIN=/path/to/pdftotext",
+    setCmd,
   ].join("\n"));
 }
 

--- a/make-pdf/src/pdftotext.ts
+++ b/make-pdf/src/pdftotext.ts
@@ -15,9 +15,13 @@
  *
  * Resolution order for the pdftotext binary:
  *   1. $PDFTOTEXT_BIN env override
- *   2. `which pdftotext` on PATH
- *   3. standard Homebrew paths on macOS
+ *   2. PATH lookup (`which` on POSIX, `where` on Windows)
+ *   3. standard Homebrew / distro paths on macOS/Linux
  *   4. throws a friendly "install poppler" error
+ *
+ * On Windows, every probe also tries `.exe` / `.cmd` / `.bat` suffixes,
+ * so users can set `PDFTOTEXT_BIN=C:\tools\poppler\bin\pdftotext` and have
+ * it resolve to `pdftotext.exe` without the extension in the env var.
  *
  * The wrapper is *optional at runtime*: production renders don't need it.
  * Only the CI gate and unit tests invoke pdftotext.
@@ -46,26 +50,38 @@ export interface PdftotextInfo {
  */
 export function resolvePdftotext(): PdftotextInfo {
   const envOverride = process.env.PDFTOTEXT_BIN;
-  if (envOverride && isExecutable(envOverride)) {
-    return describeBinary(envOverride);
+  if (envOverride) {
+    const resolved = findExecutable(envOverride);
+    if (resolved) return describeBinary(resolved);
   }
 
-  // Try PATH
+  // PATH lookup — `where` on Windows (native, always in System32),
+  // `which` on POSIX. Git Bash provides `which` too, but cmd.exe and
+  // PowerShell don't.
+  const pathLookupCmd = process.platform === "win32" ? "where" : "which";
   try {
-    const which = execFileSync("which", ["pdftotext"], { encoding: "utf8" }).trim();
-    if (which && isExecutable(which)) return describeBinary(which);
+    const out = execFileSync(pathLookupCmd, ["pdftotext"], { encoding: "utf8" }).trim();
+    const firstHit = out.split(/\r?\n/)[0]?.trim();
+    if (firstHit) {
+      const resolved = findExecutable(firstHit);
+      if (resolved) return describeBinary(resolved);
+    }
   } catch {
     // fall through
   }
 
-  // Common macOS Homebrew locations
-  const macCandidates = [
-    "/opt/homebrew/bin/pdftotext",     // Apple Silicon
-    "/usr/local/bin/pdftotext",        // Intel Mac or Linuxbrew
+  // Common POSIX install locations (Homebrew, distro packages).
+  // Windows users rely on PATH + env override; Poppler distributions
+  // on Windows land in too many places to guess (Scoop, Chocolatey,
+  // oschwartz10612/poppler-windows standalone, portable zips).
+  const posixCandidates = [
+    "/opt/homebrew/bin/pdftotext",     // Apple Silicon Homebrew
+    "/usr/local/bin/pdftotext",        // Intel Mac / Linuxbrew
     "/usr/bin/pdftotext",              // distro package
   ];
-  for (const candidate of macCandidates) {
-    if (isExecutable(candidate)) return describeBinary(candidate);
+  for (const candidate of posixCandidates) {
+    const resolved = findExecutable(candidate);
+    if (resolved) return describeBinary(resolved);
   }
 
   throw new PdftotextUnavailableError([
@@ -75,13 +91,32 @@ export function resolvePdftotext(): PdftotextInfo {
     "(Runtime rendering does NOT need it. This only affects tests.)",
     "",
     "To install:",
-    "  macOS:  brew install poppler",
-    "  Ubuntu: sudo apt-get install poppler-utils",
-    "  Fedora: sudo dnf install poppler-utils",
+    "  macOS:    brew install poppler",
+    "  Ubuntu:   sudo apt-get install poppler-utils",
+    "  Fedora:   sudo dnf install poppler-utils",
+    "  Windows:  scoop install poppler  (or download from",
+    "            https://github.com/oschwartz10612/poppler-windows)",
     "",
     "Or set PDFTOTEXT_BIN to an explicit path:",
     "  export PDFTOTEXT_BIN=/path/to/pdftotext",
   ].join("\n"));
+}
+
+/**
+ * Resolve a base path to an executable, probing platform-specific extensions.
+ * See browseClient.findExecutable for the full rationale — this is a local
+ * duplicate to keep module independence (matches the existing `isExecutable`
+ * duplication pattern in this file and browseClient.ts).
+ */
+function findExecutable(base: string): string | null {
+  if (isExecutable(base)) return base;
+  if (process.platform === "win32") {
+    for (const ext of [".exe", ".cmd", ".bat"]) {
+      const withExt = base + ext;
+      if (isExecutable(withExt)) return withExt;
+    }
+  }
+  return null;
 }
 
 function isExecutable(p: string): boolean {

--- a/make-pdf/test/browseClient.test.ts
+++ b/make-pdf/test/browseClient.test.ts
@@ -5,9 +5,12 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
 import { BrowseClientError } from "../src/types";
-import { resolveBrowseBin } from "../src/browseClient";
+import { resolveBrowseBin, findExecutable } from "../src/browseClient";
 
 describe("resolveBrowseBin", () => {
   test("throws BrowseClientError with setup hint when nothing is found", () => {
@@ -43,18 +46,86 @@ describe("resolveBrowseBin", () => {
 
   test("honors BROWSE_BIN when it points at a real executable", () => {
     const originalEnv = process.env.BROWSE_BIN;
-    // `/bin/sh` exists on every POSIX system and is executable.
-    process.env.BROWSE_BIN = "/bin/sh";
+    // Pick a path that exists and is executable on the current platform.
+    // `/bin/sh` is universal on POSIX; `cmd.exe` ships with every Windows.
+    const realExe = process.platform === "win32"
+      ? "C:\\Windows\\System32\\cmd.exe"
+      : "/bin/sh";
+    process.env.BROWSE_BIN = realExe;
 
     try {
       const resolved = resolveBrowseBin();
-      expect(resolved).toBe("/bin/sh");
+      expect(resolved).toBe(realExe);
     } finally {
       if (originalEnv === undefined) {
         delete process.env.BROWSE_BIN;
       } else {
         process.env.BROWSE_BIN = originalEnv;
       }
+    }
+  });
+
+  test("on win32, honors BROWSE_BIN pointing at a base path that needs .exe", () => {
+    if (process.platform !== "win32") return;
+    const originalEnv = process.env.BROWSE_BIN;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "make-pdf-resolve-"));
+    const exePath = path.join(tmpDir, "browse.exe");
+    try {
+      fs.writeFileSync(exePath, "");
+      // Point BROWSE_BIN at the base path WITHOUT .exe — mirrors the real
+      // failure Sam hit with BROWSE_BIN=/c/.../dist/browse when the on-disk
+      // artifact was browse.exe (https://github.com/garrytan/gstack/pull/???).
+      process.env.BROWSE_BIN = path.join(tmpDir, "browse");
+      const resolved = resolveBrowseBin();
+      expect(resolved).toBe(exePath);
+    } finally {
+      if (originalEnv === undefined) delete process.env.BROWSE_BIN;
+      else process.env.BROWSE_BIN = originalEnv;
+      try { fs.unlinkSync(exePath); } catch { /* best-effort */ }
+      try { fs.rmdirSync(tmpDir); } catch { /* best-effort */ }
+    }
+  });
+});
+
+describe("findExecutable", () => {
+  test("returns the path as-is when it's directly executable", () => {
+    const probe = process.platform === "win32"
+      ? "C:\\Windows\\System32\\cmd.exe"
+      : "/bin/sh";
+    expect(findExecutable(probe)).toBe(probe);
+  });
+
+  test("returns null when the path does not exist in any known form", () => {
+    expect(findExecutable("/nonexistent/definitely-not-here")).toBeNull();
+  });
+
+  test("on win32, probes .exe when the bare path is missing", () => {
+    if (process.platform !== "win32") return;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "make-pdf-findexe-"));
+    const exePath = path.join(tmpDir, "fake-browse.exe");
+    try {
+      fs.writeFileSync(exePath, "");
+      // Base path WITHOUT .exe — exactly how the hardcoded sibling and
+      // global candidates inside resolveBrowseBin probe for the binary.
+      const resolved = findExecutable(path.join(tmpDir, "fake-browse"));
+      expect(resolved).toBe(exePath);
+    } finally {
+      try { fs.unlinkSync(exePath); } catch { /* best-effort */ }
+      try { fs.rmdirSync(tmpDir); } catch { /* best-effort */ }
+    }
+  });
+
+  test("on win32, probes .cmd and .bat as well as .exe", () => {
+    if (process.platform !== "win32") return;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "make-pdf-findexe-"));
+    const cmdPath = path.join(tmpDir, "wrapper.cmd");
+    try {
+      fs.writeFileSync(cmdPath, "@echo off\r\n");
+      const resolved = findExecutable(path.join(tmpDir, "wrapper"));
+      expect(resolved).toBe(cmdPath);
+    } finally {
+      try { fs.unlinkSync(cmdPath); } catch { /* best-effort */ }
+      try { fs.rmdirSync(tmpDir); } catch { /* best-effort */ }
     }
   });
 });

--- a/make-pdf/test/pdftotext.test.ts
+++ b/make-pdf/test/pdftotext.test.ts
@@ -7,8 +7,11 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
-import { normalize, copyPasteGate } from "../src/pdftotext";
+import { normalize, copyPasteGate, resolvePdftotext } from "../src/pdftotext";
 
 describe("normalize", () => {
   test("strips trailing spaces", () => {
@@ -102,5 +105,28 @@ describe("copyPasteGate — assertion logic", () => {
     expect(Math.abs(expectedBreaks - tooFewBreaks)).toBeGreaterThan(1);
     // After normalize, 3+ newlines become 2, so the count matches
     expect(Math.abs(expectedBreaks - tooManyBreaksNormalized)).toBeLessThanOrEqual(4);
+  });
+});
+
+describe("resolvePdftotext", () => {
+  test("on win32, honors PDFTOTEXT_BIN pointing at a base path that needs .exe", () => {
+    if (process.platform !== "win32") return;
+    const originalEnv = process.env.PDFTOTEXT_BIN;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pdftotext-resolve-"));
+    const exePath = path.join(tmpDir, "pdftotext.exe");
+    try {
+      // Empty .exe is fine — describeBinary() swallows the non-zero exit
+      // from `bin -v` and returns version: "unknown". We only assert on
+      // the resolved path.
+      fs.writeFileSync(exePath, "");
+      process.env.PDFTOTEXT_BIN = path.join(tmpDir, "pdftotext");
+      const info = resolvePdftotext();
+      expect(info.bin).toBe(exePath);
+    } finally {
+      if (originalEnv === undefined) delete process.env.PDFTOTEXT_BIN;
+      else process.env.PDFTOTEXT_BIN = originalEnv;
+      try { fs.unlinkSync(exePath); } catch { /* best-effort */ }
+      try { fs.rmdirSync(tmpDir); } catch { /* best-effort */ }
+    }
   });
 });


### PR DESCRIPTION
## Summary

On Windows, `make-pdf generate` fails with `browse binary not found` even after a successful `./setup`. The resolution logic in `make-pdf/src/browseClient.ts` probes bare paths (`browse`, `$selfDir/../browse/dist/browse`, `~/.claude/skills/gstack/browse/dist/browse`), but `bun build --compile --outfile browse/dist/browse` emits `browse/dist/browse.exe` on Windows, so every probe misses.

Repro (Windows, bun 1.3.11, gstack v1.5.1.0, Node v25+):

```console
$ ~/.claude/skills/gstack/make-pdf/dist/pdf.exe generate in.md out.pdf
Reading markdown (1ms)
Rendering HTML (135ms) — 8504 words
Opening tab...which: no browse in (<PATH>)
$P: browse resolve exited 127: browse binary not found.
```

Workaround the user has today: `export BROWSE_BIN=/c/.../browse/dist/browse.exe`. Fix in this PR: the resolver itself probes `.exe` on win32, so the workaround is no longer needed.

## Root cause

Two independent issues compound:

**1. `fs.constants.X_OK` is degraded to existence-checking on Windows.** Per the Node.js docs on [`fs.accessSync`](https://nodejs.org/api/fs.html#fsaccesspath-mode-callback):

> On Windows, the file system accessibility checks can behave differently. For example, changing visibility using chmod does not update read and write permissions ... Only the presence of the read-only attribute is reflected.

So `fs.accessSync('/path/to/browse', X_OK)` on Windows checks whether a file literally named `browse` (no extension) exists. When bun emits `browse.exe`, the check returns false. The local `isExecutable()` helper inherits this semantic and returns false for every candidate.

**2. bun `--compile --outfile` appends `.exe` on Windows unconditionally.** The build command in `package.json` targets `browse/dist/browse` / `make-pdf/dist/pdf` / `design/dist/design`:

```
bun build --compile browse/src/cli.ts --outfile browse/dist/browse
```

On Windows, bun silently appends `.exe` (the PE format requires it for `CreateProcess` to locate the entrypoint). Confirmed on a fresh Windows checkout:

```console
$ ls ~/.claude/skills/gstack/{browse,make-pdf,design}/dist/*.exe
browse/dist/browse.exe
browse/dist/find-browse.exe
make-pdf/dist/pdf.exe
design/dist/design.exe
```

There are no files named `browse`, `pdf`, or `design` in those directories — only their `.exe` variants.

**3. The `which browse` PATH fallback doesn't help native Windows.** `which` ships with Git Bash (MSYS2) but not with cmd.exe or PowerShell. A user running the compiled `pdf.exe` from PowerShell doesn't have `which` in PATH, so `execFileSync("which", ...)` throws ENOENT, the catch block swallows it, and we fall through to the `browse binary not found` error.

## Why this shipped unnoticed

`.github/workflows/make-pdf-gate.yml:25`:

```yaml
matrix:
  os: [ubuntu-latest, macos-latest]
  # Windows is tolerant-mode — Xpdf / Poppler-Windows extraction
  # differs enough from the Linux/macOS baseline that the strict
  # exact-diff gate is unreliable. Enable once the normalized
  # comparator proves tolerant enough (Codex round 2 #18).
```

No gstack workflow runs on Windows — not `make-pdf-gate`, not `evals`, not `ci-image`. This PR doesn't enable Windows CI (the tolerance-mode question the comment flags still needs a separate call), but it is a prerequisite — as-is, binary resolution would ERR out before pdftotext comparisons even started. A pre-existing test in `browseClient.test.ts` that hardcoded `/bin/sh` would also have broken Windows CI immediately; this PR makes that test cross-platform.

## Scope

Three sites in the repo currently probe executable paths with `fs.accessSync(p, X_OK)`:

| File | Symbol | Affected? | In scope? |
|------|--------|-----------|-----------|
| `make-pdf/src/browseClient.ts` | `resolveBrowseBin` | Yes — primary bug | Yes |
| `make-pdf/src/pdftotext.ts` | `resolvePdftotext` | Yes — same root cause; smaller blast radius (only affects `bun test` on Windows, not runtime renders) | Yes |
| `browse/src/security.ts` | `findTelemetryBinary` | No — the telemetry binary is a bash script (`#!/usr/bin/env bash`), not a compiled `.exe`. Windows has a different blocker there (shebang scripts cannot be `CreateProcess`-ed directly). | Out of scope — different bug, different fix |

## The fix

A file-local `findExecutable(base)` helper in each affected module. On win32, after the bare-path probe fails, it probes `.exe`, `.cmd`, `.bat` suffixes. On POSIX, `isExecutable(base)` is load-bearing and the Windows branch never runs, so Linux/macOS behavior is bit-identical to the old code.

```ts
export function findExecutable(base: string): string | null {
  if (isExecutable(base)) return base;
  if (process.platform === "win32") {
    for (const ext of [".exe", ".cmd", ".bat"]) {
      const withExt = base + ext;
      if (isExecutable(withExt)) return withExt;
    }
  }
  return null;
}
```

Exported from `browseClient.ts` (it is useful beyond internal resolution — any future site that probes an executable should route through it). Duplicated (not shared) in `pdftotext.ts` to match the existing `isExecutable` duplication pattern across the two modules.

Secondary change: the PATH fallback uses `where` on win32, `which` on POSIX. `where` ships in `C:\Windows\System32\` on every Windows install, so `execFileSync("where", ...)` works from cmd.exe, PowerShell, AND Git Bash.

Tertiary change: pdftotext's `macCandidates` is renamed `posixCandidates` (it was always POSIX-only — `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`). No Windows candidates added — Poppler on Windows scatters across Scoop, Chocolatey, oschwartz10612/poppler-windows releases, and portable zips; guessing causes false positives. Users set `PDFTOTEXT_BIN` instead, which now works. The not-found error picks up a Windows install hint:

```
To install:
  macOS:    brew install poppler
  Ubuntu:   sudo apt-get install poppler-utils
  Fedora:   sudo dnf install poppler-utils
  Windows:  scoop install poppler  (or download from
            https://github.com/oschwartz10612/poppler-windows)
```

## Test plan

- [x] `bun test make-pdf/test/browseClient.test.ts make-pdf/test/pdftotext.test.ts` on win32 — 21 pass, 0 fail (including 5 new Windows-specific assertions that early-return on POSIX)
- [x] Full `bun test make-pdf/test/` on win32 — 80 pass, 1 skip (e2e test needs built binary), 0 fail
- [x] End-to-end: `unset BROWSE_BIN && bun run make-pdf/src/cli.ts generate /tmp/in.md /tmp/out.pdf` on win32 produces a valid 31KB PDF using the patched `resolveBrowseBin` against the pre-existing `browse.exe`
- [x] Pre-existing `resolveBrowseBin > honors BROWSE_BIN when it points at a real executable` made cross-platform (was hardcoded `/bin/sh`, now uses `cmd.exe` on Windows). This would have been a Windows-CI blocker.
- [ ] Ubuntu/macOS CI pass — relying on the make-pdf-gate workflow once this PR is opened. POSIX branch is unchanged; `isExecutable(base)` is the first probe and short-circuits before the Windows-only extension loop.
- [ ] `/pair-agent` / OAuth flows not exercised — unchanged, no touchpoint with this PR's surface area.

## Commits

- `705996b` — `fix(make-pdf): resolve bun-compiled .exe binaries on Windows` (browseClient + its test)
- `f04bbd1` — `fix(make-pdf): apply .exe extension probe to pdftotext resolver` (pdftotext + its test)

Atomic: each commit is independently reviewable and leaves the test suite green on POSIX. Commit 1 is the user-visible fix (what the failing render hit); commit 2 is the matching fix for the same root cause in a less-exercised code path.

## What this PR does not do

- **Enable Windows CI.** The `make-pdf-gate.yml` matrix comment about pdftotext extraction tolerance on Windows is a separate question that still needs a call.
- **Fix `findTelemetryBinary` in `browse/src/security.ts`.** Different bug (shebang-script invocation on Windows), different fix, separate PR if it ever becomes user-facing.
- **Touch the sidebar agent's `fs.accessSync` call.** That one checks a directory for reachability, not executability — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
