### PR TITLE
fix(careful): BSD sed compatibility for safe exception detection on macOS

### DIFF
--- a/careful/bin/check-careful.sh
+++ b/careful/bin/check-careful.sh
@@ -28,7 +28,7 @@ CMD_LOWER=$(printf '%s' "$CMD" | tr '[:upper:]' '[:lower:]')
 # --- Check for safe exceptions (rm -rf of build artifacts) ---
 if printf '%s' "$CMD" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+|--recursive\s+)' 2>/dev/null; then
   SAFE_ONLY=true
-  RM_ARGS=$(printf '%s' "$CMD" | sed -E 's/.*rm\s+(-[a-zA-Z]+\s+)*//;s/--recursive\s*//')
+  RM_ARGS=$(printf '%s' "$CMD" | sed -E 's/.*rm[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*//;s/--recursive[[:space:]]*//')
   for target in $RM_ARGS; do
     case "$target" in
       */node_modules|node_modules|*/\.next|\.next|*/dist|dist|*/__pycache__|__pycache__|*/\.cache|\.cache|*/build|build|*/\.turbo|\.turbo|*/coverage|coverage)

--- a/test/hook-scripts.test.ts
+++ b/test/hook-scripts.test.ts
@@ -56,13 +56,6 @@ function withFreezeDir(freezePath: string, fn: (stateDir: string) => void) {
   }
 }
 
-// Detect whether the safe-rm-targets regex works on this platform.
-// macOS sed -E does not support \s, so the safe exception check fails there.
-function detectSafeRmWorks(): boolean {
-  const { output } = runHook(CAREFUL_SCRIPT, carefulInput('rm -rf node_modules'));
-  return output.permissionDecision === undefined;
-}
-
 // ============================================================
 // check-careful.sh tests
 // ============================================================
@@ -88,24 +81,13 @@ describe('check-careful.sh', () => {
     test('rm -rf node_modules allows (safe exception)', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('rm -rf node_modules'));
       expect(exitCode).toBe(0);
-      if (detectSafeRmWorks()) {
-        // GNU sed: safe exception triggers, allows through
-        expect(output.permissionDecision).toBeUndefined();
-      } else {
-        // macOS sed: safe exception regex uses \\s which is unsupported,
-        // so the safe-targets check fails and the command warns
-        expect(output.permissionDecision).toBe('ask');
-      }
+      expect(output.permissionDecision).toBeUndefined();
     });
 
     test('rm -rf .next dist allows (multiple safe targets)', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('rm -rf .next dist'));
       expect(exitCode).toBe(0);
-      if (detectSafeRmWorks()) {
-        expect(output.permissionDecision).toBeUndefined();
-      } else {
-        expect(output.permissionDecision).toBe('ask');
-      }
+      expect(output.permissionDecision).toBeUndefined();
     });
 
     test('rm -rf node_modules /var/data warns (mixed safe+unsafe)', () => {


### PR DESCRIPTION
## Summary

`careful/bin/check-careful.sh` uses `\s+` in its sed regex, which is a GNU sed extension not supported by BSD sed (the default on macOS). On macOS this causes the safe-exception detection to fail silently, so even safe commands like `rm -rf node_modules` trigger the destructive warning instead of being permitted as designed.

Replacing `\s+` with the POSIX `[[:space:]]+` makes the expression work correctly on both GNU sed (Linux) and BSD sed (macOS).

## Reproduction (on macOS)

```bash
echo '{"tool_input":{"command":"rm -rf node_modules"}}' | bash careful/bin/check-careful.sh
# Expected: {} (safe exception)
# Actual:   {"permissionDecision":"ask",...} (warning fires, bug)
```

`bash -x` tracing confirmed that `sed -E 's/.*rm\s+(-[a-zA-Z]+\s+)*//'` does not strip anything on macOS BSD sed.

## Fix

```diff
- RM_ARGS=$(printf '%s' "$CMD" | sed -E 's/.*rm\s+(-[a-zA-Z]+\s+)*//;s/--recursive\s*//')
+ RM_ARGS=$(printf '%s' "$CMD" | sed -E 's/.*rm[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*//;s/--recursive[[:space:]]*//')
```

Note: the `grep -qE` line in the same file also uses `\s+`, but BSD grep on macOS does support `\s` (verified via `bash -x` trace), so only the sed expression needs the fix.

## Test cleanup

`test/hook-scripts.test.ts` already documented this limitation with a `detectSafeRmWorks()` helper and a platform-conditional assertion (\`if GNU sed: expect undefined, else: expect ask\`). Now that the regex works on both platforms, this dead path is removed and the safe-exception tests assert the same expectation on every OS.

Net diff: **3 insertions(+), 21 deletions(-)** across the two files.

## Test plan

After applying the fix, verified on macOS:

- \`rm -rf node_modules\` → \`{}\` (safe exception, fixed)
- \`rm -rf ./fake_dir/node_modules\` → \`{}\` (matches \`*/node_modules\` pattern, fixed)
- \`rm -rf .next dist\` → \`{}\` (multiple safe targets, fixed)
- \`rm -rf node_modules /var/data\` → warning fires (mixed safe+unsafe still flagged correctly)
- \`rm -rf /etc/important\` → warning fires (unchanged)
- \`git reset --hard HEAD~3\` → warning fires (unchanged)
- \`ls -la\` → \`{}\` (non-destructive, unchanged)

\`bun test test/hook-scripts.test.ts\` → 32 pass, 0 fail. Full \`bun test\` shows the same 6 pre-existing failures on \`main\` (all in \`browse/test/server-auth.test.ts\`, \`integration smoke\`, \`gstack-gbrain-lib.sh\`) — unrelated to this change.

## Discovery

I found this while translating gstack's careful skill into Japanese for a derivative project (uzustack — https://github.com/uzumaki-inc/uzustack). During integration testing on macOS, the safe exception logic appeared broken, and \`bash -x\` tracing revealed the BSD sed compatibility issue.

Reference: same fix applied in uzustack at https://github.com/uzumaki-inc/uzustack/commit/bc67c8d