### PR TITLE
fix: keep Claude install source out of skill root

### DIFF
--- a/BROWSER.md
+++ b/BROWSER.md
@@ -470,11 +470,12 @@ Tests spin up a local HTTP server (`browse/test/test-server.ts`) serving HTML fi
 
 ### Deploying to the active skill
 
-The active skill lives at `~/.claude/skills/gstack/`. After making changes:
+The source checkout lives at `~/.gstack/repos/gstack/`. Claude discovers a
+runtime-only sidecar at `~/.claude/skills/gstack/`. After making changes:
 
 1. Push your branch
-2. Pull in the skill directory: `cd ~/.claude/skills/gstack && git pull`
-3. Rebuild: `cd ~/.claude/skills/gstack && bun run build`
+2. Pull in the source checkout: `cd ~/.gstack/repos/gstack && git pull`
+3. Rebuild and relink runtime assets: `cd ~/.gstack/repos/gstack && bun run build && ./setup`
 
 Or copy the binary directly: `cp browse/dist/browse ~/.claude/skills/gstack/browse/dist/browse`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -674,11 +674,12 @@ Repeat for each skill: `gstack-openclaw-ceo-review`, `gstack-openclaw-investigat
 
 ## Deploying to the active skill
 
-The active skill lives at `~/.claude/skills/gstack/`. After making changes:
+The source checkout lives at `~/.gstack/repos/gstack/`. Claude discovers a
+runtime-only sidecar at `~/.claude/skills/gstack/`. After making changes:
 
 1. Push your branch
-2. Fetch and reset in the skill directory: `cd ~/.claude/skills/gstack && git fetch origin && git reset --hard origin/main`
-3. Rebuild: `cd ~/.claude/skills/gstack && bun run build`
+2. Fetch and reset in the source checkout: `cd ~/.gstack/repos/gstack && git fetch origin && git reset --hard origin/main`
+3. Rebuild and relink runtime assets: `cd ~/.gstack/repos/gstack && bun run build && ./setup`
 
 Or copy the binaries directly:
 - `cp browse/dist/browse ~/.claude/skills/gstack/browse/dist/browse`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -402,7 +402,7 @@ Setup cleans up the old symlinks automatically. No manual cleanup needed.
 If you don't want per-project symlinks, you can switch the global install:
 
 ```bash
