### PR TITLE
fix(token-registry): constant-time root-token comparison

### DIFF
--- a/browse/src/token-registry.ts
+++ b/browse/src/token-registry.ts
@@ -155,7 +155,16 @@ export function getRootToken(): string {
 }
 
 export function isRootToken(token: string): boolean {
-  return token === rootToken;
+  // Constant-time compare so a tunnel-reachable caller who can provoke an
+  // isRootToken() call (e.g., via the 403 "root over tunnel" rejection path)
+  // can't measure byte-by-byte string-compare timing to recover the token.
+  // Length check is fine to short-circuit — it only reveals the token length
+  // (which is already public: 36 chars of crypto.randomUUID()).
+  if (!rootToken) return false;
+  if (token.length !== rootToken.length) return false;
+  const a = Buffer.from(token);
+  const b = Buffer.from(rootToken);
+  return crypto.timingSafeEqual(a, b);
 }
 
 function generateToken(prefix: string): string {

--- a/browse/test/token-registry.test.ts
+++ b/browse/test/token-registry.test.ts
@@ -28,6 +28,26 @@ describe('token-registry', () => {
       expect(info!.scopes).toEqual(['read', 'write', 'admin', 'meta', 'control']);
       expect(info!.rateLimit).toBe(0);
     });
+
+    // Regression: isRootToken used to do 'token === rootToken' which short-circuits
+    // on the first differing byte. crypto.timingSafeEqual requires equal-length
+    // inputs, so these cases exercise the wrapper's length short-circuit and the
+    // same-length branch that actually calls timingSafeEqual.
+    it('returns false for a token that differs only in length (same prefix)', () => {
+      expect(isRootToken('root-token-for-tests-extra')).toBe(false);
+      expect(isRootToken('root-token-for-test')).toBe(false);
+    });
+
+    it('returns false for a same-length token that differs only in the last byte', () => {
+      const expected = 'root-token-for-tests';
+      const wrong = expected.slice(0, -1) + (expected.endsWith('x') ? 'y' : 'x');
+      expect(wrong.length).toBe(expected.length);
+      expect(isRootToken(wrong)).toBe(false);
+    });
+
+    it('returns false for the empty string even when root is set', () => {
+      expect(isRootToken('')).toBe(false);
+    });
   });
 
   describe('createToken', () => {


### PR DESCRIPTION
## Summary

`isRootToken()` in `browse/src/token-registry.ts` compared the incoming token against the stored root token with strict equality (`token === rootToken`). V8's string `===` short-circuits on the first differing byte, turning the call into a timing oracle.

A tunnel-reachable caller can provoke `isRootToken()` on every `/command` request (the check runs to produce the 403 "root over tunnel" rejection) and, with enough samples, recover the token byte-by-byte from response-time deltas.

## Severity

**MEDIUM, not CRITICAL.** Practical exploitation is hard:
- Root token is `crypto.randomUUID()` — 122 bits of entropy. Byte-by-byte timing attack narrows this to ~36 × 16 = 576 probes, but each probe needs sub-microsecond precision.
- ngrok jitter and network round-trip variance usually dominate the JS compare's timing signal in the real world.
- Tunnel listener rejects root-token attempts at a higher layer, so success wouldn't even grant tunnel access — only local-listener access, which a local attacker has other ways to get.

But the fix is one-line-equivalent, `crypto` is already imported, and nothing else changes. No reason to leave a textbook side channel in the auth path.

## Change

`isRootToken()` now uses `crypto.timingSafeEqual()` with a length short-circuit:

```ts
export function isRootToken(token: string): boolean {
  if (!rootToken) return false;
  if (token.length !== rootToken.length) return false;
  const a = Buffer.from(token);
  const b = Buffer.from(rootToken);
  return crypto.timingSafeEqual(a, b);
}
```

The length short-circuit is safe — UUID length is public (36 chars). `timingSafeEqual` requires equal-length buffers so the length check is also necessary, not just an optimization.

## Other comparison paths — checked, no change needed

- `validateToken()` (`token-registry.ts:301`) — falls through to `tokens.get(token)`, which is `Map.get`. O(1) hash lookup; doesn't leak per-byte timing.
- `validateSseSessionToken()` (`sse-session-cookie.ts:55`) — same pattern, `sessions.get(token)`.

So `isRootToken` was the only strict-equality compare on the auth hot path.

## Tests

Added three regression cases to the existing `describe('root token', ...)` block in `browse/test/token-registry.test.ts`:

1. **Different length, same prefix** — exercises the `length !==` short-circuit. Previously `===` would also return false here, but now the path goes through the length check explicitly.
2. **Same length, differs in last byte only** — exercises `timingSafeEqual` on inputs that would have passed a naive prefix-only compare. Guards against a future refactor that might re-introduce one.
3. **Empty string with root set** — guards the `Buffer.from('')` edge before the length check runs.

The existing positive-case assertion (`isRootToken('root-token-for-tests') === true`) still passes — behavior is unchanged on the accept path.

## Test plan

- [ ] `bun test browse/test/token-registry.test.ts` — 4 test cases in the root-token describe block should all pass.
- [ ] `bun test` — full suite. No other test touches `isRootToken` directly.
- [ ] No runtime verification of the timing-attack closure itself — that would need a controlled benchmark with statistical analysis. The fix is structural: `timingSafeEqual` is what you're supposed to use, and the length check is public information.

## Scope

This is a one-function fix with three new test cases. No new dependencies. No behavior change on any accept path. Separate PR from #1169 on purpose — different concern, easier to review and revert.

Happy to split the test additions into a follow-up commit if you'd prefer the fix and tests to land as two commits. As-is, they're one commit because the tests document why the fix was needed.