### PR TITLE
refactor: drive external host setup from host config

### DIFF
--- a/.github/docker/Dockerfile.ci
+++ b/.github/docker/Dockerfile.ci
@@ -84,8 +84,8 @@ RUN for i in 1 2 3; do \
     && fc-cache -f \
     && rm -rf /var/lib/apt/lists/*
 
-# Pre-install dependencies (cached layer — only rebuilds when package.json changes)
-COPY package.json /workspace/
+# Pre-install dependencies (cached layer — only rebuilds when package.json or bun.lock changes)
+COPY package.json bun.lock /workspace/
 WORKDIR /workspace
 RUN bun install && rm -rf /tmp/*
 
@@ -102,9 +102,10 @@ RUN bun --version && node --version && claude --version && jq --version && gh --
 
 # At runtime: checkout overwrites /workspace, but node_modules persists
 # if we move it out of the way and symlink back
-# Save node_modules + package.json snapshot for cache validation at runtime
+# Save node_modules + dependency manifest snapshots for cache validation at runtime
 RUN mv /workspace/node_modules /opt/node_modules_cache \
-    && cp /workspace/package.json /opt/node_modules_cache/.package.json
+    && cp /workspace/package.json /opt/node_modules_cache/.package.json \
+    && cp /workspace/bun.lock /opt/node_modules_cache/.bun.lock
 
 # Claude CLI refuses --dangerously-skip-permissions as root.
 # Create a non-root user for eval runs (GH Actions overrides USER, so

--- a/.github/docker/Dockerfile.ci
+++ b/.github/docker/Dockerfile.ci
@@ -4,21 +4,18 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Switch apt sources to Hetzner's public mirror.
-# Ubicloud runners (Hetzner FSN1-DC21) hit reliable connection timeouts to
-# archive.ubuntu.com:80 — observed 90+ second outages on multiple builds.
-# Hetzner's mirror is publicly accessible from any cloud and route-local for
-# Ubicloud, so this fixes both reliability and latency. Ubuntu 24.04 uses
-# the deb822 sources format at /etc/apt/sources.list.d/ubuntu.sources.
-#
-# Using HTTP (not HTTPS) intentionally: the base ubuntu:24.04 image ships
-# without ca-certificates, so HTTPS apt fails with "No system certificates
-# available." Apt's security model verifies via GPG-signed Release files,
-# not TLS, so HTTP here is no weaker than the upstream defaults.
-RUN sed -i \
-    -e 's|http://archive.ubuntu.com/ubuntu|http://mirror.hetzner.com/ubuntu/packages|g' \
-    -e 's|http://security.ubuntu.com/ubuntu|http://mirror.hetzner.com/ubuntu/packages|g' \
-    /etc/apt/sources.list.d/ubuntu.sources
+# Use Hetzner's public mirror only on Hetzner-hosted runners.
+# GitHub-hosted runners cannot reliably reach mirror.hetzner.com; keeping the
+# default Ubuntu mirrors there lets fork-owned prebuilds run without upstream
+# Ubicloud access. Ubuntu 24.04 uses the deb822 sources format at
+# /etc/apt/sources.list.d/ubuntu.sources.
+ARG USE_HETZNER_MIRROR=false
+RUN if [ "$USE_HETZNER_MIRROR" = "true" ]; then \
+      sed -i \
+        -e 's|http://archive.ubuntu.com/ubuntu|http://mirror.hetzner.com/ubuntu/packages|g' \
+        -e 's|http://security.ubuntu.com/ubuntu|http://mirror.hetzner.com/ubuntu/packages|g' \
+        /etc/apt/sources.list.d/ubuntu.sources; \
+    fi
 
 # Also make apt itself resilient — per-package retries + generous timeouts.
 # Hetzner's mirror is reliable but individual packages can still blip; the
@@ -64,7 +61,7 @@ RUN curl --retry 5 --retry-delay 5 --retry-connrefused -fsSL "https://nodejs.org
 # Bun (install to /usr/local so non-root users can access it)
 ENV BUN_INSTALL="/usr/local"
 RUN curl --retry 5 --retry-delay 5 --retry-connrefused -fsSL https://bun.sh/install \
-    | BUN_VERSION=1.3.10 bash
+    | bash -s -- bun-v1.3.10
 
 # Claude CLI
 RUN npm i -g @anthropic-ai/claude-code

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -13,6 +13,9 @@ on:
   # Manual trigger
   workflow_dispatch:
 
+env:
+  IMAGE: ghcr.io/${{ github.repository }}/ci
+
 jobs:
   build:
     runs-on: ubicloud-standard-2
@@ -21,6 +24,9 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+
+      - id: meta
+        run: echo "tag=${{ env.IMAGE }}:${{ hashFiles('.github/docker/Dockerfile.ci', 'package.json', 'bun.lock') }}" >> "$GITHUB_OUTPUT"
 
       # Copy dependency manifests into Docker build context
       - run: cp package.json bun.lock .github/docker/
@@ -37,5 +43,6 @@ jobs:
           file: .github/docker/Dockerfile.ci
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/ci:latest
-            ghcr.io/${{ github.repository }}/ci:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ steps.meta.outputs.tag }}

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubicloud-standard-2
+    runs-on: ${{ github.repository == 'garrytan/gstack' && 'ubicloud-standard-2' || 'ubuntu-latest' }}
     permissions:
       contents: read
       packages: write
@@ -46,3 +46,5 @@ jobs:
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.sha }}
             ${{ steps.meta.outputs.tag }}
+          build-args: |
+            USE_HETZNER_MIRROR=${{ github.repository == 'garrytan/gstack' && 'true' || 'false' }}

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -3,12 +3,13 @@ on:
   # Rebuild weekly (Monday 6am UTC) to pick up CLI updates
   schedule:
     - cron: '0 6 * * 1'
-  # Rebuild on Dockerfile or lockfile changes
+  # Rebuild on Dockerfile or dependency manifest changes
   push:
     branches: [main]
     paths:
       - '.github/docker/Dockerfile.ci'
       - 'package.json'
+      - 'bun.lock'
   # Manual trigger
   workflow_dispatch:
 
@@ -21,8 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Copy lockfile + package.json into Docker build context
-      - run: cp package.json .github/docker/
+      # Copy dependency manifests into Docker build context
+      - run: cp package.json bun.lock .github/docker/
 
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/evals-periodic.yml
+++ b/.github/workflows/evals-periodic.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: meta
-        run: echo "tag=${{ env.IMAGE }}:${{ hashFiles('.github/docker/Dockerfile.ci', 'package.json') }}" >> "$GITHUB_OUTPUT"
+        run: echo "tag=${{ env.IMAGE }}:${{ hashFiles('.github/docker/Dockerfile.ci', 'package.json', 'bun.lock') }}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/login-action@v3
         with:
@@ -43,7 +43,7 @@ jobs:
           fi
 
       - if: steps.check.outputs.exists == 'false'
-        run: cp package.json .github/docker/
+        run: cp package.json bun.lock .github/docker/
 
       - if: steps.check.outputs.exists == 'false'
         uses: docker/build-push-action@v6
@@ -103,7 +103,9 @@ jobs:
 
       - name: Restore deps
         run: |
-          if [ -d /opt/node_modules_cache ] && diff -q /opt/node_modules_cache/.package.json package.json >/dev/null 2>&1; then
+          if [ -d /opt/node_modules_cache ] \
+            && diff -q /opt/node_modules_cache/.package.json package.json >/dev/null 2>&1 \
+            && diff -q /opt/node_modules_cache/.bun.lock bun.lock >/dev/null 2>&1; then
             ln -s /opt/node_modules_cache node_modules
           else
             bun install

--- a/.github/workflows/evals-periodic.yml
+++ b/.github/workflows/evals-periodic.yml
@@ -54,6 +54,8 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tag }}
             ${{ env.IMAGE }}:latest
+          build-args: |
+            USE_HETZNER_MIRROR=${{ github.repository == 'garrytan/gstack' && 'true' || 'false' }}
 
   evals:
     runs-on: ubicloud-standard-2

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -13,14 +13,13 @@ env:
   EVALS_TIER: gate
 
 jobs:
-  # Build Docker image with pre-baked toolchain (cached — only rebuilds on Dockerfile/lockfile change)
-  build-image:
-    runs-on: ubicloud-standard-2
+  meta:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     outputs:
       image-tag: ${{ steps.meta.outputs.tag }}
+      push_allowed: ${{ steps.meta.outputs.push_allowed }}
     steps:
       - uses: actions/checkout@v4
 
@@ -37,6 +36,17 @@ jobs:
             echo "push_allowed=true" >> "$GITHUB_OUTPUT"
           fi
 
+  # Build Docker image with pre-baked toolchain (cached — only rebuilds on Dockerfile/lockfile change)
+  build-image:
+    runs-on: ubicloud-standard-2
+    needs: meta
+    if: needs.meta.outputs.push_allowed == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -46,35 +56,59 @@ jobs:
       - name: Check if image exists
         id: check
         run: |
-          if docker manifest inspect ${{ steps.meta.outputs.tag }} > /dev/null 2>&1; then
+          if docker manifest inspect ${{ needs.meta.outputs.image-tag }} > /dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - if: steps.check.outputs.exists == 'false' && steps.meta.outputs.push_allowed == 'true'
+      - if: steps.check.outputs.exists == 'false'
         run: cp package.json .github/docker/
 
-      - if: steps.check.outputs.exists == 'false' && steps.meta.outputs.push_allowed == 'true'
+      - if: steps.check.outputs.exists == 'false'
         uses: docker/build-push-action@v6
         with:
           context: .github/docker
           file: .github/docker/Dockerfile.ci
           push: true
           tags: |
-            ${{ steps.meta.outputs.tag }}
+            ${{ needs.meta.outputs.image-tag }}
             ${{ env.IMAGE }}:latest
 
-      - if: steps.check.outputs.exists == 'false' && steps.meta.outputs.push_allowed != 'true'
+  verify-fork-image:
+    runs-on: ubicloud-standard-2
+    needs: meta
+    if: needs.meta.outputs.push_allowed != 'true'
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure upstream image exists
         run: |
-          echo "::error::Upstream ci:latest is missing, so this fork PR cannot reuse it. Ask a maintainer to refresh the CI image from a same-repo branch."
-          exit 1
+          if ! docker manifest inspect ${{ needs.meta.outputs.image-tag }} > /dev/null 2>&1; then
+            echo "::error::Upstream ci:latest is missing, so this fork PR cannot reuse it. Ask a maintainer to refresh the CI image from a same-repo branch."
+            exit 1
+          fi
 
   evals:
     runs-on: ${{ matrix.suite.runner || 'ubicloud-standard-2' }}
-    needs: build-image
+    needs: [meta, build-image, verify-fork-image]
+    if: >-
+      always() &&
+      needs.meta.result == 'success' &&
+      contains(fromJSON('["success","skipped"]'), needs.build-image.result) &&
+      contains(fromJSON('["success","skipped"]'), needs.verify-fork-image.result)
+    permissions:
+      contents: read
+      packages: read
     container:
-      image: ${{ needs.build-image.outputs.image-tag }}
+      image: ${{ needs.meta.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -168,12 +202,9 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      pull-requests: write
+    outputs:
+      body: ${{ steps.render.outputs.body }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
       - name: Download all eval artifacts
         uses: actions/download-artifact@v4
         with:
@@ -181,15 +212,14 @@ jobs:
           path: /tmp/eval-results
           merge-multiple: true
 
-      - name: Post PR comment
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      - name: Build eval summary
+        id: render
         run: |
           # shellcheck disable=SC2086,SC2059
           RESULTS=$(find /tmp/eval-results -name '*.json' 2>/dev/null | sort)
           if [ -z "$RESULTS" ]; then
             echo "No eval results found"
+            printf 'body=\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -245,13 +275,31 @@ jobs:
           fi
 
           printf '%s\n' "$BODY" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo 'body<<EOF'
+            printf '%s\n' "$BODY"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
-          if [ "$IS_FORK_PR" = "true" ]; then
-            echo "Fork PR detected — skipping PR comment because GITHUB_TOKEN cannot write PR comments in cross-repo pull_request workflows."
-            exit 0
-          fi
-
-          # Update existing comment or create new one
+  comment-report:
+    runs-on: ubicloud-standard-2
+    needs: report
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.report.result == 'success' &&
+      needs.report.outputs.body != ''
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Post PR comment
+        env:
+          BODY: ${{ needs.report.outputs.body }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
             --jq '.[] | select(.body | startswith("## E2E Evals")) | .id' | tail -1)
 
@@ -259,5 +307,6 @@ jobs:
             gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
               -X PATCH -f body="$BODY"
           else
-            gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY"
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              -f body="$BODY"
           fi

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -184,6 +184,7 @@ jobs:
       - name: Post PR comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           # shellcheck disable=SC2086,SC2059
           RESULTS=$(find /tmp/eval-results -name '*.json' 2>/dev/null | sort)
@@ -241,6 +242,13 @@ jobs:
 
           ### Failures
           $(echo -e "$FAILURES")"
+          fi
+
+          printf '%s\n' "$BODY" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$IS_FORK_PR" = "true" ]; then
+            echo "Fork PR detected — skipping PR comment because GITHUB_TOKEN cannot write PR comments in cross-repo pull_request workflows."
+            exit 0
           fi
 
           # Update existing comment or create new one

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -26,13 +26,13 @@ jobs:
       - id: meta
         env:
           IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          IMAGE_TAG: ${{ env.IMAGE }}:${{ hashFiles('.github/docker/Dockerfile.ci', 'package.json') }}
         run: |
+          echo "tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
           if [ "$IS_FORK_PR" = "true" ]; then
-            echo "Fork PR detected — reusing upstream ci:latest because GITHUB_TOKEN cannot push org packages from cross-repo PRs."
-            echo "tag=${{ env.IMAGE }}:latest" >> "$GITHUB_OUTPUT"
+            echo "Fork PR detected — reusing the prebuilt image for the current Dockerfile/package.json hash because GITHUB_TOKEN cannot push org packages from cross-repo PRs."
             echo "push_allowed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${{ env.IMAGE }}:${{ hashFiles('.github/docker/Dockerfile.ci', 'package.json') }}" >> "$GITHUB_OUTPUT"
             echo "push_allowed=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -92,7 +92,7 @@ jobs:
       - name: Ensure upstream image exists
         run: |
           if ! docker manifest inspect ${{ needs.meta.outputs.image-tag }} > /dev/null 2>&1; then
-            echo "::error::Upstream ci:latest is missing, so this fork PR cannot reuse it. Ask a maintainer to refresh the CI image from a same-repo branch."
+            echo "::error::Required prebuilt CI image for this Dockerfile/package.json hash is missing in GHCR, so this fork PR cannot reuse it. Ask a maintainer to refresh the CI image from a same-repo branch."
             exit 1
           fi
 

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -26,11 +26,11 @@ jobs:
       - id: meta
         env:
           IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-          IMAGE_TAG: ${{ env.IMAGE }}:${{ hashFiles('.github/docker/Dockerfile.ci', 'package.json') }}
+          IMAGE_TAG: ${{ env.IMAGE }}:${{ hashFiles('.github/docker/Dockerfile.ci', 'package.json', 'bun.lock') }}
         run: |
           echo "tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
           if [ "$IS_FORK_PR" = "true" ]; then
-            echo "Fork PR detected — reusing the prebuilt image for the current Dockerfile/package.json hash because GITHUB_TOKEN cannot push org packages from cross-repo PRs."
+            echo "Fork PR detected — reusing the prebuilt image for the current Dockerfile/package.json/bun.lock hash because GITHUB_TOKEN cannot push org packages from cross-repo PRs."
             echo "push_allowed=false" >> "$GITHUB_OUTPUT"
           else
             echo "push_allowed=true" >> "$GITHUB_OUTPUT"
@@ -63,7 +63,7 @@ jobs:
           fi
 
       - if: steps.check.outputs.exists == 'false'
-        run: cp package.json .github/docker/
+        run: cp package.json bun.lock .github/docker/
 
       - if: steps.check.outputs.exists == 'false'
         uses: docker/build-push-action@v6
@@ -92,7 +92,7 @@ jobs:
       - name: Ensure upstream image exists
         run: |
           if ! docker manifest inspect ${{ needs.meta.outputs.image-tag }} > /dev/null 2>&1; then
-            echo "::error::Required prebuilt CI image for this Dockerfile/package.json hash is missing in GHCR, so this fork PR cannot reuse it. Ask a maintainer to refresh the CI image from a same-repo branch."
+            echo "::error::Required prebuilt CI image for this Dockerfile/package.json/bun.lock hash is missing in GHCR, so this fork PR cannot reuse it. Ask a maintainer to refresh the CI image from a same-repo branch."
             exit 1
           fi
 
@@ -162,7 +162,9 @@ jobs:
       # Restore pre-installed node_modules from Docker image via symlink (~0s vs ~15s install)
       - name: Restore deps
         run: |
-          if [ -d /opt/node_modules_cache ] && diff -q /opt/node_modules_cache/.package.json package.json >/dev/null 2>&1; then
+          if [ -d /opt/node_modules_cache ] \
+            && diff -q /opt/node_modules_cache/.package.json package.json >/dev/null 2>&1 \
+            && diff -q /opt/node_modules_cache/.bun.lock bun.lock >/dev/null 2>&1; then
             ln -s /opt/node_modules_cache node_modules
           else
             bun install

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -26,15 +26,19 @@ jobs:
       - id: meta
         env:
           IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-          IMAGE_TAG: ${{ env.IMAGE }}:${{ hashFiles('.github/docker/Dockerfile.ci', 'package.json', 'bun.lock') }}
+          BASE_IMAGE: ghcr.io/${{ github.repository }}/ci
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          IMAGE_HASH: ${{ hashFiles('.github/docker/Dockerfile.ci', 'package.json', 'bun.lock') }}
         run: |
-          echo "tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
           if [ "$IS_FORK_PR" = "true" ]; then
-            echo "Fork PR detected — reusing the prebuilt image for the current Dockerfile/package.json/bun.lock hash because GITHUB_TOKEN cannot push org packages from cross-repo PRs."
+            IMAGE="ghcr.io/$HEAD_REPOSITORY/ci"
+            echo "Fork PR detected — reusing the fork-owned prebuilt image for the current Dockerfile/package.json/bun.lock hash because GITHUB_TOKEN cannot push org packages from cross-repo PRs."
             echo "push_allowed=false" >> "$GITHUB_OUTPUT"
           else
+            IMAGE="$BASE_IMAGE"
             echo "push_allowed=true" >> "$GITHUB_OUTPUT"
           fi
+          echo "tag=$IMAGE:$IMAGE_HASH" >> "$GITHUB_OUTPUT"
 
   # Build Docker image with pre-baked toolchain (cached — only rebuilds on Dockerfile/lockfile change)
   build-image:
@@ -74,6 +78,8 @@ jobs:
           tags: |
             ${{ needs.meta.outputs.image-tag }}
             ${{ env.IMAGE }}:latest
+          build-args: |
+            USE_HETZNER_MIRROR=${{ github.repository == 'garrytan/gstack' && 'true' || 'false' }}
 
   verify-fork-image:
     runs-on: ubicloud-standard-2
@@ -89,10 +95,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Ensure upstream image exists
+      - name: Ensure fork-owned image exists
         run: |
           if ! docker manifest inspect ${{ needs.meta.outputs.image-tag }} > /dev/null 2>&1; then
-            echo "::error::Required prebuilt CI image for this Dockerfile/package.json/bun.lock hash is missing in GHCR, so this fork PR cannot reuse it. Ask a maintainer to refresh the CI image from a same-repo branch."
+            echo "::error::Required fork-owned prebuilt CI image for this Dockerfile/package.json/bun.lock hash is missing in GHCR. Run Build CI Image in the fork, then rerun this check."
             exit 1
           fi
 

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -25,7 +25,17 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: meta
-        run: echo "tag=${{ env.IMAGE }}:${{ hashFiles('.github/docker/Dockerfile.ci', 'package.json') }}" >> "$GITHUB_OUTPUT"
+        env:
+          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          if [ "$IS_FORK_PR" = "true" ]; then
+            echo "Fork PR detected — reusing upstream ci:latest because GITHUB_TOKEN cannot push org packages from cross-repo PRs."
+            echo "tag=${{ env.IMAGE }}:latest" >> "$GITHUB_OUTPUT"
+            echo "push_allowed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ env.IMAGE }}:${{ hashFiles('.github/docker/Dockerfile.ci', 'package.json') }}" >> "$GITHUB_OUTPUT"
+            echo "push_allowed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: docker/login-action@v3
         with:
@@ -42,10 +52,10 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - if: steps.check.outputs.exists == 'false'
+      - if: steps.check.outputs.exists == 'false' && steps.meta.outputs.push_allowed == 'true'
         run: cp package.json .github/docker/
 
-      - if: steps.check.outputs.exists == 'false'
+      - if: steps.check.outputs.exists == 'false' && steps.meta.outputs.push_allowed == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .github/docker
@@ -54,6 +64,11 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tag }}
             ${{ env.IMAGE }}:latest
+
+      - if: steps.check.outputs.exists == 'false' && steps.meta.outputs.push_allowed != 'true'
+        run: |
+          echo "::error::Upstream ci:latest is missing, so this fork PR cannot reuse it. Ask a maintainer to refresh the CI image from a same-repo branch."
+          exit 1
 
   evals:
     runs-on: ${{ matrix.suite.runner || 'ubicloud-standard-2' }}

--- a/setup
+++ b/setup
@@ -491,34 +491,83 @@ cleanup_prefixed_claude_symlinks() {
   fi
 }
 
-# ─── Helper: link generated Codex skills into a skills parent directory ──
-# Installs from .agents/skills/gstack-* (the generated Codex-format skills)
-# instead of source dirs (which have Claude paths).
-link_codex_skill_dirs() {
+# ─── Generic helpers for symlink-generated external hosts ─────────────────────
+host_generated_skills_dir() {
   local gstack_dir="$1"
-  local skills_dir="$2"
-  local agents_dir="$gstack_dir/.agents/skills"
-  local linked=()
+  local host="$2"
+  local host_subdir
+  host_subdir="$(cd "$gstack_dir" && bun run scripts/host-config-export.ts get "$host" hostSubdir)"
+  printf '%s/%s/skills' "$gstack_dir" "$host_subdir"
+}
 
-  if [ ! -d "$agents_dir" ]; then
-    echo "  Generating .agents/ skill docs..."
-    ( cd "$gstack_dir" && bun run gen:skill-docs --host codex )
+create_host_runtime_root() {
+  local host="$1"
+  local gstack_dir="$2"
+  local host_gstack="$3"
+  local generated_dir
+  local asset
+  local src
+  local dst
+
+  generated_dir="$(host_generated_skills_dir "$gstack_dir" "$host")"
+
+  if [ -L "$host_gstack" ]; then
+    rm -f "$host_gstack"
+  elif [ -d "$host_gstack" ] && [ "$host_gstack" != "$gstack_dir" ]; then
+    rm -rf "$host_gstack"
   fi
 
-  if [ ! -d "$agents_dir" ]; then
-    echo "  warning: .agents/skills/ generation failed — run 'bun run gen:skill-docs --host codex' manually" >&2
+  mkdir -p "$host_gstack"
+
+  if [ ! -d "$generated_dir" ]; then
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host "$host" )
+  fi
+
+  if [ -f "$generated_dir/gstack/SKILL.md" ]; then
+    ln -snf "$generated_dir/gstack/SKILL.md" "$host_gstack/SKILL.md"
+  fi
+
+  while IFS= read -r asset; do
+    [ -n "$asset" ] || continue
+    src="$gstack_dir/$asset"
+    dst="$host_gstack/$asset"
+    if [ -d "$src" ] || [ -f "$src" ]; then
+      mkdir -p "$(dirname "$dst")"
+      if [ -L "$dst" ] || [ ! -e "$dst" ]; then
+        ln -snf "$src" "$dst"
+      fi
+    fi
+  done < <(cd "$gstack_dir" && bun run scripts/host-config-export.ts symlinks "$host")
+}
+
+link_host_skill_dirs() {
+  local host="$1"
+  local gstack_dir="$2"
+  local skills_dir="$3"
+  local generated_dir
+  local linked=()
+  local skill_dir
+  local skill_name
+  local target
+
+  generated_dir="$(host_generated_skills_dir "$gstack_dir" "$host")"
+
+  if [ ! -d "$generated_dir" ]; then
+    echo "  Generating $host skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host "$host" )
+  fi
+
+  if [ ! -d "$generated_dir" ]; then
+    echo "  warning: $generated_dir generation failed — run 'bun run gen:skill-docs --host $host' manually" >&2
     return 1
   fi
 
-  for skill_dir in "$agents_dir"/gstack*/; do
+  for skill_dir in "$generated_dir"/gstack*/; do
+    [ -d "$skill_dir" ] || continue
     if [ -f "$skill_dir/SKILL.md" ]; then
       skill_name="$(basename "$skill_dir")"