-cd ~/.claude/skills/gstack
+cd ~/.gstack/repos/gstack
 git fetch origin
 git checkout origin/<branch>
 bun install && bun run build && ./setup

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Data is stored in [Supabase](https://supabase.com) (open source Firebase alterna
 
 **Want namespaced commands?** `cd ~/.gstack/repos/gstack && ./setup --prefix` — switches from `/qa` to `/gstack-qa`. Useful if you run other skill packs alongside gstack.
 
-**Codex says "Skipped loading skill(s) due to invalid SKILL.md"?** Your Codex skill descriptions are stale. Fix: `cd ~/.codex/skills/gstack && git pull && ./setup --host codex` — or for repo-local installs: `cd "$(readlink -f .agents/skills/gstack)" && git pull && ./setup --host codex`
+**Codex says "Skipped loading skill(s) due to invalid SKILL.md"?** Your Codex skill descriptions are stale. Fix: `cd ~/.gstack/repos/gstack && git pull && ./setup --host codex` — or for repo-local installs: `cd "$(readlink -f .agents/skills/gstack)" && git pull && ./setup --host codex`
 
 **Windows users:** gstack works on Windows 11 via Git Bash or WSL. Node.js is required in addition to Bun — Bun has a known bug with Playwright's pipe transport on Windows ([bun#4253](https://github.com/oven-sh/bun/issues/4253)). The browse server automatically falls back to Node.js. Make sure both `bun` and `node` are on your PATH.
 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ Fork it. Improve it. Make it yours. And if you want to hate on free open source 
 
 Open Claude Code and paste this. Claude does the rest.
 
-> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.
+> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.gstack/repos/gstack && cd ~/.gstack/repos/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.
 
 ### Step 2: Team mode — auto-update for shared repos (recommended)
 
 From inside your repo, paste this. Switches you to team mode, bootstraps the repo so teammates get gstack automatically, and commits the change:
 
 ```bash
-(cd ~/.claude/skills/gstack && ./setup --team) && ~/.claude/skills/gstack/bin/gstack-team-init required && git add .claude/ CLAUDE.md && git commit -m "require gstack for AI-assisted work"
+(cd ~/.gstack/repos/gstack && ./setup --team) && ~/.claude/skills/gstack/bin/gstack-team-init required && git add .claude/ CLAUDE.md && git commit -m "require gstack for AI-assisted work"
 ```
 
 No vendored files in your repo, no version drift, no manual upgrades. Every Claude Code session starts with a fast auto-update check (throttled to once/hour, network-failure-safe, completely silent).
@@ -67,7 +67,7 @@ Swap `required` for `optional` if you'd rather nudge teammates than block them.
 OpenClaw spawns Claude Code sessions via ACP, so every gstack skill just works
 when Claude Code has gstack installed. Paste this to your OpenClaw agent:
 
-> Install gstack: run `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup` to install gstack for Claude Code. Then add a "Coding Tasks" section to AGENTS.md that says: when spawning Claude Code sessions for coding work, tell the session to use gstack skills. Include these examples — security audit: "Load gstack. Run /cso", code review: "Load gstack. Run /review", QA test a URL: "Load gstack. Run /qa https://...", build a feature end-to-end: "Load gstack. Run /autoplan, implement the plan, then run /ship", plan before building: "Load gstack. Run /office-hours then /autoplan. Save the plan, don't implement."
+> Install gstack: run `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.gstack/repos/gstack && cd ~/.gstack/repos/gstack && ./setup` to install gstack for Claude Code. Then add a "Coding Tasks" section to AGENTS.md that says: when spawning Claude Code sessions for coding work, tell the session to use gstack skills. Include these examples — security audit: "Load gstack. Run /cso", code review: "Load gstack. Run /review", QA test a URL: "Load gstack. Run /qa https://...", build a feature end-to-end: "Load gstack. Run /autoplan, implement the plan, then run /ship", plan before building: "Load gstack. Run /office-hours then /autoplan. Save the plan, don't implement."
 
 **After setup, just talk to your OpenClaw agent naturally:**
 
@@ -423,15 +423,15 @@ Data is stored in [Supabase](https://supabase.com) (open source Firebase alterna
 
 ## Troubleshooting
 
-**Skill not showing up?** `cd ~/.claude/skills/gstack && ./setup`
+**Skill not showing up?** `cd ~/.gstack/repos/gstack && ./setup`
 
-**`/browse` fails?** `cd ~/.claude/skills/gstack && bun install && bun run build`
+**`/browse` fails?** `cd ~/.gstack/repos/gstack && bun install && bun run build && ./setup`
 
 **Stale install?** Run `/gstack-upgrade` — or set `auto_upgrade: true` in `~/.gstack/config.yaml`
 
-**Want shorter commands?** `cd ~/.claude/skills/gstack && ./setup --no-prefix` — switches from `/gstack-qa` to `/qa`. Your choice is remembered for future upgrades.
+**Want shorter commands?** `cd ~/.gstack/repos/gstack && ./setup --no-prefix` — switches from `/gstack-qa` to `/qa`. Your choice is remembered for future upgrades.
 
-**Want namespaced commands?** `cd ~/.claude/skills/gstack && ./setup --prefix` — switches from `/qa` to `/gstack-qa`. Useful if you run other skill packs alongside gstack.
+**Want namespaced commands?** `cd ~/.gstack/repos/gstack && ./setup --prefix` — switches from `/qa` to `/gstack-qa`. Useful if you run other skill packs alongside gstack.
 
 **Codex says "Skipped loading skill(s) due to invalid SKILL.md"?** Your Codex skill descriptions are stale. Fix: `cd ~/.codex/skills/gstack && git pull && ./setup --host codex` — or for repo-local installs: `cd "$(readlink -f .agents/skills/gstack)" && git pull && ./setup --host codex`
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -24,6 +24,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -135,9 +144,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/SKILL.md
+++ b/SKILL.md
@@ -135,9 +135,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -345,7 +345,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -33,6 +33,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -144,9 +153,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -1109,7 +1118,7 @@ If they choose A:
 Say: "Running /office-hours inline. Once the design doc is ready, I'll pick up
 the review right where we left off."
 
-Read the `/office-hours` skill file at `~/.gstack/repos/gstack/office-hours/SKILL.md` using the Read tool.
+Read the `/office-hours` skill file at `$GSTACK_SOURCE_ROOT/office-hours/SKILL.md` using the Read tool.
 
 **If unreadable:** Skip with "Could not load /office-hours — skipping." and continue.
 
@@ -1313,10 +1322,10 @@ Then prepend a one-line HTML comment to the plan file:
 ### Step 3: Load skill files from disk
 
 Read each file using the Read tool:
-- `~/.gstack/repos/gstack/plan-ceo-review/SKILL.md`
-- `~/.gstack/repos/gstack/plan-design-review/SKILL.md` (only if UI scope detected)
-- `~/.gstack/repos/gstack/plan-eng-review/SKILL.md`
-- `~/.gstack/repos/gstack/plan-devex-review/SKILL.md` (only if DX scope detected)
+- `$GSTACK_SOURCE_ROOT/plan-ceo-review/SKILL.md`
+- `$GSTACK_SOURCE_ROOT/plan-design-review/SKILL.md` (only if UI scope detected)
+- `$GSTACK_SOURCE_ROOT/plan-eng-review/SKILL.md`
+- `$GSTACK_SOURCE_ROOT/plan-devex-review/SKILL.md` (only if DX scope detected)
 
 **Section skip list — when following a loaded skill file, SKIP these sections
 (they are already handled by /autoplan):**

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -144,9 +144,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -354,7 +354,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 
@@ -1109,7 +1109,7 @@ If they choose A:
 Say: "Running /office-hours inline. Once the design doc is ready, I'll pick up
 the review right where we left off."
 
-Read the `/office-hours` skill file at `~/.claude/skills/gstack/office-hours/SKILL.md` using the Read tool.
+Read the `/office-hours` skill file at `~/.gstack/repos/gstack/office-hours/SKILL.md` using the Read tool.
 
 **If unreadable:** Skip with "Could not load /office-hours — skipping." and continue.
 
@@ -1313,10 +1313,10 @@ Then prepend a one-line HTML comment to the plan file:
 ### Step 3: Load skill files from disk
 
 Read each file using the Read tool:
-- `~/.claude/skills/gstack/plan-ceo-review/SKILL.md`
-- `~/.claude/skills/gstack/plan-design-review/SKILL.md` (only if UI scope detected)
-- `~/.claude/skills/gstack/plan-eng-review/SKILL.md`
-- `~/.claude/skills/gstack/plan-devex-review/SKILL.md` (only if DX scope detected)
+- `~/.gstack/repos/gstack/plan-ceo-review/SKILL.md`
+- `~/.gstack/repos/gstack/plan-design-review/SKILL.md` (only if UI scope detected)
+- `~/.gstack/repos/gstack/plan-eng-review/SKILL.md`
+- `~/.gstack/repos/gstack/plan-devex-review/SKILL.md` (only if DX scope detected)
 
 **Section skip list — when following a loaded skill file, SKIP these sections
 (they are already handled by /autoplan):**

--- a/autoplan/SKILL.md.tmpl
+++ b/autoplan/SKILL.md.tmpl
@@ -207,10 +207,10 @@ Then prepend a one-line HTML comment to the plan file:
 ### Step 3: Load skill files from disk
 
 Read each file using the Read tool:
-- `~/.claude/skills/gstack/plan-ceo-review/SKILL.md`
-- `~/.claude/skills/gstack/plan-design-review/SKILL.md` (only if UI scope detected)
-- `~/.claude/skills/gstack/plan-eng-review/SKILL.md`
-- `~/.claude/skills/gstack/plan-devex-review/SKILL.md` (only if DX scope detected)
+- `~/.gstack/repos/gstack/plan-ceo-review/SKILL.md`
+- `~/.gstack/repos/gstack/plan-design-review/SKILL.md` (only if UI scope detected)
+- `~/.gstack/repos/gstack/plan-eng-review/SKILL.md`
+- `~/.gstack/repos/gstack/plan-devex-review/SKILL.md` (only if DX scope detected)
 
 **Section skip list — when following a loaded skill file, SKIP these sections
 (they are already handled by /autoplan):**

--- a/autoplan/SKILL.md.tmpl
+++ b/autoplan/SKILL.md.tmpl
@@ -207,10 +207,10 @@ Then prepend a one-line HTML comment to the plan file:
 ### Step 3: Load skill files from disk
 
 Read each file using the Read tool:
-- `~/.gstack/repos/gstack/plan-ceo-review/SKILL.md`
-- `~/.gstack/repos/gstack/plan-design-review/SKILL.md` (only if UI scope detected)
-- `~/.gstack/repos/gstack/plan-eng-review/SKILL.md`
-- `~/.gstack/repos/gstack/plan-devex-review/SKILL.md` (only if DX scope detected)
+- `{{SKILL_DOCS_ROOT}}/plan-ceo-review/SKILL.md`
+- `{{SKILL_DOCS_ROOT}}/plan-design-review/SKILL.md` (only if UI scope detected)
+- `{{SKILL_DOCS_ROOT}}/plan-eng-review/SKILL.md`
+- `{{SKILL_DOCS_ROOT}}/plan-devex-review/SKILL.md` (only if DX scope detected)
 
 **Section skip list — when following a loaded skill file, SKIP these sections
 (they are already handled by /autoplan):**

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -26,6 +26,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -137,9 +146,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -137,9 +137,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -347,7 +347,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -26,6 +26,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -137,9 +146,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -137,9 +137,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -347,7 +347,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/bin/gstack-team-init
+++ b/bin/gstack-team-init
@@ -63,7 +63,7 @@ cd ~/.gstack/repos/gstack && ./setup --team
 ```
 
 Skills like /qa, /ship, /review, /investigate, and /browse become available after install.
-Use /browse for all web browsing. Use ~/.claude/skills/gstack/... for gstack file paths.'
+Use /browse for all web browsing. Use ~/.gstack/repos/gstack/... for gstack source and skill files; ~/.claude/skills/gstack/... is runtime assets only.'
 else
   SNIPPET='## gstack (REQUIRED — global install)
 
@@ -87,7 +87,7 @@ Do not skip skills, ignore gstack errors, or work around missing gstack.
 
 Using gstack skills: After install, skills like /qa, /ship, /review, /investigate,
 and /browse are available. Use /browse for all web browsing.
-Use ~/.claude/skills/gstack/... for gstack file paths (the global path).'
+Use ~/.gstack/repos/gstack/... for gstack source and skill files; ~/.claude/skills/gstack/... is runtime assets only.'
 fi
 
 # Check if CLAUDE.md already has a gstack section

--- a/bin/gstack-team-init
+++ b/bin/gstack-team-init
@@ -58,8 +58,8 @@ This project uses [gstack](https://github.com/garrytan/gstack) for AI-assisted w
 Install it for the best experience:
 
 ```bash
-git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
-cd ~/.claude/skills/gstack && ./setup --team
+git clone --depth 1 https://github.com/garrytan/gstack.git ~/.gstack/repos/gstack
+cd ~/.gstack/repos/gstack && ./setup --team
 ```
 
 Skills like /qa, /ship, /review, /investigate, and /browse become available after install.
@@ -78,8 +78,8 @@ If GSTACK_MISSING: STOP. Do not proceed. Tell the user:
 > gstack is required for all AI-assisted work in this repo.
 > Install it:
 > ```bash
-> git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
-> cd ~/.claude/skills/gstack && ./setup --team
+> git clone --depth 1 https://github.com/garrytan/gstack.git ~/.gstack/repos/gstack
+> cd ~/.gstack/repos/gstack && ./setup --team
 > ```
 > Then restart your AI coding tool.
 
@@ -122,8 +122,8 @@ BLOCKED: gstack is not installed globally.
 gstack is required for AI-assisted work in this repo.
 
 Install it:
-  git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
-  cd ~/.claude/skills/gstack && ./setup --team
+  git clone --depth 1 https://github.com/garrytan/gstack.git ~/.gstack/repos/gstack
+  cd ~/.gstack/repos/gstack && ./setup --team
 
 Then restart your AI coding tool.
 MSG
@@ -188,5 +188,5 @@ if [ ${#GENERATED[@]} -gt 0 ]; then
 fi
 echo ""
 echo "Each developer then runs:"
-echo "  git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack"
-echo "  cd ~/.claude/skills/gstack && ./setup --team"
+echo "  git clone --depth 1 https://github.com/garrytan/gstack.git ~/.gstack/repos/gstack"
+echo "  cd ~/.gstack/repos/gstack && ./setup --team"

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -25,6 +25,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -136,9 +145,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -136,9 +136,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -346,7 +346,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -136,9 +136,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -346,7 +346,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -25,6 +25,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -136,9 +145,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -27,6 +27,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -138,9 +147,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -138,9 +138,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -348,7 +348,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -140,9 +140,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -350,7 +350,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -29,6 +29,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -140,9 +149,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -140,9 +140,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -350,7 +350,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -29,6 +29,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -140,9 +149,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -141,9 +141,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -351,7 +351,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -30,6 +30,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -141,9 +150,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -141,9 +141,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -351,7 +351,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -30,6 +30,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -141,9 +150,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -32,6 +32,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -143,9 +152,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -143,9 +143,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -353,7 +353,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -141,9 +141,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -351,7 +351,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -30,6 +30,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -141,9 +150,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -27,6 +27,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -138,9 +147,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -138,9 +138,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -348,7 +348,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -141,9 +141,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -351,7 +351,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -30,6 +30,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -141,9 +150,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/docs/OPENCLAW.md
+++ b/docs/OPENCLAW.md
@@ -22,7 +22,9 @@ No compatibility matrices. The prompt is the bridge.
        ├── sessions_spawn(runtime: "acp")       │   (planning discipline)
        │       │                                │
        │       └── Claude Code                  ├── Generates gstack-full
-       │           └── gstack installed at      │   (complete pipeline)
+       │           └── gstack source at         │   (complete pipeline)
+       │               ~/.gstack/repos/gstack   │
+       │               + Claude sidecar at      │
        │               ~/.claude/skills/gstack  │
        │                                        └── docs/OPENCLAW.md (this file)
        └── Dispatch routing (AGENTS.md)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1084,7 +1084,7 @@ Remove the `/freeze` boundary, allowing edits everywhere again. The hooks stay r
 
 ## `/gstack-upgrade`
 
-Keep gstack current with one command. It detects your install type (global at `~/.claude/skills/gstack` vs vendored in your project at `.claude/skills/gstack`), runs the upgrade, syncs both copies if you have dual installs, and shows you what changed.
+Keep gstack current with one command. It detects your install type (global source checkout at `~/.gstack/repos/gstack` with a Claude runtime sidecar at `~/.claude/skills/gstack` vs vendored in your project at `.claude/skills/gstack`), runs the upgrade, syncs both copies if you have dual installs, and shows you what changed.
 
 ```
 You:   /gstack-upgrade

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -27,6 +27,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -138,9 +147,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -138,9 +138,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -348,7 +348,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -27,6 +27,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -138,9 +147,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -138,9 +138,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -348,7 +348,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/hosts/claude.ts
+++ b/hosts/claude.ts
@@ -27,7 +27,7 @@ const claude: HostConfig = {
   suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'make-pdf/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
       'review': ['checklist.md', 'TODOS-format.md'],
     },

--- a/hosts/codex.ts
+++ b/hosts/codex.ts
@@ -42,7 +42,7 @@ const codex: HostConfig = {
   ],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'make-pdf/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
       'review': ['checklist.md', 'TODOS-format.md'],
     },

--- a/hosts/cursor.ts
+++ b/hosts/cursor.ts
@@ -31,7 +31,7 @@ const cursor: HostConfig = {
   suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'make-pdf/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
       'review': ['checklist.md', 'TODOS-format.md'],
     },

--- a/hosts/factory.ts
+++ b/hosts/factory.ts
@@ -46,7 +46,7 @@ const factory: HostConfig = {
   suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'make-pdf/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
       'review': ['checklist.md', 'TODOS-format.md'],
     },

--- a/hosts/gbrain.ts
+++ b/hosts/gbrain.ts
@@ -60,7 +60,7 @@ const gbrain: HostConfig = {
   ],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'make-pdf/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
       'review': ['checklist.md', 'TODOS-format.md'],
     },

