### PR TITLE
fix(skills): use command -v instead of which for codex detection

### DIFF
--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -1092,7 +1092,7 @@ assumptions, catches things you might miss. Present its output faithfully, not s
 ## Step 0: Check codex binary
 
 ```bash
-CODEX_BIN=$(which codex 2>/dev/null || echo "")
+CODEX_BIN=$(command -v codex || echo "")
 [ -z "$CODEX_BIN" ] && echo "NOT_FOUND" || echo "FOUND: $CODEX_BIN"
 ```
 

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -42,7 +42,7 @@ assumptions, catches things you might miss. Present its output faithfully, not s
 ## Step 0: Check codex binary
 
 ```bash
-CODEX_BIN=$(which codex 2>/dev/null || echo "")
+CODEX_BIN=$(command -v codex || echo "")
 [ -z "$CODEX_BIN" ] && echo "NOT_FOUND" || echo "FOUND: $CODEX_BIN"
 ```
 

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -1345,7 +1345,7 @@ If user chooses B, skip this step and continue.
 
 **Check Codex availability:**
 ```bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
 **If Codex is available**, launch both voices simultaneously:

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -1965,7 +1965,7 @@ Record baseline design score and AI slop score at end of Phase 6.
 
 **Check Codex availability:**
 ```bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
 **If Codex is available**, launch both voices simultaneously:

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -1470,7 +1470,7 @@ Use AskUserQuestion to confirm. If the user disagrees with a premise, revise und
 **Binary check first:**
 
 ```bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
 Use AskUserQuestion (regardless of codex availability):
@@ -1740,7 +1740,7 @@ The screenshot file at `/tmp/gstack-sketch.png` can be referenced by downstream 
 After the wireframe is approved, offer outside design perspectives:
 
 ```bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
 If Codex is available, use AskUserQuestion:

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -1865,7 +1865,7 @@ thorough review.
 **Check tool availability:**
 
 ```bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
 Use AskUserQuestion:

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -1519,7 +1519,7 @@ If user chooses B, skip this step and continue.
 
 **Check Codex availability:**
 ```bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
 **If Codex is available**, launch both voices simultaneously:

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -1861,7 +1861,7 @@ thorough review.
 **Check tool availability:**
 
 ```bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
 Use AskUserQuestion:

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -1478,7 +1478,7 @@ thorough review.
 **Check tool availability:**
 
 ```bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
 Use AskUserQuestion:

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -1818,7 +1818,7 @@ Every diff gets adversarial review from both Claude and Codex. LOC is not a prox
 DIFF_INS=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
 DIFF_DEL=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
 DIFF_TOTAL=$((DIFF_INS + DIFF_DEL))
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 # Legacy opt-out — only gates Codex passes, Claude always runs
 OLD_CFG=$(~/.claude/skills/gstack/bin/gstack-config get codex_reviews 2>/dev/null || true)
 echo "DIFF_SIZE: $DIFF_TOTAL"

