### PR TITLE
fix(docs): match README manual-uninstall snippet to install layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,9 +316,13 @@ If you don't have the repo cloned (e.g. you installed via a Claude Code paste an
 # 1. Stop browse daemons
 pkill -f "gstack.*browse" 2>/dev/null || true
 
-# 2. Remove per-skill symlinks pointing into gstack/
-find ~/.claude/skills -maxdepth 1 -type l 2>/dev/null | while read -r link; do
-  case "$(readlink "$link" 2>/dev/null)" in gstack/*|*/gstack/*) rm -f "$link" ;; esac
+# 2. Remove per-skill directories created by setup
+#    setup creates a real directory per skill, with SKILL.md symlinked into gstack/
+find ~/.claude/skills -mindepth 1 -maxdepth 1 -type d 2>/dev/null | while IFS= read -r dir; do
+  [ "$(basename "$dir")" = "gstack" ] && continue
+  link="$dir/SKILL.md"
+  [ -L "$link" ] || continue
+  case "$(readlink "$link" 2>/dev/null)" in gstack/*|*/gstack/*) rm -rf "$dir" ;; esac
 done
 
 # 3. Remove gstack


### PR DESCRIPTION
## Summary

The manual-removal block in README.md told users to run:

```bash
find ~/.claude/skills -maxdepth 1 -type l 2>/dev/null | while read -r link; do
  case "$(readlink "$link" 2>/dev/null)" in gstack/*|*/gstack/*) rm -f "$link" ;; esac
done
```

`setup` (lines 399-404) creates each skill as a **real directory** at the top level with `SKILL.md` as a nested symlink. `-maxdepth 1 -type l` only matches top-level symlinks, so this `find` matched nothing on current installs and users were left with ~30 empty per-skill directories.

## Fix

Replace the snippet with one that iterates real directories, skips `gstack` itself, checks the nested `SKILL.md` is a symlink pointing into `gstack/`, and removes the directory if so.

```bash
find ~/.claude/skills -mindepth 1 -maxdepth 1 -type d 2>/dev/null | while IFS= read -r dir; do
  [ "$(basename "$dir")" = "gstack" ] && continue
  link="$dir/SKILL.md"
  [ -L "$link" ] || continue
  case "$(readlink "$link" 2>/dev/null)" in gstack/*|*/gstack/*) rm -rf "$dir" ;; esac
done
```

Verified on a fake HOME:

```
BEFORE:  ~/.claude/skills/{autoplan, ship, gstack, other-tool}
AFTER:   ~/.claude/skills/{gstack, other-tool}
         (autoplan and ship removed; gstack untouched for step 3; other-tool preserved)
```

Sibling fix for the same root cause in `bin/gstack-uninstall` is in #902.

Fixes #1130
