### PR TITLE
fix(ask-user-format): forbid \uXXXX escaping of CJK chars in AskUserQuestion

### DIFF
--- a/scripts/resolvers/preamble/generate-ask-user-format.ts
+++ b/scripts/resolvers/preamble/generate-ask-user-format.ts
@@ -112,6 +112,26 @@ Net: <one-line synthesis of what you're actually trading off>
     markdown goes in the question body; the \`options\` array stays short
     labels (A, B, C).
 
+12. **Non-ASCII characters — write directly, never \\u-escape.** When any
+    string field (question, option label, option description) contains
+    Chinese (繁體/簡體), Japanese, Korean, or other non-ASCII text, emit
+    the literal UTF-8 characters in the JSON string. **Never escape them
+    as \`\\uXXXX\`.** Claude Code's tool parameter pipe is UTF-8 native
+    and passes characters through unchanged. Manually escaping requires
+    recalling each codepoint from training, which is unreliable for long
+    CJK strings — the model regularly emits the wrong codepoint (e.g.
+    writes \`\\u3103\` thinking it is 管 U+7BA1, but \`\\u3103\` is
+    actually ㄃, so the user sees \`管理工具\` rendered as \`㄃3用箱\`).
+    The trigger is long, multi-line questions with hundreds of CJK
+    characters: that is exactly when reflexive escaping kicks in and
+    exactly when miscoding is most damaging. Long ≠ escape. Keep
+    characters literal.
+
+    Wrong: \`"question": "請選擇\\uXXXX\\uXXXX\\uXXXX\\uXXXX"\`
+    Right: \`"question": "請選擇管理工具"\`
+
+    Only JSON-mandatory escapes remain allowed: \`\\n\`, \`\\t\`, \`\\"\`, \`\\\\\`.
+
 ### Self-check before emitting
 
 Before calling AskUserQuestion, verify:
@@ -123,6 +143,7 @@ Before calling AskUserQuestion, verify:
 - [ ] (recommended) label on one option (even for neutral-posture — see rule 9)
 - [ ] Net line closes the decision
 - [ ] You are calling the tool, not writing prose
+- [ ] Non-ASCII characters (CJK / accents) written directly, NOT \\u-escaped
 
 If you'd need to read the source to understand your own explanation, it's
 too complex — simplify before emitting.


### PR DESCRIPTION
Closes #1203.

## Summary

- Adds rule 12 + self-check item to `generateAskUserFormat()` forbidding `\uXXXX` escaping of CJK / non-ASCII characters in AskUserQuestion JSON params.
- Fixes a corruption pattern where the model writes wrong codepoints from memory on long CJK questions (e.g. `管理工具` → `㄃3用箱`).
- One file changed; the shared preamble propagates the fix to all 30 tier-2+ skills via the existing build pipeline.

## Why this lives in skill body, not docs

The guidance has to be inside `generateAskUserFormat()`'s returned template string so it lands in every compiled SKILL.md, right next to the AskUserQuestion contract the model just read. Putting it in a side doc or a global preamble (e.g. user-side CLAUDE.md) doesn't have enough salience to suppress reflexive escaping on multi-hundred-character questions — empirically tested in TW.

## Test plan

- [ ] `bun run gen:skill-docs --host all` succeeds
- [ ] Compiled `.agents/skills/gstack-plan-eng-review/SKILL.md` (and the other 29 tier-2+ skills) contain rule 12 and the new self-check item
- [ ] Manual repro in CJK locale: run `/plan-eng-review` on a multi-step plan; AskUserQuestion options render intact CJK with no `㄃3用箱`-style codepoint substitution
- [ ] `bun test` passes (no regression on existing eval harness)
- [ ] Tier-1 skills unaffected (they don't load `generateAskUserFormat`)

## Locally validated

Patch was applied to a local gstack install + `bun run gen:skill-docs` regenerated; rule 12 appears at the expected position across all 30 tier-2+ SKILL.md outputs and the corruption pattern stops reproducing.
