### PR TITLE
Support copy-based AI export and standalone browse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,5 +45,6 @@ bun run skill:check      # health dashboard for all skills
 
 - SKILL.md files are **generated** from `.tmpl` templates. Edit the template, not the output.
 - Run `bun run gen:skill-docs --host codex` to regenerate Codex-specific output.
+- Publish the `~/.ai/skills` export with `./bin/gstack-sync ai` from the repo checkout; keep Codex installs on `./setup --host codex`. Do not symlink the repo checkout into `~/.ai/skills` when you need a reproducible, copy-based install.
 - The browse binary provides headless browser access. Use `$B <command>` in skills.
 - Safety skills (careful, freeze, guard) use inline advisory prose — always confirm before destructive operations.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,17 @@ Real files get committed to your repo (not a submodule), so `git clone` just wor
 
 ### Codex, Gemini CLI, or Cursor
 
-gstack works on any agent that supports the [SKILL.md standard](https://github.com/anthropics/claude-code). Skills live in `.agents/skills/` and are discovered automatically.
+gstack works on any agent that supports the [SKILL.md standard](https://github.com/anthropics/claude-code). Skills live in `.agents/skills/` and are discovered automatically. For Codex installs, use `./setup --host codex` from the repo checkout or from `.agents/skills/gstack`; that creates `~/.codex/skills/gstack` and the linked `gstack-*` skills there.
+
+### NixOS or other copy-based setups
+
+If you want a writable export in `~/.ai/skills`, sync from your repo checkout instead of symlinking into it:
+
+```bash
+cd ~/gstack && ./bin/gstack-sync ai
+```
+
+That publishes the full gstack skill set into `~/.ai/skills` as copies — the top-level skills like `office-hours`, `plan-ceo-review`, `plan-design-review`, `review`, and the generated `gstack-*` skills — which keeps NixOS happy. When you upgrade gstack, rerun the same sync command from the updated checkout. This `~/.ai` export is separate from the Codex install path; do not symlink the repo checkout into `~/.ai/skills` if you want predictable updates.
 
 Install to one repo:
 

--- a/bin/gstack-sync
+++ b/bin/gstack-sync
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# gstack-sync — export the repo checkout into a writable skills directory
+#
+# Usage:
+#   gstack-sync ai             — export the current repo into ~/.ai/skills
+#   gstack-sync ai --check      — verify the export matches without writing
+#   gstack-sync ai --dry-run    — show what would change without writing
+#
+# Env overrides (for tests or custom layouts):
+#   GSTACK_SOURCE_DIR     — source repo root (defaults to this checkout)
+#   GSTACK_AI_SKILLS_DIR  — target skills root (defaults to ~/.ai/skills)
+set -euo pipefail
+
+if [ -z "${HOME:-}" ]; then
+  echo "ERROR: \$HOME is not set" >&2
+  exit 1
+fi
+
+GSTACK_SOURCE_DIR="${GSTACK_SOURCE_DIR:-$(cd "$(dirname "$0")/.." && pwd -P)}"
+TARGET_NAME="ai"
+TARGET_SKILLS_DIR="${GSTACK_AI_SKILLS_DIR:-$HOME/.ai/skills}"
+CHECK=0
+DRY_RUN=0
+
+usage() {
+  cat <<'EOF'
+gstack-sync — export a gstack checkout into a writable skills directory
+
+Usage:
+  gstack-sync ai [--check] [--dry-run]
+
+Options:
+  --check     Verify the export matches the target tree, exit non-zero on drift
+  --dry-run   Show the planned export and drift summary, do not write
+  -h, --help  Show this help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    ai)
+      TARGET_NAME="ai"
+      shift
+      ;;
+    --check)
+      CHECK=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$TARGET_NAME" != "ai" ]; then
+  echo "Unsupported sync target: $TARGET_NAME" >&2
+  exit 1
+fi
+
+if [ ! -d "$GSTACK_SOURCE_DIR" ]; then
+  echo "ERROR: source repo not found at $GSTACK_SOURCE_DIR" >&2
+  exit 1
+fi
+
+ensure_generated_skills() {
+  if [ -d "$GSTACK_SOURCE_DIR/.agents/skills" ]; then
+    return 0
+  fi
+
+  echo "Generating .agents/skills docs..."
+  ( cd "$GSTACK_SOURCE_DIR" && bun run gen:skill-docs --host codex )
+
+  if [ ! -d "$GSTACK_SOURCE_DIR/.agents/skills" ]; then
+    echo "ERROR: generated Codex skills not found at $GSTACK_SOURCE_DIR/.agents/skills" >&2
+    echo "Run: cd \"$GSTACK_SOURCE_DIR\" && bun run gen:skill-docs --host codex" >&2
+    exit 1
+  fi
+}
+
+list_source_skills() {
+  find "$GSTACK_SOURCE_DIR" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null |
+    while IFS= read -r path; do
+      [ -f "$path/SKILL.md" ] || continue
+      basename "$path"
+    done | sort
+}
+
+manifest_entries() {
+  local manifest_path="$1"
+  [ -f "$manifest_path" ] || return 0
+  sed '/^[[:space:]]*$/d' "$manifest_path" | sort -u
+}
+
+rewrite_skill_files() {
+  local root="$1"
+  local file tmp
+  while IFS= read -r -d '' file; do
+    tmp="${file}.tmp"
+    sed -e 's|\$HOME/.claude/skills/gstack|$HOME/.ai/skills/gstack|g' \
+        -e 's|\$HOME/.codex/skills/gstack|$HOME/.ai/skills/gstack|g' \
+        -e 's|~/.claude/skills/gstack|~/.ai/skills/gstack|g' \
+        -e 's|~/.codex/skills/gstack|~/.ai/skills/gstack|g' \
+        -e 's|\.claude/skills/gstack|.ai/skills/gstack|g' \
+        -e 's|\.codex/skills/gstack|.ai/skills/gstack|g' \
+        "$file" > "$tmp"
+    mv "$tmp" "$file"
+  done < <(find "$root" -type f -name SKILL.md -print0)
+}
+
+top_level_entries() {
+  local root="$1"
+  find "$root" -mindepth 1 -maxdepth 1 \( -type d -o -type f -o -type l \) -print 2>/dev/null |
+    while IFS= read -r path; do
+      basename "$path"
+    done | sort
+}
+
+build_stage() {
+  local stage_dir="$1"
+  local stage_root="$stage_dir/gstack"
+  local stage_manifest="$stage_root/.gstack-export-manifest"
+  local skill_name
+
+  mkdir -p "$stage_root"
+
+  for item in SKILL.md ETHOS.md VERSION CHANGELOG.md README.md CONTRIBUTING.md AGENTS.md CLAUDE.md bin browse qa review agents; do
+    if [ -e "$GSTACK_SOURCE_DIR/$item" ]; then
+      cp -R "$GSTACK_SOURCE_DIR/$item" "$stage_root/"
+    fi
+  done
+
+  printf '%s\n' "$GSTACK_SOURCE_DIR" > "$stage_root/.gstack-source"
+  list_source_skills > "$stage_manifest"
+
+  while IFS= read -r skill_name; do
+    [ -n "$skill_name" ] || continue
+    cp -R "$GSTACK_SOURCE_DIR/$skill_name" "$stage_dir/$skill_name"
+  done < "$stage_manifest"
+
+  rewrite_skill_files "$stage_dir"
+}
+
+remove_managed_entries() {
+  local root="$1"
+  local manifest_path="${2:-}"
+  local entry
+
+  if [ -f "$root/gstack/.gstack-export-manifest" ]; then
+    manifest_path="$root/gstack/.gstack-export-manifest"
+  fi
+
+  if [ -n "$manifest_path" ] && [ -f "$manifest_path" ]; then
+    while IFS= read -r entry; do
+      [ -n "$entry" ] || continue
+      rm -rf "$root/$entry"
+    done < <(manifest_entries "$manifest_path")
+  else
+    while IFS= read -r entry; do
+      case "$entry" in
+        gstack|gstack-*) rm -rf "$root/$entry" ;;
+      esac
+    done < <(top_level_entries "$root")
+  fi
+
+  if [ -e "$root/gstack" ] || [ -L "$root/gstack" ]; then
+    rm -rf "$root/gstack"
+  fi
+}
+
+compare_stage_to_target() {
+  local stage_dir="$1"
+  local target_dir="$2"
+  local status=0
+  local entry stage_manifest target_manifest
+
+  stage_manifest="$stage_dir/gstack/.gstack-export-manifest"
+  target_manifest="$target_dir/gstack/.gstack-export-manifest"
+
+  if [ ! -d "$target_dir/gstack" ]; then
+    echo "MISSING: gstack" >&2
+    return 1
+  fi
+
+  if ! diff -qr "$stage_dir/gstack" "$target_dir/gstack" >/dev/null 2>&1; then
+    echo "DIFFERS: gstack" >&2
+    status=1
+  fi
+
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    if [ ! -e "$target_dir/$entry" ]; then
+      echo "MISSING: $entry" >&2
+      status=1
+      continue
+    fi
+    if ! diff -qr "$stage_dir/$entry" "$target_dir/$entry" >/dev/null 2>&1; then
+      echo "DIFFERS: $entry" >&2
+      status=1
+    fi
+  done < <(manifest_entries "$stage_manifest")
+
+  if [ -f "$target_manifest" ]; then
+    if ! diff -qr "$stage_manifest" "$target_manifest" >/dev/null 2>&1; then
+      echo "DIFFERS: .gstack-export-manifest" >&2
+      status=1
+    fi
+  elif [ -e "$target_manifest" ]; then
+    echo "DIFFERS: .gstack-export-manifest" >&2
+    status=1
+  fi
+
+  return "$status"
+}
+
+STAGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/gstack-sync-XXXXXX")"
+trap 'rm -rf "$STAGE_DIR"' EXIT
+
+ensure_generated_skills
+build_stage "$STAGE_DIR"
+
+if [ "$CHECK" -eq 1 ]; then
+  if compare_stage_to_target "$STAGE_DIR" "$TARGET_SKILLS_DIR"; then
+    echo "gstack ai export is current"
+    exit 0
+  fi
+  echo "gstack ai export is stale" >&2
+  exit 1
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  if compare_stage_to_target "$STAGE_DIR" "$TARGET_SKILLS_DIR"; then
+    echo "FRESH: $TARGET_SKILLS_DIR"
+  else
+    echo "STALE: $TARGET_SKILLS_DIR"
+    top_level_entries "$STAGE_DIR" | sed 's/^/  expected: /'
+  fi
+  exit 0
+fi
+
+mkdir -p "$TARGET_SKILLS_DIR"
+remove_managed_entries "$TARGET_SKILLS_DIR" "$STAGE_DIR/gstack/.gstack-export-manifest"
+cp -R "$STAGE_DIR"/. "$TARGET_SKILLS_DIR"/
+
+echo "synced gstack to $TARGET_SKILLS_DIR"

