### PR TITLE
feat(browse): Honor system proxy env vars (HTTPS_PROXY / BROWSE_PROXY) for chromium launch

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -169,6 +169,18 @@ export class BrowserManager {
       console.log(`[browse] Extensions loaded from: ${extensionsDir}`);
     }
 
+    // Honor system proxy env vars for users behind a corporate or VPN proxy.
+    // Playwright's chromium.launch() does not auto-read these — must be passed
+    // explicitly via the `proxy` launch option.
+    //   BROWSE_PROXY  — explicit override (e.g. socks5://host:port for remote DNS)
+    //   HTTPS_PROXY   — standard system HTTPS proxy
+    //   HTTP_PROXY    — standard system HTTP proxy
+    // BROWSE_PROXY exists for fakeip/TUN environments where the system HTTP
+    // proxy resolves DNS locally to fake addresses; using socks5:// forces
+    // remote DNS resolution at the proxy, bypassing the fake IP.
+    const proxyServer = process.env.BROWSE_PROXY || process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+    const proxyBypass = process.env.NO_PROXY;
+
     this.browser = await chromium.launch({
       headless: useHeadless,
       // On Windows, Chromium's sandbox fails when the server is spawned through
@@ -176,6 +188,7 @@ export class BrowserManager {
       // browsing user-specified URLs has marginal sandbox benefit.
       chromiumSandbox: process.platform !== 'win32',
       ...(launchArgs.length > 0 ? { args: launchArgs } : {}),
+      ...(proxyServer ? { proxy: { server: proxyServer, ...(proxyBypass ? { bypass: proxyBypass } : {}) } } : {}),
     });
 
     // Chromium crash → exit with clear message


### PR DESCRIPTION
## Summary

Adds proxy support to `gstack browse` by passing system proxy env vars
through to Playwright's `chromium.launch({ proxy: ... })` option.

Without this, users behind a corporate/VPN proxy see
`ERR_TUNNEL_CONNECTION_FAILED` or `ERR_SSL_UNRECOGNIZED_NAME_ALERT`
when navigating to public URLs — Playwright does not auto-read
`HTTPS_PROXY` for chromium launch.

## Behavior

- Reads `BROWSE_PROXY` (priority) → `HTTPS_PROXY` → `HTTP_PROXY` from env
- Reads `NO_PROXY` for bypass list
- Passes them via Playwright's first-class `proxy` launch option
- **Zero effect when no proxy env vars are set** (fully backward-compatible)

## Why a separate `BROWSE_PROXY` override?

Some environments (mihomo/clash with `mixed-port` + `fakeip` / TUN mode)
make the system HTTP proxy resolve DNS to fake addresses locally, then
forward via HTTP CONNECT. Chromium honors that and sends fakeip in the
CONNECT line, which the proxy can't route.

`BROWSE_PROXY=socks5://host:port` lets the user opt into SOCKS5 protocol,
which does remote DNS at the proxy — bypassing the fake IP. The standard
`HTTPS_PROXY` path is preserved for regular HTTP proxies.

## Test plan

- [x] No proxy env: chromium launches as before, no behavior change
- [x] `HTTPS_PROXY=http://corp-proxy:8080`: chromium routes through it
- [x] `BROWSE_PROXY=socks5://127.0.0.1:1082` in mihomo + fakeip env:
      navigation succeeds (verified end-to-end with public TLS sites)
- [x] `NO_PROXY=localhost,127.0.0.1`: bypass list applied via Playwright

## Diff

13 lines added in `browse/src/browser-manager.ts`. No changes elsewhere.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->