### PR TITLE
fix(codex): remove invalid resume flags

### DIFF
--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -1188,7 +1188,7 @@ For a **resumed session** (user chose "Continue"):
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 # Fix 1: wrap with timeout (gtimeout/timeout fallback chain via probe helper)
-_gstack_codex_timeout_wrapper 600 codex exec resume <session-id> "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="medium"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
+_gstack_codex_timeout_wrapper 600 codex exec resume <session-id> "<prompt>" -c 'model_reasoning_effort="medium"' -c 'sandbox_mode="read-only"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
 <same python streaming parser as above, with flush=True on all print() calls>
 "
 # Fix 1: same hang detection pattern as new-session block
@@ -1206,6 +1206,8 @@ mkdir -p .context
 ```
 Save the session ID printed by the parser (the line starting with `SESSION_ID:`)
 to `.context/codex-session-id`.
+
+Working directory already comes from the resumed shell/session context, so `codex exec resume` should not pass `-C`. The resume subcommand also rejects `-s`; use `-c 'sandbox_mode="read-only"'` instead.
 
 6. Present the full streamed output:
 

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -427,7 +427,7 @@ For a **resumed session** (user chose "Continue"):
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 # Fix 1: wrap with timeout (gtimeout/timeout fallback chain via probe helper)
-_gstack_codex_timeout_wrapper 600 codex exec resume <session-id> "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="medium"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
+_gstack_codex_timeout_wrapper 600 codex exec resume <session-id> "<prompt>" -c 'model_reasoning_effort="medium"' -c 'sandbox_mode="read-only"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
 <same python streaming parser as above, with flush=True on all print() calls>
 "
 # Fix 1: same hang detection pattern as new-session block
@@ -445,6 +445,8 @@ mkdir -p .context
 ```
 Save the session ID printed by the parser (the line starting with `SESSION_ID:`)
 to `.context/codex-session-id`.
+
+Working directory already comes from the resumed shell/session context, so `codex exec resume` should not pass `-C`. The resume subcommand also rejects `-s`; use `-c 'sandbox_mode="read-only"'` instead.
 
 6. Present the full streamed output:
 


### PR DESCRIPTION
## Summary
- remove `-C` and `-s` from the `codex exec resume` consult-mode command in the Codex skill
- switch the resumed-session example to `-c "sandbox_mode="read-only""`, which the resume subcommand actually accepts
- document that resume inherits working directory from the current shell/session context

## Why
Issue #1258 reports that `/codex` consult-mode resume currently documents flags that `codex exec resume` rejects on codex-cli 0.125.0, causing the skill flow to fail with exit 2 instead of resuming the session.

## Testing
- `bun run gen:skill-docs`
- `bun test test/skill-validation.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->