### PR TITLE
feat(setup): honor CLAUDE_CONFIG_DIR for Claude install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Open Claude Code and paste this. Claude does the rest.
 
 > Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.
 
+> [!NOTE]
+> **Custom `CLAUDE_CONFIG_DIR`?** If you've moved Claude Code's config (e.g. `export CLAUDE_CONFIG_DIR=~/.config/claude`), substitute that for `~/.claude` everywhere in the install/uninstall commands below. `./setup` and `gstack-uninstall` honor `CLAUDE_CONFIG_DIR` automatically — they only need the clone in the right place.
+
 ### Step 2: Team mode — auto-update for shared repos (recommended)
 
 From inside your repo, paste this. Switches you to team mode, bootstraps the repo so teammates get gstack automatically, and commits the change:

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Fork it. Improve it. Make it yours. And if you want to hate on free open source 
 
 Open Claude Code and paste this. Claude does the rest.
 
-> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.
-
 > [!NOTE]
-> **Custom `CLAUDE_CONFIG_DIR`?** If you've moved Claude Code's config (e.g. `export CLAUDE_CONFIG_DIR=~/.config/claude`), substitute that for `~/.claude` everywhere in the install/uninstall commands below. `./setup` and `gstack-uninstall` honor `CLAUDE_CONFIG_DIR` automatically — they only need the clone in the right place.
+> **Custom `CLAUDE_CONFIG_DIR`?** If you've moved Claude Code's config (e.g. `export CLAUDE_CONFIG_DIR=~/.config/claude`), substitute that for `~/.claude` everywhere in the install/uninstall commands in this section. `./setup` and `gstack-uninstall` honor `CLAUDE_CONFIG_DIR` automatically — they only need the clone in the right place.
+
+> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.
 
 ### Step 2: Team mode — auto-update for shared repos (recommended)
 

--- a/bin/gstack-uninstall
+++ b/bin/gstack-uninstall
@@ -38,6 +38,9 @@ fi
 
 GSTACK_DIR="${GSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 STATE_DIR="${GSTACK_STATE_DIR:-$HOME/.gstack}"
+# Honor CLAUDE_CONFIG_DIR (matches setup behavior) so uninstall finds skills
+# wherever setup placed them. Falls back to ~/.claude when unset.
+CLAUDE_HOME="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 _GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 
 # ─── Parse flags ─────────────────────────────────────────────
@@ -62,7 +65,7 @@ done
 # ─── Confirmation ────────────────────────────────────────────
 if [ "$FORCE" -eq 0 ]; then
   echo "This will remove gstack from your system:"
-  { [ -d "$HOME/.claude/skills/gstack" ] || [ -L "$HOME/.claude/skills/gstack" ]; } && echo "  ~/.claude/skills/gstack (+ per-skill symlinks)"
+  { [ -d "$CLAUDE_HOME/skills/gstack" ] || [ -L "$CLAUDE_HOME/skills/gstack" ]; } && echo "  $CLAUDE_HOME/skills/gstack (+ per-skill symlinks)"
   [ -d "$HOME/.codex/skills" ] && echo "  ~/.codex/skills/gstack*"
   [ -d "$HOME/.factory/skills" ] && echo "  ~/.factory/skills/gstack*"
   [ -d "$HOME/.kiro/skills" ] && echo "  ~/.kiro/skills/gstack*"
@@ -129,7 +132,7 @@ if [ -d "$STATE_DIR/projects" ]; then
 fi
 
 # ─── Remove global Claude skills ────────────────────────────