--- a/hosts/hermes.ts
+++ b/hosts/hermes.ts
@@ -55,7 +55,7 @@ const hermes: HostConfig = {
   ],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'make-pdf/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
       'review': ['checklist.md', 'TODOS-format.md'],
     },

--- a/hosts/kiro.ts
+++ b/hosts/kiro.ts
@@ -33,7 +33,7 @@ const kiro: HostConfig = {
   suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'make-pdf/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
       'review': ['checklist.md', 'TODOS-format.md'],
     },

--- a/hosts/openclaw.ts
+++ b/hosts/openclaw.ts
@@ -58,7 +58,7 @@ const openclaw: HostConfig = {
   ],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'make-pdf/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
       'review': ['checklist.md', 'TODOS-format.md'],
     },

--- a/hosts/opencode.ts
+++ b/hosts/opencode.ts
@@ -31,7 +31,7 @@ const opencode: HostConfig = {
   suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'design/dist', 'gstack-upgrade', 'ETHOS.md', 'review/specialists', 'qa/templates', 'qa/references', 'plan-devex-review/dx-hall-of-fame.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'design/dist', 'make-pdf/dist', 'gstack-upgrade', 'ETHOS.md', 'review/specialists', 'qa/templates', 'qa/references', 'plan-devex-review/dx-hall-of-fame.md'],
     globalFiles: {
       'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
     },

--- a/hosts/slate.ts
+++ b/hosts/slate.ts
@@ -31,7 +31,7 @@ const slate: HostConfig = {
   suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'make-pdf/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
       'review': ['checklist.md', 'TODOS-format.md'],
     },

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -44,6 +44,15 @@ hooks:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -155,9 +164,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -155,9 +155,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -365,7 +365,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -24,6 +24,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -135,9 +144,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -135,9 +135,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -345,7 +345,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -25,6 +25,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -136,9 +145,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -136,9 +136,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -346,7 +346,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -27,6 +27,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -138,9 +147,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -138,9 +138,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -348,7 +348,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -25,6 +25,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -136,9 +145,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -136,9 +136,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -346,7 +346,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -146,9 +146,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -356,7 +356,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -35,6 +35,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -146,9 +155,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -135,9 +135,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -345,7 +345,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -24,6 +24,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -135,9 +144,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -25,6 +25,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -136,9 +145,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -136,9 +136,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -346,7 +346,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -32,6 +32,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -143,9 +152,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -1213,7 +1222,7 @@ If they choose A:
 Say: "Running /office-hours inline. Once the design doc is ready, I'll pick up
 the review right where we left off."
 
-Read the `/office-hours` skill file at `~/.gstack/repos/gstack/office-hours/SKILL.md` using the Read tool.
+Read the `/office-hours` skill file at `$GSTACK_SOURCE_ROOT/office-hours/SKILL.md` using the Read tool.
 
 **If unreadable:** Skip with "Could not load /office-hours — skipping." and continue.
 
@@ -1259,7 +1268,7 @@ If they keep going, proceed normally — no guilt, no re-asking.
 
 If they choose A:
 
-Read the `/office-hours` skill file at `~/.gstack/repos/gstack/office-hours/SKILL.md` using the Read tool.
+Read the `/office-hours` skill file at `$GSTACK_SOURCE_ROOT/office-hours/SKILL.md` using the Read tool.
 
 **If unreadable:** Skip with "Could not load /office-hours — skipping." and continue.
 

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -143,9 +143,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -353,7 +353,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 
@@ -1213,7 +1213,7 @@ If they choose A:
 Say: "Running /office-hours inline. Once the design doc is ready, I'll pick up
 the review right where we left off."
 
-Read the `/office-hours` skill file at `~/.claude/skills/gstack/office-hours/SKILL.md` using the Read tool.
+Read the `/office-hours` skill file at `~/.gstack/repos/gstack/office-hours/SKILL.md` using the Read tool.
 
 **If unreadable:** Skip with "Could not load /office-hours — skipping." and continue.
 
@@ -1259,7 +1259,7 @@ If they keep going, proceed normally — no guilt, no re-asking.
 
 If they choose A:
 
-Read the `/office-hours` skill file at `~/.claude/skills/gstack/office-hours/SKILL.md` using the Read tool.
+Read the `/office-hours` skill file at `~/.gstack/repos/gstack/office-hours/SKILL.md` using the Read tool.
 
 **If unreadable:** Skip with "Could not load /office-hours — skipping." and continue.
 

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -140,9 +140,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -350,7 +350,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -29,6 +29,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -140,9 +149,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -33,6 +33,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -144,9 +153,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -1249,7 +1258,7 @@ If they choose A:
 Say: "Running /office-hours inline. Once the design doc is ready, I'll pick up
 the review right where we left off."
 
-Read the `/office-hours` skill file at `~/.gstack/repos/gstack/office-hours/SKILL.md` using the Read tool.
+Read the `/office-hours` skill file at `$GSTACK_SOURCE_ROOT/office-hours/SKILL.md` using the Read tool.
 
 **If unreadable:** Skip with "Could not load /office-hours — skipping." and continue.
 

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -144,9 +144,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -354,7 +354,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 
@@ -1249,7 +1249,7 @@ If they choose A:
 Say: "Running /office-hours inline. Once the design doc is ready, I'll pick up
 the review right where we left off."
 
-Read the `/office-hours` skill file at `~/.claude/skills/gstack/office-hours/SKILL.md` using the Read tool.
+Read the `/office-hours` skill file at `~/.gstack/repos/gstack/office-hours/SKILL.md` using the Read tool.
 
 **If unreadable:** Skip with "Could not load /office-hours — skipping." and continue.
 

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -142,9 +142,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -352,7 +352,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 
@@ -1125,7 +1125,7 @@ If they choose A:
 Say: "Running /office-hours inline. Once the design doc is ready, I'll pick up
 the review right where we left off."
 
-Read the `/office-hours` skill file at `~/.claude/skills/gstack/office-hours/SKILL.md` using the Read tool.
+Read the `/office-hours` skill file at `~/.gstack/repos/gstack/office-hours/SKILL.md` using the Read tool.
 
 **If unreadable:** Skip with "Could not load /office-hours — skipping." and continue.
 

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -31,6 +31,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -142,9 +151,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -1125,7 +1134,7 @@ If they choose A:
 Say: "Running /office-hours inline. Once the design doc is ready, I'll pick up
 the review right where we left off."
 
-Read the `/office-hours` skill file at `~/.gstack/repos/gstack/office-hours/SKILL.md` using the Read tool.
+Read the `/office-hours` skill file at `$GSTACK_SOURCE_ROOT/office-hours/SKILL.md` using the Read tool.
 
 **If unreadable:** Skip with "Could not load /office-hours — skipping." and continue.
 

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -38,6 +38,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -149,9 +158,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -149,9 +149,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -359,7 +359,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -137,9 +137,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -347,7 +347,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -26,6 +26,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -137,9 +146,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -32,6 +32,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -143,9 +152,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -143,9 +143,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -353,7 +353,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -136,9 +136,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -346,7 +346,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -25,6 +25,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -136,9 +145,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -140,9 +140,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -350,7 +350,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -29,6 +29,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -140,9 +149,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/scripts/resolvers/composition.ts
+++ b/scripts/resolvers/composition.ts
@@ -37,7 +37,7 @@ export function generateInvokeSkill(ctx: TemplateContext, args?: string[]): stri
 
   const allSkips = [...DEFAULT_SKIPS, ...extraSkips];
 
-  return `Read the \`/${skillName}\` skill file at \`${ctx.paths.skillRoot}/${skillName}/SKILL.md\` using the Read tool.
+  return `Read the \`/${skillName}\` skill file at \`${ctx.paths.skillDocsRoot}/${skillName}/SKILL.md\` using the Read tool.
 
 **If unreadable:** Skip with "Could not load /${skillName} — skipping." and continue.
 

--- a/scripts/resolvers/index.ts
+++ b/scripts/resolvers/index.ts
@@ -3,7 +3,7 @@
  * Each resolver takes a TemplateContext and returns the replacement string.
  */
 
-import type { TemplateContext, ResolverFn } from './types';
+import type { ResolverFn } from './types';
 
 // Domain modules
 import { generatePreamble } from './preamble';
@@ -70,6 +70,7 @@ export const RESOLVERS: Record<string, ResolverFn> = {
   MODEL_OVERLAY: generateModelOverlay,
   TASTE_PROFILE: generateTasteProfile,
   BIN_DIR: (ctx) => ctx.paths.binDir,
+  SKILL_DOCS_ROOT: (ctx) => ctx.paths.skillDocsRoot,
   GBRAIN_CONTEXT_LOAD: generateGBrainContextLoad,
   GBRAIN_SAVE_RESULTS: generateGBrainSaveResults,
   QUESTION_PREFERENCE_CHECK: generateQuestionPreferenceCheck,

--- a/scripts/resolvers/make-pdf.ts
+++ b/scripts/resolvers/make-pdf.ts
@@ -12,6 +12,10 @@ import type { TemplateContext } from './types';
  *   3. Env override (MAKE_PDF_BIN) — for contributor dev builds
  */
 export function generateMakePdfSetup(ctx: TemplateContext): string {
+  const globalMakePdfPath = ctx.paths.makePdfDir.startsWith('$') || ctx.paths.makePdfDir.startsWith('/')
+    ? `${ctx.paths.makePdfDir}/pdf`
+    : `$HOME${ctx.paths.makePdfDir.replace(/^~/, '')}/pdf`;
+
   return `## MAKE-PDF SETUP (run this check BEFORE any make-pdf command)
 
 \`\`\`bash
@@ -19,7 +23,7 @@ _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 P=""
 [ -n "$MAKE_PDF_BIN" ] && [ -x "$MAKE_PDF_BIN" ] && P="$MAKE_PDF_BIN"
 [ -z "$P" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf" ] && P="$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf"
-[ -z "$P" ] && P="$HOME${ctx.paths.makePdfDir.replace(/^~/, '')}/pdf"
+[ -z "$P" ] && P="${globalMakePdfPath}"
 if [ -x "$P" ]; then
   echo "MAKE_PDF_READY: $P"
   alias _p_="$P"   # shellcheck alias helper (not exported)

--- a/scripts/resolvers/preamble/generate-preamble-bash.ts
+++ b/scripts/resolvers/preamble/generate-preamble-bash.ts
@@ -13,11 +13,23 @@ GSTACK_DESIGN="$GSTACK_ROOT/design/dist"
 GSTACK_MAKE_PDF="$GSTACK_ROOT/make-pdf/dist"
 `
     : '';
+  const sourceRoot = ctx.host === 'claude'
+    ? `_ROOT=\${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
+`
+    : '';
 
   return `## Preamble (run first)
 
 \`\`\`bash
-${runtimeRoot}_UPD=$(${ctx.paths.binDir}/gstack-update-check 2>/dev/null || ${ctx.paths.localSkillRoot}/bin/gstack-update-check 2>/dev/null || true)
+${runtimeRoot}${sourceRoot}_UPD=$(${ctx.paths.binDir}/gstack-update-check 2>/dev/null || ${ctx.paths.localSkillRoot}/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
 touch ~/.gstack/sessions/"$PPID"

--- a/scripts/resolvers/preamble/generate-preamble-bash.ts
+++ b/scripts/resolvers/preamble/generate-preamble-bash.ts
@@ -10,6 +10,7 @@ GSTACK_ROOT="$HOME/${hostConfig.globalRoot}"
 GSTACK_BIN="$GSTACK_ROOT/bin"
 GSTACK_BROWSE="$GSTACK_ROOT/browse/dist"
 GSTACK_DESIGN="$GSTACK_ROOT/design/dist"
+GSTACK_MAKE_PDF="$GSTACK_ROOT/make-pdf/dist"
 `
     : '';
 
@@ -114,4 +115,3 @@ if command -v gbrain &>/dev/null; then
 fi` : ''}
 \`\`\``;
 }
