### PR TITLE
fix(setup): make bin root detection CDPATH-safe

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -11,7 +11,7 @@
 #        bin/dev-teardown    # clean up
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." >/dev/null && pwd)"
 
 # 1. Copy .env from main worktree (if we're a worktree and don't have one)
 if [ ! -f "$REPO_ROOT/.env" ]; then

--- a/bin/dev-teardown
+++ b/bin/dev-teardown
@@ -2,7 +2,7 @@
 # Remove local dev skill symlinks. Restores global gstack as the active install.
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." >/dev/null && pwd)"
 
 removed=()
 

--- a/bin/gstack-community-dashboard
+++ b/bin/gstack-community-dashboard
@@ -10,7 +10,7 @@
 #   GSTACK_SUPABASE_ANON_KEY      — override Supabase anon key
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 
 # Source Supabase config if not overridden by env
 if [ -z "${GSTACK_SUPABASE_URL:-}" ] && [ -f "$GSTACK_DIR/supabase/config.sh" ]; then

--- a/bin/gstack-telemetry-log
+++ b/bin/gstack-telemetry-log
@@ -17,7 +17,7 @@
 # NOTE: Uses set -uo pipefail (no -e) — telemetry must never exit non-zero
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 ANALYTICS_DIR="$STATE_DIR/analytics"
 JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"

--- a/bin/gstack-telemetry-sync
+++ b/bin/gstack-telemetry-sync
@@ -11,7 +11,7 @@
 #   GSTACK_SUPABASE_URL        — override Supabase project URL
 set -uo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 ANALYTICS_DIR="$STATE_DIR/analytics"
 JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"

--- a/bin/gstack-uninstall
+++ b/bin/gstack-uninstall
@@ -36,7 +36,7 @@ if [ -z "${HOME:-}" ]; then
   exit 1
 fi
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 _GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 

--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -12,7 +12,7 @@
 #   GSTACK_STATE_DIR    — override ~/.gstack state directory
 set -euo pipefail
 
-GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." >/dev/null && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
 CACHE_FILE="$STATE_DIR/last-update-check"
 MARKER_FILE="$STATE_DIR/just-upgraded-from"


### PR DESCRIPTION
## Summary
- make repo root discovery ignore `CDPATH` output in the shell helper scripts under `bin/`
- keep the fix narrowly scoped to the root path detection used by setup, teardown, telemetry, uninstall, dashboard, and update-check commands
- preserve existing behavior while avoiding stray path output when `CDPATH` is set

## Testing
- `bash -n bin/dev-setup bin/dev-teardown bin/gstack-community-dashboard bin/gstack-telemetry-log bin/gstack-telemetry-sync bin/gstack-uninstall bin/gstack-update-check`
- `CDPATH='.:/tmp' GSTACK_DIR='' bin/gstack-update-check --force`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->