### PR TITLE
docs(plan-reviews): add Execution-settings recommendation preamble

### DIFF
--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -1086,6 +1086,12 @@ branch name wherever the instructions say "the base branch" or `<default>`.
 
 # Mega Plan Review Mode
 
+> **Execution settings recommendation**
+> Bounded strategic review: assess a plan against business / product /
+> investor framing. Second-tier compute (e.g., Opus Extra high) is
+> right. Top-tier compute is warranted only when the plan involves
+> material strategic ambiguity that benefits from open-ended exploration.
+
 ## Philosophy
 You are not here to rubber-stamp this plan. You are here to make it extraordinary, catch every landmine before it explodes, and ensure that when this ships, it ships at the highest possible standard.
 But your posture depends on what the user needs:

--- a/plan-ceo-review/SKILL.md.tmpl
+++ b/plan-ceo-review/SKILL.md.tmpl
@@ -33,6 +33,12 @@ triggers:
 
 # Mega Plan Review Mode
 
+> **Execution settings recommendation**
+> Bounded strategic review: assess a plan against business / product /
+> investor framing. Second-tier compute (e.g., Opus Extra high) is
+> right. Top-tier compute is warranted only when the plan involves
+> material strategic ambiguity that benefits from open-ended exploration.
+
 ## Philosophy
 You are not here to rubber-stamp this plan. You are here to make it extraordinary, catch every landmine before it explodes, and ensure that when this ships, it ships at the highest possible standard.
 But your posture depends on what the user needs:

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -1048,6 +1048,13 @@ PLAN MODE EXCEPTION — always allowed (it's the plan file).
 
 # Plan Review Mode
 
+> **Execution settings recommendation**
+> Bounded engineering planning: produce a build plan from a spec, with
+> known target files and patterns. Second-tier compute (e.g., Opus
+> Extra high) handles this cleanly. Top-tier compute is warranted only
+> if the spec is unusually large or touches an unfamiliar codebase
+> region.
+
 Review this plan thoroughly before making any code changes. For every issue or recommendation, explain the concrete tradeoffs, give me an opinionated recommendation, and ask for my input before assuming a direction.
 
 ## Priority hierarchy

--- a/plan-eng-review/SKILL.md.tmpl
+++ b/plan-eng-review/SKILL.md.tmpl
@@ -35,6 +35,13 @@ triggers:
 
 # Plan Review Mode
 
+> **Execution settings recommendation**
+> Bounded engineering planning: produce a build plan from a spec, with
+> known target files and patterns. Second-tier compute (e.g., Opus
+> Extra high) handles this cleanly. Top-tier compute is warranted only
+> if the spec is unusually large or touches an unfamiliar codebase
+> region.
+
 Review this plan thoroughly before making any code changes. For every issue or recommendation, explain the concrete tradeoffs, give me an opinionated recommendation, and ask for my input before assuming a direction.
 
 ## Priority hierarchy


### PR DESCRIPTION
## What

Adds a short **Execution settings recommendation** blockquote at the top of `/plan-ceo-review` and `/plan-eng-review` so users pick the right compute tier *before* invoking the skill.

> **Execution settings recommendation**
> Bounded strategic review: assess a plan against business / product /
> investor framing. Second-tier compute (e.g., Opus Extra high) is
> right. Top-tier compute is warranted only when the plan involves
> material strategic ambiguity that benefits from open-ended exploration.

## Why

Claude Code now exposes meaningfully different compute tiers (Opus Max, Opus Extra high, Sonnet, etc.). Some skills genuinely benefit from the top tier; many are bounded enough that mid-tier handles them at a fraction of the cost. Without per-skill guidance, users either over-spend on routine reviews or under-spend on review tasks that need headroom.

Wording is **task-shape framing** ("bounded strategic review", "second-tier compute (e.g., Opus Extra high)") rather than pinned model names, so the guidance survives model-version churn (Opus 4.7 → 4.8 → 5 etc.) without doc maintenance.

The pattern was developed across a set of project-local skills (six narrative-deck skills with similarly-shaped recommendations); the eng + CEO plan reviews were the natural upstream candidates — stable, non-domain-specific, and used widely.

## Files

- `plan-ceo-review/SKILL.md.tmpl` — preamble after H1, before `## Philosophy`
- `plan-eng-review/SKILL.md.tmpl` — preamble after H1, before "Review this plan thoroughly..."
- `plan-ceo-review/SKILL.md` and `plan-eng-review/SKILL.md` — regenerated via `bun run gen:skill-docs` (all three hosts: Claude, Codex, Factory)

Diff is purely additive: 4 files, +26 lines.

## Reviewer notes

- Skill-docs freshness gate passes locally — `bun run gen:skill-docs && git diff --exit-code` is clean.
- Templates and rendered docs are committed together so the `skill-docs.yml` workflow lands green on first build.
- No `version-gate.yml` trigger — `VERSION` / `CHANGELOG.md` / `package.json` untouched. Happy to bump if your release cadence wants this in a versioned drop.
- Posture matches your existing template structure (blockquote sits between the H1 and the first body section, not embedded in `{{PREAMBLE}}` macro space).

## Aside (separate issue, not this PR)

While regenerating on Windows I noticed the repo has no `.gitattributes`, so on Windows clones with `core.autocrlf=true` (the default), `bun run gen:skill-docs` produces CRLF-line files where `transformFrontmatter()`'s strip regex `^${field}:\s*.*\n` fails to match — `sensitive: true` leaks through into Claude `SKILL.md` outputs. Worked around it locally by setting `core.autocrlf=false`. Happy to file a separate issue or send a tiny fix PR (a one-line `.gitattributes` would close it).
