### PR TITLE
fix(extension): add "tabs" permission so live tab awareness works on non-localhost sites

### DIFF
--- a/browse/test/sidebar-tabs.test.ts
+++ b/browse/test/sidebar-tabs.test.ts
@@ -254,3 +254,15 @@ describe('manifest: ws permission + xterm-safe CSP', () => {
     }
   });
 });
+
+describe('manifest: live tab awareness needs "tabs" permission', () => {
+  // Without "tabs", chrome.tabs.query() returns tab objects with undefined
+  // url/title for any site outside host_permissions (e.g., everything except
+  // 127.0.0.1). snapshotTabs() then writes empty strings into tabs.json and
+  // active-tab.json silently skips the write — the sidebar agent loses track
+  // of what page the user is on. activeTab is too narrow (only after a user
+  // gesture on the extension action) for background polling.
+  test('permissions includes "tabs"', () => {
+    expect(MANIFEST.permissions).toContain('tabs');
+  });
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "gstack browse",
   "version": "0.1.0",
   "description": "Live activity feed and @ref overlays for gstack browse",
-  "permissions": ["sidePanel", "storage", "activeTab", "scripting"],
+  "permissions": ["sidePanel", "storage", "activeTab", "scripting", "tabs"],
   "host_permissions": ["http://127.0.0.1:*/", "ws://127.0.0.1:*/"],
   "action": {
     "default_icon": {


### PR DESCRIPTION
## Summary

- Adds the `\"tabs\"` permission to `extension/manifest.json` so `chrome.tabs.query()` returns real `url` / `title` for tabs outside `127.0.0.1`.
- Adds a manifest source-level regression test in `browse/test/sidebar-tabs.test.ts`.

Closes #1256.

## Why

Since `v1.14.0.0` (`ed1e4be2` introduced live tab awareness), `tabs.json` has been written with empty `url` / `title` strings for any user-visited site outside localhost, and `active-tab.json` has stopped updating after the first non-localhost navigation. The sidebar Claude Code REPL can't see what tab the user is actually on, and falls back to stale state.

Repro:

1. `gstack browse connect`
2. Navigate (URL bar or click) to any non-localhost page, e.g. `https://news.ycombinator.com`
3. `cat <repo>/.gstack/tabs.json` — `url` / `title` are empty
4. `cat <repo>/.gstack/active-tab.json` — still pinned to `/welcome`

(`browse status` from the CLI works fine — the daemon sees the live URL — so the break is isolated to the extension → state-file pipeline.)

## Root cause

The code path is correct end-to-end. The break is at the Chrome boundary.

`extension/background.js`:

- `snapshotTabs()` (L521) — calls `chrome.tabs.query({})` and tolerates missing fields with `t.url || ''` / `t.title || ''`.
- `chrome.tabs.onUpdated` listener (L571) — fires `pushTabState('updated')` on URL/title changes.

`browse/src/terminal-agent.ts`:

- L441 — atomic `tabs.json` write.
- L457 — `active-tab.json` write only if `active.url` is truthy and not `chrome://` / `chrome-extension://`.

In Manifest V3, `chrome.tabs.query()` returns `tab.url` / `tab.title` only when one of:
- `\"tabs\"` permission is granted, **or**
- `host_permissions` matches the tab's URL, **or**
- `activeTab` is granted **and** the user just clicked the extension action on that tab (does not apply to background polling).

Current `manifest.json`:

\`\`\`json
\"permissions\": [\"sidePanel\", \"storage\", \"activeTab\", \"scripting\"],
\"host_permissions\": [\"http://127.0.0.1:*/\", \"ws://127.0.0.1:*/\"]
\`\`\`

For any site outside `127.0.0.1`, none of these hold → Chrome returns `undefined` for both fields → `snapshotTabs()` writes empty strings → `active-tab.json` gate skips silently.

## Why `\"tabs\"` and not `\"<all_urls>\"` host permission

Both fix the symptom, but `\"tabs\"` is the tighter scope match:

| | `\"tabs\"` permission | `\"<all_urls>\"` host permission |
|---|---|---|
| Install-time warning | None (non-host permission) | \"Read your browsing history on all websites\" |
| Grants `tab.url` / `tab.title` to `chrome.tabs.*` | ✅ | ✅ |
| Grants content-script injection | ❌ | ✅ |
| Grants cross-origin fetch | ❌ | ✅ |

`snapshotTabs()` only needs the metadata, not injection / fetch — `\"tabs\"` is the minimum sufficient grant. No new install warnings, no cross-origin attack surface.

## Tests

\`\`\`
$ bun test browse/test/sidebar-tabs.test.ts
 28 pass
 0 fail
\`\`\`

Without the manifest fix, the new test fails:
\`\`\`
expect(received).toContain(expected)
Expected to contain: \"tabs\"
Received: [\"sidePanel\", \"storage\", \"activeTab\", \"scripting\"]
\`\`\`

## Test plan

- [x] Existing `browse/test/sidebar-tabs.test.ts` suite still passes (28/28).
- [x] New manifest test fails on `main` (without the permission), passes on this branch.
- [ ] Manual e2e (recommended for reviewer): `gstack browse connect`, navigate to a non-localhost URL, confirm `tabs.json` shows the real URL and `active-tab.json` updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->