### PR TITLE
feat: /glossary skill — Evans DDD ubiquitous language + bounded contexts

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -227,6 +227,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -236,6 +236,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -229,6 +229,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -229,6 +229,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -228,6 +228,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -228,6 +228,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -230,6 +230,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -232,6 +232,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -232,6 +232,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -233,6 +233,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -233,6 +233,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -235,6 +235,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -233,6 +233,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -230,6 +230,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -233,6 +233,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -230,6 +230,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/glossary/SKILL.md
+++ b/glossary/SKILL.md
@@ -1,27 +1,28 @@
 ---
-name: setup-gbrain
+name: glossary
 preamble-tier: 2
 version: 1.0.0
 description: |
-  Set up gbrain for this coding agent: install the CLI, initialize a
-  local PGLite or Supabase brain, register MCP, capture per-remote trust
-  policy. One command from zero to "gbrain is running, and this agent
-  can call it." Use when: "setup gbrain", "connect gbrain", "start
-  gbrain", "install gbrain", "configure gbrain for this machine". (gstack)
-triggers:
-  - setup gbrain
-  - install gbrain
-  - connect gbrain
-  - start gbrain
-  - configure gbrain
+  Build (or update) an ubiquitous language for the codebase — a glossary of
+  domain terms grouped by bounded context, with a context map showing how
+  those contexts relate. Grounded in Evans, Domain-Driven Design (2003),
+  Ch. 2 (Ubiquitous Language) and Ch. 14 (Maintaining Model Integrity).
+  Use when asked to "build a glossary", "document our domain language",
+  "context map", "bounded contexts", or "why does 'Customer' mean different
+  things in different parts of the codebase". (gstack)
 allowed-tools:
   - Bash
   - Read
   - Write
-  - Edit
-  - Glob
   - Grep
+  - Glob
   - AskUserQuestion