-

--- a/scripts/resolvers/preamble/generate-upgrade-check.ts
+++ b/scripts/resolvers/preamble/generate-upgrade-check.ts
@@ -1,6 +1,8 @@
 import type { TemplateContext } from '../types';
 
 export function generateUpgradeCheck(ctx: TemplateContext): string {
+  const skillDocsRoot = ctx.paths.skillDocsRoot;
+
   return `If \`PROACTIVE\` is \`"false"\`, do not proactively suggest gstack skills AND do not
 auto-invoke skills based on conversation context. Only run skills the user explicitly
 types (e.g., /qa, /ship). If you would have auto-invoked a skill, instead briefly say:
@@ -10,9 +12,9 @@ The user opted out of proactive behavior.
 If \`SKILL_PREFIX\` is \`"true"\`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the \`/gstack-\` prefix (e.g., \`/gstack-qa\` instead
 of \`/qa\`, \`/gstack-ship\` instead of \`/ship\`). Disk paths are unaffected — always use
-\`${ctx.paths.skillRoot}/[skill-name]/SKILL.md\` for reading skill files.
+\`${skillDocsRoot}/[skill-name]/SKILL.md\` for reading skill files.
 
-If output shows \`UPGRADE_AVAILABLE <old> <new>\`: read \`${ctx.paths.skillRoot}/gstack-upgrade/SKILL.md\` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows \`UPGRADE_AVAILABLE <old> <new>\`: read \`${skillDocsRoot}/gstack-upgrade/SKILL.md\` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows \`JUST_UPGRADED <from> <to>\` AND \`SPAWNED_SESSION\` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -45,4 +47,3 @@ prompts from sub-sessions.
 After handling JUST_UPGRADED (prompts done or skipped), continue with the skill
 workflow.`;
 }
-

--- a/scripts/resolvers/preamble/generate-vendoring-deprecation.ts
+++ b/scripts/resolvers/preamble/generate-vendoring-deprecation.ts
@@ -1,6 +1,8 @@
 import type { TemplateContext } from '../types';
 
 export function generateVendoringDeprecation(ctx: TemplateContext): string {
+  const setupRoot = ctx.host === 'claude' ? '~/.gstack/repos/gstack' : ctx.paths.skillRoot;
+
   return `If \`VENDORED_GSTACK\` is \`yes\`: This project has a vendored copy of gstack at
 \`.claude/skills/gstack/\`. Vendoring is deprecated. We will not keep vendored copies
 up to date, so this project's gstack will fall behind.
@@ -21,7 +23,7 @@ If A:
 2. Run \`echo '.claude/skills/gstack/' >> .gitignore\`
 3. Run \`${ctx.paths.binDir}/gstack-team-init required\` (or \`optional\`)
 4. Run \`git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"\`
-5. Tell the user: "Done. Each developer now runs: \`cd ~/.claude/skills/gstack && ./setup --team\`"
+5. Tell the user: "Done. Each developer now runs: \`cd ${setupRoot} && ./setup --team\`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 
@@ -33,4 +35,3 @@ touch ~/.gstack/.vendoring-warned-\${SLUG:-unknown}
 
 This only happens once per project. If the marker file exists, skip entirely.`;
 }
-

