### PR TITLE
security: reject internal-network gbrain_url before consumer registration

### DIFF
--- a/bin/gstack-brain-init
+++ b/bin/gstack-brain-init
@@ -287,18 +287,31 @@ GBRAIN_URL_VAL="${GBRAIN_URL:-$("$CONFIG_BIN" get gbrain_url 2>/dev/null || echo
 GBRAIN_TOKEN_VAL="${GBRAIN_TOKEN:-$("$CONFIG_BIN" get gbrain_token 2>/dev/null || echo "")}"
 
 if [ -n "$GBRAIN_URL_VAL" ] && [ -n "$GBRAIN_TOKEN_VAL" ]; then
-  # Try the HTTP handoff.
-  HTTP_RESP=$(curl -sS -X POST "${GBRAIN_URL_VAL%/}/ingest-repo" \
-    -H "Authorization: Bearer $GBRAIN_TOKEN_VAL" \
-    -H "Content-Type: application/json" \
-    --data "{\"repo_url\":\"$REMOTE_URL\"}" \
-    -w "\n%{http_code}" 2>&1 || echo -e "\ncurl-error")
-  HTTP_CODE=$(echo "$HTTP_RESP" | tail -1)
-  if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "201" ] || [ "$HTTP_CODE" = "204" ]; then
-    CONSUMER_STATUS="ok"
-    echo "GBrain consumer registered: $GBRAIN_URL_VAL"
+  # SSRF guard: re-validate the URL even when it came from env. The
+  # `gstack-config set gbrain_url` path validates at write time; the
+  # GBRAIN_URL env override skips that path entirely, so we re-check
+  # here so an env-supplied loopback / RFC1918 / link-local target
+  # cannot turn this curl into a token + repo-URL exfil to an internal
+  # endpoint. GSTACK_ALLOW_INTERNAL_URL=1 opts into local targets for
+  # dev (e.g. http://127.0.0.1:8080 against a personal gbrain).
+  if ! "$CONFIG_BIN" __validate-url "$GBRAIN_URL_VAL" >/dev/null 2>&1; then
+    "$CONFIG_BIN" __validate-url "$GBRAIN_URL_VAL" || true
+    echo "Skipping GBrain consumer registration — gbrain_url failed SSRF validation." >&2
+    CONSUMER_STATUS="rejected"
   else
-    echo "GBrain ingest endpoint returned HTTP $HTTP_CODE; will retry on next skill run."
+    # Try the HTTP handoff.
+    HTTP_RESP=$(curl -sS -X POST "${GBRAIN_URL_VAL%/}/ingest-repo" \
+      -H "Authorization: Bearer $GBRAIN_TOKEN_VAL" \
+      -H "Content-Type: application/json" \
+      --data "{\"repo_url\":\"$REMOTE_URL\"}" \
+      -w "\n%{http_code}" 2>&1 || echo -e "\ncurl-error")
+    HTTP_CODE=$(echo "$HTTP_RESP" | tail -1)
+    if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "201" ] || [ "$HTTP_CODE" = "204" ]; then
+      CONSUMER_STATUS="ok"
+      echo "GBrain consumer registered: $GBRAIN_URL_VAL"
+    else
+      echo "GBrain ingest endpoint returned HTTP $HTTP_CODE; will retry on next skill run."
+    fi
   fi
 elif [ -z "$GBRAIN_URL_VAL" ]; then
   echo "(GBRAIN_URL not configured; skipping consumer registration. Set it with:"

--- a/bin/gstack-config
+++ b/bin/gstack-config
@@ -87,6 +87,101 @@ CONFIG_HEADER='# gstack configuration — edit freely, changes take effect on ne
 #
 '
 
