### PR TITLE
fix: make local gstack hotfixes permanent

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -942,9 +942,7 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${existingState.token}`,
         },
-        body: JSON.stringify({
-      domains,
- command: 'disconnect', args: [] }),
+        body: JSON.stringify({ command: 'disconnect', args: [] }),
         signal: AbortSignal.timeout(3000),
       });
       if (resp.ok) {

--- a/browse/test/server-auth.test.ts
+++ b/browse/test/server-auth.test.ts
@@ -62,13 +62,13 @@ describe('Server auth security', () => {
 
   // Test 4: /activity/history requires auth via validateAuth
   test('/activity/history requires authentication', () => {
-    const historyBlock = sliceBetween(SERVER_SRC, "url.pathname === '/activity/history'", 'Sidebar endpoints');
+    const historyBlock = sliceBetween(SERVER_SRC, "url.pathname === '/activity/history'", 'Sidebar chat endpoints ripped');
     expect(historyBlock).toContain('validateAuth');
   });
 
   // Test 5: /activity/history has no wildcard CORS header
   test('/activity/history has no wildcard CORS header', () => {
-    const historyBlock = sliceBetween(SERVER_SRC, "url.pathname === '/activity/history'", 'Sidebar endpoints');
+    const historyBlock = sliceBetween(SERVER_SRC, "url.pathname === '/activity/history'", 'Sidebar chat endpoints ripped');
     expect(historyBlock).not.toContain("'*'");
   });
 
@@ -311,7 +311,7 @@ describe('Server auth security', () => {
   // Regression: connect command crashed with "domains is not defined" because
   // a stray `domains,` variable was in the status fetch body (cli.ts:852).
   test('connect command status fetch body has no undefined variable references', () => {
-    const connectBlock = sliceBetween(CLI_SRC, 'Launching headed Chromium', 'Sidebar agent started');
+    const connectBlock = sliceBetween(CLI_SRC, 'Launching headed Chromium', 'Terminal agent started');
     // The status fetch should use a clean JSON body
     expect(connectBlock).toContain("command: 'status'");
     // Must NOT contain a bare `domains` reference in the fetch body
@@ -320,6 +320,18 @@ describe('Server auth security', () => {
     expect(bodyMatch).not.toBeNull();
     if (bodyMatch) {
       // The body should only contain command and args, no stray variables
+      expect(bodyMatch[1]).not.toMatch(/\bdomains\b/);
+    }
+  });
+
+  // Regression: disconnect crashed before reaching the server because a stray
+  // `domains,` variable was left in the JSON body.
+  test('disconnect command fetch body has no undefined variable references', () => {
+    const disconnectBlock = sliceBetween(CLI_SRC, "if (command === 'disconnect')", 'Special case: chain reads from stdin');
+    expect(disconnectBlock).toContain("command: 'disconnect'");
+    const bodyMatch = disconnectBlock.match(/body:\s*JSON\.stringify\(\{([^}]+)\}\)/);
+    expect(bodyMatch).not.toBeNull();
+    if (bodyMatch) {
       expect(bodyMatch[1]).not.toMatch(/\bdomains\b/);
     }
   });
@@ -333,9 +345,9 @@ describe('Server auth security', () => {
     expect(pairBlock).toContain("BROWSE_PARENT_PID");
     expect(pairBlock).toContain("'0'");
     // The connect command must propagate BROWSE_PARENT_PID=0 to serverEnv
-    const connectBlock = sliceBetween(CLI_SRC, 'Launching headed Chromium', 'Sidebar agent started');
-    expect(connectBlock).toContain("BROWSE_PARENT_PID");
-    expect(connectBlock).toContain("serverEnv.BROWSE_PARENT_PID");
+    const connectBlock = sliceBetween(CLI_SRC, 'Launching headed Chromium', 'Terminal agent started');
+    expect(connectBlock).toContain("BROWSE_PARENT_PID: '0'");
+    expect(connectBlock).toContain('startServer(serverEnv)');
   });
 
   // Regression: newtab returned 403 for scoped tokens because the tab ownership

--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -13,6 +13,7 @@ import { discoverTemplates, discoverSkillFiles } from './discover-skills';
 import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
+import { ALL_HOST_CONFIGS, getExternalHosts } from '../hosts/index';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const ROOT_REALPATH = fs.realpathSync(ROOT);
@@ -64,10 +65,18 @@ for (const file of SKILL_FILES) {
 
 console.log('\n  Templates:');
 const TEMPLATES = discoverTemplates(ROOT);
+const PRIMARY_HOST_CONFIG = ALL_HOST_CONFIGS.find(c => c.name === 'claude');
+const PRIMARY_SKIPPED_OUTPUTS = new Set(
+  (PRIMARY_HOST_CONFIG?.generation.skipSkills || []).map(skill => `${skill}/SKILL.md`)
+);
 
 for (const { tmpl, output } of TEMPLATES) {
   const tmplPath = path.join(ROOT, tmpl);
   const outPath = path.join(ROOT, output);
+  if (PRIMARY_SKIPPED_OUTPUTS.has(output)) {
+    console.log(`  -  ${output.padEnd(30)} — skipped by primary host config`);
+    continue;
+  }
   if (!fs.existsSync(tmplPath)) {
     console.log(`  \u26a0\ufe0f  ${output.padEnd(30)} — no template`);
     continue;
@@ -89,8 +98,6 @@ for (const file of SKILL_FILES) {
 }
 
 // ─── External Host Skills (config-driven) ───────────────────
-
-import { getExternalHosts } from '../hosts/index';
 
 for (const hostConfig of getExternalHosts()) {
   const hostDir = path.join(ROOT, hostConfig.hostSubdir, 'skills');
@@ -129,8 +136,6 @@ for (const hostConfig of getExternalHosts()) {
 }
 
 // ─── Freshness (config-driven) ──────────────────────────────
-
-import { ALL_HOST_CONFIGS } from '../hosts/index';
 
 for (const hostConfig of ALL_HOST_CONFIGS) {
   const hostFlag = hostConfig.name === 'claude' ? '' : ` --host ${hostConfig.name}`;


### PR DESCRIPTION
## Summary
- removes the stray bare `domains` reference from the headed `disconnect` request body
- updates source-level auth tests to match the current Terminal/sidebar marker strings
- teaches `skill-check` to respect the primary host's configured skipped skills when validating generated templates
- adds regression coverage for the headed `disconnect` payload body

## Test Plan
- `HOME=/Users/kdp-jarvis bun test browse/test/server-auth.test.ts`
- `HOME=/Users/kdp-jarvis bun run skill:check`
- `HOME=/Users/kdp-jarvis bun run test`
- `HOME=/Users/kdp-jarvis bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->