--- a/scripts/resolvers/types.ts
+++ b/scripts/resolvers/types.ts
@@ -9,6 +9,7 @@ export type Host = (typeof ALL_HOST_CONFIGS)[number]['name'];
 
 export interface HostPaths {
   skillRoot: string;
+  skillDocsRoot: string;
   localSkillRoot: string;
   binDir: string;
   browseDir: string;
@@ -27,6 +28,7 @@ function buildHostPaths(): Record<string, HostPaths> {
     if (config.usesEnvVars) {
       paths[config.name] = {
         skillRoot: '$GSTACK_ROOT',
+        skillDocsRoot: '$GSTACK_ROOT',
         localSkillRoot: config.localSkillRoot,
         binDir: '$GSTACK_BIN',
         browseDir: '$GSTACK_BROWSE',
@@ -35,8 +37,10 @@ function buildHostPaths(): Record<string, HostPaths> {
       };
     } else {
       const root = `~/${config.globalRoot}`;
+      const skillDocsRoot = config.name === 'claude' ? '~/.gstack/repos/gstack' : root;
       paths[config.name] = {
         skillRoot: root,
+        skillDocsRoot,
         localSkillRoot: config.localSkillRoot,
         binDir: `${root}/bin`,
         browseDir: `${root}/browse/dist`,

--- a/scripts/resolvers/types.ts
+++ b/scripts/resolvers/types.ts
@@ -37,7 +37,7 @@ function buildHostPaths(): Record<string, HostPaths> {
       };
     } else {
       const root = `~/${config.globalRoot}`;
-      const skillDocsRoot = config.name === 'claude' ? '~/.gstack/repos/gstack' : root;
+      const skillDocsRoot = config.name === 'claude' ? '$GSTACK_SOURCE_ROOT' : root;
       paths[config.name] = {
         skillRoot: root,
         skillDocsRoot,

--- a/setup
+++ b/setup
@@ -180,9 +180,11 @@ fi
 migrate_direct_codex_install() {
   local gstack_dir="$1"
   local codex_gstack="$2"
+  local codex_gstack_real
   local migrated_dir="$HOME/.gstack/repos/gstack"
 
-  [ "$gstack_dir" = "$codex_gstack" ] || return 0
+  codex_gstack_real="$(cd "$(dirname "$codex_gstack")" 2>/dev/null && pwd -P)/$(basename "$codex_gstack")"
+  [ "$gstack_dir" = "$codex_gstack" ] || [ "$gstack_dir" = "$codex_gstack_real" ] || return 0
   [ -L "$gstack_dir" ] && return 0
 
   mkdir -p "$(dirname "$migrated_dir")"
@@ -199,6 +201,92 @@ migrate_direct_codex_install() {
   INSTALL_SKILLS_DIR="$(dirname "$INSTALL_GSTACK_DIR")"
   BROWSE_BIN="$SOURCE_GSTACK_DIR/browse/dist/browse"
 }
+
+create_claude_runtime_root() {
+  local gstack_dir="$1"
+  local claude_gstack="$2"
+
+  [ "$gstack_dir" = "$claude_gstack" ] && return 0
+
+  if [ -L "$claude_gstack" ]; then
+    rm -f "$claude_gstack"
+  elif [ -d "$claude_gstack" ] && [ "$claude_gstack" != "$gstack_dir" ]; then
+    if [ -d "$claude_gstack/.git" ]; then
+      echo "gstack setup failed: existing Claude checkout found at $claude_gstack" >&2
+      echo "Move it aside or run setup from that checkout so it can be migrated safely." >&2
+      exit 1
+    fi
+    # Old direct installs left a real checkout here with source skills for every
+    # host. Remove it so Claude only sees top-level Claude skills plus runtime
+    # assets under gstack/.
+    rm -rf "$claude_gstack"
+  fi
+
+  mkdir -p "$claude_gstack" "$claude_gstack/browse" "$claude_gstack/design" "$claude_gstack/make-pdf" "$claude_gstack/review" "$claude_gstack/qa"
+
+  if [ -d "$gstack_dir/bin" ]; then
+    ln -snf "$gstack_dir/bin" "$claude_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    ln -snf "$gstack_dir/browse/dist" "$claude_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    ln -snf "$gstack_dir/browse/bin" "$claude_gstack/browse/bin"
+  fi
+  if [ -d "$gstack_dir/design/dist" ]; then
+    ln -snf "$gstack_dir/design/dist" "$claude_gstack/design/dist"
+  fi
+  if [ -d "$gstack_dir/make-pdf/dist" ]; then
+    ln -snf "$gstack_dir/make-pdf/dist" "$claude_gstack/make-pdf/dist"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      ln -snf "$gstack_dir/review/$f" "$claude_gstack/review/$f"
+    fi
+  done
+  if [ -d "$gstack_dir/review/specialists" ]; then
+    ln -snf "$gstack_dir/review/specialists" "$claude_gstack/review/specialists"
+  fi
+  if [ -d "$gstack_dir/qa/templates" ]; then
+    ln -snf "$gstack_dir/qa/templates" "$claude_gstack/qa/templates"
+  fi
+  if [ -d "$gstack_dir/qa/references" ]; then
+    ln -snf "$gstack_dir/qa/references" "$claude_gstack/qa/references"
+  fi
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    ln -snf "$gstack_dir/ETHOS.md" "$claude_gstack/ETHOS.md"
+  fi
+}
+
+migrate_direct_claude_install() {
+  local gstack_dir="$1"
+  local claude_gstack="$2"
+  local claude_gstack_real
+  local migrated_dir="$HOME/.gstack/repos/gstack"
+
+  claude_gstack_real="$(cd "$(dirname "$claude_gstack")" 2>/dev/null && pwd -P)/$(basename "$claude_gstack")"
+  [ "$gstack_dir" = "$claude_gstack" ] || [ "$gstack_dir" = "$claude_gstack_real" ] || return 0
+  [ -L "$gstack_dir" ] && return 0
+  [ "$LOCAL_INSTALL" -eq 1 ] && return 0
+
+  mkdir -p "$(dirname "$migrated_dir")"
+  if [ -e "$migrated_dir" ] && [ "$migrated_dir" != "$gstack_dir" ]; then
+    echo "gstack setup failed: direct Claude install detected at $gstack_dir" >&2
+    echo "A migrated repo already exists at $migrated_dir; move one of them aside and rerun setup." >&2
+    exit 1
+  fi
+
+  log "Migrating direct Claude install to $migrated_dir to keep Claude skill discovery clean..."
+  mv "$gstack_dir" "$migrated_dir"
+  SOURCE_GSTACK_DIR="$migrated_dir"
+  INSTALL_GSTACK_DIR="$claude_gstack"
+  INSTALL_SKILLS_DIR="$(dirname "$INSTALL_GSTACK_DIR")"
+  BROWSE_BIN="$SOURCE_GSTACK_DIR/browse/dist/browse"
+}
+
+if [ "$INSTALL_CLAUDE" -eq 1 ]; then
+  migrate_direct_claude_install "$SOURCE_GSTACK_DIR" "$HOME/.claude/skills/gstack"
+fi
 
 if [ "$INSTALL_CODEX" -eq 1 ]; then
   migrate_direct_codex_install "$SOURCE_GSTACK_DIR" "$CODEX_GSTACK"
@@ -540,7 +628,7 @@ create_agents_sidecar() {
   mkdir -p "$agents_gstack"
 
   # Sidecar directories that skills reference at runtime
-  for asset in bin browse review qa; do
+  for asset in bin browse make-pdf review qa; do
     local src="$SOURCE_GSTACK_DIR/$asset"
     local dst="$agents_gstack/$asset"
     if [ -d "$src" ] || [ -f "$src" ]; then
@@ -579,7 +667,7 @@ create_codex_runtime_root() {
     rm -rf "$codex_gstack"
   fi
 
-  mkdir -p "$codex_gstack" "$codex_gstack/browse" "$codex_gstack/gstack-upgrade" "$codex_gstack/review"
+  mkdir -p "$codex_gstack" "$codex_gstack/browse" "$codex_gstack/make-pdf" "$codex_gstack/gstack-upgrade" "$codex_gstack/review"
 
   if [ -f "$agents_dir/gstack/SKILL.md" ]; then
     ln -snf "$agents_dir/gstack/SKILL.md" "$codex_gstack/SKILL.md"
@@ -592,6 +680,9 @@ create_codex_runtime_root() {
   fi
   if [ -d "$gstack_dir/browse/bin" ]; then
     ln -snf "$gstack_dir/browse/bin" "$codex_gstack/browse/bin"
+  fi
+  if [ -d "$gstack_dir/make-pdf/dist" ]; then
+    ln -snf "$gstack_dir/make-pdf/dist" "$codex_gstack/make-pdf/dist"
   fi
   if [ -f "$agents_dir/gstack-upgrade/SKILL.md" ]; then
     ln -snf "$agents_dir/gstack-upgrade/SKILL.md" "$codex_gstack/gstack-upgrade/SKILL.md"
@@ -619,7 +710,7 @@ create_factory_runtime_root() {
     rm -rf "$factory_gstack"
   fi
 
-  mkdir -p "$factory_gstack" "$factory_gstack/browse" "$factory_gstack/gstack-upgrade" "$factory_gstack/review"
+  mkdir -p "$factory_gstack" "$factory_gstack/browse" "$factory_gstack/make-pdf" "$factory_gstack/gstack-upgrade" "$factory_gstack/review"
 
   if [ -f "$factory_dir/gstack/SKILL.md" ]; then
     ln -snf "$factory_dir/gstack/SKILL.md" "$factory_gstack/SKILL.md"
@@ -632,6 +723,9 @@ create_factory_runtime_root() {
   fi
   if [ -d "$gstack_dir/browse/bin" ]; then
     ln -snf "$gstack_dir/browse/bin" "$factory_gstack/browse/bin"
+  fi
+  if [ -d "$gstack_dir/make-pdf/dist" ]; then
+    ln -snf "$gstack_dir/make-pdf/dist" "$factory_gstack/make-pdf/dist"
   fi
   if [ -f "$factory_dir/gstack-upgrade/SKILL.md" ]; then
     ln -snf "$factory_dir/gstack-upgrade/SKILL.md" "$factory_gstack/gstack-upgrade/SKILL.md"
@@ -657,7 +751,7 @@ create_opencode_runtime_root() {
     rm -rf "$opencode_gstack"
   fi
 
-  mkdir -p "$opencode_gstack" "$opencode_gstack/browse" "$opencode_gstack/design" "$opencode_gstack/gstack-upgrade" "$opencode_gstack/review" "$opencode_gstack/qa" "$opencode_gstack/plan-devex-review"
+  mkdir -p "$opencode_gstack" "$opencode_gstack/browse" "$opencode_gstack/design" "$opencode_gstack/make-pdf" "$opencode_gstack/gstack-upgrade" "$opencode_gstack/review" "$opencode_gstack/qa" "$opencode_gstack/plan-devex-review"
 
   if [ -f "$opencode_dir/gstack/SKILL.md" ]; then
     ln -snf "$opencode_dir/gstack/SKILL.md" "$opencode_gstack/SKILL.md"
@@ -673,6 +767,9 @@ create_opencode_runtime_root() {
   fi
   if [ -d "$gstack_dir/design/dist" ]; then
     ln -snf "$gstack_dir/design/dist" "$opencode_gstack/design/dist"
+  fi
+  if [ -d "$gstack_dir/make-pdf/dist" ]; then
+    ln -snf "$gstack_dir/make-pdf/dist" "$opencode_gstack/make-pdf/dist"
   fi
   if [ -f "$opencode_dir/gstack-upgrade/SKILL.md" ]; then
     ln -snf "$opencode_dir/gstack-upgrade/SKILL.md" "$opencode_gstack/gstack-upgrade/SKILL.md"
@@ -773,6 +870,13 @@ fi
 
 if [ "$INSTALL_CLAUDE" -eq 1 ]; then
   if [ "$SKILLS_BASENAME" = "skills" ]; then
+    # Global installs need a runtime-only sidecar at ~/.claude/skills/gstack.
+    # Project-local contributor/dev-mode installs intentionally keep
+    # .claude/skills/gstack as a symlink to the working tree, as documented in
+    # CONTRIBUTING.md, so edits are live while developing gstack itself.
+    if [ "$INSTALL_SKILLS_DIR" = "$HOME/.claude/skills" ]; then
+      create_claude_runtime_root "$SOURCE_GSTACK_DIR" "$INSTALL_GSTACK_DIR"
+    fi
     # Clean up stale symlinks from the opposite prefix mode
     if [ "$SKILL_PREFIX" -eq 1 ]; then
       cleanup_old_claude_symlinks "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
@@ -810,8 +914,8 @@ if [ "$INSTALL_CLAUDE" -eq 1 ]; then
     CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
     CLAUDE_GSTACK_LINK="$CLAUDE_SKILLS_DIR/gstack"
     mkdir -p "$CLAUDE_SKILLS_DIR"
-    ln -snf "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"
-    log "  symlinked $CLAUDE_GSTACK_LINK -> $SOURCE_GSTACK_DIR"
+    create_claude_runtime_root "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"
+    log "  created runtime root $CLAUDE_GSTACK_LINK"
     INSTALL_SKILLS_DIR="$CLAUDE_SKILLS_DIR"
     INSTALL_GSTACK_DIR="$CLAUDE_GSTACK_LINK"
     # Clean up stale symlinks from the opposite prefix mode
@@ -869,10 +973,13 @@ if [ "$INSTALL_KIRO" -eq 1 ]; then
   KIRO_GSTACK="$KIRO_SKILLS/gstack"
   # Remove old whole-dir symlink from previous installs
   [ -L "$KIRO_GSTACK" ] && rm -f "$KIRO_GSTACK"
-  mkdir -p "$KIRO_GSTACK" "$KIRO_GSTACK/browse" "$KIRO_GSTACK/gstack-upgrade" "$KIRO_GSTACK/review"
+  mkdir -p "$KIRO_GSTACK" "$KIRO_GSTACK/browse" "$KIRO_GSTACK/make-pdf" "$KIRO_GSTACK/gstack-upgrade" "$KIRO_GSTACK/review"
   ln -snf "$SOURCE_GSTACK_DIR/bin" "$KIRO_GSTACK/bin"
   ln -snf "$SOURCE_GSTACK_DIR/browse/dist" "$KIRO_GSTACK/browse/dist"
   ln -snf "$SOURCE_GSTACK_DIR/browse/bin" "$KIRO_GSTACK/browse/bin"
+  if [ -d "$SOURCE_GSTACK_DIR/make-pdf/dist" ]; then
+    ln -snf "$SOURCE_GSTACK_DIR/make-pdf/dist" "$KIRO_GSTACK/make-pdf/dist"
+  fi
   # ETHOS.md — referenced by "Search Before Building" in all skill preambles
   if [ -f "$SOURCE_GSTACK_DIR/ETHOS.md" ]; then
     ln -snf "$SOURCE_GSTACK_DIR/ETHOS.md" "$KIRO_GSTACK/ETHOS.md"

--- a/setup
+++ b/setup
@@ -223,6 +223,7 @@ create_claude_runtime_root() {
   fi
 
   mkdir -p "$claude_gstack" "$claude_gstack/browse" "$claude_gstack/design" "$claude_gstack/make-pdf" "$claude_gstack/review" "$claude_gstack/qa"
+  printf '%s\n' "$gstack_dir" > "$claude_gstack/SOURCE_ROOT"
 
   if [ -d "$gstack_dir/bin" ]; then
     ln -snf "$gstack_dir/bin" "$claude_gstack/bin"
@@ -896,11 +897,13 @@ if [ "$INSTALL_CLAUDE" -eq 1 ]; then
     fi
     # Backwards-compat alias: /connect-chrome → /open-gstack-browser
     _OGB_LINK="$INSTALL_SKILLS_DIR/connect-chrome"
+    _OGB_TARGET="open-gstack-browser"
     if [ "$SKILL_PREFIX" -eq 1 ]; then
       _OGB_LINK="$INSTALL_SKILLS_DIR/gstack-connect-chrome"
+      _OGB_TARGET="gstack-open-gstack-browser"
     fi
     if [ -L "$_OGB_LINK" ] || [ ! -e "$_OGB_LINK" ]; then
-      ln -snf "gstack/open-gstack-browser" "$_OGB_LINK"
+      ln -snf "$_OGB_TARGET" "$_OGB_LINK"
     fi
     if [ "$LOCAL_INSTALL" -eq 1 ]; then
       log "gstack ready (project-local)."
@@ -931,11 +934,13 @@ if [ "$INSTALL_CLAUDE" -eq 1 ]; then
       GSTACK_SKILLS_DIR="$INSTALL_SKILLS_DIR" GSTACK_INSTALL_DIR="$SOURCE_GSTACK_DIR" "$GSTACK_RELINK" >/dev/null 2>&1 || true
     fi
     _OGB_LINK="$INSTALL_SKILLS_DIR/connect-chrome"
+    _OGB_TARGET="open-gstack-browser"
     if [ "$SKILL_PREFIX" -eq 1 ]; then
       _OGB_LINK="$INSTALL_SKILLS_DIR/gstack-connect-chrome"
+      _OGB_TARGET="gstack-open-gstack-browser"
     fi
     if [ -L "$_OGB_LINK" ] || [ ! -e "$_OGB_LINK" ]; then
-      ln -snf "gstack/open-gstack-browser" "$_OGB_LINK"
+      ln -snf "$_OGB_TARGET" "$_OGB_LINK"
     fi
     log "gstack ready (claude)."
     log "  browse: $BROWSE_BIN"

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -22,6 +22,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -133,9 +142,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -133,9 +133,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -343,7 +343,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -139,9 +139,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -349,7 +349,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -28,6 +28,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -139,9 +148,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -140,9 +140,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -350,7 +350,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -29,6 +29,15 @@ allowed-tools:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -140,9 +149,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -30,6 +30,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -141,9 +150,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -3084,7 +3093,7 @@ git push -u origin <branch-name>
 
 **Subagent prompt:**
 
-> You are executing the /document-release workflow after a code push. Read the full skill file `${HOME}/.claude/skills/gstack/document-release/SKILL.md` and execute its complete workflow end-to-end, including CHANGELOG clobber protection, doc exclusions, risky-change gates, and named staging. Do NOT attempt to edit the PR body — no PR exists yet. Branch: `<branch>`, base: `<base>`.
+> You are executing the /document-release workflow after a code push. Read the full skill file `$GSTACK_SOURCE_ROOT/document-release/SKILL.md` and execute its complete workflow end-to-end, including CHANGELOG clobber protection, doc exclusions, risky-change gates, and named staging. Do NOT attempt to edit the PR body — no PR exists yet. Branch: `<branch>`, base: `<base>`.
 >
 > After completing the workflow, output a single JSON object on the LAST LINE of your response (no other text after it):
 > `{"files_updated":["README.md","CLAUDE.md",...],"commit_sha":"abc1234","pushed":true,"documentation_section":"<markdown block for PR body's ## Documentation section>"}`

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -141,9 +141,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -351,7 +351,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/ship/SKILL.md.tmpl
+++ b/ship/SKILL.md.tmpl
@@ -759,7 +759,7 @@ git push -u origin <branch-name>
 
 **Subagent prompt:**
 
-> You are executing the /document-release workflow after a code push. Read the full skill file `${HOME}/.claude/skills/gstack/document-release/SKILL.md` and execute its complete workflow end-to-end, including CHANGELOG clobber protection, doc exclusions, risky-change gates, and named staging. Do NOT attempt to edit the PR body — no PR exists yet. Branch: `<branch>`, base: `<base>`.
+> You are executing the /document-release workflow after a code push. Read the full skill file `{{SKILL_DOCS_ROOT}}/document-release/SKILL.md` and execute its complete workflow end-to-end, including CHANGELOG clobber protection, doc exclusions, risky-change gates, and named staging. Do NOT attempt to edit the PR body — no PR exists yet. Branch: `<branch>`, base: `<base>`.
 >
 > After completing the workflow, output a single JSON object on the LAST LINE of your response (no other text after it):
 > `{"files_updated":["README.md","CLAUDE.md",...],"commit_sha":"abc1234","pushed":true,"documentation_section":"<markdown block for PR body's ## Documentation section>"}`

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -30,6 +30,15 @@ triggers:
 ## Preamble (run first)
 
 ```bash
+_ROOT=${_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}
+GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"
+if [ -n "$_ROOT" ] && [ -f "$_ROOT/.claude/skills/gstack/SKILL.md" ]; then
+  GSTACK_SOURCE_ROOT="$_ROOT/.claude/skills/gstack"
+elif [ -f "$HOME/.claude/skills/gstack/SOURCE_ROOT" ]; then
+  _GSTACK_SOURCE_ROOT_CANDIDATE=$(cat "$HOME/.claude/skills/gstack/SOURCE_ROOT" 2>/dev/null || true)
+  [ -n "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && [ -d "$_GSTACK_SOURCE_ROOT_CANDIDATE" ] && GSTACK_SOURCE_ROOT="$_GSTACK_SOURCE_ROOT_CANDIDATE"
+fi
+echo "GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT"
 _UPD=$(~/.claude/skills/gstack/bin/gstack-update-check 2>/dev/null || .claude/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions
@@ -141,9 +150,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
+`$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -3084,7 +3093,7 @@ git push -u origin <branch-name>
 
 **Subagent prompt:**
 
-> You are executing the /document-release workflow after a code push. Read the full skill file `${HOME}/.claude/skills/gstack/document-release/SKILL.md` and execute its complete workflow end-to-end, including CHANGELOG clobber protection, doc exclusions, risky-change gates, and named staging. Do NOT attempt to edit the PR body — no PR exists yet. Branch: `<branch>`, base: `<base>`.
+> You are executing the /document-release workflow after a code push. Read the full skill file `$GSTACK_SOURCE_ROOT/document-release/SKILL.md` and execute its complete workflow end-to-end, including CHANGELOG clobber protection, doc exclusions, risky-change gates, and named staging. Do NOT attempt to edit the PR body — no PR exists yet. Branch: `<branch>`, base: `<base>`.
 >
 > After completing the workflow, output a single JSON object on the LAST LINE of your response (no other text after it):
 > `{"files_updated":["README.md","CLAUDE.md",...],"commit_sha":"abc1234","pushed":true,"documentation_section":"<markdown block for PR body's ## Documentation section>"}`

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -141,9 +141,9 @@ The user opted out of proactive behavior.
 If `SKILL_PREFIX` is `"true"`, the user has namespaced skill names. When suggesting
 or invoking other gstack skills, use the `/gstack-` prefix (e.g., `/gstack-qa` instead
 of `/qa`, `/gstack-ship` instead of `/ship`). Disk paths are unaffected — always use
-`~/.claude/skills/gstack/[skill-name]/SKILL.md` for reading skill files.
+`~/.gstack/repos/gstack/[skill-name]/SKILL.md` for reading skill files.
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.claude/skills/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
+If output shows `UPGRADE_AVAILABLE <old> <new>`: read `~/.gstack/repos/gstack/gstack-upgrade/SKILL.md` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined).
 
 If output shows `JUST_UPGRADED <from> <to>` AND `SPAWNED_SESSION` is NOT set: tell
 the user "Running gstack v{to} (just updated!)" and then check for new features to
@@ -351,7 +351,7 @@ If A:
 2. Run `echo '.claude/skills/gstack/' >> .gitignore`
 3. Run `~/.claude/skills/gstack/bin/gstack-team-init required` (or `optional`)
 4. Run `git add .claude/ .gitignore CLAUDE.md && git commit -m "chore: migrate gstack from vendored to team mode"`
-5. Tell the user: "Done. Each developer now runs: `cd ~/.claude/skills/gstack && ./setup --team`"
+5. Tell the user: "Done. Each developer now runs: `cd ~/.gstack/repos/gstack && ./setup --team`"
 
 If B: say "OK, you're on your own to keep the vendored copy up to date."
 

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -19,6 +19,7 @@ GSTACK_ROOT="$HOME/.codex/skills/gstack"
 GSTACK_BIN="$GSTACK_ROOT/bin"
 GSTACK_BROWSE="$GSTACK_ROOT/browse/dist"
 GSTACK_DESIGN="$GSTACK_ROOT/design/dist"
+GSTACK_MAKE_PDF="$GSTACK_ROOT/make-pdf/dist"
 _UPD=$($GSTACK_BIN/gstack-update-check 2>/dev/null || .agents/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -2700,7 +2700,7 @@ git push -u origin <branch-name>
 
 **Subagent prompt:**
 
-> You are executing the /document-release workflow after a code push. Read the full skill file `${HOME}/.agents/skills/gstack/document-release/SKILL.md` and execute its complete workflow end-to-end, including CHANGELOG clobber protection, doc exclusions, risky-change gates, and named staging. Do NOT attempt to edit the PR body — no PR exists yet. Branch: `<branch>`, base: `<base>`.
+> You are executing the /document-release workflow after a code push. Read the full skill file `$GSTACK_ROOT/document-release/SKILL.md` and execute its complete workflow end-to-end, including CHANGELOG clobber protection, doc exclusions, risky-change gates, and named staging. Do NOT attempt to edit the PR body — no PR exists yet. Branch: `<branch>`, base: `<base>`.
 >
 > After completing the workflow, output a single JSON object on the LAST LINE of your response (no other text after it):
 > `{"files_updated":["README.md","CLAUDE.md",...],"commit_sha":"abc1234","pushed":true,"documentation_section":"<markdown block for PR body's ## Documentation section>"}`

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -3076,7 +3076,7 @@ git push -u origin <branch-name>
 
 **Subagent prompt:**
 
-> You are executing the /document-release workflow after a code push. Read the full skill file `${HOME}/.factory/skills/gstack/document-release/SKILL.md` and execute its complete workflow end-to-end, including CHANGELOG clobber protection, doc exclusions, risky-change gates, and named staging. Do NOT attempt to edit the PR body — no PR exists yet. Branch: `<branch>`, base: `<base>`.
+> You are executing the /document-release workflow after a code push. Read the full skill file `$GSTACK_ROOT/document-release/SKILL.md` and execute its complete workflow end-to-end, including CHANGELOG clobber protection, doc exclusions, risky-change gates, and named staging. Do NOT attempt to edit the PR body — no PR exists yet. Branch: `<branch>`, base: `<base>`.
 >
 > After completing the workflow, output a single JSON object on the LAST LINE of your response (no other text after it):
 > `{"files_updated":["README.md","CLAUDE.md",...],"commit_sha":"abc1234","pushed":true,"documentation_section":"<markdown block for PR body's ## Documentation section>"}`

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -21,6 +21,7 @@ GSTACK_ROOT="$HOME/.factory/skills/gstack"
 GSTACK_BIN="$GSTACK_ROOT/bin"
 GSTACK_BROWSE="$GSTACK_ROOT/browse/dist"
 GSTACK_DESIGN="$GSTACK_ROOT/design/dist"
+GSTACK_MAKE_PDF="$GSTACK_ROOT/make-pdf/dist"
 _UPD=$($GSTACK_BIN/gstack-update-check 2>/dev/null || .factory/skills/gstack/bin/gstack-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 mkdir -p ~/.gstack/sessions

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2054,6 +2054,7 @@ describe('setup script validation', () => {
       setupContent.indexOf('# 5. Install for Codex')
     );
     expect(claudeSection).toContain('link_claude_skill_dirs');
+    expect(claudeSection).toContain('create_claude_runtime_root');
     expect(claudeSection).not.toContain('link_codex_skill_dirs');
   });
 
@@ -2190,12 +2191,13 @@ describe('setup script validation', () => {
   });
 
   test('create_agents_sidecar links runtime assets', () => {
-    // Sidecar must link bin, browse, review, qa
+    // Sidecar must link bin, browse, make-pdf, review, qa
     const fnStart = setupContent.indexOf('create_agents_sidecar()');
     const fnEnd = setupContent.indexOf('}', setupContent.indexOf('done', fnStart));
     const fnBody = setupContent.slice(fnStart, fnEnd);
     expect(fnBody).toContain('bin');
     expect(fnBody).toContain('browse');
+    expect(fnBody).toContain('make-pdf');
     expect(fnBody).toContain('review');
     expect(fnBody).toContain('qa');
   });
@@ -2207,6 +2209,7 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('gstack/SKILL.md');
     expect(fnBody).toContain('browse/dist');
     expect(fnBody).toContain('browse/bin');
+    expect(fnBody).toContain('make-pdf/dist');
     expect(fnBody).toContain('gstack-upgrade/SKILL.md');
     // Review runtime assets (individual files, not the whole dir)
     expect(fnBody).toContain('checklist.md');
@@ -2216,10 +2219,99 @@ describe('setup script validation', () => {
     expect(fnBody).not.toContain('ln -snf "$gstack_dir" "$codex_gstack"');
   });
 
+  test('create_claude_runtime_root exposes only runtime assets', () => {
+    const fnStart = setupContent.indexOf('create_claude_runtime_root()');
+    const fnEnd = setupContent.indexOf('}', setupContent.indexOf('done', setupContent.indexOf('review/', fnStart)));
+    const fnBody = setupContent.slice(fnStart, fnEnd);
+    expect(fnBody).toContain('browse/dist');
+    expect(fnBody).toContain('browse/bin');
+    expect(fnBody).toContain('design/dist');
+    expect(fnBody).toContain('make-pdf/dist');
+    expect(fnBody).toContain('qa/templates');
+    expect(fnBody).toContain('ETHOS.md');
+    expect(fnBody).not.toContain('SKILL.md');
+    expect(fnBody).not.toContain('ln -snf "$gstack_dir" "$claude_gstack"');
+  });
+
+  test('create_claude_runtime_root refuses to delete existing checkout', () => {
+    const fnStart = setupContent.indexOf('create_claude_runtime_root()');
+    const fnEnd = setupContent.indexOf('}', setupContent.indexOf('done', setupContent.indexOf('review/', fnStart)));
+    const fnBody = setupContent.slice(fnStart, fnEnd);
+    expect(fnBody).toContain('[ -d "$claude_gstack/.git" ]');
+    expect(fnBody).toContain('Move it aside or run setup from that checkout so it can be migrated safely.');
+    expect(fnBody.indexOf('[ -d "$claude_gstack/.git" ]')).toBeLessThan(fnBody.indexOf('rm -rf "$claude_gstack"'));
+  });
+
+  test('Claude runtime root creation refuses old checkout from new source path', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-safe-'));
+    const home = path.join(tmp, 'home');
+    const source = path.join(tmp, 'source');
+    fs.mkdirSync(path.join(home, '.claude', 'skills', 'gstack', '.git'), { recursive: true });
+    fs.mkdirSync(source, { recursive: true });
+    const fnStart = setupContent.indexOf('create_claude_runtime_root()');
+    const fnEnd = setupContent.indexOf('\nmigrate_direct_claude_install()', fnStart);
+    const script = path.join(tmp, 'check-runtime-root.sh');
+    fs.writeFileSync(script, [
+      'set -e',
+      setupContent.slice(fnStart, fnEnd),
+      `create_claude_runtime_root ${JSON.stringify(source)} "$HOME/.claude/skills/gstack"`,
+    ].join('\n'));
+
+    const result = Bun.spawnSync(['bash', script], {
+      env: { ...process.env, HOME: home },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain('existing Claude checkout found');
+    expect(fs.existsSync(path.join(home, '.claude', 'skills', 'gstack', '.git'))).toBe(true);
+  });
+
+  test('setup preserves project-local Claude dev symlink', () => {
+    const claudeInstallSection = setupContent.slice(
+      setupContent.indexOf('if [ "$INSTALL_CLAUDE" -eq 1 ]; then'),
+      setupContent.indexOf('else', setupContent.indexOf('if [ "$SKILLS_BASENAME" = "skills" ]; then'))
+    );
+    expect(claudeInstallSection).toContain('[ "$INSTALL_SKILLS_DIR" = "$HOME/.claude/skills" ]');
+    expect(claudeInstallSection).toContain('CONTRIBUTING.md');
+    expect(claudeInstallSection).toContain('Project-local contributor/dev-mode installs intentionally keep');
+  });
+
+  test('direct Claude installs are migrated out of ~/.claude/skills/gstack', () => {
+    expect(setupContent).toContain('migrate_direct_claude_install');
+    expect(setupContent).toContain('$HOME/.gstack/repos/gstack');
+    expect(setupContent).toContain('keep Claude skill discovery clean');
+    expect(setupContent).toContain('claude_gstack_real');
+    expect(setupContent).toContain('pwd -P');
+  });
+
   test('direct Codex installs are migrated out of ~/.codex/skills/gstack', () => {
     expect(setupContent).toContain('migrate_direct_codex_install');
     expect(setupContent).toContain('$HOME/.gstack/repos/gstack');
     expect(setupContent).toContain('avoid duplicate skill discovery');
+    expect(setupContent).toContain('codex_gstack_real');
+  });
+
+  test('generated Claude docs read skill files from source repo, not runtime sidecar', () => {
+    expect(setupContent).toContain('create_claude_runtime_root');
+    expect(setupContent).not.toContain('ln -snf "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"');
+    const shipContent = fs.readFileSync(path.join(ROOT, 'ship', 'SKILL.md'), 'utf-8');
+    expect(shipContent).toContain('~/.gstack/repos/gstack/[skill-name]/SKILL.md');
+    expect(shipContent).toContain('~/.gstack/repos/gstack/gstack-upgrade/SKILL.md');
+    expect(shipContent).not.toContain('~/.claude/skills/gstack/[skill-name]/SKILL.md');
+    expect(shipContent).not.toContain('~/.claude/skills/gstack/gstack-upgrade/SKILL.md');
+  });
+
+  test('generated make-pdf setup has runtime env path', () => {
+    const makePdfContent = fs.readFileSync(path.join(ROOT, 'make-pdf', 'SKILL.md'), 'utf-8');
+    expect(makePdfContent).toContain('.claude/skills/gstack/make-pdf/dist/pdf');
+    const codexMakePdf = path.join(ROOT, '.agents', 'skills', 'gstack-make-pdf', 'SKILL.md');
+    if (fs.existsSync(codexMakePdf)) {
+      const codexContent = fs.readFileSync(codexMakePdf, 'utf-8');
+      expect(codexContent).toContain('GSTACK_MAKE_PDF="$GSTACK_ROOT/make-pdf/dist"');
+      expect(codexContent).toContain('$HOME$GSTACK_MAKE_PDF/pdf');
+    }
   });
 
   // --- Symlink prefix tests (PR #503) ---

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1200,6 +1200,30 @@ describe('Codex filesystem boundary', () => {
     expect(boundarySection).toContain('skills/gstack');
     expect(boundarySection).toContain(BOUNDARY_MARKER);
   });
+
+  test('autoplan skill-loading step uses host-resolved docs root', () => {
+    const tmplContent = fs.readFileSync(path.join(ROOT, 'autoplan', 'SKILL.md.tmpl'), 'utf-8');
+    const stepStart = tmplContent.indexOf('### Step 3: Load skill files from disk');
+    const stepEnd = tmplContent.indexOf('**Section skip list', stepStart);
+    const stepSection = tmplContent.slice(stepStart, stepEnd);
+
+    expect(stepSection).toContain('{{SKILL_DOCS_ROOT}}/plan-ceo-review/SKILL.md');
+    expect(stepSection).not.toContain('~/.gstack/repos/gstack/plan-ceo-review/SKILL.md');
+
+    const claudeContent = fs.readFileSync(path.join(ROOT, 'autoplan', 'SKILL.md'), 'utf-8');
+    expect(claudeContent).toContain('$GSTACK_SOURCE_ROOT/plan-ceo-review/SKILL.md');
+
+    for (const generatedPath of [
+      path.join(ROOT, '.agents', 'skills', 'gstack-autoplan', 'SKILL.md'),
+      path.join(ROOT, '.factory', 'skills', 'gstack-autoplan', 'SKILL.md'),
+      path.join(ROOT, '.opencode', 'skills', 'gstack-autoplan', 'SKILL.md'),
+    ]) {
+      if (!fs.existsSync(generatedPath)) continue;
+      const generatedContent = fs.readFileSync(generatedPath, 'utf-8');
+      expect(generatedContent).toContain('$GSTACK_ROOT/plan-ceo-review/SKILL.md');
+      expect(generatedContent).not.toContain('~/.gstack/repos/gstack/plan-ceo-review/SKILL.md');
+    }
+  });
 });
 
 // --- {{BENEFITS_FROM}} resolver tests ---
@@ -2227,10 +2251,35 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('browse/bin');
     expect(fnBody).toContain('design/dist');
     expect(fnBody).toContain('make-pdf/dist');
+    expect(fnBody).toContain('SOURCE_ROOT');
     expect(fnBody).toContain('qa/templates');
     expect(fnBody).toContain('ETHOS.md');
     expect(fnBody).not.toContain('SKILL.md');
     expect(fnBody).not.toContain('ln -snf "$gstack_dir" "$claude_gstack"');
+  });
+
+  test('Claude runtime root records source checkout path', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-source-root-'));
+    const home = path.join(tmp, 'home');
+    const source = path.join(tmp, 'source');
+    fs.mkdirSync(source, { recursive: true });
+    const fnStart = setupContent.indexOf('create_claude_runtime_root()');
+    const fnEnd = setupContent.indexOf('\nmigrate_direct_claude_install()', fnStart);
+    const script = path.join(tmp, 'check-source-root.sh');
+    fs.writeFileSync(script, [
+      'set -e',
+      setupContent.slice(fnStart, fnEnd),
+      `create_claude_runtime_root ${JSON.stringify(source)} "$HOME/.claude/skills/gstack"`,
+    ].join('\n'));
+
+    const result = Bun.spawnSync(['bash', script], {
+      env: { ...process.env, HOME: home },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(fs.readFileSync(path.join(home, '.claude', 'skills', 'gstack', 'SOURCE_ROOT'), 'utf-8').trim()).toBe(source);
   });
 
   test('create_claude_runtime_root refuses to delete existing checkout', () => {
@@ -2297,10 +2346,30 @@ describe('setup script validation', () => {
     expect(setupContent).toContain('create_claude_runtime_root');
     expect(setupContent).not.toContain('ln -snf "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"');
     const shipContent = fs.readFileSync(path.join(ROOT, 'ship', 'SKILL.md'), 'utf-8');
-    expect(shipContent).toContain('~/.gstack/repos/gstack/[skill-name]/SKILL.md');
-    expect(shipContent).toContain('~/.gstack/repos/gstack/gstack-upgrade/SKILL.md');
+    expect(shipContent).toContain('GSTACK_SOURCE_ROOT="$HOME/.gstack/repos/gstack"');
+    expect(shipContent).toContain('GSTACK_SOURCE_ROOT: $GSTACK_SOURCE_ROOT');
+    expect(shipContent).toContain('$GSTACK_SOURCE_ROOT/[skill-name]/SKILL.md');
+    expect(shipContent).toContain('$GSTACK_SOURCE_ROOT/gstack-upgrade/SKILL.md');
     expect(shipContent).not.toContain('~/.claude/skills/gstack/[skill-name]/SKILL.md');
     expect(shipContent).not.toContain('~/.claude/skills/gstack/gstack-upgrade/SKILL.md');
+  });
+
+  test('generated Claude docs contain no hardcoded runtime sidecar skill-file reads', () => {
+    const claudeSkillFiles = ALL_SKILLS.map(skill =>
+      skill.dir === '.'
+        ? path.join(ROOT, 'SKILL.md')
+        : path.join(ROOT, skill.dir, 'SKILL.md')
+    );
+
+    const hardcodedSidecarReads = claudeSkillFiles.flatMap(file => {
+      const content = fs.readFileSync(file, 'utf-8');
+      return [...content.matchAll(/(?:~|\$\{HOME\}|\$HOME)\/\.claude\/skills\/gstack\/[^`\s]+\/SKILL\.md/g)]
+        .map(match => `${path.relative(ROOT, file)}: ${match[0]}`);
+    });
+
+    expect(hardcodedSidecarReads).toEqual([]);
+    const shipContent = fs.readFileSync(path.join(ROOT, 'ship', 'SKILL.md'), 'utf-8');
+    expect(shipContent).toContain('$GSTACK_SOURCE_ROOT/document-release/SKILL.md');
   });
 
   test('generated make-pdf setup has runtime env path', () => {
@@ -2310,8 +2379,29 @@ describe('setup script validation', () => {
     if (fs.existsSync(codexMakePdf)) {
       const codexContent = fs.readFileSync(codexMakePdf, 'utf-8');
       expect(codexContent).toContain('GSTACK_MAKE_PDF="$GSTACK_ROOT/make-pdf/dist"');
-      expect(codexContent).toContain('$HOME$GSTACK_MAKE_PDF/pdf');
+      expect(codexContent).toContain('P="$GSTACK_MAKE_PDF/pdf"');
+      expect(codexContent).not.toContain('$HOME$GSTACK_MAKE_PDF');
     }
+  });
+
+  test('connect-chrome alias points at top-level open-gstack-browser skill', () => {
+    expect(setupContent).toContain('_OGB_TARGET="open-gstack-browser"');
+    expect(setupContent).toContain('_OGB_TARGET="gstack-open-gstack-browser"');
+    expect(setupContent).toContain('ln -snf "$_OGB_TARGET" "$_OGB_LINK"');
+    expect(setupContent).not.toContain('ln -snf "gstack/open-gstack-browser" "$_OGB_LINK"');
+  });
+
+  test('team-mode snippets distinguish source files from Claude runtime assets', () => {
+    const teamInitContent = fs.readFileSync(path.join(ROOT, 'bin', 'gstack-team-init'), 'utf-8');
+    expect(teamInitContent).toContain('~/.gstack/repos/gstack/... for gstack source and skill files');
+    expect(teamInitContent).toContain('~/.claude/skills/gstack/... is runtime assets only');
+    expect(teamInitContent).not.toContain('Use ~/.claude/skills/gstack/... for gstack file paths');
+  });
+
+  test('Codex stale-skill troubleshooting updates source checkout, not runtime root', () => {
+    const readmeContent = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf-8');
+    expect(readmeContent).toContain('cd ~/.gstack/repos/gstack && git pull && ./setup --host codex');
+    expect(readmeContent).not.toContain('cd ~/.codex/skills/gstack && git pull');
   });
 
   // --- Symlink prefix tests (PR #503) ---


### PR DESCRIPTION
## Summary
- Move global Claude source installs out of `~/.claude/skills/gstack` and into `~/.gstack/repos/gstack` so Claude does not recursively discover host-specific generated skills.
- Recreate `~/.claude/skills/gstack` as a runtime-only sidecar for shared binaries/assets, including `browse`, `design`, `make-pdf`, review, and QA resources.
- Preserve contributor/dev-mode behavior where project-local `.claude/skills/gstack` remains a symlink to the working tree, and document the source-checkout vs sidecar split.

Fixes #1202.

## Commit structure
1. `fix: keep Claude install source out of skill root` — installer, resolver, host config, and regression coverage.
2. `chore: regenerate skill docs` — generated `SKILL.md` output only.
3. `docs: explain Claude source checkout and sidecar` — README/contributor/maintainer docs only.

## Verification
- `bash -n setup && bash -n bin/dev-setup && bash -n bin/dev-teardown && bash -n bin/gstack-team-init`
- `bun test test/gen-skill-docs.test.ts --test-name-pattern "setup script validation"`
- `bun test test/setup-codesign.test.ts`
- `bun test test/host-config.test.ts`
- `bun test test/team-mode.test.ts`
- `bun run gen:skill-docs --host all --dry-run`
- `bun run build`