--- a/bin/gstack-uninstall
+++ b/bin/gstack-uninstall
@@ -10,6 +10,7 @@
 #   ~/.claude/skills/gstack       — global Claude skill install (git clone or vendored)
 #   ~/.claude/skills/{skill}      — per-skill symlinks created by setup
 #   ~/.codex/skills/gstack*       — Codex skill install + per-skill symlinks
+#   ~/.ai/skills/gstack*          — copy-exported AI skill install + exported skills
 #   ~/.kiro/skills/gstack*        — Kiro skill install + per-skill symlinks
 #   ~/.gstack/                    — global state (config, analytics, sessions, projects,
 #                                   repos, installation-id, browse error logs)
@@ -63,6 +64,7 @@ if [ "$FORCE" -eq 0 ]; then
   echo "This will remove gstack from your system:"
   { [ -d "$HOME/.claude/skills/gstack" ] || [ -L "$HOME/.claude/skills/gstack" ]; } && echo "  ~/.claude/skills/gstack (+ per-skill symlinks)"
   [ -d "$HOME/.codex/skills" ] && echo "  ~/.codex/skills/gstack*"
+  [ -d "$HOME/.ai/skills" ] && echo "  ~/.ai/skills/gstack*"
   [ -d "$HOME/.kiro/skills" ] && echo "  ~/.kiro/skills/gstack*"
   [ "$KEEP_STATE" -eq 0 ] && [ -d "$STATE_DIR" ] && echo "  $STATE_DIR"
 
