### PR TITLE
fix: seven CRITICAL/HIGH bugs from an external code audit

### DIFF
--- a/bin/gstack-global-discover.ts
+++ b/bin/gstack-global-discover.ts
@@ -274,15 +274,22 @@ function resolveClaudeCodeCwd(
 }
 
 function extractCwdFromJsonl(filePath: string): string | null {
+  // Read a capped prefix so huge JSONL files don't blow up memory. 64KB
+  // comfortably fits the largest observed session headers; the old 8KB cap
+  // would sometimes fall inside a single long line and silently drop the
+  // project (JSON.parse failure on the truncated tail).
+  const MAX_BYTES = 64 * 1024;
+  const MAX_LINES = 30;
   try {
-    // Read only the first 8KB to avoid loading huge JSONL files into memory
     const fd = openSync(filePath, "r");
-    const buf = Buffer.alloc(8192);
-    const bytesRead = readSync(fd, buf, 0, 8192, 0);
+    const buf = Buffer.alloc(MAX_BYTES);
+    const bytesRead = readSync(fd, buf, 0, MAX_BYTES, 0);
     closeSync(fd);
     const text = buf.toString("utf-8", 0, bytesRead);
-    const lines = text.split("\n").slice(0, 15);
-    for (const line of lines) {
+    // Drop the final segment — it may be an incomplete line at the cap boundary.
+    const parts = text.split("\n");
+    const completeLines = parts.length > 1 ? parts.slice(0, -1) : parts;
+    for (const line of completeLines.slice(0, MAX_LINES)) {
       if (!line.trim()) continue;
       try {
         const obj = JSON.parse(line);

--- a/bin/gstack-telemetry-sync
+++ b/bin/gstack-telemetry-sync
@@ -107,7 +107,13 @@ BATCH="$BATCH]"
 [ "$COUNT" -eq 0 ] && exit 0
 
 # ─── POST to edge function ───────────────────────────────────
-RESP_FILE="$(mktemp /tmp/gstack-sync-XXXXXX 2>/dev/null || echo "/tmp/gstack-sync-$$")"
+# Create response file atomically. If mktemp fails, refuse to continue rather
+# than fall back to a predictable $$-based path (race + overwrite footgun).
+RESP_FILE="$(mktemp "${TMPDIR:-/tmp}/gstack-sync-XXXXXX")" || {
+  echo "gstack-telemetry-sync: mktemp failed — skipping this run" >&2
+  exit 0
+}
+trap 'rm -f "$RESP_FILE"' EXIT
 HTTP_CODE="$(curl -s -w '%{http_code}' --max-time 10 \
   -X POST "${SUPABASE_URL}/functions/v1/telemetry-ingest" \
   -H "Content-Type: application/json" \

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -957,9 +957,7 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${existingState.token}`,
         },
-        body: JSON.stringify({
-      domains,
- command: 'disconnect', args: [] }),
+        body: JSON.stringify({ command: 'disconnect', args: [] }),
         signal: AbortSignal.timeout(3000),
       });
       if (resp.ok) {

--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -146,7 +146,16 @@ function parsePdfFromFile(payloadPath: string): ParsedPdfArgs {
     );
   }
   const raw = fs.readFileSync(payloadPath, 'utf8');
-  const json = JSON.parse(raw);
+  let json: any;
+  try {
+    json = JSON.parse(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`pdf: --from-file ${payloadPath} is not valid JSON (${msg}).`);
+  }
+  if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+    throw new Error(`pdf: --from-file ${payloadPath} must be a JSON object, got ${Array.isArray(json) ? 'array' : typeof json}.`);
+  }
   const out: ParsedPdfArgs = {
     output: json.output || `${TEMP_DIR}/browse-page.pdf`,
     format: json.format,

--- a/browse/src/security-classifier.ts
+++ b/browse/src/security-classifier.ts
@@ -142,16 +142,24 @@ async function downloadFile(url: string, dest: string): Promise<void> {
   const writer = fs.createWriteStream(tmp);
   // @ts-ignore — Node stream compat
   const reader = res.body.getReader();
-  let done = false;
-  while (!done) {
-    const chunk = await reader.read();
-    if (chunk.done) { done = true; break; }
-    writer.write(chunk.value);
+  try {
+    let done = false;
+    while (!done) {
+      const chunk = await reader.read();
+      if (chunk.done) { done = true; break; }
+      writer.write(chunk.value);
+    }
+    await new Promise<void>((resolve, reject) => {
+      writer.end((err?: Error | null) => (err ? reject(err) : resolve()));
+    });
+    fs.renameSync(tmp, dest);
+  } catch (err) {
+    // Close the writer and drop the half-written tmp so we don't leak an FD
+    // or ship a truncated model file to the renameSync path on retry.
+    try { writer.destroy(); } catch { /* already destroyed */ }
+    try { fs.unlinkSync(tmp); } catch { /* nothing to clean */ }
+    throw err;
   }
-  await new Promise<void>((resolve, reject) => {
-    writer.end((err?: Error | null) => (err ? reject(err) : resolve()));
-  });
-  fs.renameSync(tmp, dest);
 }
 
 async function ensureTestsavantStaged(onProgress?: (msg: string) => void): Promise<void> {

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -94,7 +94,9 @@ if [ -f "$CHROMIUM_PLIST" ]; then
   if [ -f "$CHROMIUM_STRINGS" ]; then
     # InfoPlist.strings may be binary plist, convert to xml first
     plutil -convert xml1 "$CHROMIUM_STRINGS" 2>/dev/null || true
-    sed -i '' "s/Google Chrome for Testing/$APP_NAME/g" "$CHROMIUM_STRINGS" 2>/dev/null || true
+    # Escape sed replacement metachars (& / \) in $APP_NAME so unusual names can't break or inject into the s/// command.
+    APP_NAME_SED_ESCAPED=$(printf '%s' "$APP_NAME" | sed 's/[&/\]/\\&/g')
+    sed -i '' "s/Google Chrome for Testing/${APP_NAME_SED_ESCAPED}/g" "$CHROMIUM_STRINGS" 2>/dev/null || true
   fi
   # Replace Chromium's icon with ours so the Dock shows the GStack icon
   # (Chromium's process owns the Dock icon, not our launcher)

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -179,7 +179,11 @@ echo "  Creating DMG..."
 rm -f "$DMG_PATH"
 
 # Create a temporary directory for DMG contents
-DMG_TMP=$(mktemp -d)
+DMG_TMP=$(mktemp -d) || { echo "ERROR: mktemp -d failed — refusing to continue so we don't cp into the filesystem root." >&2; exit 1; }
+if [ -z "$DMG_TMP" ] || [ ! -d "$DMG_TMP" ]; then
+  echo "ERROR: mktemp -d returned an invalid path ('$DMG_TMP')." >&2
+  exit 1
+fi
 cp -a "$APP_DIR" "$DMG_TMP/"
 ln -s /Applications "$DMG_TMP/Applications"
 

--- a/supabase/verify-rls.sh
+++ b/supabase/verify-rls.sh
@@ -30,7 +30,12 @@ check() {
   TOTAL=$(( TOTAL + 1 ))
 
   local resp_file
-  resp_file="$(mktemp 2>/dev/null || echo "/tmp/verify-rls-$$-$TOTAL")"
+  # Use mktemp strictly. Don't fall back to a predictable $$-based path —
+  # that's a race/overwrite footgun on shared machines.
+  resp_file="$(mktemp "${TMPDIR:-/tmp}/verify-rls-XXXXXX")" || {
+    echo "verify-rls: mktemp failed, aborting" >&2
+    return 1
+  }
 
   local http_code
   if [ "$method" = "GET" ]; then


### PR DESCRIPTION
## Summary

Eight commits, seven bugs. Each commit is a single logical change so the series bisects cleanly per `CLAUDE.md`'s commit rules. The bugs were surfaced by an external audit of `v1.6.3.0` master and re-verified against `v1.6.4.0` (`d75402b`) before filing — all seven targets still reproduce.

No touches to `ETHOS.md`, voice/tone in skill templates, YC/founder material, or any generated `SKILL.md`. No `browse/dist/` or `design/dist/` binaries staged. No new features, no refactors, no dependency churn.

### The bugs

| # | Sev | File | Bug | Commit |
|---|---|---|---|---|
| 1 | **CRITICAL** | `browse/src/cli.ts` | `browse disconnect` hits `ReferenceError: domains is not defined` before the graceful shutdown POST goes out. `domains` is declared only in `handlePairAgent` (line 613), but the `disconnect` branch at line 961 references it from `main()` scope. | `a3c2fe6` |
| 2 | HIGH | `scripts/build-app.sh` | The Chromium rebrand interpolates `$APP_NAME` straight into sed's `s///` replacement half. A name containing `/`, `&`, or `\` either breaks the command or gets interpreted as sed syntax, and the trailing `\|\| true` hides it. | `3ce22d3` |
| 3 | HIGH | `scripts/build-app.sh` | `DMG_TMP=$(mktemp -d)` is unchecked. On failure `$DMG_TMP` is empty and the next line is `cp -a "$APP_DIR" "$DMG_TMP/"` — which copies the `.app` bundle into the filesystem root. | `0172bea` |
| 4 | HIGH | `bin/gstack-telemetry-sync` | `mktemp` failure falls back to `/tmp/gstack-sync-$$`. `$$` is the PID — predictable, races on shared hosts. Attacker can pre-create or symlink the path and either read the response body or redirect curl's `-o`. | `40d9865` |
| 5 | HIGH | `supabase/verify-rls.sh` | Same shape: `/tmp/verify-rls-$$-$TOTAL` fallback on mktemp failure. Worse blast radius because the response bodies contain whatever RLS leak the test discovered. | `7e278f2` |
| 6 | HIGH | `browse/src/security-classifier.ts` | `downloadFile()` opens a `fs.WriteStream` to `<dest>.tmp.<pid>` but never closes it on error paths. Reader/writer throw mid-download → FD leak + half-written tmp that a retry's `renameSync` can promote to the real path, loading a truncated ONNX model. | `3aa97ad` |
| 7 | HIGH | `browse/src/meta-commands.ts` | `parsePdfFromFile()` runs `JSON.parse` on user-supplied file contents with no try/catch. A malformed payload crashes the `pdf` handler with an uncaught `SyntaxError` instead of a readable "this file isn't valid JSON". | `758bc2c` |
| 8 | HIGH | `bin/gstack-global-discover.ts` | `extractCwdFromJsonl()` reads first 8KB + parses every line. When a session header straddles the 8KB cap, `JSON.parse` fails on the truncated tail, the catch `continue`s silently, and the project disappears from the discovery output. | `4c51176` |

### Fix shape

Every fix is the smallest change that closes the bug:

- **#1** — delete the stray `domains` field from the disconnect body. One-line diff.
- **#2** — escape `&`, `/`, `\` in `$APP_NAME` before interpolating into the sed replacement.
- **#3** — fail loudly if `mktemp -d` produced an empty string or a non-directory; don't continue into `cp`.
- **#4 / #5** — drop the predictable `$$` fallback entirely. On mktemp failure, skip this run (telemetry) or `return 1` from the check (verify-rls). Telemetry also gets a `trap ... EXIT` so the tmp is cleaned up on unexpected exit.
- **#6** — wrap the read loop in `try/catch`; on failure destroy the writer and unlink the tmp before rethrowing.
- **#7** — wrap `JSON.parse`, surface the parser's own message with the offending path, and reject non-object top-level JSON.
- **#8** — raise the cap from 8KB to 64KB and drop the final (possibly truncated) segment before parsing.

## Test plan

- [ ] `bun test` — skill validation + browse integration tests (no new tests added; these are narrow bug fixes and I didn't want to expand the PR surface).
- [ ] Manual: `browse connect` then `browse disconnect` — should shut down gracefully (regression of #1).
- [ ] Manual: `APP_NAME='Foo/Bar&Baz' ./scripts/build-app.sh` — rebrand should succeed with the literal name (regression of #2).
- [ ] Manual: temporarily make `/tmp` read-only for your user, run `./scripts/build-app.sh` — should error out cleanly instead of cp-ing into `/` (regression of #3).
- [ ] Manual: feed `parsePdfFromFile` a file that's not valid JSON — should get a helpful error message (regression of #7).
- [ ] `bun run test:evals` on the gate tier — untouched code paths; would just verify no fallout.

Happy to split further, squash, or rewrite any of the commit messages if that helps. Also happy to add regression tests if you'd like — I kept the PR scope tight to stay under your community-PR guardrails (no voice/ETHOS.md/promo changes).