+triggers:
+  - build a glossary
+  - ubiquitous language
+  - bounded contexts
+  - context map
+  - domain vocabulary
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->
@@ -61,7 +62,7 @@ _QUESTION_TUNING=$(~/.claude/skills/gstack/bin/gstack-config get question_tuning
 echo "QUESTION_TUNING: $_QUESTION_TUNING"
 mkdir -p ~/.gstack/analytics
 if [ "$_TEL" != "off" ]; then
-echo '{"skill":"setup-gbrain","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+echo '{"skill":"glossary","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 fi
 for _PF in $(find ~/.gstack/analytics -maxdepth 1 -name '.pending-*' 2>/dev/null); do
   if [ -f "$_PF" ]; then
@@ -83,7 +84,7 @@ if [ -f "$_LEARN_FILE" ]; then
 else
   echo "LEARNINGS: 0"
 fi
-~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"setup-gbrain","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"glossary","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
 _HAS_ROUTING="no"
 if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
   _HAS_ROUTING="yes"
@@ -597,7 +598,7 @@ Before each AskUserQuestion, choose `question_id` from `scripts/question-registr
 
 After answer, log best-effort:
 ```bash
-~/.claude/skills/gstack/bin/gstack-question-log '{"skill":"setup-gbrain","question_id":"<id>","question_summary":"<short>","category":"<approval|clarification|routing|cherry-pick|feedback-loop>","door_type":"<one-way|two-way>","options_count":N,"user_choice":"<key>","recommended":"<key>","session_id":"'"$_SESSION_ID"'"}' 2>/dev/null || true
+~/.claude/skills/gstack/bin/gstack-question-log '{"skill":"glossary","question_id":"<id>","question_summary":"<short>","category":"<approval|clarification|routing|cherry-pick|feedback-loop>","door_type":"<one-way|two-way>","options_count":N,"user_choice":"<key>","recommended":"<key>","session_id":"'"$_SESSION_ID"'"}' 2>/dev/null || true
 ```
 
 For two-way questions, offer: "Tune this question? Reply `tune: never-ask`, `tune: always-ask`, or free-form."
@@ -666,440 +667,280 @@ In plan mode before ExitPlanMode: if the plan file lacks `## GSTACK REVIEW REPOR
 
 PLAN MODE EXCEPTION — always allowed (it's the plan file).
 
-# /setup-gbrain — Coding-Agent Onboarding for gbrain
+# /glossary — Ubiquitous Language & Context Map
 
-You are setting up gbrain (https://github.com/garrytan/gbrain), a persistent
-knowledge base, on the user's local Mac so that this coding agent (typically
-Claude Code) can call it as both a CLI and an MCP tool.
+You are a **Domain-Driven Design consultant** who has spent years helping teams turn accidental, drifting codebases into deliberate, bounded ones. Your first job is never to invent new vocabulary — it's to surface the vocabulary that already exists in the code and make it explicit, consistent, and mappable.
 
-**Scope honesty:** This skill's MCP registration step (5a) uses
-`claude mcp add` and targets Claude Code specifically. Other local hosts
-(Cursor, Codex CLI, etc.) will still get the gbrain CLI on PATH — they can
-register `gbrain serve` in their own MCP config manually after setup.
+**Why this skill exists:** On any codebase older than a year, the same word means different things in different modules. "Customer" in `billing/` is "the entity we invoice." In `support/` it's "the person we talk to on the phone." In `analytics/` it's "a deduplicated device fingerprint." These drifts are not a problem IF they are named and contained. They are a problem when nobody has written them down — then every cross-module conversation re-negotiates the term from scratch, and refactors split the concept silently.
 
-**Audience:** local-Mac users. openclaw/hermes agents typically run in cloud
-docker containers with their own gbrain; "sharing" a brain between them and
-local Claude Code is only possible through shared Postgres (Supabase).
+Evans' answer is **bounded contexts**: a coherent subsystem in which the language is consistent, with explicit relationships (via a **context map**) to other contexts. Your output is one document that makes the contexts and their relationships visible.
+
+**HARD GATE:** Do NOT rename anything, refactor anything, or propose architecture changes. This skill produces documentation only. Renames are a separate conversation (the output of this skill will often motivate them).
+
+---
 
 ## User-invocable
-When the user types `/setup-gbrain`, run this skill. Three shortcut modes:
 
-- `/setup-gbrain` — full flow (default)
-- `/setup-gbrain --repo` — only flip the per-remote policy for the current repo
-- `/setup-gbrain --switch` — only migrate the engine (PGLite ↔ Supabase)
-- `/setup-gbrain --resume-provision <ref>` — re-enter a previously interrupted
-  Supabase auto-provision at the polling step
-- `/setup-gbrain --cleanup-orphans` — list + delete in-flight Supabase projects
+When the user types `/glossary`, run this skill.
 
-Parse the invocation args yourself — these are prose hints to the skill, not
-implemented as a dispatcher binary.
+## Arguments
+
+- `/glossary` — first-run or update. Re-scans the codebase, presents changes vs the existing `UBIQUITOUS_LANGUAGE.md` (if any), and writes an updated one after approval.
+- `/glossary --scope <path>` — limit to a specific directory (useful for mono-repo subprojects).
+- `/glossary --dry-run` — produce the analysis but don't write the file. User reads output and decides.
 
 ---
 
-## Step 1: Detect current state
+## Phase 1: Discover domain terms
 
-```bash
-~/.claude/skills/gstack/bin/gstack-gbrain-detect
-```
+Surface the nouns, verbs, and roles that already appear in the code. Do NOT invent — only collect what is already there.
 
-Capture the JSON output. It contains: `gbrain_on_path`, `gbrain_version`,
-`gbrain_config_exists`, `gbrain_engine`, `gbrain_doctor_ok`,
-`gstack_brain_sync_mode`, `gstack_brain_git`.
+1. **Module structure.** List top-level source directories. Each directory name is a first-cut domain area:
+   ```bash
+   ls -d */ src/*/ lib/*/ app/*/ 2>/dev/null | grep -Ev '^(node_modules|dist|build|vendor|test|tests|spec|\.)' | head -40
+   ```
 
-Skip downstream steps that are already done. Report the detected state in
-one line so the user knows what you found:
+2. **Class / type / interface names.** Use Grep to find the domain types. Scope to detected languages from the repo (check `package.json`, `requirements.txt`, `Gemfile`, `go.mod` etc. — same stack detection as `/cso` Phase 0).
+   - TypeScript/JavaScript: `interface\s+[A-Z]`, `class\s+[A-Z]`, `type\s+[A-Z]\w*\s*=`
+   - Python: `class\s+[A-Z]`
+   - Ruby: `class\s+[A-Z]`, `module\s+[A-Z]`
+   - Go: `type\s+[A-Z]\w+\s+(struct|interface)`
+   - Java/Kotlin/C#: `(class|interface|record)\s+[A-Z]`
+   Filter out framework base classes (e.g., `React.Component`, `ApplicationController`) and test doubles.
 
-> "Detected: gbrain v0.18.2 on PATH, engine=postgres, doctor=ok,
->  sync=artifacts-only. Nothing to install; jumping to the policy check."
+3. **Database tables.** Check migration files, `schema.rb`, `schema.prisma`, `*.sql`, `db/` directory. Table names are often the cleanest domain terms because the DB resists casual renaming.
 
-Branch on the `--repo`, `--switch`, `--resume-provision`, `--cleanup-orphans`
-invocation flags here and skip to the matching step.
+4. **URL path segments.** Grep routers for top-level paths. `/orders`, `/shipments`, `/returns` are domain nouns. `/api/v2/admin/users/bulk-suspend` is the language of a specific context.
 
----
+5. **API response field names.** If there's an OpenAPI spec or typed API schema, read it. Response field names travel further than class names — they are public contract.
 
-## Step 2: Pick a path (AskUserQuestion)
+6. **Terms the team uses in docs/CHANGELOG/README.** Grep the docs for capitalized phrases and acronyms.
 
-Only fire this if Step 1 shows no existing working config AND no shortcut
-flag was passed. The question title: "Where should your brain live?"
-
-Options (present based on detected state):
-
-- **1 — Supabase, I already have a connection string.** Cloud-agent users
-  whose openclaw/hermes provisioned one already. Paste the Session Pooler
-  URL from the Supabase dashboard (Settings → Database → Connection Pooler
-  → Session). *Trust-surface caveat to include in the prompt:* "Pasting this
-  URL gives your local Claude Code full read/write access to every page your
-  cloud agent can see. If that's not the trust level you want, pick PGLite
-  local instead and accept the brains are disjoint."
-- **2a — Supabase, auto-provision a new project.** You'll need a Supabase
-  Personal Access Token (~90 seconds). Best choice for a shared team brain.
-- **2b — Supabase, create manually.** Walk through supabase.com signup
-  yourself; paste the URL back when ready.
-- **3 — PGLite local.** Zero accounts, ~30 seconds. Isolated brain on this
-  Mac only. Best for try-first.
-- **Switch** (only if Step 1 detected an existing engine): "You already have
-  a `<engine>` brain. Migrate it to the other engine?" → runs
-  `gbrain migrate --to <other>` wrapped in `timeout 180s` (D9).
-
-Do NOT silently pick; fire the AskUserQuestion.
+**Output a raw candidate list** — deduplicated, roughly 30-120 terms. Do not classify yet. This is raw material for Phase 2.
 
 ---
 
-## Step 3: Install gbrain CLI (if missing)
+## Phase 2: Cluster into bounded contexts
 
-Only if `gbrain_on_path=false`:
+Now group the terms into coherent subsystems where the language is internally consistent.
 
-```bash
-~/.claude/skills/gstack/bin/gstack-gbrain-install
+**First cut:** directory structure. `src/billing/` is usually a bounded context boundary. `src/shared/` usually is NOT — it's likely a shared kernel OR a big ball of mud. Name this out.
+
+**Second cut:** find **language seams** — terms that appear in multiple directories with different definitions. These are the high-value findings:
+
+1. Grep for the candidate term across all source directories.
+2. Read the class/type definition in each location. Are they the same concept, or different concepts sharing a name?
+3. If different: the split is a bounded context boundary. Document both meanings separately.
+
+**Third cut:** ask the user. For the top 5-10 ambiguous terms, use AskUserQuestion:
+
+```
+The term "Account" appears in both `billing/` (as a payment target — has
+a balance, invoices, payment methods) and `auth/` (as a login entity —
+has credentials, sessions, MFA). Same concept or two concepts sharing a name?
+
+A) Same concept — they should be the same type (renaming one in code)
+B) Two concepts — rename one in the glossary (e.g. BillingAccount / UserAccount)
+   and mark the seam explicitly
+C) I don't know — save this question for the next team review
 ```
 
-The installer runs D5 detect-first (probes `~/git/gbrain`, `~/gbrain` first),
-then D19 PATH-shadow validation (post-link `gbrain --version` must match
-install-dir `package.json`). On D19 failure the installer exits 3 with a
-clear remediation menu; surface the full output to the user and STOP. Do not
-continue the skill — the environment is broken until the user fixes PATH.
+**Output a context list.** Usually 3-8 contexts for a mature app; 1-3 for early-stage. Name each context by what it does in the business, not by the directory. Example:
 
----
-
-## Step 4: Initialize the brain
-
-Path-specific.
-
-### Path 1 (Supabase, existing URL)
-
-Source the secret-read helper, collect URL with `read -s` + redacted preview:
-
-```bash
-. ~/.claude/skills/gstack/bin/gstack-gbrain-lib.sh
-read_secret_to_env GBRAIN_POOLER_URL "Paste Session Pooler URL: " \
-  --echo-redacted 's#://[^@]*@#://***@#'
 ```
-
-Then validate structurally:
-
-```bash
-printf '%s' "$GBRAIN_POOLER_URL" | ~/.claude/skills/gstack/bin/gstack-gbrain-supabase-verify -
-```
-
-If the verify exit code is 3 (direct-connection URL), the verifier's own
-message explains the fix; surface it and re-prompt for a Session Pooler URL.
-
-On success, hand off to gbrain via env var (D10, never argv):
-
-```bash
-GBRAIN_DATABASE_URL="$GBRAIN_POOLER_URL" gbrain init --non-interactive --json
-```
-
-Then `unset GBRAIN_POOLER_URL GBRAIN_DATABASE_URL` immediately. The URL is
-now persisted in `~/.gbrain/config.json` at mode 0600 by gbrain itself.
-
-### Path 2a (Supabase, auto-provision — D7)
-
-Show the D11 PAT scope disclosure verbatim BEFORE collecting the token:
-
-> *This Supabase Personal Access Token grants full read/write/delete access
-> to every project in your Supabase account, not just the `gbrain` one we're
-> about to create. Supabase doesn't currently support scoped tokens. We use
-> this PAT only to: create one project, poll it until healthy, read the
-> Session Pooler URL — then discard it from process memory. The token
-> remains valid on Supabase's side until you manually revoke it at
-> https://supabase.com/dashboard/account/tokens — we recommend revoking
-> immediately after setup completes.*
-
-Then:
-
-```bash
-. ~/.claude/skills/gstack/bin/gstack-gbrain-lib.sh
-read_secret_to_env SUPABASE_ACCESS_TOKEN "Paste PAT: "
-```
-
-Ask the D17 tier prompt via AskUserQuestion: "Which Supabase tier?" Present
-Free (2-project limit, pauses after 7d inactivity) vs Pro ($25/mo, no
-pauses, recommended for real use). Explain that tier is **org-level** (per
-the Management API contract) — user picks their org based on its current
-tier. Pro may require them to upgrade the org first at supabase.com.
-
-List orgs, pick one (AskUserQuestion if multiple):
-
-```bash
-orgs=$(~/.claude/skills/gstack/bin/gstack-gbrain-supabase-provision list-orgs --json)
-```
-
-If the `.orgs` array is empty, surface: "Your Supabase account has no
-organizations. Create one at https://supabase.com/dashboard, then re-run
-`/setup-gbrain`." STOP.
-
-Ask the user for a region (default `us-east-1`; valid values are the 18
-enum values in the Supabase Management API — list a few common ones, let
-them pick "Other" for a full list).
-
-Generate the DB password (never shown to the user):
-
-```bash
-export DB_PASS=$(openssl rand -base64 24)
-```
-
-Set up a SIGINT trap (D12 basic recovery):
-
-```bash
-trap 'echo ""; echo "gstack-gbrain: interrupted. In-flight ref: $INFLIGHT_REF"; \
-      echo "Resume: /setup-gbrain --resume-provision $INFLIGHT_REF"; \
-      echo "Delete: https://supabase.com/dashboard/project/$INFLIGHT_REF"; \
-      unset SUPABASE_ACCESS_TOKEN DB_PASS; exit 130' INT TERM
-```
-
-Create + wait + fetch:
-
-```bash
-result=$(~/.claude/skills/gstack/bin/gstack-gbrain-supabase-provision \
-  create gbrain "$REGION" "$ORG_SLUG" --json)
-INFLIGHT_REF=$(echo "$result" | jq -r .ref)
-~/.claude/skills/gstack/bin/gstack-gbrain-supabase-provision wait "$INFLIGHT_REF" --json
-pooler=$(~/.claude/skills/gstack/bin/gstack-gbrain-supabase-provision \
-  pooler-url "$INFLIGHT_REF" --json)
-GBRAIN_DATABASE_URL=$(echo "$pooler" | jq -r .pooler_url)
-export GBRAIN_DATABASE_URL
-gbrain init --non-interactive --json
-unset SUPABASE_ACCESS_TOKEN DB_PASS GBRAIN_DATABASE_URL INFLIGHT_REF
-trap - INT TERM
-```
-
-After success, emit the PAT revocation reminder:
-
-> "Setup complete. Revoke the PAT you pasted at
-> https://supabase.com/dashboard/account/tokens — we've already discarded
-> it from memory and don't need it again. The gbrain project will continue
-> working because it uses its own embedded database password."
-
-### Path 2b (Supabase, manual)
-
-Walk the user through the supabase.com steps:
-1. Login at https://supabase.com/dashboard
-2. Click "New Project," name it `gbrain`, pick a region, copy the generated
-   database password (you'll need it for paste-back? no — it's embedded in
-   the pooler URL we collect next)
-3. Wait ~2 min for the project to initialize
-4. Settings → Database → Connection Pooler → Session → copy the URL (port
-   6543)
-
-Then follow the same secret-read + verify + init flow as Path 1.
-
-### Path 3 (PGLite local)
-
-```bash
-gbrain init --pglite --json
-```
-
-Done. No network, no secrets.
-
-### Switch (from detect's existing-engine state)
-
-```bash
-# Going PGLite → Supabase, collect URL first (Path 1 flow), then:
-timeout 180s gbrain migrate --to supabase --url "$URL" --json
-# Going Supabase → PGLite:
-timeout 180s gbrain migrate --to pglite --json
-```
-
-If `timeout` returns 124 (exit code for timeout): surface D9 message
-("Migration didn't complete in 3 minutes — another gstack session may be
-holding a lock on the source brain. Close other workspaces and re-run
-`/setup-gbrain --switch`. Your original brain is untouched."). STOP.
-
----
-
-## Step 5: Verify gbrain doctor
-
-```bash
-doctor=$(gbrain doctor --json)
-status=$(echo "$doctor" | jq -r .status)
-```
-
-If status is `ok` or `warnings`, proceed. Anything else → surface the full
-doctor output and STOP.
-
----
-
-## Step 5a: Register gbrain as Claude Code MCP (D18)
-
-Only if `which claude` resolves. Ask: "Give Claude Code a typed tool surface
-for gbrain? (recommended yes)"
-
-If yes, register at **user scope** with an **absolute path** to the gbrain
-binary. User scope makes the MCP available in every Claude Code session on
-this machine, not just the current workspace. Absolute path avoids PATH
-resolution issues when Claude Code spawns `gbrain serve` as a subprocess.
-
-```bash
-GBRAIN_BIN=$(command -v gbrain)
-[ -z "$GBRAIN_BIN" ] && GBRAIN_BIN="$HOME/.bun/bin/gbrain"
-claude mcp add --scope user gbrain -- "$GBRAIN_BIN" serve
-claude mcp list | grep gbrain  # verify: should show "✓ Connected"
-```
-
-If the user already had a local-scope registration from an earlier run,
-remove it first so both scopes don't conflict:
-```bash
-claude mcp remove gbrain 2>/dev/null || true
-```
-
-If `claude` is not on PATH: emit "MCP registration skipped — this skill is
-Claude-Code-targeted; register `gbrain serve` in your agent's MCP config
-manually." Continue to step 6.
-
-**Heads-up for the user:** an already-open Claude Code session will not
-pick up the new MCP tools until restart. Tell them: "Restart any open
-Claude Code sessions to see `mcp__gbrain__*` tools — they're loaded at
-session start, not mid-session."
-
----
-
-## Step 6: Per-remote policy (D3 triad, gated repo-import)
-
-If we're in a git repo with an `origin` remote, check the policy:
-
-```bash
-current_tier=$(~/.claude/skills/gstack/bin/gstack-gbrain-repo-policy get)
-```
-
-Branches:
-- `read-write` → import this repo: `gbrain import "$(pwd)" --no-embed` then
-  `gbrain embed --stale &` in the background.
-- `read-only` → skip import entirely (this tier is enforced by the future
-  auto-import hook + by gbrain resolver injection, not here).
-- `deny` → do nothing.
-- `unset` → AskUserQuestion: "How should `<normalized-remote>` interact with
-  gbrain?"
-  - `read-write` — agent can search AND write new pages from this repo
-  - `read-only` — agent can search but never write
-  - `deny` — no interaction at all
-  - `skip-for-now` — don't persist, ask next time
-
-  On answer (other than skip-for-now):
-  ```bash
-  ~/.claude/skills/gstack/bin/gstack-gbrain-repo-policy set "$REMOTE" "$TIER"
-  ```
-  Then import iff `read-write`.
-
-If outside a git repo OR no origin remote: skip this step with a note.
-
-For `/setup-gbrain --repo` invocations, execute ONLY Step 6 and exit.
-
----
-
-## Step 7: Offer gstack-brain-sync
-
-Separate AskUserQuestion: "Also sync your gstack session memory (learnings,
-plans, retros) to a private git repo that gbrain can index across machines?"
-
-Options:
-- Yes, full sync (everything allowlisted)
-- Yes, artifacts-only (plans, designs, retros — skip behavioral data)
-- No thanks
-
-If yes:
-
-```bash
-~/.claude/skills/gstack/bin/gstack-brain-init
-~/.claude/skills/gstack/bin/gstack-config set gbrain_sync_mode artifacts-only
-# or "full" if user picked yes-full
+Contexts discovered (draft — user to confirm):
+  1. Identity            src/auth/, src/users/
+  2. Billing             src/billing/, src/payments/
+  3. Reporting           src/analytics/, src/dashboards/
+  4. Support             src/tickets/, src/chat/
+  5. Shared Kernel       src/shared/, src/db/, src/lib/ (small — needs justification)
 ```
 
 ---
 
-## Step 8: Persist `## GBrain Configuration` in CLAUDE.md
+## Phase 3: Map context relationships
 
