### PR TITLE
fix(browse,design): resolve ~/.gstack via os.homedir() on Windows

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -15,6 +15,7 @@
  *   restores state. Falls back to clean slate on any failure.
  */
 
+import * as os from 'os';
 import { chromium, type Browser, type BrowserContext, type BrowserContextOptions, type Page, type Locator, type Cookie } from 'playwright';
 import { addConsoleEntry, addNetworkEntry, addDialogEntry, networkBuffer, type DialogEntry } from './buffers';
 import { validateNavigationUrl } from './url-validation';
@@ -139,7 +140,7 @@ export class BrowserManager {
       // Relative to this source file (dev mode: browse/src/ -> ../../extension)
       path.resolve(__dirname, '..', '..', 'extension'),
       // Global gstack install
-      path.join(process.env.HOME || '', '.claude', 'skills', 'gstack', 'extension'),
+      path.join(os.homedir(), '.claude', 'skills', 'gstack', 'extension'),
       // Git repo root (detected via BROWSE_STATE_FILE location)
       (() => {
         const stateFile = process.env.BROWSE_STATE_FILE || '';
@@ -266,7 +267,7 @@ export class BrowserManager {
       if (authToken) {
         const fs = require('fs');
         const path = require('path');
-        const gstackDir = path.join(process.env.HOME || '/tmp', '.gstack');
+        const gstackDir = path.join(os.homedir(), '.gstack');
         fs.mkdirSync(gstackDir, { recursive: true });
         const authFile = path.join(gstackDir, '.auth.json');
         try {
@@ -283,7 +284,7 @@ export class BrowserManager {
     // so we use Playwright's bundled Chromium which reliably loads extensions.
     const fs = require('fs');
     const path = require('path');
-    const userDataDir = path.join(process.env.HOME || '/tmp', '.gstack', 'chromium-profile');
+    const userDataDir = path.join(os.homedir(), '.gstack', 'chromium-profile');
     fs.mkdirSync(userDataDir, { recursive: true });
 
     // Support custom Chromium binary via GSTACK_CHROMIUM_PATH env var.
@@ -310,7 +311,7 @@ export class BrowserManager {
         // Replace Chromium's Dock icon with ours (Chromium's process owns the Dock icon)
         const iconCandidates = [
           path.join(__dirname, '..', '..', 'scripts', 'app', 'icon.icns'),       // repo dev mode
-          path.join(process.env.HOME || '', '.claude', 'skills', 'gstack', 'scripts', 'app', 'icon.icns'), // global install
+          path.join(os.homedir(), '.claude', 'skills', 'gstack', 'scripts', 'app', 'icon.icns'), // global install
         ];
         const iconSrc = iconCandidates.find(p => fs.existsSync(p));
         if (iconSrc) {
@@ -1158,7 +1159,7 @@ export class BrowserManager {
         console.log('[browse] Handoff: extension not found — headed mode without side panel');
       }
 
-      const userDataDir = path.join(process.env.HOME || '/tmp', '.gstack', 'chromium-profile');
+      const userDataDir = path.join(os.homedir(), '.gstack', 'chromium-profile');
       fs.mkdirSync(userDataDir, { recursive: true });
 
       newContext = await chromium.launchPersistentContext(userDataDir, {

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -10,6 +10,7 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { safeUnlink, safeUnlinkQuiet, safeKill, isProcessAlive } from './error-handling';
 import { resolveConfig, ensureStateDir, readVersionHash } from './config';
@@ -471,7 +472,7 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
 /** Check if ngrok is installed and authenticated (native config or gstack env). */
 function isNgrokAvailable(): boolean {
   // Check gstack's own ngrok env
-  const ngrokEnvPath = path.join(process.env.HOME || '/tmp', '.gstack', 'ngrok.env');
+  const ngrokEnvPath = path.join(os.homedir(), '.gstack', 'ngrok.env');
   if (fs.existsSync(ngrokEnvPath)) return true;
 
   // Check NGROK_AUTHTOKEN env var
@@ -479,9 +480,9 @@ function isNgrokAvailable(): boolean {
 
   // Check ngrok's native config (macOS + Linux)
   const ngrokConfigs = [
-    path.join(process.env.HOME || '/tmp', 'Library', 'Application Support', 'ngrok', 'ngrok.yml'),
-    path.join(process.env.HOME || '/tmp', '.config', 'ngrok', 'ngrok.yml'),
-    path.join(process.env.HOME || '/tmp', '.ngrok2', 'ngrok.yml'),
+    path.join(os.homedir(), 'Library', 'Application Support', 'ngrok', 'ngrok.yml'),
+    path.join(os.homedir(), '.config', 'ngrok', 'ngrok.yml'),
+    path.join(os.homedir(), '.ngrok2', 'ngrok.yml'),
   ];
   for (const conf of ngrokConfigs) {
     try {
@@ -720,7 +721,7 @@ async function handlePairAgent(state: ServerState, args: string[]): Promise<void
         // Fallback to convention-based path
       }
 
-      const configDir = path.join(process.env.HOME || '/tmp', globalRoot);
+      const configDir = path.join(os.homedir(), globalRoot);
       fs.mkdirSync(configDir, { recursive: true });
       const configFile = path.join(configDir, 'browse-remote.json');
       const configData = {
@@ -828,7 +829,7 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
     // Kill orphaned Chromium processes that may still hold the profile lock.
     // The server PID is the Bun process; Chromium is a child that can outlive it
     // if the server is killed abruptly (SIGKILL, crash, manual rm of state file).
-    const profileDir = path.join(process.env.HOME || '/tmp', '.gstack', 'chromium-profile');
+    const profileDir = path.join(os.homedir(), '.gstack', 'chromium-profile');
     try {
       const singletonLock = path.join(profileDir, 'SingletonLock');
       const lockTarget = fs.readlinkSync(singletonLock); // e.g. "hostname-12345"
@@ -893,7 +894,7 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
           throw new Error(`sidebar-agent.ts not found at ${agentScript}`);
         }
         // Clear old agent queue
-        const agentQueue = path.join(process.env.HOME || '/tmp', '.gstack', 'sidebar-agent-queue.jsonl');
+        const agentQueue = path.join(os.homedir(), '.gstack', 'sidebar-agent-queue.jsonl');
         try {
           fs.mkdirSync(path.dirname(agentQueue), { recursive: true, mode: 0o700 });
           fs.writeFileSync(agentQueue, '', { mode: 0o600 });
@@ -978,7 +979,7 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
       }
     }
     // Clean profile locks and state file
-    const profileDir = path.join(process.env.HOME || '/tmp', '.gstack', 'chromium-profile');
+    const profileDir = path.join(os.homedir(), '.gstack', 'chromium-profile');
     for (const lockFile of ['SingletonLock', 'SingletonSocket', 'SingletonCookie']) {
       safeUnlinkQuiet(path.join(profileDir, lockFile));
     }

--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -13,6 +13,7 @@
  *   Port:       random 10000-60000 (or BROWSE_PORT env for debug override)
  */
 
+import * as os from 'os';
 import { BrowserManager } from './browser-manager';
 import { handleReadCommand } from './read-commands';
 import { handleWriteCommand } from './write-commands';
@@ -185,7 +186,7 @@ interface SidebarSession {
   lastActiveAt: string;
 }
 
-const SESSIONS_DIR = path.join(process.env.HOME || '/tmp', '.gstack', 'sidebar-sessions');
+const SESSIONS_DIR = path.join(os.homedir(), '.gstack', 'sidebar-sessions');
 const AGENT_TIMEOUT_MS = 300_000; // 5 minutes — multi-page tasks need time
 const MAX_QUEUE = 5;
 
@@ -234,7 +235,7 @@ function findBrowseBin(): string {
   const candidates = [
     path.resolve(__dirname, '..', 'dist', 'browse'),
     path.resolve(__dirname, '..', '..', '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse'),
-    path.join(process.env.HOME || '', '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse'),
+    path.join(os.homedir(), '.claude', 'skills', 'gstack', 'browse', 'dist', 'browse'),
   ];
   for (const c of candidates) {
     try { if (fs.existsSync(c)) return c; } catch (err: any) {
@@ -247,7 +248,7 @@ function findBrowseBin(): string {
 const BROWSE_BIN = findBrowseBin();
 
 function findClaudeBin(): string | null {
-  const home = process.env.HOME || '';
+  const home = os.homedir();
   const candidates = [
     // Conductor app bundled binary (not a symlink — works reliably)
     path.join(home, 'Library', 'Application Support', 'com.conductor.app', 'bin', 'claude'),
@@ -381,7 +382,7 @@ function createWorktree(sessionId: string): string | null {
     if (gitCheck.exitCode !== 0) return null;
     const repoRoot = gitCheck.stdout.toString().trim();
 
-    const worktreeDir = path.join(process.env.HOME || '/tmp', '.gstack', 'worktrees', sessionId.slice(0, 8));
+    const worktreeDir = path.join(os.homedir(), '.gstack', 'worktrees', sessionId.slice(0, 8));
 
     // Clean up if dir exists from prior crash
     if (fs.existsSync(worktreeDir)) {
@@ -632,7 +633,7 @@ function spawnClaude(userMessage: string, extensionUrl?: string | null, forTabId
   // fails with ENOENT on everything, including /bin/bash). Instead,
   // write the command to a queue file that the sidebar-agent process
   // (running as non-compiled bun) picks up and spawns claude.
-  const agentQueue = process.env.SIDEBAR_QUEUE_PATH || path.join(process.env.HOME || '/tmp', '.gstack', 'sidebar-agent-queue.jsonl');
+  const agentQueue = process.env.SIDEBAR_QUEUE_PATH || path.join(os.homedir(), '.gstack', 'sidebar-agent-queue.jsonl');
   const gstackDir = path.dirname(agentQueue);
   const entry = JSON.stringify({
     ts: new Date().toISOString(),
@@ -676,7 +677,7 @@ function killAgent(targetTabId?: number | null): void {
   // Using per-tab files prevents race conditions where one agent's cancel
   // signal is consumed by a different tab's agent in concurrent mode.
   // When targetTabId is provided, only that tab's agent is cancelled.
-  const cancelDir = path.join(process.env.HOME || '/tmp', '.gstack');
+  const cancelDir = path.join(os.homedir(), '.gstack');
   const tabId = targetTabId ?? agentTabId ?? 0;
   const cancelFile = path.join(cancelDir, `sidebar-agent-cancel-${tabId}`);
   try {
@@ -1304,7 +1305,7 @@ async function shutdown(exitCode: number = 0) {
   await browserManager.close();
 
   // Clean up Chromium profile locks (prevent SingletonLock on next launch)
-  const profileDir = path.join(process.env.HOME || '/tmp', '.gstack', 'chromium-profile');
+  const profileDir = path.join(os.homedir(), '.gstack', 'chromium-profile');
   for (const lockFile of ['SingletonLock', 'SingletonSocket', 'SingletonCookie']) {
     safeUnlinkQuiet(path.join(profileDir, lockFile));
   }
@@ -1367,7 +1368,7 @@ function emergencyCleanup() {
     console.error('[browse] Emergency: failed to save session:', err.message);
   }
   // Clean Chromium profile locks
-  const profileDir = path.join(process.env.HOME || '/tmp', '.gstack', 'chromium-profile');
+  const profileDir = path.join(os.homedir(), '.gstack', 'chromium-profile');
   for (const lockFile of ['SingletonLock', 'SingletonSocket', 'SingletonCookie']) {
     safeUnlinkQuiet(path.join(profileDir, lockFile));
   }
@@ -1423,7 +1424,7 @@ async function start() {
         const welcomePath = (() => {
           // Check project-local designs first, then global
           const slug = process.env.GSTACK_SLUG || 'unknown';
-          const homeDir = process.env.HOME || process.env.USERPROFILE || '/tmp';
+          const homeDir = os.homedir();
           const projectWelcome = `${homeDir}/.gstack/projects/${slug}/designs/welcome-page-20260331/finalized.html`;
           if (fs.existsSync(projectWelcome)) return projectWelcome;
           // Fallback: built-in welcome page from gstack install
@@ -1681,7 +1682,7 @@ async function start() {
           // Read ngrok authtoken: env var > ~/.gstack/ngrok.env > ngrok native config
           let authtoken = process.env.NGROK_AUTHTOKEN;
           if (!authtoken) {
-            const ngrokEnvPath = path.join(process.env.HOME || '', '.gstack', 'ngrok.env');
+            const ngrokEnvPath = path.join(os.homedir(), '.gstack', 'ngrok.env');
             if (fs.existsSync(ngrokEnvPath)) {
               const envContent = fs.readFileSync(ngrokEnvPath, 'utf-8');
               const match = envContent.match(/^NGROK_AUTHTOKEN=(.+)$/m);
@@ -1691,9 +1692,9 @@ async function start() {
           if (!authtoken) {
             // Check ngrok's native config files
             const ngrokConfigs = [
-              path.join(process.env.HOME || '', 'Library', 'Application Support', 'ngrok', 'ngrok.yml'),
-              path.join(process.env.HOME || '', '.config', 'ngrok', 'ngrok.yml'),
-              path.join(process.env.HOME || '', '.ngrok2', 'ngrok.yml'),
+              path.join(os.homedir(), 'Library', 'Application Support', 'ngrok', 'ngrok.yml'),
+              path.join(os.homedir(), '.config', 'ngrok', 'ngrok.yml'),
+              path.join(os.homedir(), '.ngrok2', 'ngrok.yml'),
             ];
             for (const conf of ngrokConfigs) {
               try {
@@ -2505,7 +2506,7 @@ async function start() {
       // Read ngrok authtoken from env or config file
       let authtoken = process.env.NGROK_AUTHTOKEN;
       if (!authtoken) {
-        const ngrokEnvPath = path.join(process.env.HOME || '', '.gstack', 'ngrok.env');
+        const ngrokEnvPath = path.join(os.homedir(), '.gstack', 'ngrok.env');
         if (fs.existsSync(ngrokEnvPath)) {
           const envContent = fs.readFileSync(ngrokEnvPath, 'utf-8');
           const match = envContent.match(/^NGROK_AUTHTOKEN=(.+)$/m);

--- a/browse/src/sidebar-agent.ts
+++ b/browse/src/sidebar-agent.ts
@@ -11,6 +11,7 @@
 
 import { spawn } from 'child_process';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { safeUnlink } from './error-handling';
 import {
@@ -26,14 +27,14 @@ import {
   type ToolCallInput,
 } from './security-classifier';
 
-const QUEUE = process.env.SIDEBAR_QUEUE_PATH || path.join(process.env.HOME || '/tmp', '.gstack', 'sidebar-agent-queue.jsonl');
+const QUEUE = process.env.SIDEBAR_QUEUE_PATH || path.join(os.homedir(), '.gstack', 'sidebar-agent-queue.jsonl');
 const KILL_FILE = path.join(path.dirname(QUEUE), 'sidebar-agent-kill');
 const SERVER_PORT = parseInt(process.env.BROWSE_SERVER_PORT || '34567', 10);
 const SERVER_URL = `http://127.0.0.1:${SERVER_PORT}`;
 const POLL_MS = 200;  // 200ms poll — keeps time-to-first-token low
 const B = process.env.BROWSE_BIN || path.resolve(__dirname, '../../.claude/skills/gstack/browse/dist/browse');
 
-const CANCEL_DIR = path.join(process.env.HOME || '/tmp', '.gstack');
+const CANCEL_DIR = path.join(os.homedir(), '.gstack');
 function cancelFileForTab(tabId: number): string {
   return path.join(CANCEL_DIR, `sidebar-agent-cancel-${tabId}`);
 }
@@ -129,7 +130,7 @@ async function refreshToken(): Promise<string | null> {
   // Read token from state file (same-user, mode 0o600) instead of /health
   try {
     const stateFile = process.env.BROWSE_STATE_FILE ||
-      path.join(process.env.HOME || '/tmp', '.gstack', 'browse.json');
+      path.join(os.homedir(), '.gstack', 'browse.json');
     const data = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
     authToken = data.token || null;
     return authToken;

--- a/design/prototype.ts
+++ b/design/prototype.ts
@@ -7,10 +7,11 @@
  */
 
 import fs from "fs";
+import os from "os";
 import path from "path";
 
 const API_KEY = process.env.OPENAI_API_KEY
-  || JSON.parse(fs.readFileSync(path.join(process.env.HOME!, ".gstack/openai.json"), "utf-8")).api_key;
+  || JSON.parse(fs.readFileSync(path.join(os.homedir(), ".gstack/openai.json"), "utf-8")).api_key;
 
 if (!API_KEY) {
   console.error("No API key found. Set OPENAI_API_KEY or save to ~/.gstack/openai.json");

--- a/design/src/auth.ts
+++ b/design/src/auth.ts
@@ -8,9 +8,10 @@
  */
 
 import fs from "fs";
+import os from "os";
 import path from "path";
 
-const CONFIG_PATH = path.join(process.env.HOME || "~", ".gstack", "openai.json");
+const CONFIG_PATH = path.join(os.homedir(), ".gstack", "openai.json");
 
 export function resolveApiKey(): string | null {
   // 1. Check ~/.gstack/openai.json


### PR DESCRIPTION
## Summary

On Windows, gstack's persistent state directory (`~/.gstack/`) lands at nonsense paths — chromium profile, sidebar session data, ngrok config, agent queue, worktree cache, OpenAI key file, browse state — whenever a user runs gstack binaries (`browse.exe`, `pdf.exe`, `design.exe`, sidebar agent) from any shell that isn't Git Bash. That covers cmd.exe, PowerShell, VS Code's integrated terminal when not explicitly configured for Git Bash, Windows Terminal default profile, and any IDE spawning subprocesses with its own env block.

Root cause: 31 sites in `browse/src/` and `design/` construct paths with `process.env.HOME || <fallback>`. On Windows, `HOME` is unset (Windows uses `USERPROFILE`), so the fallback kicks in. The fallbacks are all broken in different ways:

| Pattern | Site count | Behavior on Windows when HOME unset |
|---------|-----------:|-------------------------------------|
| `process.env.HOME \|\| '/tmp'` | 20 | `path.join('/tmp', ...)` → `\tmp\.gstack\...` — literal path, doesn't exist |
| `process.env.HOME \|\| ''` | 8 | `path.join('', ...)` → CWD-relative — silently mislocates |
| `process.env.HOME!` | 1 | Non-null assertion crashes at load time |
| `process.env.HOME \|\| "~"` | 1 | Creates literal `~` directory under CWD; Node path APIs never expand `~` |
| `process.env.HOME \|\| process.env.USERPROFILE \|\| '/tmp'` | 1 | Already platform-aware; simplified |

## Repro

Minimal Node script simulating an invocation from a native-Windows shell:

```js
delete process.env.HOME;
console.log('HOME was unset:', process.env.HOME === undefined);
console.log('USERPROFILE:', process.env.USERPROFILE);

const path = require('path');
const os = require('os');

const oldFallback = path.join(process.env.HOME || '/tmp', '.gstack', 'sidebar-agent-queue.jsonl');
const newFix      = path.join(os.homedir(),                 '.gstack', 'sidebar-agent-queue.jsonl');

console.log('OLD (|| "/tmp"):', oldFallback);
console.log('NEW (os.homedir):', newFix);
```

Output on Windows 11:

```
HOME was unset: true
USERPROFILE: C:\Users\Sam

OLD (|| "/tmp"):  \tmp\.gstack\sidebar-agent-queue.jsonl
NEW (os.homedir): C:\Users\Sam\.gstack\sidebar-agent-queue.jsonl
```

The OLD path doesn't exist. Every `fs.writeFileSync` targeting `~/.gstack/` against the OLD path fails with `ENOENT`, usually caught and logged as a confusing "couldn't save state" warning, and the feature appears partially-working to the user — tokens don't persist across restarts, the chromium profile resets every launch, the sidebar session directory rotates and loses chat history.

## Why this shipped unnoticed

- Sam's clone (and most gstack Windows users') runs every command from Git Bash, which sets `HOME` by default. So `HOME || '/tmp'` short-circuits on `HOME` and the state lands correctly — until an IDE-spawned subprocess inherits a sanitized env without `HOME`, or the user runs `browse.exe` from PowerShell to see what happens.
- Every `.github/workflows/` job runs on `ubuntu-latest` or `macos-latest`. CI never touches the Windows branch of this fallback. #1118's analysis of the make-pdf-gate matrix comment applies identically here.

## The fix

Replace every variant with `os.homedir()`. Per [Node docs](https://nodejs.org/api/os.html#oshomedir):

> `os.homedir()` returns the string path of the current user's home directory.
> On POSIX, it uses the `$HOME` environment variable if defined. Otherwise it uses the effective UID to look up the user's home directory.
> On Windows, it uses the `USERPROFILE` environment variable if defined. Otherwise it uses the path to the profile directory of the current user.

Strictly better than every pattern it replaces, on every platform. Specifically:

- POSIX CI test isolation that sets `process.env.HOME = tmpHome` (see `browse/test/security-review-flow.test.ts:30`) keeps working — `os.homedir()` still reads `HOME` on POSIX.
- The one site already using `HOME || USERPROFILE || '/tmp'` collapses cleanly to `os.homedir()`.
- The `HOME!` non-null assertion in `design/prototype.ts:13` stops being a load-time crash risk.

### Files changed

| File | Sites | What lived there |
|------|------:|------------------|
| `browse/src/cli.ts` | 8 | ngrok env, ngrok config search path (3 paths), gstack dir, chromium profile (x2), agent queue |
| `browse/src/server.ts` | 13 | sessions dir, browse binary lookup, global home, worktree dir, agent queue, cancel dir, chromium profile (x2), welcome path, ngrok env, ngrok config search (3 paths), ngrok env (second use site) |
| `browse/src/browser-manager.ts` | 5 | extension path, gstack dir, chromium profile (x2), app icon path |
| `browse/src/sidebar-agent.ts` | 3 | queue, cancel dir, browse.json |
| `design/prototype.ts` | 1 | `process.env.HOME!` → `os.homedir()` (crash-on-unset bug) |
| `design/src/auth.ts` | 1 | `\|\| "~"` → `os.homedir()` (literal-tilde bug) |

Added `import * as os from 'os'` (or `import os from "os"` for the design files, matching each file's existing default-import style) to the 6 files that didn't already import it.

## Test plan

- [x] Full `bun test browse/test/ make-pdf/test/` on Windows — 163 pass, 10 fail. Same 163/10 on clean upstream main (stashed + re-ran for exact comparison), identical failing test names. All 10 failures are pre-existing and unrelated to this PR's surface:
  - `batch.test.ts` + `compare-board.test.ts` — `beforeEach/afterEach` hook timeouts (5s limit; appears to be a Windows-specific test-harness issue, not the code under test)
  - `bun-polyfill.test.ts` x4 — `Bun.serve`/`spawn`/`spawnSync`/`sleep` assertions, all expecting `"OK"` or `"HAS_STOP"` and receiving `""`, suggesting a pre-existing Bun polyfill subshell stdout-capture issue on this platform
  - `sidebar-integration.test.ts` + `sidebar-agent-roundtrip.test.ts` — `agent_done transitions to idle`, `queues message when agent is processing`, `kill adds error entry` — same failures on clean main, unrelated to path construction
- [x] Empirical proof with HOME unset on Windows 11 (see Repro above) — `os.homedir()` produces the correct `C:\Users\Sam\.gstack\...` path where the OLD fallback produced `\tmp\.gstack\...`
- [ ] Ubuntu/macOS CI pass — relying on the existing matrix. POSIX branch is semantically identical (`os.homedir()` falls through to `$HOME` on POSIX, same as the old short-circuit), so no regression expected. Test that overrides `process.env.HOME` in `security-review-flow.test.ts` keeps passing because `os.homedir()` on POSIX honors HOME overrides.
- [ ] End-to-end `browse.exe` start from PowerShell/cmd.exe verified — not run. The unit-test pass rate + empirical before/after is sufficient confidence given the mechanical nature of the change.

## What this PR doesn't do

- **Fix `/tmp` usage in dev-only scripts.** `design/prototype.ts:20` uses `/tmp/gstack-prototype-<timestamp>/` as an output dir. It's a manual-run validation script (`bun run design/prototype.ts`), not user-facing production code. Separate concern.
- **Fix `/tmp` usage in `cookie-import-browser.ts`.** That's the scope of @Gonzih's #748 already open — deferring to that PR.
- **Touch bash preamble `~` expansion** (#558, #843). Those are about bash path expansion in generated SKILL.md files, a different subsystem from TypeScript runtime paths.
- **Address Windows ACL / `fs.chmodSync` no-op.** Filed separately as #1121 — sensitive files (auth tokens, canary tokens, chat history, agent queue) end up with 6 inherited ACEs on Windows because `chmod` mode bits don't map to NTFS ACLs. #1121 fixes it via a shell-out to `icacls` and includes an empirical before/after showing 6 ACEs → 1.

## Commits

- `d3a6b5e` — `fix(browse,design): resolve ~/.gstack via os.homedir() not $HOME || /tmp`

Single commit. The change is mechanical and atomic across the 6 files — no value in splitting further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

