### PR TITLE
fix(setup): add cursor and slate host support

### DIFF
--- a/setup
+++ b/setup
@@ -24,6 +24,10 @@ FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
 OPENCODE_SKILLS="$HOME/.config/opencode/skills"
 OPENCODE_GSTACK="$OPENCODE_SKILLS/gstack"
+CURSOR_SKILLS="$HOME/.cursor/skills"
+CURSOR_GSTACK="$CURSOR_SKILLS/gstack"
+SLATE_SKILLS="$HOME/.slate/skills"
+SLATE_GSTACK="$SLATE_SKILLS/gstack"
 
 IS_WINDOWS=0
 case "$(uname -s)" in
@@ -56,7 +60,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|opencode|auto) ;;
+  claude|codex|kiro|factory|opencode|cursor|slate|auto) ;;
   openclaw)
     echo ""
     echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
@@ -155,14 +159,18 @@ INSTALL_CODEX=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
 INSTALL_OPENCODE=0
+INSTALL_CURSOR=0
+INSTALL_SLATE=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
   command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
+  command -v cursor >/dev/null 2>&1 && INSTALL_CURSOR=1
+  command -v slate >/dev/null 2>&1 && INSTALL_SLATE=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ] && [ "$INSTALL_CURSOR" -eq 0 ] && [ "$INSTALL_SLATE" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
@@ -175,6 +183,10 @@ elif [ "$HOST" = "factory" ]; then
   INSTALL_FACTORY=1
 elif [ "$HOST" = "opencode" ]; then
   INSTALL_OPENCODE=1
+elif [ "$HOST" = "cursor" ]; then
+  INSTALL_CURSOR=1
+elif [ "$HOST" = "slate" ]; then
+  INSTALL_SLATE=1
 fi
 
 migrate_direct_codex_install() {
@@ -292,33 +304,38 @@ fi
 AGENTS_DIR="$SOURCE_GSTACK_DIR/.agents/skills"
 NEEDS_AGENTS_GEN=1
 
+# Ensure dependencies are installed once before any host-specific generation.
+if [ "$NEEDS_BUILD" -eq 0 ]; then
+  ( cd "$SOURCE_GSTACK_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install )
+fi
+
 if [ "$NEEDS_AGENTS_GEN" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
   log "Generating .agents/ skill docs..."
-  (
-    cd "$SOURCE_GSTACK_DIR"
-    bun install --frozen-lockfile 2>/dev/null || bun install
-    bun run gen:skill-docs --host codex
-  )
+  ( cd "$SOURCE_GSTACK_DIR" && bun run gen:skill-docs --host codex )
 fi
 
 # 1c. Generate .factory/ Factory Droid skill docs
 if [ "$INSTALL_FACTORY" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
   log "Generating .factory/ skill docs..."
-  (
-    cd "$SOURCE_GSTACK_DIR"
-    bun install --frozen-lockfile 2>/dev/null || bun install
-    bun run gen:skill-docs --host factory
-  )
+  ( cd "$SOURCE_GSTACK_DIR" && bun run gen:skill-docs --host factory )
 fi
 
 # 1d. Generate .opencode/ OpenCode skill docs
 if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
   log "Generating .opencode/ skill docs..."
-  (
-    cd "$SOURCE_GSTACK_DIR"
-    bun install --frozen-lockfile 2>/dev/null || bun install
-    bun run gen:skill-docs --host opencode
-  )
+  ( cd "$SOURCE_GSTACK_DIR" && bun run gen:skill-docs --host opencode )
+fi
+
+# 1e. Generate .cursor/ Cursor skill docs
+if [ "$INSTALL_CURSOR" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .cursor/ skill docs..."
+  ( cd "$SOURCE_GSTACK_DIR" && bun run gen:skill-docs --host cursor )
+fi
+
+# 1f. Generate .slate/ Slate skill docs
+if [ "$INSTALL_SLATE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .slate/ skill docs..."
+  ( cd "$SOURCE_GSTACK_DIR" && bun run gen:skill-docs --host slate )
 fi
 
 # 2. Ensure Playwright's Chromium is available
@@ -699,6 +716,82 @@ create_opencode_runtime_root() {
   fi
 }
 
+create_cursor_runtime_root() {
+  local gstack_dir="$1"
+  local cursor_gstack="$2"
+  local cursor_dir="$gstack_dir/.cursor/skills"
+
+  if [ -L "$cursor_gstack" ]; then
+    rm -f "$cursor_gstack"
+  elif [ -d "$cursor_gstack" ] && [ "$cursor_gstack" != "$gstack_dir" ]; then
+    rm -rf "$cursor_gstack"
+  fi
+
+  mkdir -p "$cursor_gstack" "$cursor_gstack/browse" "$cursor_gstack/gstack-upgrade" "$cursor_gstack/review"
+
+  if [ -f "$cursor_dir/gstack/SKILL.md" ]; then
+    ln -snf "$cursor_dir/gstack/SKILL.md" "$cursor_gstack/SKILL.md"
+  fi
+  if [ -d "$gstack_dir/bin" ]; then
+    ln -snf "$gstack_dir/bin" "$cursor_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    ln -snf "$gstack_dir/browse/dist" "$cursor_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    ln -snf "$gstack_dir/browse/bin" "$cursor_gstack/browse/bin"
+  fi
+  if [ -f "$cursor_dir/gstack-upgrade/SKILL.md" ]; then
+    ln -snf "$cursor_dir/gstack-upgrade/SKILL.md" "$cursor_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      ln -snf "$gstack_dir/review/$f" "$cursor_gstack/review/$f"
+    fi
+  done
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    ln -snf "$gstack_dir/ETHOS.md" "$cursor_gstack/ETHOS.md"
+  fi
+}
+
+create_slate_runtime_root() {
+  local gstack_dir="$1"
+  local slate_gstack="$2"
+  local slate_dir="$gstack_dir/.slate/skills"
+
+  if [ -L "$slate_gstack" ]; then
+    rm -f "$slate_gstack"
+  elif [ -d "$slate_gstack" ] && [ "$slate_gstack" != "$gstack_dir" ]; then
+    rm -rf "$slate_gstack"
+  fi
+
+  mkdir -p "$slate_gstack" "$slate_gstack/browse" "$slate_gstack/gstack-upgrade" "$slate_gstack/review"
+
+  if [ -f "$slate_dir/gstack/SKILL.md" ]; then
+    ln -snf "$slate_dir/gstack/SKILL.md" "$slate_gstack/SKILL.md"
+  fi
+  if [ -d "$gstack_dir/bin" ]; then
+    ln -snf "$gstack_dir/bin" "$slate_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    ln -snf "$gstack_dir/browse/dist" "$slate_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    ln -snf "$gstack_dir/browse/bin" "$slate_gstack/browse/bin"
+  fi
+  if [ -f "$slate_dir/gstack-upgrade/SKILL.md" ]; then
+    ln -snf "$slate_dir/gstack-upgrade/SKILL.md" "$slate_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      ln -snf "$gstack_dir/review/$f" "$slate_gstack/review/$f"
+    fi
+  done
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    ln -snf "$gstack_dir/ETHOS.md" "$slate_gstack/ETHOS.md"
+  fi
+}
+
 link_factory_skill_dirs() {
   local gstack_dir="$1"
   local skills_dir="$2"
@@ -748,6 +841,70 @@ link_opencode_skill_dirs() {
   fi
 
   for skill_dir in "$opencode_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+link_cursor_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local cursor_dir="$gstack_dir/.cursor/skills"
+  local linked=()
+
+  if [ ! -d "$cursor_dir" ]; then
+    echo "  Generating .cursor/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host cursor )
+  fi
+
+  if [ ! -d "$cursor_dir" ]; then
+    echo "  warning: .cursor/skills/ generation failed — run 'bun run gen:skill-docs --host cursor' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$cursor_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+link_slate_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local slate_dir="$gstack_dir/.slate/skills"
+  local linked=()
+
+  if [ ! -d "$slate_dir" ]; then
+    echo "  Generating .slate/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host slate )
+  fi
+
+  if [ ! -d "$slate_dir" ]; then
+    echo "  warning: .slate/skills/ generation failed — run 'bun run gen:skill-docs --host slate' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$slate_dir"/gstack*/; do
     if [ -f "$skill_dir/SKILL.md" ]; then
       skill_name="$(basename "$skill_dir")"
       [ "$skill_name" = "gstack" ] && continue
@@ -933,6 +1090,26 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   echo "gstack ready (opencode)."
   echo "  browse: $BROWSE_BIN"
   echo "  opencode skills: $OPENCODE_SKILLS"
+fi
+
+# 6d. Install for Cursor
+if [ "$INSTALL_CURSOR" -eq 1 ]; then
+  mkdir -p "$CURSOR_SKILLS"
+  create_cursor_runtime_root "$SOURCE_GSTACK_DIR" "$CURSOR_GSTACK"
+  link_cursor_skill_dirs "$SOURCE_GSTACK_DIR" "$CURSOR_SKILLS"
+  echo "gstack ready (cursor)."
+  echo "  browse: $BROWSE_BIN"
+  echo "  cursor skills: $CURSOR_SKILLS"
+fi
+
+# 6e. Install for Slate
+if [ "$INSTALL_SLATE" -eq 1 ]; then
+  mkdir -p "$SLATE_SKILLS"
+  create_slate_runtime_root "$SOURCE_GSTACK_DIR" "$SLATE_GSTACK"
+  link_slate_skill_dirs "$SOURCE_GSTACK_DIR" "$SLATE_SKILLS"
+  echo "gstack ready (slate)."
+  echo "  browse: $BROWSE_BIN"
+  echo "  slate skills: $SLATE_SKILLS"
 fi
 
 # 7. Create .agents/ sidecar symlinks for the real Codex skill target.


### PR DESCRIPTION
## Summary

Adds cursor and slate to the setup script's host allowlist, auto-detection, docs generation, runtime root creation, and skill linking.

- `./setup --host cursor` and `./setup --host slate` now work
- Consolidates redundant `bun install` calls into a single execution before all host-specific generation blocks
- Fixes cursor/slate runtime root functions to use the minimal asset set matching their TypeScript configs (was erroneously copied from the expanded opencode runtime root)

## Test plan

- `bash -n setup` passes
- `./setup --host cursor` should proceed past the host validation into bun install + skill doc generation
- `./setup --host slate` should work identically
- `./setup --host auto` should auto-detect cursor/slate if their CLIs are on PATH
- Existing hosts (claude, codex, factory, opencode) are unaffected