### PR TITLE
feat: add BROWSE_CHANNEL persistent context for macOS SSO

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -179,6 +179,7 @@ export class BrowserManager {
     // BROWSE_EXTENSIONS_DIR points to an unpacked Chrome extension directory.
     // Extensions only work in headed mode, so we use an off-screen window.
     const extensionsDir = process.env.BROWSE_EXTENSIONS_DIR;
+    const channel = process.env.BROWSE_CHANNEL;
     const launchArgs: string[] = [];
     let useHeadless = true;
 
@@ -200,14 +201,31 @@ export class BrowserManager {
       console.log(`[browse] Extensions loaded from: ${extensionsDir}`);
     }
 
-    this.browser = await chromium.launch({
+    const launchOpts = {
       headless: useHeadless,
       // On Windows, Chromium's sandbox fails when the server is spawned through
       // the Bun→Node process chain (GitHub #276). Disable it — local daemon
       // browsing user-specified URLs has marginal sandbox benefit.
       chromiumSandbox: process.platform !== 'win32',
       ...(launchArgs.length > 0 ? { args: launchArgs } : {}),
-    });
+    };
+
+    const contextOpts: BrowserContextOptions = {
+      viewport: this.currentViewport,
+      deviceScaleFactor: this.deviceScaleFactor,
+      ...(this.customUserAgent ? { userAgent: this.customUserAgent } : {}),
+    };
+
+    if (channel) {
+      // launchPersistentContext enables macOS platform SSO (newContext does not)
+      this.context = await chromium.launchPersistentContext('', {
+        ...launchOpts, ...contextOpts, channel,
+      });
+      this.browser = this.context.browser();
+    } else {
+      this.browser = await chromium.launch(launchOpts);
+      this.context = await this.browser.newContext(contextOpts);
+    }
 
     // Chromium crash → exit with clear message
     this.browser.on('disconnected', () => {
@@ -215,15 +233,6 @@ export class BrowserManager {
       console.error('[browse] Console/network logs flushed to .gstack/browse-*.log');
       process.exit(1);
     });
-
-    const contextOptions: BrowserContextOptions = {
-      viewport: { width: this.currentViewport.width, height: this.currentViewport.height },
-      deviceScaleFactor: this.deviceScaleFactor,
-    };
-    if (this.customUserAgent) {
-      contextOptions.userAgent = this.customUserAgent;
-    }
-    this.context = await this.browser.newContext(contextOptions);
 
     if (Object.keys(this.extraHeaders).length > 0) {
       await this.context.setExtraHTTPHeaders(this.extraHeaders);

--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -342,6 +342,7 @@ export class BrowserManager {
     // BROWSE_EXTENSIONS_DIR points to an unpacked Chrome extension directory.
     // Extensions only work in headed mode, so we use an off-screen window.
     const extensionsDir = process.env.BROWSE_EXTENSIONS_DIR;
+    const channel = process.env.BROWSE_CHANNEL;
     const { STEALTH_LAUNCH_ARGS, buildGStackLaunchArgs } = await import('./stealth');
     const launchArgs: string[] = [...STEALTH_LAUNCH_ARGS, ...buildGStackLaunchArgs()];
     let useHeadless = true;
@@ -369,7 +370,7 @@ export class BrowserManager {
       console.log(`[browse] Extensions loaded from: ${extensionsDir}`);
     }
 
-    this.browser = await chromium.launch({
+    const launchOpts = {
       headless: useHeadless,
       // On Windows, Chromium's sandbox fails when the server is spawned through
       // the Bun→Node process chain (GitHub #276). Disable it — local daemon
@@ -379,7 +380,24 @@ export class BrowserManager {
       chromiumSandbox: shouldEnableChromiumSandbox(),
       ...(launchArgs.length > 0 ? { args: launchArgs } : {}),
       ...(this.proxyConfig ? { proxy: this.proxyConfig } : {}),
-    });
+    };
+
+    const contextOpts: BrowserContextOptions = {
+      viewport: this.currentViewport,
+      deviceScaleFactor: this.deviceScaleFactor,
+      ...(this.customUserAgent ? { userAgent: this.customUserAgent } : {}),
+    };
+
+    if (channel) {
+      // launchPersistentContext enables macOS platform SSO (newContext does not)
+      this.context = await chromium.launchPersistentContext('', {
+        ...launchOpts, ...contextOpts, channel,
+      });
+      this.browser = this.context.browser();
+    } else {
+      this.browser = await chromium.launch(launchOpts);
+      this.context = await this.browser.newContext(contextOpts);
+    }
 
     // Chromium disconnect → distinguish clean user-quit from crash. Both
     // events look identical to Playwright (one 'disconnected' fires), but
@@ -393,15 +411,6 @@ export class BrowserManager {
     this.browser.on('disconnected', () => {
       void handleChromiumDisconnect(this.browser);
     });
-
-    const contextOptions: BrowserContextOptions = {
-      viewport: { width: this.currentViewport.width, height: this.currentViewport.height },
-      deviceScaleFactor: this.deviceScaleFactor,
-    };
-    if (this.customUserAgent) {
-      contextOptions.userAgent = this.customUserAgent;
-    }
-    this.context = await this.browser.newContext(contextOptions);
 
     if (Object.keys(this.extraHeaders).length > 0) {
       await this.context.setExtraHTTPHeaders(this.extraHeaders);


### PR DESCRIPTION
## Summary
- Adds `BROWSE_CHANNEL` env var support to `browser-manager.ts`
- When set (e.g., `BROWSE_CHANNEL=chrome`), uses `chromium.launchPersistentContext` instead of `chromium.launch` + `newContext`
- This enables macOS platform SSO passthrough, allowing browse to access authenticated internal sites (Azure DevOps, SharePoint) without manual cookie import

## Motivation
`launchPersistentContext` with a `channel` option picks up the system's SSO tokens, which `newContext` does not. This is required for browsing Microsoft internal sites that rely on platform SSO.

## Changes
- `browse/src/browser-manager.ts`: Read `BROWSE_CHANNEL` from env, branch launch logic between persistent context (with channel) and regular launch (without)

## Test plan
- [x] Verified `BROWSE_CHANNEL=chrome` successfully navigates to ADO and reads authenticated content
- [x] Verified default behavior (no `BROWSE_CHANNEL`) still works as before with `chromium.launch`