--- a/scripts/resolvers/design.ts
+++ b/scripts/resolvers/design.ts
@@ -10,7 +10,7 @@ export function generateDesignReviewLite(ctx: TemplateContext): string {
 7. **Codex design voice** (optional, automatic if available):
 
 \`\`\`bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 \`\`\`
 
 If Codex is available, run a lightweight design check on the diff:
@@ -512,7 +512,7 @@ The screenshot file at \`/tmp/gstack-sketch.png\` can be referenced by downstrea
 After the wireframe is approved, offer outside design perspectives:
 
 \`\`\`bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 \`\`\`
 
 If Codex is available, use AskUserQuestion:
@@ -688,7 +688,7 @@ ${optInSection}
 
 **Check Codex availability:**
 \`\`\`bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 \`\`\`
 
 **If Codex is available**, launch both voices simultaneously:

--- a/scripts/resolvers/review.ts
+++ b/scripts/resolvers/review.ts
@@ -266,7 +266,7 @@ export function generateCodexSecondOpinion(ctx: TemplateContext): string {
 **Binary check first:**
 
 \`\`\`bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 \`\`\`
 
 Use AskUserQuestion (regardless of codex availability):
@@ -425,7 +425,7 @@ Every diff gets adversarial review from both Claude and Codex. LOC is not a prox
 DIFF_INS=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
 DIFF_DEL=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
 DIFF_TOTAL=$((DIFF_INS + DIFF_DEL))
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 # Legacy opt-out — only gates Codex passes, Claude always runs
 OLD_CFG=$(~/.claude/skills/gstack/bin/gstack-config get codex_reviews 2>/dev/null || true)
 echo "DIFF_SIZE: $DIFF_TOTAL"
@@ -554,7 +554,7 @@ thorough review.
 **Check tool availability:**
 
 \`\`\`bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 \`\`\`
 
 Use AskUserQuestion:

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -2191,7 +2191,7 @@ Substitute: TIMESTAMP = ISO 8601 datetime, STATUS = "clean" if 0 findings or "is
 7. **Codex design voice** (optional, automatic if available):
 
 ```bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
 If Codex is available, run a lightweight design check on the diff:
@@ -2544,7 +2544,7 @@ Every diff gets adversarial review from both Claude and Codex. LOC is not a prox
 DIFF_INS=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
 DIFF_DEL=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
 DIFF_TOTAL=$((DIFF_INS + DIFF_DEL))
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 # Legacy opt-out — only gates Codex passes, Claude always runs
 OLD_CFG=$(~/.claude/skills/gstack/bin/gstack-config get codex_reviews 2>/dev/null || true)
 echo "DIFF_SIZE: $DIFF_TOTAL"

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -2191,7 +2191,7 @@ Substitute: TIMESTAMP = ISO 8601 datetime, STATUS = "clean" if 0 findings or "is
 7. **Codex design voice** (optional, automatic if available):
 
 ```bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
 If Codex is available, run a lightweight design check on the diff:
@@ -2544,7 +2544,7 @@ Every diff gets adversarial review from both Claude and Codex. LOC is not a prox
 DIFF_INS=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
 DIFF_DEL=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
 DIFF_TOTAL=$((DIFF_INS + DIFF_DEL))
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 # Legacy opt-out — only gates Codex passes, Claude always runs
 OLD_CFG=$(~/.claude/skills/gstack/bin/gstack-config get codex_reviews 2>/dev/null || true)
 echo "DIFF_SIZE: $DIFF_TOTAL"

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -2182,7 +2182,7 @@ Substitute: TIMESTAMP = ISO 8601 datetime, STATUS = "clean" if 0 findings or "is
 7. **Codex design voice** (optional, automatic if available):
 
 ```bash
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
 If Codex is available, run a lightweight design check on the diff:
@@ -2535,7 +2535,7 @@ Every diff gets adversarial review from both Claude and Codex. LOC is not a prox
 DIFF_INS=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
 DIFF_DEL=$(git diff origin/<base> --stat | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
 DIFF_TOTAL=$((DIFF_INS + DIFF_DEL))
-which codex 2>/dev/null && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
+command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 # Legacy opt-out — only gates Codex passes, Claude always runs
 OLD_CFG=$($GSTACK_ROOT/bin/gstack-config get codex_reviews 2>/dev/null || true)
 echo "DIFF_SIZE: $DIFF_TOTAL"

--- a/test/skill-e2e-plan.test.ts
+++ b/test/skill-e2e-plan.test.ts
@@ -776,7 +776,7 @@ Write your summary to ${testDir}/${testName}-summary.md`,
 
     const summary = fs.readFileSync(summaryPath, 'utf-8').toLowerCase();
     // All skills should have codex availability check
-    expect(summary).toMatch(/which codex/);
+    expect(summary).toMatch(/command -v codex/);
     // All skills should have fallback behavior
     expect(summary).toMatch(/fallback|subagent|unavailable|not available|skip/);
     // All skills should show it's optional/non-blocking

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -1315,9 +1315,9 @@ describe('Codex skill', () => {
     expect(content).toContain('gstack-review-log');
   });
 
-  test('codex/SKILL.md uses which for binary discovery, not hardcoded path', () => {
+  test('codex/SKILL.md uses command -v for binary discovery, not hardcoded path', () => {
     const content = fs.readFileSync(path.join(ROOT, 'codex', 'SKILL.md'), 'utf-8');
-    expect(content).toContain('which codex');
+    expect(content).toContain('command -v codex');
     expect(content).not.toContain('/opt/homebrew/bin/codex');
   });
 


### PR DESCRIPTION
## Summary

Replace `which codex` with `command -v codex` in the Codex availability gate used by `/review`, `/ship`, `/office-hours`, `/plan-ceo-review`, `/plan-eng-review`, `/plan-design-review`, `/plan-devex-review`, `/design-consultation`, `/design-review`, and `/codex` itself.

## Why this matters

`which` is not POSIX. Its behavior varies across platforms:

- Debian and Ubuntu ship `/usr/bin/which` from debianutils, which scans PATH
- Some systems alias `which` to a bash function that reads the hash table
- macOS ships a small csh-compatible script
- Busybox does not ship `which` at all

In non-interactive shells spawned by tool runners, PATH hydration and hash state can diverge in ways that cause `which codex` to miss a binary that `command -v codex` and `type codex` resolve correctly. The reporter on #1193 hit this on Ubuntu/Pop!_OS with `@openai/codex@0.125.0` installed under nvm:

```
$ which codex 2>&1
/bin/bash: line 1: codex: command not found

$ command -v codex
/home/btallman/.nvm/versions/node/v24.12.0/bin/codex
```

When the availability probe misses, `/review` silently falls back to "Claude adversarial only" without telling the user. The reporter approved a PR that way.

`command -v` is POSIX-specified and uses the same resolution the shell itself uses to run a command, so a positive result means the binary is runnable.

## Changes

Source files edited directly:

- `codex/SKILL.md.tmpl` line 45 (one callsite in the template used by `/codex`)
- `scripts/resolvers/review.ts` lines 269, 428, 557 (three callsites consumed by `/review` and `/ship`)
- `scripts/resolvers/design.ts` lines 13, 515, 691 (three callsites consumed by design/review skills)
- `test/skill-validation.test.ts` line 1320 (assertion updated to match new literal)
- `test/skill-e2e-plan.test.ts` line 779 (assertion updated to match new literal)

Regenerated via `bun run gen:skill-docs --host all`:

- `codex/SKILL.md`, `review/SKILL.md`, `ship/SKILL.md`, `office-hours/SKILL.md`, `plan-ceo-review/SKILL.md`, `plan-eng-review/SKILL.md`, `plan-design-review/SKILL.md`, `plan-devex-review/SKILL.md`, `design-consultation/SKILL.md`, `design-review/SKILL.md`
- `test/fixtures/golden/claude-ship-SKILL.md` and `test/fixtures/golden/factory-ship-SKILL.md` refreshed from regenerated ship output (the codex-ship golden was already byte-identical to the regenerated `.agents/` output)

gstack already uses `command -v codex` in `autoplan/SKILL.md.tmpl:250` and `test/helpers/providers/gpt.ts:20`. This aligns the rest of the codebase with that existing convention.

## Not in scope

- `pair-agent/SKILL.md.tmpl:131` and `pair-agent/SKILL.md:1177` use the same `which ngrok 2>/dev/null` shape. The reporter's issue is about codex detection, so ngrok is left alone. Happy to open a follow-up PR for it.
- `test/fixtures/golden-ship-claude.md` (top-level, not under `golden/`) still contains `which codex` but is not referenced by any test and was last touched in 2026-04 via a community PR. Treated as an orphan artifact.

## Testing

```
bun run gen:skill-docs --dry-run --host all     # exit 0, all files fresh
bun run skill:check                              # 43/43 skills OK, all hosts fresh
bun test test/host-config.test.ts -t "golden"    # 3/3 golden regression tests pass
bun test test/skill-validation.test.ts -t "codex/SKILL.md"  # 12/12 pass
```

Three unrelated tests fail on both `upstream/main` and this branch (`no compiled binaries > 2MB`, `read_secret_to_env > rejects invalid var names`, `Opus 4.7 overlay > Fan out`). Verified by running them on `upstream/main` HEAD before branching.

Fixes #1193