+# validate_gbrain_url — reject URLs that point at the operator's own
+# private network. gstack-brain-init POSTs the brain bearer token plus
+# the brain repo URL to ${gbrain_url}/ingest-repo; without this check,
+# `gstack-config set gbrain_url http://169.254.169.254/...` (or any
+# RFC1918 / loopback / link-local target) lets a process that controls
+# the config exfiltrate both the token and the repo URL to an internal
+# target via the regular consumer-registration flow.
+#
+# Returns 0 if the URL is acceptable, non-zero with a stderr explanation
+# otherwise. Set GSTACK_ALLOW_INTERNAL_URL=1 to opt into local targets
+# for dev (e.g. running a personal gbrain on http://127.0.0.1:8080).
+validate_gbrain_url() {
+  local url="${1:-}"
+  local allow_internal="${GSTACK_ALLOW_INTERNAL_URL:-0}"
+
+  if [ -z "$url" ]; then
+    echo "Error: gbrain_url must not be empty" >&2
+    return 1
+  fi
+
+  # Require http:// or https://. No other schemes (file://, gopher://,
+  # data:, etc.) ever make sense for the consumer-registration POST.
+  case "$url" in
+    http://*|https://*) ;;
+    *)
+      echo "Error: gbrain_url must start with http:// or https://" >&2
+      return 1
+      ;;
+  esac
+
+  # Extract the authority (host[:port]) — strip the scheme prefix and
+  # everything from the first slash onwards. No userinfo support: a
+  # gbrain_url should never carry credentials in the URL.
+  local host_port="${url#*://}"
+  host_port="${host_port%%/*}"
+  local host
+  case "$host_port" in
+    \[*)
+      # IPv6 literal: host is everything through the closing bracket.
+      host="${host_port%%\]*}]"
+      ;;
+    *)
+      host="${host_port%%:*}"
+      ;;
+  esac
+  local host_lower
+  host_lower=$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]')
+
+  if [ "$allow_internal" = "1" ]; then
+    return 0
+  fi
+
+  # Reject literal hostnames that always resolve to the local box.
+  # `localhost.*` covers `localhost.localdomain` and any other
+  # variant that is conventionally aliased back to 127.0.0.1.
+  case "$host_lower" in
+    localhost|localhost.*|*.local|*.localhost|local|broadcasthost)
+      echo "Error: gbrain_url host \"$host_lower\" resolves to local-only network. Set GSTACK_ALLOW_INTERNAL_URL=1 to override (dev only)." >&2
+      return 1
+      ;;
+  esac
+
+  # Reject IPv6 loopback / link-local / unique-local literal forms.
+  # URL host syntax wraps IPv6 in [brackets]; we keep them in the
+  # string for matching. The patterns intentionally end at the closing
+  # bracket so a port suffix like `[fe80::1]:8443` would produce host
+  # `[fe80::1]` after the extraction above and still match here.
+  case "$host_lower" in
+    \[::1\]|\[::\]|\[fe80:*|\[fc00:*|\[fd*)
+      echo "Error: gbrain_url host \"$host\" is IPv6 loopback / link-local / unique-local. Set GSTACK_ALLOW_INTERNAL_URL=1 to override." >&2
+      return 1
+      ;;
+  esac
+
+  # IPv4 private / loopback / link-local / IMDS check.
+  if printf '%s' "$host_lower" | grep -qE '^[0-9]{1,3}(\.[0-9]{1,3}){3}$'; then
+    local a b c d
+    IFS='.' read -r a b c d <<<"$host_lower"
+    local reason=""
+    if [ "$a" = "127" ]; then reason="loopback (127.0.0.0/8)";
+    elif [ "$a" = "0" ]; then reason="reserved (0.0.0.0/8)";
+    elif [ "$a" = "10" ]; then reason="RFC1918 private (10.0.0.0/8)";
+    elif [ "$a" = "192" ] && [ "$b" = "168" ]; then reason="RFC1918 private (192.168.0.0/16)";
+    elif [ "$a" = "172" ] && [ "$b" -ge 16 ] && [ "$b" -le 31 ] 2>/dev/null; then reason="RFC1918 private (172.16.0.0/12)";
+    elif [ "$a" = "169" ] && [ "$b" = "254" ]; then reason="link-local / cloud IMDS (169.254.0.0/16)";
+    fi
+    if [ -n "$reason" ]; then
+      echo "Error: gbrain_url host $host_lower is $reason. Set GSTACK_ALLOW_INTERNAL_URL=1 to override (dev only)." >&2
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
 # DEFAULTS table — canonical default values for known keys.
 # `get <key>` returns DEFAULTS[key] when the key is absent from the config file
 # AND the env override is not set. Keep in sync with the CONFIG_HEADER comments.
@@ -142,6 +237,18 @@ case "${1:-}" in
       echo "Warning: gbrain_sync_mode '$VALUE' not recognized. Valid values: off, artifacts-only, full. Using off." >&2
       VALUE="off"
     fi
+    # SSRF guard: reject gbrain_url targets that point at the operator's
+    # own private network. gstack-brain-init POSTs the brain bearer
+    # token + repo URL to ${gbrain_url}/ingest-repo; without this check,
+    # `gstack-config set gbrain_url http://169.254.169.254/...` lets a
+    # config-write turn into token + repo-URL exfil to an internal
+    # target. Set GSTACK_ALLOW_INTERNAL_URL=1 to opt into local targets
+    # for dev (e.g. http://127.0.0.1:8080 against a personal gbrain).
+    if [ "$KEY" = "gbrain_url" ]; then
+      if ! validate_gbrain_url "$VALUE"; then
+        exit 1
+      fi
+    fi
     mkdir -p "$STATE_DIR"
     # Write annotated header on first creation
     if [ ! -f "$CONFIG_FILE" ]; then
@@ -190,6 +297,16 @@ case "${1:-}" in
                gbrain_sync_mode gbrain_sync_mode_prompted; do
       printf '  %-24s %s\n' "$KEY:" "$(lookup_default "$KEY")"
     done
+    ;;
+  __validate-url)
+    # Internal subcommand: defense-in-depth validator that other bin/
+    # scripts can invoke without duplicating the SSRF guard. Keeps the
+    # validation rules in one place even when GBRAIN_URL is supplied
+    # via env var (and therefore bypasses gstack-config set entirely).
+    # Empty arg falls through to validate_gbrain_url which returns the
+    # specific "must not be empty" message instead of bash's generic
+    # parameter-substitution error.
+    validate_gbrain_url "${2:-}"
     ;;
   *)
     echo "Usage: gstack-config {get|set|list|defaults} [key] [value]"