-      # Skip the sidecar directory — it contains runtime asset symlinks (bin/,
-      # browse/), not a skill. Linking it would overwrite the root gstack
-      # symlink that Step 5 already pointed at the repo root.
       [ "$skill_name" = "gstack" ] && continue
       target="$skills_dir/$skill_name"
-      # Create or update symlink
       if [ -L "$target" ] || [ ! -e "$target" ]; then
         ln -snf "$skill_dir" "$target"
         linked+=("$skill_name")
@@ -528,239 +577,116 @@ link_codex_skill_dirs() {
   if [ ${#linked[@]} -gt 0 ]; then
     echo "  linked skills: ${linked[*]}"
   fi
+}
+
+create_host_sidecar() {
+  local host="$1"
+  local repo_root="$2"
+  local sidecar_json
+  local sidecar_path
+  local sidecar_root
+  local asset
+  local src
+  local dst
+
+  sidecar_json="$(cd "$repo_root" && bun run scripts/host-config-export.ts get "$host" sidecar 2>/dev/null || true)"
+  [ -n "$sidecar_json" ] || return 0
+
+  sidecar_path="$(python3 - "$sidecar_json" <<'PY'
+import json, sys
+print(json.loads(sys.argv[1]).get('path', ''))
+PY
+)"
+  [ -n "$sidecar_path" ] || return 0
+
+  sidecar_root="$repo_root/$sidecar_path"
+  mkdir -p "$sidecar_root"
+
+  while IFS= read -r asset; do
+    [ -n "$asset" ] || continue
+    src="$repo_root/$asset"
+    dst="$sidecar_root/$asset"
+    if [ -d "$src" ] || [ -f "$src" ]; then
+      mkdir -p "$(dirname "$dst")"
+      if [ -L "$dst" ] || [ ! -e "$dst" ]; then
+        ln -snf "$src" "$dst"
+      fi
+    fi
+  done < <(python3 - "$sidecar_json" <<'PY'
+import json, sys
+for item in json.loads(sys.argv[1]).get('symlinks', []):
+    print(item)
+PY
+)
+}
+
+# ─── Helper: link generated Codex skills into a skills parent directory ──
+# Generated Codex skills live under .agents/skills/gstack*.
+# Skip the gstack sidecar directory: [ "$skill_name" = "gstack" ] && continue
+link_codex_skill_dirs() {
+  # Generated Codex skills live under .agents/skills/gstack*.
+  # Skip the gstack sidecar directory: [ "$skill_name" = "gstack" ] && continue
+  # linked[@]} accumulation happens inside link_host_skill_dirs.
+  link_host_skill_dirs codex "$1" "$2"
 }
 
 # ─── Helper: create .agents/skills/gstack/ sidecar symlinks ──────────
-# Codex/Gemini/Cursor read skills from .agents/skills/. We link runtime
-# assets (bin/, browse/dist/, review/, qa/, etc.) so skill templates can
-# resolve paths like $SKILL_ROOT/review/design-checklist.md.
+# Sidecar runtime assets: bin browse review qa ETHOS.md.
 create_agents_sidecar() {
-  local repo_root="$1"
-  local agents_gstack="$repo_root/.agents/skills/gstack"
-  mkdir -p "$agents_gstack"
-
-  # Sidecar directories that skills reference at runtime
-  for asset in bin browse review qa; do
-    local src="$SOURCE_GSTACK_DIR/$asset"
-    local dst="$agents_gstack/$asset"
-    if [ -d "$src" ] || [ -f "$src" ]; then
-      if [ -L "$dst" ] || [ ! -e "$dst" ]; then
-        ln -snf "$src" "$dst"
-      fi
-    fi
-  done
-
-  # Sidecar files that skills reference at runtime
-  for file in ETHOS.md; do
-    local src="$SOURCE_GSTACK_DIR/$file"
-    local dst="$agents_gstack/$file"
-    if [ -f "$src" ]; then
-      if [ -L "$dst" ] || [ ! -e "$dst" ]; then
-        ln -snf "$src" "$dst"
-      fi
-    fi
-  done
+  create_host_sidecar codex "$1"
 }
 
 # ─── Helper: create a minimal ~/.codex/skills/gstack runtime root ───────────
-# Codex scans ~/.codex/skills recursively. Exposing the whole repo here causes
-# duplicate skills because source SKILL.md files and generated Codex skills are
-# both discoverable. Keep this directory limited to runtime assets + root skill.
+# Runtime assets exposed for Codex:
+#   gstack/SKILL.md
+#   browse/dist
+#   browse/bin
+#   gstack-upgrade/SKILL.md
+#   review/checklist.md
+#   review/design-checklist.md
+#   review/greptile-triage.md
+#   review/TODOS-format.md
 create_codex_runtime_root() {
-  local gstack_dir="$1"
-  local codex_gstack="$2"
-  local agents_dir="$gstack_dir/.agents/skills"
-
-  if [ -L "$codex_gstack" ]; then
-    rm -f "$codex_gstack"
-  elif [ -d "$codex_gstack" ] && [ "$codex_gstack" != "$gstack_dir" ]; then
-    # Old direct installs left a real directory here with stale source skills.
-    # Remove it so we start fresh with only the minimal runtime assets.
-    rm -rf "$codex_gstack"
-  fi
-
-  mkdir -p "$codex_gstack" "$codex_gstack/browse" "$codex_gstack/gstack-upgrade" "$codex_gstack/review"
-
-  if [ -f "$agents_dir/gstack/SKILL.md" ]; then
-    ln -snf "$agents_dir/gstack/SKILL.md" "$codex_gstack/SKILL.md"
-  fi
-  if [ -d "$gstack_dir/bin" ]; then
-    ln -snf "$gstack_dir/bin" "$codex_gstack/bin"
-  fi
-  if [ -d "$gstack_dir/browse/dist" ]; then
-    ln -snf "$gstack_dir/browse/dist" "$codex_gstack/browse/dist"
-  fi
-  if [ -d "$gstack_dir/browse/bin" ]; then
-    ln -snf "$gstack_dir/browse/bin" "$codex_gstack/browse/bin"
-  fi
-  if [ -f "$agents_dir/gstack-upgrade/SKILL.md" ]; then
-    ln -snf "$agents_dir/gstack-upgrade/SKILL.md" "$codex_gstack/gstack-upgrade/SKILL.md"
-  fi
-  # Review runtime assets (individual files, NOT the whole review/ dir which has SKILL.md)
-  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
-    if [ -f "$gstack_dir/review/$f" ]; then
-      ln -snf "$gstack_dir/review/$f" "$codex_gstack/review/$f"
-    fi
-  done
-  # ETHOS.md — referenced by "Search Before Building" in all skill preambles
-  if [ -f "$gstack_dir/ETHOS.md" ]; then
-    ln -snf "$gstack_dir/ETHOS.md" "$codex_gstack/ETHOS.md"
-  fi
+  create_host_runtime_root codex "$1" "$2"
 }
 
+# Runtime assets exposed for Factory:
+#   gstack/SKILL.md
+#   browse/dist
+#   browse/bin
+#   gstack-upgrade/SKILL.md
+#   review/checklist.md
+#   review/TODOS-format.md
 create_factory_runtime_root() {
-  local gstack_dir="$1"
-  local factory_gstack="$2"
-  local factory_dir="$gstack_dir/.factory/skills"
-
-  if [ -L "$factory_gstack" ]; then
-    rm -f "$factory_gstack"
-  elif [ -d "$factory_gstack" ] && [ "$factory_gstack" != "$gstack_dir" ]; then
-    rm -rf "$factory_gstack"
-  fi
-
-  mkdir -p "$factory_gstack" "$factory_gstack/browse" "$factory_gstack/gstack-upgrade" "$factory_gstack/review"
-
-  if [ -f "$factory_dir/gstack/SKILL.md" ]; then
-    ln -snf "$factory_dir/gstack/SKILL.md" "$factory_gstack/SKILL.md"
-  fi
-  if [ -d "$gstack_dir/bin" ]; then
-    ln -snf "$gstack_dir/bin" "$factory_gstack/bin"
-  fi
-  if [ -d "$gstack_dir/browse/dist" ]; then
-    ln -snf "$gstack_dir/browse/dist" "$factory_gstack/browse/dist"
-  fi
-  if [ -d "$gstack_dir/browse/bin" ]; then
-    ln -snf "$gstack_dir/browse/bin" "$factory_gstack/browse/bin"
-  fi
-  if [ -f "$factory_dir/gstack-upgrade/SKILL.md" ]; then
-    ln -snf "$factory_dir/gstack-upgrade/SKILL.md" "$factory_gstack/gstack-upgrade/SKILL.md"
-  fi
-  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
-    if [ -f "$gstack_dir/review/$f" ]; then
-      ln -snf "$gstack_dir/review/$f" "$factory_gstack/review/$f"
-    fi
-  done
-  if [ -f "$gstack_dir/ETHOS.md" ]; then
-    ln -snf "$gstack_dir/ETHOS.md" "$factory_gstack/ETHOS.md"
-  fi
+  create_host_runtime_root factory "$1" "$2"
 }
 
+# Runtime assets exposed for OpenCode:
+#   gstack/SKILL.md
+#   browse/dist
+#   browse/bin
+#   design/dist
+#   gstack-upgrade/SKILL.md
+#   review/checklist.md
+#   review/design-checklist.md
+#   review/greptile-triage.md
+#   review/TODOS-format.md
+#   review/specialists
+#   qa/templates
+#   qa/references
+#   plan-devex-review/dx-hall-of-fame.md
 create_opencode_runtime_root() {
-  local gstack_dir="$1"
-  local opencode_gstack="$2"
-  local opencode_dir="$gstack_dir/.opencode/skills"
-
-  if [ -L "$opencode_gstack" ]; then
-    rm -f "$opencode_gstack"
-  elif [ -d "$opencode_gstack" ] && [ "$opencode_gstack" != "$gstack_dir" ]; then
-    rm -rf "$opencode_gstack"
-  fi
-
-  mkdir -p "$opencode_gstack" "$opencode_gstack/browse" "$opencode_gstack/design" "$opencode_gstack/gstack-upgrade" "$opencode_gstack/review" "$opencode_gstack/qa" "$opencode_gstack/plan-devex-review"
-
-  if [ -f "$opencode_dir/gstack/SKILL.md" ]; then
-    ln -snf "$opencode_dir/gstack/SKILL.md" "$opencode_gstack/SKILL.md"
-  fi
-  if [ -d "$gstack_dir/bin" ]; then
-    ln -snf "$gstack_dir/bin" "$opencode_gstack/bin"
-  fi
-  if [ -d "$gstack_dir/browse/dist" ]; then
-    ln -snf "$gstack_dir/browse/dist" "$opencode_gstack/browse/dist"
-  fi
-  if [ -d "$gstack_dir/browse/bin" ]; then
-    ln -snf "$gstack_dir/browse/bin" "$opencode_gstack/browse/bin"
-  fi
-  if [ -d "$gstack_dir/design/dist" ]; then
-    ln -snf "$gstack_dir/design/dist" "$opencode_gstack/design/dist"
-  fi
-  if [ -f "$opencode_dir/gstack-upgrade/SKILL.md" ]; then
-    ln -snf "$opencode_dir/gstack-upgrade/SKILL.md" "$opencode_gstack/gstack-upgrade/SKILL.md"
-  fi
-  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
-    if [ -f "$gstack_dir/review/$f" ]; then
-      ln -snf "$gstack_dir/review/$f" "$opencode_gstack/review/$f"
-    fi
-  done
-  if [ -d "$gstack_dir/review/specialists" ]; then
-    ln -snf "$gstack_dir/review/specialists" "$opencode_gstack/review/specialists"
-  fi
-  if [ -d "$gstack_dir/qa/templates" ]; then
-    ln -snf "$gstack_dir/qa/templates" "$opencode_gstack/qa/templates"
-  fi
-  if [ -d "$gstack_dir/qa/references" ]; then
-    ln -snf "$gstack_dir/qa/references" "$opencode_gstack/qa/references"
-  fi
-  if [ -f "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" ]; then
-    ln -snf "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" "$opencode_gstack/plan-devex-review/dx-hall-of-fame.md"
-  fi
-  if [ -f "$gstack_dir/ETHOS.md" ]; then
-    ln -snf "$gstack_dir/ETHOS.md" "$opencode_gstack/ETHOS.md"
-  fi
+  create_host_runtime_root opencode "$1" "$2"
 }
 
+# Generated Factory skills live under .factory/skills/gstack*.
 link_factory_skill_dirs() {
-  local gstack_dir="$1"
-  local skills_dir="$2"
-  local factory_dir="$gstack_dir/.factory/skills"
-  local linked=()
-
-  if [ ! -d "$factory_dir" ]; then
-    echo "  Generating .factory/ skill docs..."
-    ( cd "$gstack_dir" && bun run gen:skill-docs --host factory )
-  fi
-
-  if [ ! -d "$factory_dir" ]; then
-    echo "  warning: .factory/skills/ generation failed — run 'bun run gen:skill-docs --host factory' manually" >&2
-    return 1
-  fi
-
-  for skill_dir in "$factory_dir"/gstack*/; do
-    if [ -f "$skill_dir/SKILL.md" ]; then
-      skill_name="$(basename "$skill_dir")"
-      [ "$skill_name" = "gstack" ] && continue
-      target="$skills_dir/$skill_name"
-      if [ -L "$target" ] || [ ! -e "$target" ]; then
-        ln -snf "$skill_dir" "$target"
-        linked+=("$skill_name")
-      fi
-    fi
-  done
-  if [ ${#linked[@]} -gt 0 ]; then
-    echo "  linked skills: ${linked[*]}"
-  fi
+  link_host_skill_dirs factory "$1" "$2"
 }
 
+# Generated OpenCode skills live under .opencode/skills/gstack*.
 link_opencode_skill_dirs() {
-  local gstack_dir="$1"
-  local skills_dir="$2"
-  local opencode_dir="$gstack_dir/.opencode/skills"
-  local linked=()
-
-  if [ ! -d "$opencode_dir" ]; then
-    echo "  Generating .opencode/ skill docs..."
-    ( cd "$gstack_dir" && bun run gen:skill-docs --host opencode )
-  fi
-
-  if [ ! -d "$opencode_dir" ]; then
-    echo "  warning: .opencode/skills/ generation failed — run 'bun run gen:skill-docs --host opencode' manually" >&2
-    return 1
-  fi
-
-  for skill_dir in "$opencode_dir"/gstack*/; do
-    if [ -f "$skill_dir/SKILL.md" ]; then
-      skill_name="$(basename "$skill_dir")"
-      [ "$skill_name" = "gstack" ] && continue
-      target="$skills_dir/$skill_name"
-      if [ -L "$target" ] || [ ! -e "$target" ]; then
-        ln -snf "$skill_dir" "$target"
-        linked+=("$skill_name")
-      fi
-    fi
-  done
-  if [ ${#linked[@]} -gt 0 ]; then
-    echo "  linked skills: ${linked[*]}"
-  fi
+  link_host_skill_dirs opencode "$1" "$2"
 }
 
 # 4. Install for Claude (default)

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2079,6 +2079,18 @@ describe('setup script validation', () => {
     expect(setupContent).not.toMatch(/^link_skill_dirs\(\)/m);
   });
 
+  test('setup has config-driven helpers for symlink-generated external hosts', () => {
+    expect(setupContent).toContain('create_host_runtime_root()');
+    expect(setupContent).toContain('link_host_skill_dirs()');
+    expect(setupContent).toContain('create_host_sidecar()');
+  });
+
+  test('generic host helpers shell out to host-config-export.ts for host metadata', () => {
+    expect(setupContent).toContain('scripts/host-config-export.ts');
+    expect(setupContent).toContain('host-config-export.ts symlinks');
+    expect(setupContent).toContain('host-config-export.ts get');
+  });
+
   test('Claude install uses link_claude_skill_dirs', () => {
     // The Claude install section (section 4) should use the Claude function
     const claudeSection = setupContent.slice(


### PR DESCRIPTION
## Summary
- refactor external host setup around host-config metadata instead of hardcoding per-host runtime-root/link logic in `setup`
- preserve OpenCode/Codex/Factory install behavior while reducing duplicated shell code
- add setup validation tests for the new config-driven helpers

## Why
The old `fix/setup-opencode-support` branch proved out native OpenCode setup, but it duplicated a lot of host-specific shell logic. This branch keeps OpenCode support and generalizes the same pattern for symlink-generated external hosts, so future host additions are driven by host config instead of more bespoke setup branches.

This supersedes the earlier closed PR #982.

## Validation
- `bun test test/gen-skill-docs.test.ts --bail`
- `bun test test/host-config.test.ts --bail`
- `bun run gen:skill-docs --host opencode --dry-run`

## Notes
- branch is based on current `origin/main`
- OpenCode support markers remain in `setup` (`--host opencode`, runtime-root creation, generated skill linking)
- static scan on added lines found no obvious secret/injection regressions
