### PR TITLE
docs(readme): align manual uninstall with --keep-state split

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ This handles skills, symlinks, global state (`~/.gstack/`), project-local state,
 
 If you don't have the repo cloned (e.g. you installed via a Claude Code paste and later deleted the clone):
 
+Mirrors `gstack-uninstall --keep-state` (preserves `~/.gstack/` data):
+
 ```bash
 # 1. Stop browse daemons
 pkill -f "gstack.*browse" 2>/dev/null || true
@@ -324,21 +326,26 @@ done
 # 3. Remove gstack
 rm -rf ~/.claude/skills/gstack
 
-# 4. Remove global state
-rm -rf ~/.gstack
-
-# 5. Remove integrations (skip any you never installed)
+# 4. Remove integrations (skip any you never installed)
 rm -rf ~/.codex/skills/gstack* 2>/dev/null
 rm -rf ~/.factory/skills/gstack* 2>/dev/null
 rm -rf ~/.kiro/skills/gstack* 2>/dev/null
 rm -rf ~/.openclaw/skills/gstack* 2>/dev/null
 
-# 6. Remove temp files
+# 5. Remove temp files
 rm -f /tmp/gstack-* 2>/dev/null
 
-# 7. Per-project cleanup (run from each project root)
+# 6. Per-project cleanup (run from each project root)
 rm -rf .gstack .gstack-worktrees .claude/skills/gstack 2>/dev/null
 rm -rf .agents/skills/gstack* .factory/skills/gstack* 2>/dev/null
+```
+
+#### Also purge gstack data (optional)
+
+`~/.gstack/` holds config, analytics, sessions, project history, and the installation-id. Run this only if you want a clean slate (equivalent to `gstack-uninstall` without `--keep-state`):
+
+```bash
+rm -rf ~/.gstack
 ```
 
 ### Clean up CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ This handles skills, symlinks, global state (`~/.gstack/`), project-local state,
 
 If you don't have the repo cloned (e.g. you installed via a Claude Code paste and later deleted the clone):
 
+Mirrors `gstack-uninstall --keep-state` (preserves `~/.gstack/` data):
+
 ```bash
 # 1. Stop browse daemons
 pkill -f "gstack.*browse" 2>/dev/null || true
@@ -388,10 +390,7 @@ rm -rf ~/.claude/skills/_gstack-command ~/.claude/skills/connect-chrome 2>/dev/n
 # 3. Remove gstack
 rm -rf ~/.claude/skills/gstack
 
-# 4. Remove global state
-rm -rf ~/.gstack
-
-# 5. Remove integrations (skip any you never installed)
+# 4. Remove integrations (skip any you never installed)
 rm -rf "${CODEX_HOME:-$HOME/.codex}/skills/gstack"* 2>/dev/null
 rm -rf ~/.factory/skills/gstack* 2>/dev/null
 rm -rf ~/.kiro/skills/gstack* 2>/dev/null
@@ -399,10 +398,10 @@ rm -rf ~/.openclaw/skills/gstack* 2>/dev/null
 rm -rf ~/.cursor/skills/gstack* 2>/dev/null
 rm -rf ~/.config/opencode/skills/gstack* 2>/dev/null
 
-# 6. Remove temp files
+# 5. Remove temp files
 rm -f /tmp/gstack-* 2>/dev/null
 
-# 7. Per-project cleanup (run from each project root)
+# 6. Per-project cleanup (run from each project root)
 rm -rf .gstack .gstack-worktrees .claude/skills/gstack 2>/dev/null
 rm -rf .agents/skills/gstack* .factory/skills/gstack* 2>/dev/null
 ```
@@ -414,6 +413,14 @@ command path points into `.claude/skills/gstack/`: the SessionStart auto-update
 hook, the AskUserQuestion PreToolUse/PostToolUse hooks, and the Stop hooks
 (session timeline, plus verify-gate if you opted in). Left in place, they error
 on every matching event once the install directory is gone.
+
+#### Also purge gstack data (optional)
+
+`~/.gstack/` holds config, analytics, sessions, project history, and the installation-id. Run this only if you want a clean slate (equivalent to `gstack-uninstall` without `--keep-state`):
+
+```bash
+rm -rf ~/.gstack
+```
 
 ### Clean up CLAUDE.md
 


### PR DESCRIPTION
## Summary

The `bin/gstack-uninstall` script already supports `--keep-state`, which removes skills but preserves `~/.gstack/` (config, analytics, sessions, project history, installation-id). The manual-removal block in README didn't reflect that split: it dropped `rm -rf ~/.gstack` inline as step 4 alongside the skill cleanup, so users following the manual path always lost their state even when the scripted path lets them keep it.

Reported in #1131.

## Fix

- Label the numbered block as the `--keep-state` equivalent.
- Move the `~/.gstack` purge into an "Also purge gstack data (optional)" subsection after the block, so users can decide whether to run it.

No script changes. Same behaviour is available, just documented as two choices instead of one.

## Diff

```diff
+ Mirrors `gstack-uninstall --keep-state` (preserves `~/.gstack/` data):

  ```bash
  # 1. Stop browse daemons
  ...
  # 3. Remove gstack
  rm -rf ~/.claude/skills/gstack

- # 4. Remove global state
- rm -rf ~/.gstack
-
- # 5. Remove integrations ...
+ # 4. Remove integrations ...
  ...
  ```

+ #### Also purge gstack data (optional)
+
+ `~/.gstack/` holds config, analytics, sessions, project history, and the
+ installation-id. Run this only if you want a clean slate (equivalent to
+ `gstack-uninstall` without `--keep-state`):
+
+ ```bash
+ rm -rf ~/.gstack
+ ```
```

Fixes #1131