-Find-and-replace (or append) this section in CLAUDE.md:
+For each pair of contexts that interact (not every pair does — that's information too), classify the relationship using Evans' canonical types. The classification is the hard work; name it explicitly so the team can agree or push back.
+
+| Relationship | When to use | Signal in code |
+|---|---|---|
+| **Shared Kernel** | Two contexts jointly own a small shared model (types, constants, utility). Joint ownership — changes require buy-in from both teams. | A `shared/` directory imported by both, with types both contexts reference by their core names (not via adapters). |
+| **Customer / Supplier** | Upstream supplies downstream. Downstream is the customer — they can ask for changes but don't dictate. | Import direction is one-way. The downstream has some voice in the upstream's API (issues filed, reviews). |
+| **Conformist** | Downstream adopts upstream's model wholesale. No translation. Fast to build, painful to diverge later. | No adapter layer. Downstream uses upstream types directly throughout its internals. |
+| **Anticorruption Layer (ACL)** | Downstream protects its own model via a translation layer. Best when upstream is legacy or external. | A clearly-named adapter module (e.g. `billing/external/stripe-adapter.ts`) translating upstream types → internal types. |
+| **Open Host Service** | Upstream publishes a stable API many downstreams consume. Upstream prioritizes stability over flexibility. | Versioned API, public docs, deprecation policy. |
+| **Published Language** | Upstream defines a formal shared vocabulary (JSON schema, protobuf, XSD). All consumers speak it. | `schemas/`, `.proto` files, OpenAPI spec with explicit types. |
+| **Separate Ways** | Two contexts do NOT integrate. Each owns its own model. Accept duplication over the cost of coupling. | No imports between the two. Same concept implemented twice, intentionally. |
+| **Partnership** | Two teams jointly succeed or fail. Close coordination. Often a transitional state — either it becomes Shared Kernel or splits. | Cross-team standups on a shared feature. |
+| **Big Ball of Mud (BBoM)** | No structure. Mixing models, leaks everywhere, renames break everything. Flag where this exists. | Hundreds of unplanned imports across directories. |
+
+**Draw the context map.** Use Mermaid (renders on GitHub/GitLab). Example:
+
+```mermaid
+graph LR
+  Identity -->|Published Language: user.v1| Billing
+  Identity -->|Published Language: user.v1| Reporting
+  Billing  -->|ACL: StripeAdapter| Stripe[External: Stripe]
+  Support  -.Separate Ways.-> Billing
+  SharedKernel[Shared Kernel: IDs, Money]
+  SharedKernel --- Identity
+  SharedKernel --- Billing
+  SharedKernel --- Reporting
+```
+
+If Mermaid isn't supported in the repo's renderer, emit an ASCII table of pairs + relationship type.
+
+---
+
+## Phase 4: Write `UBIQUITOUS_LANGUAGE.md`
+
+Choose the path:
+- If `docs/` exists → `docs/UBIQUITOUS_LANGUAGE.md`
+- Else → `UBIQUITOUS_LANGUAGE.md` at repo root
+
+If a file already exists at that path, read it first and produce a **diff summary** (added contexts, renamed terms, changed relationships) before overwriting. Present the diff via AskUserQuestion:
+
+```
+UBIQUITOUS_LANGUAGE.md already exists.
+Changes detected this run:
+  + 2 new contexts (Notifications, Partnerships)
+  ~ 1 renamed term (Account → BillingAccount in the Billing context)
+  - 1 removed term (LegacyUser — no longer referenced in code)
+
+A) Overwrite with the new version
+B) Show me the full diff first
+C) Write a patch file instead (I'll merge manually)
+D) Cancel — keep the existing file
+```
+
+**File structure:**
 
 ```markdown
-## GBrain Configuration (configured by /setup-gbrain)
-- Engine: {pglite|postgres}
-- Config file: ~/.gbrain/config.json (mode 0600)
-- Setup date: {today}
-- MCP registered: {yes/no}
-- Memory sync: {off|artifacts-only|full}
-- Current repo policy: {read-write|read-only|deny|unset}
+# Ubiquitous Language
+
+This glossary is grounded in the code as of <YYYY-MM-DD>. Every term below
+is a noun or verb that appears in the codebase; no term is invented here.
+When you rename a domain concept, update this file in the same PR.
+
+Regenerate with `/glossary`. The regeneration is idempotent — the user
+reviews all changes before the file is overwritten.
+
+## Context Map
+
+<Mermaid or ASCII diagram from Phase 3>
+
+### Relationship table
+
+| Upstream | Downstream | Type | Notes |
+|---|---|---|---|
+| Identity | Billing | Published Language (user.v1) | Stable — no breaking changes in 18mo |
+| Billing | Stripe | ACL (StripeAdapter) | External payment provider |
+| Support | Billing | Separate Ways | Support does not invoice; duplication accepted |
+
+---
+
+## Context: Identity
+
+*Located in:* `src/auth/`, `src/users/`
+*Responsible for:* authentication, authorization, user profile.
+
+| Term | Definition | Where in code |
+|---|---|---|
+| User | A person with credentials. Can log in. | `src/users/User.ts` |
+| Session | A time-bounded authenticated context. | `src/auth/Session.ts` |
+| Role | A bundle of permissions. | `src/auth/Role.ts` |
+
+---
+
+## Context: Billing
+
+*Located in:* `src/billing/`, `src/payments/`
+*Responsible for:* invoicing, payment capture, refunds.
+
+| Term | Definition | Where in code |
+|---|---|---|
+| BillingAccount | A payment target. Has a balance and payment methods. NOTE: different from Identity's "User" — a User can own 0 or many BillingAccounts. | `src/billing/BillingAccount.ts` |
+| Invoice | A dated statement of charges. | `src/billing/Invoice.ts` |
+| PaymentMethod | A stored way to charge (card, ACH, etc). | `src/payments/PaymentMethod.ts` |
+
+---
+
+[... one section per context ...]
+
+---
+
+## Language seams
+
+Terms that mean different things in different contexts. Read these carefully
+before using the term in cross-context conversation.
+
+| Term | Context A | Context B | Why the split |
+|---|---|---|---|
+| Account | Identity: "UserAccount" — login entity | Billing: "BillingAccount" — payment target | A user (person) can own many billing accounts (org, personal). Split during <date/PR>. |
+
+---
+
+## How to update this file
+
+1. When you add a new domain type, add an entry to the appropriate context section.
+2. When you rename a concept, update this file in the SAME PR as the code change.
+3. When you discover a language seam (a term meaning different things in two contexts), add it to §Language seams and rename one of them in code.
+4. Regenerate with `/glossary` quarterly or after any large refactor. The command
+   is idempotent and will show you a diff before overwriting.
 ```
 
 ---
 
-## Step 9: Smoke test
+## Phase 5: Commit guidance
 
-```bash
-SLUG="setup-gbrain-smoke-test-$(date +%s)"
-echo "Set up on $(date). Smoke test for /setup-gbrain." | gbrain put "$SLUG"
-gbrain search "smoke test" | grep -i "$SLUG"
+Do NOT commit the file automatically. Tell the user:
+
+```
+UBIQUITOUS_LANGUAGE.md written to <path>.
+Not committed — review the diff first, then:
+
+  git add <path>
+  git commit -m "docs: add/update ubiquitous language and context map"
+
+If /glossary found language seams (same term, different meanings in different
+contexts), those are the highest-value findings. Consider opening a separate
+issue / PR to rename one of them in code — the file now documents WHERE the
+seams are; fixing them is a behavioral change worth doing separately.
 ```
 
-Confirms the round trip. On failure, surface `gbrain doctor --json` output
-and STOP with a NEEDS_CONTEXT escalation.
+Log the run as a learning with `type: "glossary"` and include the contexts discovered so future runs can diff.
 
----
+## Capture Learnings
 
-## `/setup-gbrain --cleanup-orphans` (D20)
-
-Re-collect a PAT (Step 4 path-2a scope disclosure), then:
+If you discovered a non-obvious pattern, pitfall, or architectural insight during
+this session, log it for future sessions:
 
 ```bash
-# List user's Supabase projects (user has to pipe this through their own
-# shell to review; we don't rely on a stored PAT).
-export SUPABASE_ACCESS_TOKEN="<collected from read_secret_to_env>"
-projects=$(curl -s -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
-  https://api.supabase.com/v1/projects)
+~/.claude/skills/gstack/bin/gstack-learnings-log '{"skill":"glossary","type":"TYPE","key":"SHORT_KEY","insight":"DESCRIPTION","confidence":N,"source":"SOURCE","files":["path/to/relevant/file"]}'
 ```
 
-Parse the response, identify any project named starting with `gbrain` whose
-`ref` doesn't match the user's active `~/.gbrain/config.json` pooler URL.
-For each orphan, AskUserQuestion per project: "Delete orphan project
-`<ref>` (`<name>`, created `<created_at>`)?" — NEVER batch; per-project
-confirm is a one-way door.
+**Types:** `pattern` (reusable approach), `pitfall` (what NOT to do), `preference`
+(user stated), `architecture` (structural decision), `tool` (library/framework insight),
+`operational` (project environment/CLI/workflow knowledge).
 
-On confirmed delete:
-```bash
-curl -s -X DELETE -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
-  https://api.supabase.com/v1/projects/$REF
-```
+**Sources:** `observed` (you found this in the code), `user-stated` (user told you),
+`inferred` (AI deduction), `cross-model` (both Claude and Codex agree).
 
-Never delete the active brain without a second explicit confirmation.
+**Confidence:** 1-10. Be honest. An observed pattern you verified in the code is 8-9.
+An inference you're not sure about is 4-5. A user preference they explicitly stated is 10.
 
-At end: `unset SUPABASE_ACCESS_TOKEN`. Revocation reminder.
+**files:** Include the specific file paths this learning references. This enables
+staleness detection: if those files are later deleted, the learning can be flagged.
 
----
-
-## Telemetry (D4)
-
-The preamble's Telemetry block logs skill success/failure at exit. When
-emitting the event, add these enumerated categorical values to the
-telemetry payload (SAFE — no free-form secrets, never the URL or PAT):
-
-- `scenario`: `supabase-existing` | `supabase-auto-provision` |
-  `supabase-manual` | `pglite-local` | `switch-to-supabase` |
-  `switch-to-pglite` | `repo-flip-only` | `cleanup-orphans` |
-  `resume-provision`
-- `install_performed`: `yes` | `no` (D5 reuse) | `skipped` (pre-existing)
-- `mcp_registered`: `yes` | `no` | `claude-missing`
-- `trust_tier_set`: `read-write` | `read-only` | `deny` |
-  `skip-for-now` | `n/a` (outside git repo)
-
-Never pass `SUPABASE_ACCESS_TOKEN`, `DB_PASS`, `GBRAIN_POOLER_URL`,
-`GBRAIN_DATABASE_URL`, or any `postgresql://` substring to the telemetry
-invocation. The CI grep test in `test/skill-validation.test.ts` enforces
-this at build time.
+**Only log genuine discoveries.** Don't log obvious things. Don't log things the user
+already knows. A good test: would this insight save time in a future session? If yes, log it.
 
 ---
 
 ## Important Rules
 
-- **One rule for every secret.** PAT, DB_PASS, pooler URL: env-var only,
-  never argv, never logged, never persisted to disk by us. The only file
-  that holds the pooler URL long-term is `~/.gbrain/config.json`, written
-  by gbrain's own `init` at mode 0600 — that's gbrain's discipline, not
-  ours.
-- **STOP points are hard.** Gbrain doctor not healthy, D19 PATH shadow, D9
-  migrate timeout, smoke test failure — each is a STOP. Do not paper over.
-- **Concurrent-run lock.** At skill start, `mkdir ~/.gstack/.setup-gbrain.lock.d`
-  (atomic). If the mkdir fails, abort with: "Another `/setup-gbrain` instance
-  is running. Wait for it, or `rm -rf ~/.gstack/.setup-gbrain.lock.d` if
-  you're sure it's stale." Release on normal exit AND in the SIGINT trap.
-- **CLAUDE.md is the audit trail.** Always update it in Step 8 after a
-  successful setup.
+- **Don't invent vocabulary.** Every term in the file must appear in the code. If a term should exist but doesn't, that's a code finding, not a glossary entry.
+- **Name the seams.** The highest-value output of this skill is the "Language seams" section. If you skip it, you've produced a flat glossary — useful but not DDD.
+- **Don't refactor.** This skill is pure documentation. Renames based on glossary findings are a separate conversation.
+- **Accept partial.** First run of `/glossary` on a large codebase will miss terms. That's fine — the file is living; later runs tighten it.
+- **Read the old file before overwriting.** Never silently drop entries; always diff and confirm.

--- a/glossary/SKILL.md.tmpl
+++ b/glossary/SKILL.md.tmpl
@@ -1,0 +1,283 @@
+---
+name: glossary
+preamble-tier: 2
+version: 1.0.0
+description: |
+  Build (or update) an ubiquitous language for the codebase — a glossary of
+  domain terms grouped by bounded context, with a context map showing how
+  those contexts relate. Grounded in Evans, Domain-Driven Design (2003),
+  Ch. 2 (Ubiquitous Language) and Ch. 14 (Maintaining Model Integrity).
+  Use when asked to "build a glossary", "document our domain language",
+  "context map", "bounded contexts", or "why does 'Customer' mean different
+  things in different parts of the codebase". (gstack)
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Grep
+  - Glob
+  - AskUserQuestion
+triggers:
+  - build a glossary
+  - ubiquitous language
+  - bounded contexts
+  - context map
+  - domain vocabulary
+---
+
+{{PREAMBLE}}
+
+# /glossary — Ubiquitous Language & Context Map
+
+You are a **Domain-Driven Design consultant** who has spent years helping teams turn accidental, drifting codebases into deliberate, bounded ones. Your first job is never to invent new vocabulary — it's to surface the vocabulary that already exists in the code and make it explicit, consistent, and mappable.
+
+**Why this skill exists:** On any codebase older than a year, the same word means different things in different modules. "Customer" in `billing/` is "the entity we invoice." In `support/` it's "the person we talk to on the phone." In `analytics/` it's "a deduplicated device fingerprint." These drifts are not a problem IF they are named and contained. They are a problem when nobody has written them down — then every cross-module conversation re-negotiates the term from scratch, and refactors split the concept silently.
+
+Evans' answer is **bounded contexts**: a coherent subsystem in which the language is consistent, with explicit relationships (via a **context map**) to other contexts. Your output is one document that makes the contexts and their relationships visible.
+
+**HARD GATE:** Do NOT rename anything, refactor anything, or propose architecture changes. This skill produces documentation only. Renames are a separate conversation (the output of this skill will often motivate them).
+
+---
+
+## User-invocable
+
+When the user types `/glossary`, run this skill.
+
+## Arguments
+
+- `/glossary` — first-run or update. Re-scans the codebase, presents changes vs the existing `UBIQUITOUS_LANGUAGE.md` (if any), and writes an updated one after approval.
+- `/glossary --scope <path>` — limit to a specific directory (useful for mono-repo subprojects).
+- `/glossary --dry-run` — produce the analysis but don't write the file. User reads output and decides.
+
+---
+
+## Phase 1: Discover domain terms
+
+Surface the nouns, verbs, and roles that already appear in the code. Do NOT invent — only collect what is already there.
+
+1. **Module structure.** List top-level source directories. Each directory name is a first-cut domain area:
+   ```bash
+   ls -d */ src/*/ lib/*/ app/*/ 2>/dev/null | grep -Ev '^(node_modules|dist|build|vendor|test|tests|spec|\.)' | head -40
+   ```
+
+2. **Class / type / interface names.** Use Grep to find the domain types. Scope to detected languages from the repo (check `package.json`, `requirements.txt`, `Gemfile`, `go.mod` etc. — same stack detection as `/cso` Phase 0).
+   - TypeScript/JavaScript: `interface\s+[A-Z]`, `class\s+[A-Z]`, `type\s+[A-Z]\w*\s*=`
+   - Python: `class\s+[A-Z]`
+   - Ruby: `class\s+[A-Z]`, `module\s+[A-Z]`
+   - Go: `type\s+[A-Z]\w+\s+(struct|interface)`
+   - Java/Kotlin/C#: `(class|interface|record)\s+[A-Z]`
+   Filter out framework base classes (e.g., `React.Component`, `ApplicationController`) and test doubles.
+
+3. **Database tables.** Check migration files, `schema.rb`, `schema.prisma`, `*.sql`, `db/` directory. Table names are often the cleanest domain terms because the DB resists casual renaming.
+
+4. **URL path segments.** Grep routers for top-level paths. `/orders`, `/shipments`, `/returns` are domain nouns. `/api/v2/admin/users/bulk-suspend` is the language of a specific context.
+
+5. **API response field names.** If there's an OpenAPI spec or typed API schema, read it. Response field names travel further than class names — they are public contract.
+
+6. **Terms the team uses in docs/CHANGELOG/README.** Grep the docs for capitalized phrases and acronyms.
+
+**Output a raw candidate list** — deduplicated, roughly 30-120 terms. Do not classify yet. This is raw material for Phase 2.
+
+---
+
+## Phase 2: Cluster into bounded contexts
+
+Now group the terms into coherent subsystems where the language is internally consistent.
+
+**First cut:** directory structure. `src/billing/` is usually a bounded context boundary. `src/shared/` usually is NOT — it's likely a shared kernel OR a big ball of mud. Name this out.
+
+**Second cut:** find **language seams** — terms that appear in multiple directories with different definitions. These are the high-value findings:
+
+1. Grep for the candidate term across all source directories.
+2. Read the class/type definition in each location. Are they the same concept, or different concepts sharing a name?
+3. If different: the split is a bounded context boundary. Document both meanings separately.
+
+**Third cut:** ask the user. For the top 5-10 ambiguous terms, use AskUserQuestion:
+
+```
+The term "Account" appears in both `billing/` (as a payment target — has
+a balance, invoices, payment methods) and `auth/` (as a login entity —
+has credentials, sessions, MFA). Same concept or two concepts sharing a name?
+
+A) Same concept — they should be the same type (renaming one in code)
+B) Two concepts — rename one in the glossary (e.g. BillingAccount / UserAccount)
+   and mark the seam explicitly
+C) I don't know — save this question for the next team review
+```
+
+**Output a context list.** Usually 3-8 contexts for a mature app; 1-3 for early-stage. Name each context by what it does in the business, not by the directory. Example:
+
+```
+Contexts discovered (draft — user to confirm):
+  1. Identity            src/auth/, src/users/
+  2. Billing             src/billing/, src/payments/
+  3. Reporting           src/analytics/, src/dashboards/
+  4. Support             src/tickets/, src/chat/
+  5. Shared Kernel       src/shared/, src/db/, src/lib/ (small — needs justification)
+```
+
+---
+
+## Phase 3: Map context relationships
+
+For each pair of contexts that interact (not every pair does — that's information too), classify the relationship using Evans' canonical types. The classification is the hard work; name it explicitly so the team can agree or push back.
+
+| Relationship | When to use | Signal in code |
+|---|---|---|
+| **Shared Kernel** | Two contexts jointly own a small shared model (types, constants, utility). Joint ownership — changes require buy-in from both teams. | A `shared/` directory imported by both, with types both contexts reference by their core names (not via adapters). |
+| **Customer / Supplier** | Upstream supplies downstream. Downstream is the customer — they can ask for changes but don't dictate. | Import direction is one-way. The downstream has some voice in the upstream's API (issues filed, reviews). |
+| **Conformist** | Downstream adopts upstream's model wholesale. No translation. Fast to build, painful to diverge later. | No adapter layer. Downstream uses upstream types directly throughout its internals. |
+| **Anticorruption Layer (ACL)** | Downstream protects its own model via a translation layer. Best when upstream is legacy or external. | A clearly-named adapter module (e.g. `billing/external/stripe-adapter.ts`) translating upstream types → internal types. |
+| **Open Host Service** | Upstream publishes a stable API many downstreams consume. Upstream prioritizes stability over flexibility. | Versioned API, public docs, deprecation policy. |
+| **Published Language** | Upstream defines a formal shared vocabulary (JSON schema, protobuf, XSD). All consumers speak it. | `schemas/`, `.proto` files, OpenAPI spec with explicit types. |
+| **Separate Ways** | Two contexts do NOT integrate. Each owns its own model. Accept duplication over the cost of coupling. | No imports between the two. Same concept implemented twice, intentionally. |
+| **Partnership** | Two teams jointly succeed or fail. Close coordination. Often a transitional state — either it becomes Shared Kernel or splits. | Cross-team standups on a shared feature. |
+| **Big Ball of Mud (BBoM)** | No structure. Mixing models, leaks everywhere, renames break everything. Flag where this exists. | Hundreds of unplanned imports across directories. |
+
+**Draw the context map.** Use Mermaid (renders on GitHub/GitLab). Example:
+
+```mermaid
+graph LR
+  Identity -->|Published Language: user.v1| Billing
+  Identity -->|Published Language: user.v1| Reporting
+  Billing  -->|ACL: StripeAdapter| Stripe[External: Stripe]
+  Support  -.Separate Ways.-> Billing
+  SharedKernel[Shared Kernel: IDs, Money]
+  SharedKernel --- Identity
+  SharedKernel --- Billing
+  SharedKernel --- Reporting
+```
+
+If Mermaid isn't supported in the repo's renderer, emit an ASCII table of pairs + relationship type.
+
+---
+
+## Phase 4: Write `UBIQUITOUS_LANGUAGE.md`
+
+Choose the path:
+- If `docs/` exists → `docs/UBIQUITOUS_LANGUAGE.md`
+- Else → `UBIQUITOUS_LANGUAGE.md` at repo root
+
+If a file already exists at that path, read it first and produce a **diff summary** (added contexts, renamed terms, changed relationships) before overwriting. Present the diff via AskUserQuestion:
+
+```
+UBIQUITOUS_LANGUAGE.md already exists.
+Changes detected this run:
+  + 2 new contexts (Notifications, Partnerships)
+  ~ 1 renamed term (Account → BillingAccount in the Billing context)
+  - 1 removed term (LegacyUser — no longer referenced in code)
+
+A) Overwrite with the new version
+B) Show me the full diff first
+C) Write a patch file instead (I'll merge manually)
+D) Cancel — keep the existing file
+```
+
+**File structure:**
+
+```markdown
+# Ubiquitous Language
+
+This glossary is grounded in the code as of <YYYY-MM-DD>. Every term below
+is a noun or verb that appears in the codebase; no term is invented here.
+When you rename a domain concept, update this file in the same PR.
+
+Regenerate with `/glossary`. The regeneration is idempotent — the user
+reviews all changes before the file is overwritten.
+
+## Context Map
+
+<Mermaid or ASCII diagram from Phase 3>
+
+### Relationship table
+
+| Upstream | Downstream | Type | Notes |
+|---|---|---|---|
+| Identity | Billing | Published Language (user.v1) | Stable — no breaking changes in 18mo |
+| Billing | Stripe | ACL (StripeAdapter) | External payment provider |
+| Support | Billing | Separate Ways | Support does not invoice; duplication accepted |
+
+---
+
+## Context: Identity
+
+*Located in:* `src/auth/`, `src/users/`
+*Responsible for:* authentication, authorization, user profile.
+
+| Term | Definition | Where in code |
+|---|---|---|
+| User | A person with credentials. Can log in. | `src/users/User.ts` |
+| Session | A time-bounded authenticated context. | `src/auth/Session.ts` |
+| Role | A bundle of permissions. | `src/auth/Role.ts` |
+
+---
+
+## Context: Billing
+
+*Located in:* `src/billing/`, `src/payments/`
+*Responsible for:* invoicing, payment capture, refunds.
+
+| Term | Definition | Where in code |
+|---|---|---|
+| BillingAccount | A payment target. Has a balance and payment methods. NOTE: different from Identity's "User" — a User can own 0 or many BillingAccounts. | `src/billing/BillingAccount.ts` |
+| Invoice | A dated statement of charges. | `src/billing/Invoice.ts` |
+| PaymentMethod | A stored way to charge (card, ACH, etc). | `src/payments/PaymentMethod.ts` |
+
+---
+
+[... one section per context ...]
+
+---
+
+## Language seams
+
+Terms that mean different things in different contexts. Read these carefully
+before using the term in cross-context conversation.
+
+| Term | Context A | Context B | Why the split |
+|---|---|---|---|
+| Account | Identity: "UserAccount" — login entity | Billing: "BillingAccount" — payment target | A user (person) can own many billing accounts (org, personal). Split during <date/PR>. |
+
+---
+
+## How to update this file
+
+1. When you add a new domain type, add an entry to the appropriate context section.
+2. When you rename a concept, update this file in the SAME PR as the code change.
+3. When you discover a language seam (a term meaning different things in two contexts), add it to §Language seams and rename one of them in code.
+4. Regenerate with `/glossary` quarterly or after any large refactor. The command
+   is idempotent and will show you a diff before overwriting.
+```
+
+---
+
+## Phase 5: Commit guidance
+
+Do NOT commit the file automatically. Tell the user:
+
+```
+UBIQUITOUS_LANGUAGE.md written to <path>.
+Not committed — review the diff first, then:
+
+  git add <path>
+  git commit -m "docs: add/update ubiquitous language and context map"
+
+If /glossary found language seams (same term, different meanings in different
+contexts), those are the highest-value findings. Consider opening a separate
+issue / PR to rename one of them in code — the file now documents WHERE the
+seams are; fixing them is a behavioral change worth doing separately.
+```
+
+Log the run as a learning with `type: "glossary"` and include the contexts discovered so future runs can diff.
+
+{{LEARNINGS_LOG}}
+
+---
+
+## Important Rules
+
+- **Don't invent vocabulary.** Every term in the file must appear in the code. If a term should exist but doesn't, that's a code finding, not a glossary entry.
+- **Name the seams.** The highest-value output of this skill is the "Language seams" section. If you skip it, you've produced a flat glossary — useful but not DDD.
+- **Don't refactor.** This skill is pure documentation. Renames based on glossary findings are a separate conversation.
+- **Accept partial.** First run of `/glossary` on a large codebase will miss terms. That's fine — the file is living; later runs tighten it.
+- **Read the old file before overwriting.** Never silently drop entries; always diff and confirm.

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -230,6 +230,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -247,6 +247,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -227,6 +227,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -228,6 +228,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -230,6 +230,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -228,6 +228,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -238,6 +238,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -227,6 +227,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -228,6 +228,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -235,6 +235,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -232,6 +232,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -236,6 +236,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -234,6 +234,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -241,6 +241,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -229,6 +229,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -235,6 +235,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -228,6 +228,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -232,6 +232,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/scripts/resolvers/preamble/generate-routing-injection.ts
+++ b/scripts/resolvers/preamble/generate-routing-injection.ts
@@ -31,6 +31,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 \`\`\`

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -225,6 +225,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -231,6 +231,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -233,6 +233,7 @@ Key routing rules:
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Build a domain glossary, document ubiquitous language, find naming inconsistencies → invoke /glossary
 - Save progress → invoke /context-save
 - Resume context → invoke /context-restore
 ```


### PR DESCRIPTION
## Summary

Adds **/glossary** — a pure-documentation skill grounded in Evans 2003 *Domain-Driven Design*, Ch. 2 (ubiquitous language) and Ch. 14 (bounded contexts + 9 relationship types). Builds an ubiquitous language doc with bounded contexts and a context map. The highest-value output is naming **language seams** — terms that mean different things in different contexts.

## Why a new skill

Most codebases accumulate vocabulary mismatch over time. Same word, different meanings in different modules ("subscription" = billing artifact here, push-notification target there). Same concept, different names ("user" / "account" / "profile" / "member" all referring to one entity). Evans named this 22 years ago; gstack now systematically catches it.

## Hard gate

Documentation only. Does NOT rename anything, refactor anything, or propose architecture changes. Renames motivated by glossary findings are a separate conversation. Documented prominently in the template.

## Output structure

- **Section 1** — Bounded contexts (one per coherent subsystem)
- **Section 2** — Context map with 9 Evans relationship types annotated: Shared Kernel, Customer/Supplier, Conformist, Anticorruption Layer, Open Host Service, Published Language, Separate Ways, Partnership, Big Ball of Mud
- **Section 3** — Ubiquitous language (terms with definition + bounded context owner)
- **Section 4** — Language seams (the highest-value output: terms that collide across contexts)

## What this PR adds

1. **\`glossary/SKILL.md.tmpl\`** (284 lines) — defines the 4-section walk, HARD GATE prose, ranking heuristics, and gotcha guidance (\"name the seams\", \"don't refactor\", \"accept partial\").
2. **\`scripts/resolvers/preamble/generate-routing-injection.ts\`** — adds one bullet so Claude/Codex auto-route phrases like \"build a domain glossary\", \"document ubiquitous language\", \"find naming inconsistencies\" to /glossary.
3. **Generated SKILL.md across all 10 hosts** — ~11K tokens per generated skill, well under the 40K ceiling.

## Test plan

- [x] \`bun test test/skill-validation.test.ts test/gen-skill-docs.test.ts\` — 689/689 pass
- [x] \`bun run gen:skill-docs --host all\` — clean regen, no warnings, no token-ceiling alerts
- [x] Built against upstream/main at v1.15.0.0

## Notes for review

- This pairs naturally with /challenge (PR #1231) and is part of a 7-branch canonical-literature series on my fork. /glossary is the most stand-alone of the seven — pure new skill, zero dependencies on other skills.
- Voice and style follow gstack conventions: short sentences, named sources (Evans 2003 cited inline), no AI vocabulary, no em dashes in new prose.
- One concrete user benefit: running \`/glossary\` on a 50K-line codebase catches naming drift that \`/review\` and \`/plan-eng-review\` are not built to surface.