### PR TITLE
security: fail-closed gate when ML classifiers are inactive

### DIFF
--- a/browse/src/security-classifier.ts
+++ b/browse/src/security-classifier.ts
@@ -102,6 +102,11 @@ export interface ClassifierStatus {
   deberta?: 'ok' | 'degraded' | 'off'; // only present when ensemble enabled
 }
 
+export function isClassifierInactive(cs: ClassifierStatus): boolean {
+  return cs.testsavant === 'off' && cs.transcript === 'off'
+    && (!cs.deberta || cs.deberta === 'off');
+}
+
 export function getClassifierStatus(): ClassifierStatus {
   const testsavant =
     testsavantState === 'loaded' ? 'ok' :

--- a/browse/src/sidebar-agent.ts
+++ b/browse/src/sidebar-agent.ts
@@ -21,7 +21,7 @@ import {
 } from './security';
 import {
   loadTestsavant, scanPageContent, checkTranscript,
-  shouldRunTranscriptCheck, getClassifierStatus,
+  shouldRunTranscriptCheck, getClassifierStatus, isClassifierInactive,
   loadDeberta, scanPageContentDeberta,
   type ToolCallInput,
 } from './security-classifier';
@@ -469,18 +469,42 @@ async function onCanaryLeaked(params: {
 }
 
 /**
- * Pre-spawn ML scan of the user message. If the classifier fires at BLOCK,
- * we log the attempt, emit a security_event to the sidepanel, and DO NOT
- * spawn claude. Returns true if the scan blocked the session.
+ * Pre-spawn security gate. Blocks session spawn when:
+ * 1. All ML classifiers are inactive (fail-closed unless GSTACK_SECURITY_ALLOW_INACTIVE=1)
+ * 2. ML ensemble fires at BLOCK verdict on the user message
  *
- * Fail-open: any classifier error or degraded state returns false (safe) so
- * the sidebar keeps working. The architectural controls (XML framing +
- * command allowlist, live in server.ts:554-577) still defend.
+ * Individual classifier degradation (one down, one up) still passes through —
+ * only total absence of ML protection triggers the gate.
  */
 async function preSpawnSecurityCheck(entry: QueueEntry): Promise<boolean> {
   const { message, canary, pageUrl, tabId } = entry;
   if (!message || message.length === 0) return false;
   const tid = tabId ?? 0;
+
+  // Fail-closed gate: if ALL ML classifiers are inactive, refuse to spawn
+  // unless the operator explicitly opts in. Without this check, a failed
+  // model download or GSTACK_SECURITY_OFF=1 silently removes all ML
+  // protection while the agent keeps running.
+  if (process.env.GSTACK_SECURITY_OFF !== '1') {
+    const cs = getClassifierStatus();
+    if (isClassifierInactive(cs) && process.env.GSTACK_SECURITY_ALLOW_INACTIVE !== '1') {
+      const domain = extractDomain(pageUrl ?? '');
+      console.warn(`[sidebar-agent] BLOCKED — all ML classifiers inactive for tab ${tid}. Set GSTACK_SECURITY_ALLOW_INACTIVE=1 to override.`);
+      await sendEvent({
+        type: 'security_event',
+        verdict: 'block',
+        reason: 'classifiers_inactive',
+        layer: 'fail_closed_gate',
+        confidence: 1,
+        domain,
+      }, tid);
+      await sendEvent({
+        type: 'agent_error',
+        error: 'Session blocked — security classifiers failed to load. Restart gstack or set GSTACK_SECURITY_ALLOW_INACTIVE=1.',
+      }, tid);
+      return true;
+    }
+  }
 
   // L4: scan the user message for direct injection patterns (TestSavantAI)
   // L4c: also scan with DeBERTa-v3 when ensemble is enabled (opt-in)
@@ -541,8 +565,7 @@ async function askClaude(queueEntry: QueueEntry): Promise<void> {
   processingTabs.add(tid);
   await sendEvent({ type: 'agent_start' }, tid);
 
-  // Pre-spawn ML scan: if the user message trips the ensemble, refuse to
-  // spawn claude. Fail-open on classifier errors.
+  // Pre-spawn ML scan: blocks on injection detection OR classifier-inactive.
   if (await preSpawnSecurityCheck(queueEntry)) {
     processingTabs.delete(tid);
     return;

--- a/browse/test/security-classifier.test.ts
+++ b/browse/test/security-classifier.test.ts
@@ -11,6 +11,7 @@ import { describe, test, expect } from 'bun:test';
 import {
   shouldRunTranscriptCheck,
   getClassifierStatus,
+  isClassifierInactive,
 } from '../src/security-classifier';
 import { THRESHOLDS, type LayerSignal } from '../src/security';
 
@@ -69,6 +70,36 @@ describe('shouldRunTranscriptCheck — Haiku gating optimization', () => {
       { layer: 'aria_regex', confidence: 0.45 }, // just above LOG_ONLY
     ];
     expect(shouldRunTranscriptCheck(signals)).toBe(true);
+  });
+});
+
+describe('isClassifierInactive — fail-closed gate', () => {
+  test('returns true when both testsavant and transcript are off', () => {
+    expect(isClassifierInactive({ testsavant: 'off', transcript: 'off' })).toBe(true);
+  });
+
+  test('returns true when deberta is also off', () => {
+    expect(isClassifierInactive({ testsavant: 'off', transcript: 'off', deberta: 'off' })).toBe(true);
+  });
+
+  test('returns false when testsavant is ok', () => {
+    expect(isClassifierInactive({ testsavant: 'ok', transcript: 'off' })).toBe(false);
+  });
+
+  test('returns false when transcript is ok', () => {
+    expect(isClassifierInactive({ testsavant: 'off', transcript: 'ok' })).toBe(false);
+  });
+
+  test('returns false when testsavant is degraded (model load failed but attempted)', () => {
+    expect(isClassifierInactive({ testsavant: 'degraded', transcript: 'off' })).toBe(false);
+  });
+
+  test('returns false when only deberta is ok (ensemble provides coverage)', () => {
+    expect(isClassifierInactive({ testsavant: 'off', transcript: 'off', deberta: 'ok' })).toBe(false);
+  });
+
+  test('returns false when all three are ok', () => {
+    expect(isClassifierInactive({ testsavant: 'ok', transcript: 'ok', deberta: 'ok' })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

The sidebar agent's ML prompt injection defense (TestSavantAI + Haiku transcript classifier) degrades silently to zero coverage when both classifiers fail to load. `preSpawnSecurityCheck` returns `false` (safe) and the agent spawns without any ML protection — the user sees "inactive" on the shield icon but gets no blocking gate.

**An attacker who can cause model download failure** (DNS poisoning on huggingface.co, disk full, proxy blocking the 112MB ONNX download) permanently removes all ML protection while the agent keeps running as if everything is fine.

## What this PR does

Adds a **fail-closed gate** at the top of `preSpawnSecurityCheck`:

- `isClassifierInactive(status)` — pure function that returns `true` only when ALL classifiers (testsavant, transcript, and deberta if enabled) report `'off'`
- When inactive: blocks agent spawn, emits `security_event` (verdict=block, reason=classifiers_inactive) + `agent_error` to the sidepanel so the user sees exactly why the session was refused
- **Does NOT fire** when `GSTACK_SECURITY_OFF=1` — that's an explicit operator kill switch, they already know
- **Does NOT fire** on partial degradation — if one classifier is `'degraded'` or `'ok'`, the remaining coverage is enough to proceed
- **Override**: `GSTACK_SECURITY_ALLOW_INACTIVE=1` for operators who knowingly run without ML (CI, air-gapped environments)

## Files changed

| File | Change |
|------|--------|
| `browse/src/security-classifier.ts` | Extract `isClassifierInactive()` pure function |
| `browse/src/sidebar-agent.ts` | Fail-closed gate in `preSpawnSecurityCheck` |
| `browse/test/security-classifier.test.ts` | 7 test cases: all status combinations |

## Test plan

- [x] `bun test browse/test/security-classifier.test.ts` — 16/16 pass (7 new + 9 existing)
- [ ] Manual: start gstack without internet, verify agent spawn is blocked with clear error message
- [ ] Manual: set `GSTACK_SECURITY_ALLOW_INACTIVE=1`, verify agent spawns despite inactive classifiers
- [ ] Manual: start normally (classifiers load), verify no change to existing behavior