--- a/test/gstack-config-url-ssrf.test.ts
+++ b/test/gstack-config-url-ssrf.test.ts
@@ -1,0 +1,180 @@
+/**
+ * SSRF guard for gstack-config / gstack-brain-init.
+ *
+ * gstack-brain-init POSTs the brain bearer token + the brain repo URL
+ * to ${gbrain_url}/ingest-repo. Without an SSRF guard, anyone with the
+ * power to set the config (or the GBRAIN_URL env var) can redirect
+ * that POST at the operator's own private network — most pointedly
+ * AWS IMDS at 169.254.169.254 — and walk away with both the bearer
+ * token and the private brain-repo URL.
+ *
+ * These tests exercise the validator directly via the internal
+ * `gstack-config __validate-url` subcommand. The matching defense-in-
+ * depth check lives at the top of the consumer-registration block in
+ * bin/gstack-brain-init; the integration test in
+ * gstack-brain-init-gh-mock.test.ts already covers the env-supplied
+ * URL path end to end (mocked gh + tmp home).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const CONFIG_BIN = path.join(ROOT, 'bin', 'gstack-config');
+
+let tmpHome: string;
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-ssrf-'));
+});
+
+afterEach(() => {
+  if (tmpHome && fs.existsSync(tmpHome)) {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+});
+
+function validateUrl(url: string, env: Record<string, string> = {}): { code: number | null; stderr: string } {
+  const r = spawnSync(CONFIG_BIN, ['__validate-url', url], {
+    env: { PATH: process.env.PATH ?? '', GSTACK_HOME: tmpHome, ...env },
+    encoding: 'utf-8',
+  });
+  return { code: r.status, stderr: r.stderr ?? '' };
+}
+
+function setUrl(value: string, env: Record<string, string> = {}): { code: number | null; stderr: string } {
+  const r = spawnSync(CONFIG_BIN, ['set', 'gbrain_url', value], {
+    env: { PATH: process.env.PATH ?? '', GSTACK_HOME: tmpHome, ...env },
+    encoding: 'utf-8',
+  });
+  return { code: r.status, stderr: r.stderr ?? '' };
+}
+
+describe('gstack-config __validate-url — accepts public URLs', () => {
+  test.each([
+    'https://gbrain.example.com',
+    'https://gbrain.example.com/',
+    'https://gbrain.example.com/api/v1',
+    'https://gbrain.example.com:8443/ingest-repo',
+    'http://gbrain.example.com',
+    'https://203.0.113.42',     // TEST-NET-3 (public-ish, not RFC1918)
+    'https://1.1.1.1',          // public Cloudflare DNS (sanity)
+    'https://[2001:db8::1]/x',  // public IPv6 documentation prefix
+  ])('accepts %s', (url) => {
+    const { code, stderr } = validateUrl(url);
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+  });
+});
+
+describe('gstack-config __validate-url — rejects local-only targets', () => {
+  test.each([
+    ['http://localhost', /local-only/],
+    ['http://localhost:9999', /local-only/],
+    ['http://localhost.localdomain', /local-only/],
+    ['http://gbrain.local', /local-only/],
+    ['http://gbrain.local:8080/ingest-repo', /local-only/],
+  ])('rejects %s', (url, errPattern) => {
+    const { code, stderr } = validateUrl(url);
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(errPattern);
+  });
+
+  test.each([
+    'http://127.0.0.1',
+    'http://127.0.0.1:8080/ingest-repo',
+    'http://10.0.0.5/x',
+    'http://10.255.255.255',
+    'http://192.168.1.1/x',
+    'http://172.16.0.1/x',
+    'http://172.31.255.255/x',
+    'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+    'http://169.254.170.2/v2/credentials',
+  ])('rejects IPv4 %s', (url) => {
+    const { code, stderr } = validateUrl(url);
+    expect(code).not.toBe(0);
+    expect(stderr.length).toBeGreaterThan(0);
+  });
+
+  test('rejects IPv6 loopback [::1]', () => {
+    const { code, stderr } = validateUrl('http://[::1]:8080');
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/IPv6/);
+  });
+
+  test('rejects IPv6 link-local [fe80::1]', () => {
+    const { code, stderr } = validateUrl('http://[fe80::1]/x');
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/IPv6/);
+  });
+
+  test('accepts 172.32.x.x — not RFC1918 (only 172.16-31 are private)', () => {
+    const { code } = validateUrl('http://172.32.0.1/x');
+    expect(code).toBe(0);
+  });
+});
+
+describe('gstack-config __validate-url — rejects bad shapes', () => {
+  test('rejects empty string', () => {
+    const { code, stderr } = validateUrl('');
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/must not be empty/);
+  });
+
+  test('rejects non-http(s) schemes', () => {
+    for (const u of ['file:///etc/passwd', 'gopher://example.com', 'data:text/plain,x', 'javascript:alert(1)', 'ftp://example.com']) {
+      const { code, stderr } = validateUrl(u);
+      expect(code).not.toBe(0);
+      expect(stderr).toMatch(/http:\/\/ or https:\/\//);
+    }
+  });
+});
+
+describe('gstack-config __validate-url — env override (dev only)', () => {
+  test('GSTACK_ALLOW_INTERNAL_URL=1 lets a localhost target through', () => {
+    const { code, stderr } = validateUrl('http://127.0.0.1:8080', { GSTACK_ALLOW_INTERNAL_URL: '1' });
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+  });
+
+  test('GSTACK_ALLOW_INTERNAL_URL=1 still rejects empty / non-http schemes', () => {
+    expect(validateUrl('', { GSTACK_ALLOW_INTERNAL_URL: '1' }).code).not.toBe(0);
+    expect(validateUrl('file:///etc/passwd', { GSTACK_ALLOW_INTERNAL_URL: '1' }).code).not.toBe(0);
+  });
+
+  test('GSTACK_ALLOW_INTERNAL_URL=0 (default) rejects loopback', () => {
+    const { code } = validateUrl('http://127.0.0.1', { GSTACK_ALLOW_INTERNAL_URL: '0' });
+    expect(code).not.toBe(0);
+  });
+});
+
+describe('gstack-config set gbrain_url — refuses to write a hostile URL', () => {
+  test('IMDS URL is rejected by the set path, no config file written', () => {
+    const { code, stderr } = setUrl('http://169.254.169.254/latest/meta-data/');
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/link-local|169\.254/);
+    // The set path must short-circuit before writing the value to disk.
+    const cfgPath = path.join(tmpHome, 'config.yaml');
+    if (fs.existsSync(cfgPath)) {
+      const contents = fs.readFileSync(cfgPath, 'utf-8');
+      expect(contents).not.toContain('169.254.169.254');
+    }
+  });
+
+  test('valid public URL is written through to config.yaml', () => {
+    const { code } = setUrl('https://gbrain.example.com');
+    expect(code).toBe(0);
+    const contents = fs.readFileSync(path.join(tmpHome, 'config.yaml'), 'utf-8');
+    expect(contents).toContain('gbrain_url: https://gbrain.example.com');
+  });
+
+  test('GSTACK_ALLOW_INTERNAL_URL=1 lets a dev URL through the set path', () => {
+    const { code } = setUrl('http://127.0.0.1:8080', { GSTACK_ALLOW_INTERNAL_URL: '1' });
+    expect(code).toBe(0);
+    const contents = fs.readFileSync(path.join(tmpHome, 'config.yaml'), 'utf-8');
+    expect(contents).toContain('http://127.0.0.1:8080');
+  });
+});


### PR DESCRIPTION
## Summary

`gstack-brain-init` POSTs the brain bearer token + the brain repo URL
to `\${gbrain_url}/ingest-repo` with no validation of where
`\${gbrain_url}` points. Anyone with the power to set the config —
write `~/.gstack/config.yaml`, install a hook, or set `GBRAIN_URL`
via env — can redirect the POST at the operator's own private network
and walk away with both the bearer token and the private brain-repo
URL.

Worst case is the cloud metadata family. Setting
`gbrain_url=http://169.254.169.254/latest/meta-data/iam/security-credentials/<role>/`
on an EC2 host turns the consumer-registration flow into IAM
credential exfil to whoever runs the listener at the other end.

## Threat model

A process or operator that can:

- Edit `~/.gstack/config.yaml` (any local code-execution primitive)
- Install a malicious hook into the gstack pipeline
- Set `GBRAIN_URL=` in the environment of a `gstack-brain-init` run
  (any shell-rc poisoning, npm postinstall, social engineering of a
  README that says "set this env var")

None of these require root, container escape, or network position. They
turn a config-write into an outbound POST that exfils credentials to
an attacker-chosen internal target.

## What changes

`validate_gbrain_url()` is added to `bin/gstack-config` and wired into
two paths:

1. `gstack-config set gbrain_url <value>` runs the validator at write
   time and refuses to persist a hostile URL.
2. `gstack-brain-init` re-validates `\$GBRAIN_URL_VAL` through the new
   internal subcommand `gstack-config __validate-url` before the curl
   POST. The env-var path bypasses (1), so this defense-in-depth
   covers the `GBRAIN_URL=...` runtime override.

Validator rules (all reject by default; opt out with
`GSTACK_ALLOW_INTERNAL_URL=1` for local dev against a personal gbrain):

- require `http://` or `https://` scheme — no `file:`, `gopher:`,
  `data:`, `javascript:`, `ftp:`
- reject literal local hostnames: `localhost`, `localhost.*`,
  `*.local`, `*.localhost`, `broadcasthost`
- reject IPv4 RFC1918 (10/8, 172.16/12, 192.168/16), loopback (127/8),
  reserved (0/8), and link-local / cloud IMDS (169.254/16)
- reject IPv6 loopback (`[::1]`, `[::]`), link-local (`[fe80::*]`),
  and unique-local (`[fc00::*]`, `[fd*]`)
- IPv6 host extraction handles bracketed authorities so `[fe80::1]:8443`
  extracts as `[fe80::1]` rather than collapsing to `[`

## Backwards compatibility

- A normal user running `gstack-config set gbrain_url
  https://gbrain.example.com` is unaffected.
- A dev running a local gbrain at `http://127.0.0.1:8080` opts in
  with `GSTACK_ALLOW_INTERNAL_URL=1`. The error message names the env
  var explicitly so the discovery cost is one error → one re-run.
- `gstack-config get`, `list`, and `defaults` paths are unchanged.

## Test coverage

`test/gstack-config-url-ssrf.test.ts` — 33 cases following the same
spawnSync + tmp `GSTACK_HOME` pattern that
`gstack-brain-init-gh-mock.test.ts` already uses:

- 8 public URLs accepted (https + http, ports, paths, IPv6 docs)
- 5 local-only hostnames rejected (localhost flavors)
- 9 IPv4 hostile addresses rejected (loopback, all three RFC1918
  blocks, IMDS)
- IPv6 `[::1]` and `[fe80::1]` rejected
- `172.32.x.x` accepted (NOT in `172.16-31` range — boundary check)
- bad shapes rejected: empty, `file://`, `gopher://`, `data:`,
  `javascript:`, `ftp://`
- `GSTACK_ALLOW_INTERNAL_URL=1` lets a loopback target through
- `GSTACK_ALLOW_INTERNAL_URL=1` still rejects empty + non-http schemes
- the set path refuses to write a hostile URL to config.yaml
- the set path writes a valid public URL through
- the set path with `GSTACK_ALLOW_INTERNAL_URL=1` lets dev URL through

Adjacent tests still pass: `explain-level-config`,
`gstack-brain-init-gh-mock`, `brain-sync` (41/41 across 3 files).

## Why this matters

The brain-consumer registration flow trusts whatever endpoint the
operator named, which is the right default for a happy-path setup.
The cost was that any path-of-least-resistance attacker who can
influence the config — a malicious dev tool, a tampered shell rc, an
env var planted by a CI yaml — turns one curl into a bearer-token
+ private-repo-URL exfil to AWS IMDS or any internal target. The
validator is small (one function, one subcommand, two call sites)
and additive — every legitimate setup keeps working, and the dev
escape hatch is one env var away.