@@ -88,6 +90,12 @@ if [ "$FORCE" -eq 0 ]; then
 fi
 
 REMOVED=()
+
+manifest_entries() {
+  local manifest_path="$1"
+  [ -f "$manifest_path" ] || return 0
+  sed '/^[[:space:]]*$/d' "$manifest_path" | sort -u
+}
 
 # ─── Stop running browse daemons ─────────────────────────────
 # Browse servers write PID to {project}/.gstack/browse.json.
@@ -167,6 +175,45 @@ if [ -d "$CODEX_SKILLS" ]; then
     rm -rf "$_ITEM"
     REMOVED+=("codex/$(basename "$_ITEM")")
   done
+fi
+
+# ─── Remove AI skills export ─────────────────────────────────
+AI_SKILLS="$HOME/.ai/skills"
+if [ -d "$AI_SKILLS" ]; then
+  AI_GSTACK="$AI_SKILLS/gstack"
+  AI_SOURCE="$(cat "$AI_GSTACK/.gstack-source" 2>/dev/null || true)"
+  AI_MANIFEST="$AI_GSTACK/.gstack-export-manifest"
+
+  if [ -f "$AI_MANIFEST" ]; then
+    while IFS= read -r _NAME; do
+      [ -n "$_NAME" ] || continue
+      if [ -e "$AI_SKILLS/$_NAME" ] || [ -L "$AI_SKILLS/$_NAME" ]; then
+        rm -rf "$AI_SKILLS/$_NAME"
+        REMOVED+=("ai/$_NAME")
+      fi
+    done < <(manifest_entries "$AI_MANIFEST")
+  elif [ -n "$AI_SOURCE" ] && [ -d "$AI_SOURCE" ]; then
+    for _ITEM in "$AI_SOURCE"/*; do
+      [ -d "$_ITEM" ] || continue
+      [ -f "$_ITEM/SKILL.md" ] || continue
+      _NAME="$(basename "$_ITEM")"
+      if [ -e "$AI_SKILLS/$_NAME" ] || [ -L "$AI_SKILLS/$_NAME" ]; then
+        rm -rf "$AI_SKILLS/$_NAME"
+        REMOVED+=("ai/$_NAME")
+      fi
+    done
+  else
+    for _ITEM in "$AI_SKILLS"/gstack*; do
+      [ -e "$_ITEM" ] || [ -L "$_ITEM" ] || continue
+      rm -rf "$_ITEM"
+      REMOVED+=("ai/$(basename "$_ITEM")")
+    done
+  fi
+
+  if [ -e "$AI_GSTACK" ] || [ -L "$AI_GSTACK" ]; then
+    rm -rf "$AI_GSTACK"
+    REMOVED+=("~/.ai/skills/gstack")
+  fi
 fi
 
 # ─── Remove Kiro skills ─────────────────────────────────────

--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -1,48 +1,59 @@
 #!/usr/bin/env bash
-# Build a Node.js-compatible server bundle for Windows.
+# Build a Node.js-compatible server bundle for compiled installs.
 #
 # On Windows, Bun can't launch or connect to Playwright's Chromium
-# (oven-sh/bun#4253, #9911). This script produces a server bundle
-# that runs under Node.js with Bun API polyfills.
+# (oven-sh/bun#4253, #9911). On macOS/Linux compiled exports also need
+# a self-contained server bundle because the exported browse binary should
+# not depend on source-side node_modules.
 
 set -e
 
 GSTACK_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 SRC_DIR="$GSTACK_DIR/browse/src"
 DIST_DIR="$GSTACK_DIR/browse/dist"
+TMP_DIR="$DIST_DIR/.node-build"
 
 echo "Building Node-compatible server bundle..."
 
-# Step 1: Transpile server.ts to a single .mjs bundle (externalize runtime deps)
+# Step 1: Transpile server.ts to a self-contained Node bundle.
+# Keep only Electron external — Playwright's server path imports it lazily.
+rm -rf "$TMP_DIR"
+mkdir -p "$TMP_DIR"
 bun build "$SRC_DIR/server.ts" \
   --target=node \
-  --outfile "$DIST_DIR/server-node.mjs" \
-  --external playwright \
-  --external playwright-core \
-  --external diff \
+  --outdir "$TMP_DIR" \
+  --external electron \
   --external "bun:sqlite"
+
+# The bundled entry lands as server.js plus any emitted assets.
+ENTRY_JS="$TMP_DIR/server.js"
+if [ ! -f "$ENTRY_JS" ]; then
+  echo "ERROR: expected bundled server entry at $ENTRY_JS" >&2
+  exit 1
+fi
 
 # Step 2: Post-process
 # Replace import.meta.dir with a resolvable reference
-perl -pi -e 's/import\.meta\.dir/__browseNodeSrcDir/g' "$DIST_DIR/server-node.mjs"
+perl -pi -e 's/import\.meta\.dir/__browseNodeDistDir/g' "$ENTRY_JS"
 # Stub out bun:sqlite (macOS-only cookie import, not needed on Windows)
-perl -pi -e 's|import { Database } from "bun:sqlite";|const Database = null; // bun:sqlite stubbed on Node|g' "$DIST_DIR/server-node.mjs"
+perl -pi -e 's|import { Database } from "bun:sqlite";|const Database = null; // bun:sqlite stubbed on Node|g' "$ENTRY_JS"
 
 # Step 3: Create the final file with polyfill header injected after the first line
 {
-  head -1 "$DIST_DIR/server-node.mjs"
-  echo '// ── Windows Node.js compatibility (auto-generated) ──'
+  head -1 "$ENTRY_JS"
+  echo '// ── Node.js compatibility (auto-generated) ──'
   echo 'import { fileURLToPath as _ftp } from "node:url";'
   echo 'import { dirname as _dn } from "node:path";'
-  echo 'const __browseNodeSrcDir = _dn(_dn(_ftp(import.meta.url))) + "/src";'
+  echo 'const __browseNodeDistDir = _dn(_ftp(import.meta.url));'
   echo '{ const _r = createRequire(import.meta.url); _r("./bun-polyfill.cjs"); }'
   echo '// ── end compatibility ──'
-  tail -n +2 "$DIST_DIR/server-node.mjs"
-} > "$DIST_DIR/server-node.tmp.mjs"
+  tail -n +2 "$ENTRY_JS"
+} > "$DIST_DIR/server-node.mjs"
 
-mv "$DIST_DIR/server-node.tmp.mjs" "$DIST_DIR/server-node.mjs"
-
-# Step 4: Copy polyfill to dist/
+# Step 4: Copy emitted assets + polyfill to dist/
+find "$TMP_DIR" -mindepth 1 -maxdepth 1 -type f ! -name 'server.js' -exec cp {} "$DIST_DIR"/ \;
 cp "$SRC_DIR/bun-polyfill.cjs" "$DIST_DIR/bun-polyfill.cjs"
+
+rm -rf "$TMP_DIR"
 
 echo "Node server bundle ready: $DIST_DIR/server-node.mjs"

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -15,6 +15,8 @@ import { resolveConfig, ensureStateDir, readVersionHash } from './config';
 
 const config = resolveConfig();
 const IS_WINDOWS = process.platform === 'win32';
+const IS_COMPILED_BINARY = import.meta.dir.includes('$bunfs');
+const DEBUG_STARTUP = process.env.BROWSE_DEBUG_STARTUP === '1';
 const MAX_START_WAIT = IS_WINDOWS ? 15000 : (process.env.CI ? 30000 : 8000); // Node+Chromium takes longer on Windows
 
 export function resolveServerScript(
@@ -74,7 +76,18 @@ export function resolveNodeServerScript(
   return null;
 }
 
-const NODE_SERVER_SCRIPT = IS_WINDOWS ? resolveNodeServerScript() : null;
+const NODE_SERVER_SCRIPT = resolveNodeServerScript();
+const SHOULD_USE_NODE_SERVER = Boolean(NODE_SERVER_SCRIPT) && !process.env.BROWSE_SERVER_SCRIPT && (IS_WINDOWS || IS_COMPILED_BINARY);
+
+if (DEBUG_STARTUP) {
+  console.error('[browse] startup debug', JSON.stringify({
+    importMetaDir: import.meta.dir,
+    execPath: process.execPath,
+    nodeServerScript: NODE_SERVER_SCRIPT,
+    shouldUseNodeServer: SHOULD_USE_NODE_SERVER,
+    browseServerScriptEnv: process.env.BROWSE_SERVER_SCRIPT || null,
+  }));
+}
 
 // On Windows, hard-fail if server-node.mjs is missing — the Bun path is known broken.
 if (IS_WINDOWS && !NODE_SERVER_SCRIPT) {
@@ -227,17 +240,25 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
 
   let proc: any = null;
 
-  if (IS_WINDOWS && NODE_SERVER_SCRIPT) {
+  if (SHOULD_USE_NODE_SERVER && NODE_SERVER_SCRIPT) {
     // Windows: Bun.spawn() + proc.unref() doesn't truly detach on Windows —
     // when the CLI exits, the server dies with it. Use Node's child_process.spawn
     // with { detached: true } instead, which is the gold standard for Windows
     // process independence. Credit: PR #191 by @fqueiro.
-    const launcherCode =
-      `const{spawn}=require('child_process');` +
-      `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
-      `{detached:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
-      `{BROWSE_STATE_FILE:${JSON.stringify(config.stateFile)}})}).unref()`;
-    Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'] });
+    if (IS_WINDOWS) {
+      const launcherCode =
+        `const{spawn}=require('child_process');` +
+        `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
+        `{detached:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
+        `{BROWSE_STATE_FILE:${JSON.stringify(config.stateFile)}})}).unref()`;
+      Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'] });
+    } else {
+      proc = Bun.spawn(['node', NODE_SERVER_SCRIPT], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, BROWSE_STATE_FILE: config.stateFile, ...extraEnv },
+      });
+      proc.unref();
+    }
   } else {
     // macOS/Linux: Bun.spawn + unref works correctly
     proc = Bun.spawn(['bun', 'run', SERVER_SCRIPT], {

--- a/gstack-upgrade/SKILL.md
+++ b/gstack-upgrade/SKILL.md
@@ -82,6 +82,10 @@ if [ -d "$HOME/.claude/skills/gstack/.git" ]; then
 elif [ -d "$HOME/.gstack/repos/gstack/.git" ]; then
   INSTALL_TYPE="global-git"
   INSTALL_DIR="$HOME/.gstack/repos/gstack"
+elif [ -f "$HOME/.ai/skills/gstack/.gstack-source" ]; then
+  INSTALL_TYPE="ai-export"
+  INSTALL_DIR="$HOME/.ai/skills/gstack"
+  SOURCE_DIR="$(cat "$INSTALL_DIR/.gstack-source" 2>/dev/null || true)"
 elif [ -d ".claude/skills/gstack/.git" ]; then
   INSTALL_TYPE="local-git"
   INSTALL_DIR=".claude/skills/gstack"
@@ -162,6 +166,23 @@ cd "$LOCAL_GSTACK" && ./setup
 rm -rf "$LOCAL_GSTACK.bak"
 ```
 Tell user: "Also updated vendored copy at `$LOCAL_GSTACK` — commit `.claude/skills/gstack/` when you're ready."
+
+### Step 4.6: Refresh the `~/.ai/skills` export
+
+If you also maintain a copy-exported install at `~/.ai/skills/gstack`, refresh it after the source checkout is upgraded:
+
+```bash
+AI_GSTACK="$HOME/.ai/skills/gstack"
+SOURCE_GSTACK="$(cat "$AI_GSTACK/.gstack-source" 2>/dev/null || true)"
+if [ -n "$SOURCE_GSTACK" ] && [ -d "$SOURCE_GSTACK/.git" ]; then
+  cd "$SOURCE_GSTACK"
+  ./bin/gstack-sync ai
+fi
+```
+
+Tell user: "Also refreshed `~/.ai/skills/gstack` from the updated checkout."
+
+If the marker file is missing or points at a deleted checkout, tell the user to run `bin/gstack-sync ai` from the real repo checkout so the export can be rebuilt.
 
 If `./setup` fails, restore from backup and warn the user:
 ```bash

--- a/gstack-upgrade/SKILL.md.tmpl
+++ b/gstack-upgrade/SKILL.md.tmpl
@@ -80,6 +80,10 @@ if [ -d "$HOME/.claude/skills/gstack/.git" ]; then
 elif [ -d "$HOME/.gstack/repos/gstack/.git" ]; then
   INSTALL_TYPE="global-git"
   INSTALL_DIR="$HOME/.gstack/repos/gstack"
+elif [ -f "$HOME/.ai/skills/gstack/.gstack-source" ]; then
+  INSTALL_TYPE="ai-export"
+  INSTALL_DIR="$HOME/.ai/skills/gstack"
+  SOURCE_DIR="$(cat "$INSTALL_DIR/.gstack-source" 2>/dev/null || true)"
 elif [ -d ".claude/skills/gstack/.git" ]; then
   INSTALL_TYPE="local-git"
   INSTALL_DIR=".claude/skills/gstack"
@@ -160,6 +164,23 @@ cd "$LOCAL_GSTACK" && ./setup
 rm -rf "$LOCAL_GSTACK.bak"
 ```
 Tell user: "Also updated vendored copy at `$LOCAL_GSTACK` — commit `.claude/skills/gstack/` when you're ready."
+
+### Step 4.6: Refresh the `~/.ai/skills` export
+
+If you also maintain a copy-exported install at `~/.ai/skills/gstack`, refresh it after the source checkout is upgraded:
+
+```bash
+AI_GSTACK="$HOME/.ai/skills/gstack"
+SOURCE_GSTACK="$(cat "$AI_GSTACK/.gstack-source" 2>/dev/null || true)"
+if [ -n "$SOURCE_GSTACK" ] && [ -d "$SOURCE_GSTACK/.git" ]; then
+  cd "$SOURCE_GSTACK"
+  ./bin/gstack-sync ai
+fi
+```
+
+Tell user: "Also refreshed `~/.ai/skills/gstack` from the updated checkout."
+
+If the marker file is missing or points at a deleted checkout, tell the user to run `bin/gstack-sync ai` from the real repo checkout so the export can be rebuilt.
 
 If `./setup` fails, restore from backup and warn the user:
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gstack",
-  "version": "0.12.11.0",
+  "version": "0.12.12.0",
   "description": "Garry's Stack — Claude Code skills + fast headless browser. One repo, one install, entire AI engineering workflow.",
   "license": "MIT",
   "type": "module",

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1796,6 +1796,13 @@ describe('setup script validation', () => {
     // but the welcome section should exist near the prefix logic
     expect(setupContent).toContain('Run /gstack-upgrade anytime');
   });
+
+  test('gstack-upgrade mentions ~/.ai export sync', () => {
+    const content = fs.readFileSync(path.join(ROOT, 'gstack-upgrade', 'SKILL.md.tmpl'), 'utf-8');
+    expect(content).toContain('$HOME/.ai/skills/gstack');
+    expect(content).toContain('.gstack-source');
+    expect(content).toContain('bin/gstack-sync ai');
+  });
 });
 
 describe('discover-skills hidden directory filtering', () => {

--- a/test/gstack-sync.test.ts
+++ b/test/gstack-sync.test.ts
@@ -1,0 +1,191 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const SYNC = path.join(ROOT, 'bin', 'gstack-sync');
+
+describe('gstack-sync', () => {
+  test('syntax check passes', () => {
+    const result = spawnSync('bash', ['-n', SYNC], { stdio: 'pipe' });
+    expect(result.status).toBe(0);
+  });
+
+  test('--help prints usage and exits 0', () => {
+    const result = spawnSync('bash', [SYNC, '--help'], { stdio: 'pipe' });
+    expect(result.status).toBe(0);
+    const output = result.stdout.toString();
+    expect(output).toContain('gstack-sync');
+    expect(output).toContain('--check');
+    expect(output).toContain('--dry-run');
+  });
+
+  describe('integration tests with mock home', () => {
+    let tmpDir: string;
+    let mockHome: string;
+    let targetSkillsDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-sync-test-'));
+      mockHome = path.join(tmpDir, 'home');
+      targetSkillsDir = path.join(mockHome, '.ai', 'skills');
+      fs.mkdirSync(mockHome, { recursive: true });
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test('exports the full generated skill set into ~/.ai/skills', () => {
+      const result = spawnSync('bash', [SYNC, 'ai'], {
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          HOME: mockHome,
+          GSTACK_SOURCE_DIR: ROOT,
+          GSTACK_AI_SKILLS_DIR: targetSkillsDir,
+        },
+        cwd: ROOT,
+      });
+
+      expect(result.status).toBe(0);
+      expect(fs.existsSync(path.join(targetSkillsDir, 'gstack', 'SKILL.md'))).toBe(true);
+
+      const sourceSkills = fs.readdirSync(ROOT, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && fs.existsSync(path.join(ROOT, entry.name, 'SKILL.md')))
+        .map((entry) => entry.name)
+        .sort();
+
+      const manifest = fs.readFileSync(
+        path.join(targetSkillsDir, 'gstack', '.gstack-export-manifest'),
+        'utf-8',
+      )
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .sort();
+
+      expect(manifest).toEqual(sourceSkills);
+      for (const skillName of ['office-hours', 'plan-ceo-review', 'plan-design-review', 'review', 'ship', 'investigate']) {
+        expect(manifest).toContain(skillName);
+      }
+
+      for (const skillName of sourceSkills) {
+        expect(fs.existsSync(path.join(targetSkillsDir, skillName, 'SKILL.md'))).toBe(true);
+      }
+
+      const upgradeSkill = fs.readFileSync(path.join(targetSkillsDir, 'gstack-upgrade', 'SKILL.md'), 'utf-8');
+      expect(upgradeSkill).toContain('$HOME/.ai/skills/gstack');
+      expect(upgradeSkill).toContain('.gstack-source');
+      expect(upgradeSkill).toContain('bin/gstack-sync ai');
+      expect(upgradeSkill).not.toContain('~/.claude/skills/gstack');
+    });
+
+    test('exported browse server bundle starts without the source repo node_modules', () => {
+      const result = spawnSync('bash', [SYNC, 'ai'], {
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          HOME: mockHome,
+          GSTACK_SOURCE_DIR: ROOT,
+          GSTACK_AI_SKILLS_DIR: targetSkillsDir,
+        },
+        cwd: ROOT,
+      });
+
+      expect(result.status).toBe(0);
+
+      const exportedBundle = path.join(targetSkillsDir, 'gstack', 'browse', 'dist', 'server-node.mjs');
+      const exportedPolyfill = path.join(targetSkillsDir, 'gstack', 'browse', 'dist', 'bun-polyfill.cjs');
+      const stateDir = path.join(tmpDir, 'browse-state');
+      fs.mkdirSync(stateDir, { recursive: true });
+
+      expect(fs.existsSync(exportedBundle)).toBe(true);
+      expect(fs.existsSync(exportedPolyfill)).toBe(true);
+
+      const stateFile = path.join(stateDir, 'browse.json');
+      const logFile = path.join(stateDir, 'server.log');
+      const errFile = path.join(stateDir, 'server.err');
+      const shellScript = `
+        set -euo pipefail
+        rm -f ${JSON.stringify(logFile)} ${JSON.stringify(errFile)} ${JSON.stringify(stateFile)}
+        BROWSE_STATE_FILE=${JSON.stringify(stateFile)} node ${JSON.stringify(exportedBundle)} >${JSON.stringify(logFile)} 2>${JSON.stringify(errFile)} &
+        pid=$!
+        ready=0
+        for _ in $(seq 1 40); do
+          if [ -f ${JSON.stringify(stateFile)} ]; then
+            ready=1
+            break
+          fi
+          sleep 0.2
+        done
+        pkill -TERM -P "$pid" >/dev/null 2>&1 || true
+        kill "$pid" >/dev/null 2>&1 || true
+        sleep 1
+        pkill -KILL -P "$pid" >/dev/null 2>&1 || true
+        kill -KILL "$pid" >/dev/null 2>&1 || true
+        wait "$pid" >/dev/null 2>&1 || true
+        echo "READY:$ready"
+        echo "--- STDOUT ---"
+        cat ${JSON.stringify(logFile)} 2>/dev/null || true
+        echo "--- STDERR ---"
+        cat ${JSON.stringify(errFile)} 2>/dev/null || true
+      `;
+
+      const serverResult = spawnSync('bash', ['-lc', shellScript], {
+        stdio: 'pipe',
+        timeout: 12000,
+      });
+
+      const combinedOutput = serverResult.stdout.toString() + serverResult.stderr.toString();
+      expect(serverResult.status).toBe(0);
+      expect(combinedOutput).toContain('READY:1');
+      expect(combinedOutput).toContain('Server running on http://127.0.0.1:');
+      expect(combinedOutput).not.toContain("Cannot find package 'diff'");
+      expect(combinedOutput).not.toContain('Bun is not defined');
+    });
+
+    test('--check detects drift after sync', () => {
+      let result = spawnSync('bash', [SYNC, 'ai'], {
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          HOME: mockHome,
+          GSTACK_SOURCE_DIR: ROOT,
+          GSTACK_AI_SKILLS_DIR: targetSkillsDir,
+        },
+        cwd: ROOT,
+      });
+      expect(result.status).toBe(0);
+
+      result = spawnSync('bash', [SYNC, 'ai', '--check'], {
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          HOME: mockHome,
+          GSTACK_SOURCE_DIR: ROOT,
+          GSTACK_AI_SKILLS_DIR: targetSkillsDir,
+        },
+        cwd: ROOT,
+      });
+      expect(result.status).toBe(0);
+
+      fs.appendFileSync(path.join(targetSkillsDir, 'gstack-upgrade', 'SKILL.md'), '\n<!-- drift -->\n');
+
+      result = spawnSync('bash', [SYNC, 'ai', '--check'], {
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          HOME: mockHome,
+          GSTACK_SOURCE_DIR: ROOT,
+          GSTACK_AI_SKILLS_DIR: targetSkillsDir,
+        },
+        cwd: ROOT,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr.toString()).toContain('gstack ai export is stale');
+    });
+  });
+});

--- a/test/uninstall.test.ts
+++ b/test/uninstall.test.ts
@@ -45,6 +45,28 @@ describe('gstack-uninstall', () => {
       fs.mkdirSync(path.join(mockHome, '.claude', 'skills', 'gstack'), { recursive: true });
       fs.writeFileSync(path.join(mockHome, '.claude', 'skills', 'gstack', 'SKILL.md'), 'test');
 
+      // Create source skills that the AI export should mirror
+      for (const skillName of ['office-hours', 'plan-ceo-review', 'review']) {
+        fs.mkdirSync(path.join(mockGitRoot, skillName), { recursive: true });
+        fs.writeFileSync(path.join(mockGitRoot, skillName, 'SKILL.md'), 'test');
+      }
+
+      // Create copy-exported AI skills
+      fs.mkdirSync(path.join(mockHome, '.ai', 'skills', 'gstack'), { recursive: true });
+      fs.writeFileSync(path.join(mockHome, '.ai', 'skills', 'gstack', 'SKILL.md'), 'test');
+      fs.writeFileSync(path.join(mockHome, '.ai', 'skills', 'gstack', '.gstack-source'), mockGitRoot);
+      fs.writeFileSync(
+        path.join(mockHome, '.ai', 'skills', 'gstack', '.gstack-export-manifest'),
+        ['office-hours', 'plan-ceo-review', 'review'].join('\n'),
+      );
+      for (const skillName of ['office-hours', 'plan-ceo-review', 'review']) {
+        fs.mkdirSync(path.join(mockHome, '.ai', 'skills', skillName), { recursive: true });
+        fs.writeFileSync(path.join(mockHome, '.ai', 'skills', skillName, 'SKILL.md'), 'test');
+      }
+
+      fs.mkdirSync(path.join(mockHome, '.ai', 'skills', 'other-tool'), { recursive: true });
+      fs.writeFileSync(path.join(mockHome, '.ai', 'skills', 'other-tool', 'SKILL.md'), 'keep-me');
+
       // Create per-skill symlinks (both old unprefixed and new prefixed)
       fs.symlinkSync('gstack/review', path.join(mockHome, '.claude', 'skills', 'review'));
       fs.symlinkSync('gstack/ship', path.join(mockHome, '.claude', 'skills', 'gstack-ship'));
@@ -83,6 +105,13 @@ describe('gstack-uninstall', () => {
 
       // Global skill dir should be removed
       expect(fs.existsSync(path.join(mockHome, '.claude', 'skills', 'gstack'))).toBe(false);
+
+      // AI export should be removed
+      expect(fs.existsSync(path.join(mockHome, '.ai', 'skills', 'gstack'))).toBe(false);
+      expect(fs.existsSync(path.join(mockHome, '.ai', 'skills', 'office-hours'))).toBe(false);
+      expect(fs.existsSync(path.join(mockHome, '.ai', 'skills', 'plan-ceo-review'))).toBe(false);
+      expect(fs.existsSync(path.join(mockHome, '.ai', 'skills', 'review'))).toBe(false);
+      expect(fs.existsSync(path.join(mockHome, '.ai', 'skills', 'other-tool'))).toBe(true);
 
       // Per-skill symlinks pointing into gstack/ should be removed
       expect(fs.existsSync(path.join(mockHome, '.claude', 'skills', 'review'))).toBe(false);


### PR DESCRIPTION
## What
- add `bin/gstack-sync` to publish a copy-based `~/.ai/skills` export for gstack
- teach uninstall and upgrade flows about the `~/.ai` export, and document the workflow
- make compiled `browse` exports start from a self-contained Node bundle so the exported binary no longer depends on source-repo `node_modules`
- add regression coverage for the export workflow and standalone browse server startup

## Why
The `~/.ai/skills/gstack` export was incomplete and fragile. The exported `browse` binary on macOS/Linux still booted source-oriented server code, so it failed in the exported install with errors like `Cannot find package 'diff'`. The repo also lacked a first-class command for refreshing the copy-based AI export.

## Risk
Low to medium. The main behavior change is in compiled `browse` startup for exported installs and in install-management scripts. Dev-mode `bun run` behavior remains unchanged.

## How verified
- `bun test test/gstack-sync.test.ts browse/test/config.test.ts test/uninstall.test.ts`
- `bun test test/gen-skill-docs.test.ts --filter 'gstack-upgrade mentions ~/.ai export sync'`
- `bun run build`
- `./bin/gstack-sync ai`
- `BROWSE_STATE_FILE=... ~/.ai/skills/gstack/browse/dist/browse goto https://example.com`
