### PR TITLE
feat(browse): support loading extra Chrome extensions via GSTACK_EXTRA_EXTENSIONS

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -164,6 +164,32 @@ export class BrowserManager {
   }
 
   /**
+   * Parse GSTACK_EXTRA_EXTENSIONS (comma-separated paths) and return the list
+   * of unpacked extension directories that actually contain a manifest.json.
+   * Invalid entries are warned about and skipped so a typo doesn't block launch.
+   */
+  private findExtraExtensionPaths(): string[] {
+    const raw = process.env.GSTACK_EXTRA_EXTENSIONS;
+    if (!raw) return [];
+    const fs = require('fs');
+    const path = require('path');
+    const paths = raw.split(',').map(s => s.trim()).filter(Boolean);
+    const valid: string[] = [];
+    for (const p of paths) {
+      try {
+        if (fs.existsSync(path.join(p, 'manifest.json'))) {
+          valid.push(p);
+        } else {
+          console.warn(`[browse] GSTACK_EXTRA_EXTENSIONS: skipping ${p} (no manifest.json)`);
+        }
+      } catch (err: any) {
+        console.warn(`[browse] GSTACK_EXTRA_EXTENSIONS: skipping ${p} (${err?.message ?? 'error'})`);
+      }
+    }
+    return valid;
+  }
+
+  /**
    * Get the ref map for external consumers (e.g., /refs endpoint).
    */
   getRefMap(): Array<{ ref: string; role: string; name: string }> {
@@ -258,8 +284,15 @@ export class BrowserManager {
       '--disable-blink-features=AutomationControlled',
     ];
     if (extensionPath) {
-      launchArgs.push(`--disable-extensions-except=${extensionPath}`);
-      launchArgs.push(`--load-extension=${extensionPath}`);
+      // Combine gstack's extension with any user-provided extras (see
+      // GSTACK_EXTRA_EXTENSIONS). Chromium accepts comma-separated paths for
+      // both flags, so both extensions load and neither blocks the other.
+      const allExtensionPaths = [extensionPath, ...this.findExtraExtensionPaths()];
+      launchArgs.push(`--disable-extensions-except=${allExtensionPaths.join(',')}`);
+      launchArgs.push(`--load-extension=${allExtensionPaths.join(',')}`);
+      if (allExtensionPaths.length > 1) {
+        console.log(`[browse] Loading ${allExtensionPaths.length} extensions: ${allExtensionPaths.join(', ')}`);
+      }
       // Write auth token for extension bootstrap.
       // Write to ~/.gstack/.auth.json (not the extension dir, which may be read-only
       // in .app bundles and breaks codesigning).
@@ -1149,11 +1182,12 @@ export class BrowserManager {
       const extensionPath = this.findExtensionPath();
       const launchArgs = ['--hide-crash-restore-bubble'];
       if (extensionPath) {
-        launchArgs.push(`--disable-extensions-except=${extensionPath}`);
-        launchArgs.push(`--load-extension=${extensionPath}`);
+        const allExtensionPaths = [extensionPath, ...this.findExtraExtensionPaths()];
+        launchArgs.push(`--disable-extensions-except=${allExtensionPaths.join(',')}`);
+        launchArgs.push(`--load-extension=${allExtensionPaths.join(',')}`);
         // Auth token is served via /health endpoint now (no file write needed).
         // Extension reads token from /health on connect.
-        console.log(`[browse] Handoff: loading extension from ${extensionPath}`);
+        console.log(`[browse] Handoff: loading ${allExtensionPaths.length} extension(s): ${allExtensionPaths.join(', ')}`);
       } else {
         console.log('[browse] Handoff: extension not found — headed mode without side panel');
       }


### PR DESCRIPTION
## Summary

gstack's headed browser currently hardcodes `--disable-extensions-except=<gstack-extension>`, which actively blocks any other Chrome extension from loading — even if already installed in the persistent profile. Great default (keeps gstack's side panel the only extension in play, avoids surprise), but painful when you're QA'ing a site that depends on a third-party extension.

This PR adds a `GSTACK_EXTRA_EXTENSIONS` env var: comma-separated absolute paths to unpacked extension directories. Each path is validated (must contain `manifest.json`) and merged into both `--disable-extensions-except` and `--load-extension`. Invalid paths are warned and skipped so a typo doesn't block launch.

## Motivation

Real use case: QA'ing a web app (Superhuman Mail) that checks for its companion Chrome extension on load. Without the extension the landing page shows "Install Chrome Extension" instead of the real sign-in flow, so there's literally nothing to QA. Before this change the only options were (a) fork gstack and patch, (b) abandon gstack for this session and use a real Chrome.

## Example

```sh
# One-off
GSTACK_EXTRA_EXTENSIONS="$HOME/work/my-app/build/extension" browse connect

# Persistent (in ~/.zshrc)
export GSTACK_EXTRA_EXTENSIONS="$HOME/work/my-app/build/extension,$HOME/other-ext"
```

## Test plan

- [ ] Launch with no env var → gstack extension loads as before (regression)
- [ ] Launch with valid extra path → both extensions appear in `chrome://extensions`
- [ ] Launch with invalid path → warning logged, gstack extension still loads
- [ ] Launch with multiple comma-separated paths → all load
- [ ] Headless→headed handoff (`$B handoff`) preserves extras

## Files changed

- `browse/src/browser-manager.ts` — new `findExtraExtensionPaths()` helper; updated both launch sites (`launchHeaded()` and the handoff at ~line 1150) to merge extras into the flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)