### PR TITLE
Add gpt-5.5 model overlay alongside gpt-5.4

### DIFF
--- a/model-overlays/gpt-5.5.md
+++ b/model-overlays/gpt-5.5.md
@@ -1,0 +1,5 @@
+{{INHERIT:gpt}}
+
+**No 5.5-specific behavioral patches yet.** This overlay inherits the base GPT
+overlay verbatim. As 5.5-specific quirks are observed in the wild, add them here
+the same way `gpt-5.4.md` adds an anti-verbosity protocol on top of `gpt.md`.

--- a/scripts/models.ts
+++ b/scripts/models.ts
@@ -15,6 +15,7 @@ export const ALL_MODEL_NAMES = [
   'claude',
   'opus-4-7',
   'gpt',
+  'gpt-5.5',
   'gpt-5.4',
   'gemini',
   'o-series',
@@ -28,6 +29,7 @@ export type Model = (typeof ALL_MODEL_NAMES)[number];
  * Precedence rules:
  * 1. Exact match against ALL_MODEL_NAMES → return as-is.
  * 2. Family heuristics for common variants:
+ *    - `gpt-5.5-mini`, `gpt-5.5-turbo`, `gpt-5.5-*` → `gpt-5.5`
  *    - `gpt-5.4-mini`, `gpt-5.4-turbo`, `gpt-5.4-*` → `gpt-5.4`
  *    - `gpt-*` (anything else GPT) → `gpt`
  *    - `o3`, `o4`, `o4-mini`, `o1`, `o1-mini`, `o1-pro` → `o-series`
@@ -49,6 +51,7 @@ export function resolveModel(input: string): Model | null {
   }
 
   // Family heuristics
+  if (/^gpt-5\.5(-|$)/.test(s)) return 'gpt-5.5';
   if (/^gpt-5\.4(-|$)/.test(s)) return 'gpt-5.4';
   if (/^gpt(-|$)/.test(s)) return 'gpt';
   if (/^o[0-9]+(-|$)/.test(s)) return 'o-series';

--- a/test/helpers/pricing.ts
+++ b/test/helpers/pricing.ts
@@ -24,6 +24,10 @@ export const PRICING: Record<string, ModelPricing> = {
   'claude-haiku-4-5':   { input_per_mtok: 1.00,  output_per_mtok: 5.00,  as_of: '2026-04' },
 
   // OpenAI (GPT + o-series)
+  // TODO: gpt-5.5 / gpt-5.5-mini — confirm pricing at launch and add rows here.
+  // Until then, estimateCostUsd will warn-once and return 0 for those models,
+  // which is intentional: 0 in a benchmark report is louder than a placeholder
+  // that quietly ships wrong numbers.
   'gpt-5.4':            { input_per_mtok: 2.50,  output_per_mtok: 10.00, as_of: '2026-04' },
   'gpt-5.4-mini':       { input_per_mtok: 0.60,  output_per_mtok: 2.40,  as_of: '2026-04' },
   'o3':                 { input_per_mtok: 15.00, output_per_mtok: 60.00, as_of: '2026-04' },


### PR DESCRIPTION
## Summary

Additive change so existing `gpt-5.4` users are unaffected. Adds `gpt-5.5` as a recognized model family with its own overlay file inheriting from `gpt.md`.

## Changes

- **`model-overlays/gpt-5.5.md`** (new) — `{{INHERIT:gpt}}` plus a placeholder note. No 5.5-specific behavioral patches yet — same convention as how `gpt-5.4.md` started before its anti-verbosity protocol was added.
- **`scripts/models.ts`** — `'gpt-5.5'` added to `ALL_MODEL_NAMES` (above 5.4 to preserve newer-first ordering); `/^gpt-5\.5(-|$)/` family heuristic added before the 5.4 branch so `gpt-5.5-mini` / `gpt-5.5-turbo` resolve to `'gpt-5.5'`.
- **`test/helpers/pricing.ts`** — TODO comment block above the OpenAI section. Pricing intentionally NOT pre-filled. `estimateCostUsd`'s warn-once-and-return-0 path is louder in benchmark reports than a placeholder that would quietly ship wrong numbers. Add real rows when 5.5 launches.

## Why additive (not rename)

Renaming `gpt-5.4 → gpt-5.5` would (a) strand existing users pinned to 5.4, (b) require historical revisionism in CHANGELOG / docs/designs/PLAN_TUNING_V0.md / PACING_UPDATES_V0.md, and (c) break the OpenAI blog-post URL references in design-review/SKILL.md and friends. Adding alongside is what the codebase pattern already does for new model families.

## Test plan

Verified locally before pushing:

- 11 `resolveModel` cases pass: `gpt-5.5`, `gpt-5.5-mini`, `gpt-5.5-turbo` → `'gpt-5.5'`; `gpt-5.4` / `gpt-5.4-mini` unchanged; `gpt-4o` still falls through to `'gpt'`; claude / o-series / gemini families intact; unknown returns null.
- `generateModelOverlay({model:'gpt-5.5'})` returns 2511 chars: gpt.md base content (Completion bias / No preamble / AskUserQuestion-NOT-preamble) followed by the 5.5 placeholder note.
- `bun test test/helpers/ test/benchmark-runner.test.ts` — 73 pass / 0 fail.

- [ ] Reviewer: confirm pricing-as-TODO is the preferred pattern vs. shipping a placeholder row
- [ ] Reviewer: confirm `gpt-5.5` ordering above `gpt-5.4` in `ALL_MODEL_NAMES` matches house style