### PR TITLE
fix(setup): support --help

### DIFF
--- a/setup
+++ b/setup
@@ -3,6 +3,34 @@
 set -e
 umask 077  # Restrict new files to owner-only (0o600 files, 0o700 dirs)
 
+print_help() {
+  cat <<'EOF'
+Usage: ./setup [options]
+
+Build gstack binaries, generate skill docs, and install skills for supported hosts.
+
+Options:
+  --host <name>     Target host: claude, codex, kiro, factory, opencode, auto,
+                    openclaw, hermes, or gbrain
+  --local           Install locally for Claude Code (deprecated)
+  --prefix          Use gstack-prefixed Claude skill names
+  --no-prefix       Use short Claude skill names
+  --team            Enable team mode
+  --no-team         Disable team mode
+  -q, --quiet       Suppress informational output
+  -h, --help        Show this help and exit
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+  esac
+done
+
 if ! command -v bun >/dev/null 2>&1; then
   echo "Error: bun is required but not installed." >&2
   echo "Install with checksum verification:" >&2

--- a/test/setup-help.test.ts
+++ b/test/setup-help.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from 'bun:test';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const SETUP_SCRIPT = path.join(ROOT, 'setup');
+
+describe('setup: help output', () => {
+  test('`./setup --help` exits cleanly with usage text', () => {
+    const result = spawnSync('/bin/bash', [SETUP_SCRIPT, '--help'], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Usage: ./setup [options]');
+    expect(result.stdout).toContain('--host <name>');
+    expect(result.stdout).toContain('--team');
+    expect(result.stdout).toContain('--no-team');
+    expect(result.stdout).toContain('-h, --help');
+  });
+
+  test('help works even when bun is not on PATH', () => {
+    const result = spawnSync('/bin/bash', [SETUP_SCRIPT, '--help'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Usage: ./setup [options]');
+    expect(result.stdout).not.toContain('bun is required');
+  });
+
+  test('`./setup -h` is supported as a short alias', () => {
+    const result = spawnSync('/bin/bash', [SETUP_SCRIPT, '-h'], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage: ./setup [options]');
+  });
+});


### PR DESCRIPTION
Fixes #1133

## Summary
- add explicit `./setup --help` and `./setup -h` handling
- print usage before any Bun or install work starts
- add focused tests that cover normal help output and the no-Bun-on-PATH case

## Root cause
The setup script parsed flags after the Bun availability check and had no help branch, so `./setup --help` fell through into the install path instead of exiting with usage.

## Testing
- bun test test/setup-help.test.ts test/setup-codesign.test.ts