-CLAUDE_SKILLS="$HOME/.claude/skills"
+CLAUDE_SKILLS="$CLAUDE_HOME/skills"
 if [ -d "$CLAUDE_SKILLS/gstack" ] || [ -L "$CLAUDE_SKILLS/gstack" ]; then
   # Remove per-skill symlinks that point into gstack/
   for _LINK in "$CLAUDE_SKILLS"/*; do
@@ -143,7 +146,7 @@ if [ -d "$CLAUDE_SKILLS/gstack" ] || [ -L "$CLAUDE_SKILLS/gstack" ]; then
   done
 
   rm -rf "$CLAUDE_SKILLS/gstack"
-  REMOVED+=("~/.claude/skills/gstack")
+  REMOVED+=("$CLAUDE_SKILLS/gstack")
 fi
 
 # ─── Remove project-local Claude skills (--local installs) ──

--- a/setup
+++ b/setup
@@ -776,6 +776,21 @@ fi
 
 if [ "$INSTALL_CLAUDE" -eq 1 ]; then
   if [ "$SKILLS_BASENAME" = "skills" ]; then
+    # Warn when the auto-detected skills dir won't be read by Claude Code.
+    # Happens when CLAUDE_CONFIG_DIR points elsewhere (e.g. ~/.config/claude) but
+    # the clone lives under the legacy ~/.claude/skills path. Skip for --local
+    # (intentional project-scoped install) and CODEX_REPO_LOCAL (.agents/skills).
+    if [ -n "${CLAUDE_CONFIG_DIR:-}" ] && [ "$LOCAL_INSTALL" -eq 0 ] && [ "$CODEX_REPO_LOCAL" -eq 0 ] && [ "$INSTALL_SKILLS_DIR" != "$CLAUDE_HOME/skills" ]; then
+      echo "" >&2
+      echo "WARNING: CLAUDE_CONFIG_DIR is set to $CLAUDE_CONFIG_DIR" >&2
+      echo "  but this clone is at $INSTALL_GSTACK_DIR." >&2
+      echo "  Claude Code reads skills from $CLAUDE_HOME/skills, so the" >&2
+      echo "  installation below will NOT be discovered by Claude Code." >&2
+      echo "  To fix: move the clone and re-run setup:" >&2
+      echo "    mv $INSTALL_GSTACK_DIR $CLAUDE_HOME/skills/gstack" >&2
+      echo "    cd $CLAUDE_HOME/skills/gstack && ./setup" >&2
+      echo "" >&2
+    fi
     # Clean up stale symlinks from the opposite prefix mode
     if [ "$SKILL_PREFIX" -eq 1 ]; then
       cleanup_old_claude_symlinks "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"

--- a/setup
+++ b/setup
@@ -18,6 +18,9 @@ INSTALL_GSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_GSTACK_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 INSTALL_SKILLS_DIR="$(dirname "$INSTALL_GSTACK_DIR")"
 BROWSE_BIN="$SOURCE_GSTACK_DIR/browse/dist/browse"
+# Honor CLAUDE_CONFIG_DIR for users who relocate Claude Code's config (e.g. ~/.config/claude).
+# Falls back to ~/.claude when unset, preserving the default install layout.
+CLAUDE_HOME="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 CODEX_SKILLS="$HOME/.codex/skills"
 CODEX_GSTACK="$CODEX_SKILLS/gstack"
 FACTORY_SKILLS="$HOME/.factory/skills"
@@ -806,8 +809,9 @@ if [ "$INSTALL_CLAUDE" -eq 1 ]; then
     fi
     log "  browse: $BROWSE_BIN"
   else
-    # Not inside a skills/ directory — symlink into ~/.claude/skills/ and retry
-    CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
+    # Not inside a skills/ directory — symlink into $CLAUDE_HOME/skills/ and retry.
+    # $CLAUDE_HOME respects CLAUDE_CONFIG_DIR when set, else defaults to ~/.claude.
+    CLAUDE_SKILLS_DIR="$CLAUDE_HOME/skills"
     CLAUDE_GSTACK_LINK="$CLAUDE_SKILLS_DIR/gstack"
     mkdir -p "$CLAUDE_SKILLS_DIR"
     ln -snf "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"


### PR DESCRIPTION

Resolve a CLAUDE_HOME helper as ${CLAUDE_CONFIG_DIR:-$HOME/.claude} in both setup and gstack-uninstall, and use it for the fallback Claude skills directory. Default behavior is unchanged (~/.claude/skills).

When CLAUDE_CONFIG_DIR is set (e.g. ~/.config/claude), skills are installed where Claude Code actually reads them from instead of the hardcoded ~/.claude location, which is invisible to the CLI under the override. Uninstall picks them back up the same way.

Adds a short note in the Install section pointing CLAUDE_CONFIG_DIR users at the same env var.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->