### PR TITLE
Fix Codex-host autoplan outside voice routing

### DIFF
--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -981,36 +981,33 @@ Loaded review skills from disk. Starting full review pipeline with auto-decision
 
 ---
 
-## Phase 0.5: Codex auth + version preflight
+## Phase 0.5: Outside-voice preflight
 
-Before invoking any Codex voice, preflight the CLI: verify auth (multi-signal) and
-warn on known-bad CLI versions. This is infrastructure for all 4 phases below —
-source it once here and the helper functions stay in scope for the rest of the
-workflow.
+Before invoking any outside voice, preflight the CLI: verify auth (multi-signal) and
+warn on known-bad CLI versions. On non-Codex hosts, the outside voice is Codex CLI
+and the subagent is the host-native subagent.
 
 ```bash
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo off)
 source ~/.claude/skills/gstack/bin/gstack-codex-probe
 
-# Check Codex binary. If missing, tag the degradation matrix and continue
-# with Claude subagent only (autoplan's existing degradation fallback).
 if ! command -v codex >/dev/null 2>&1; then
   _gstack_codex_log_event "codex_cli_missing"
-  echo "[codex-unavailable: binary not found] — proceeding with Claude subagent only"
-  _CODEX_AVAILABLE=false
+  echo "[outside-voice-unavailable: Codex CLI not found] — proceeding with subagent only"
+  _OUTSIDE_VOICE_AVAILABLE=false
 elif ! _gstack_codex_auth_probe >/dev/null; then
   _gstack_codex_log_event "codex_auth_failed"
-  echo "[codex-unavailable: auth missing] — proceeding with Claude subagent only. Run \`codex login\` or set \$CODEX_API_KEY to enable dual-voice review."
-  _CODEX_AVAILABLE=false
+  echo "[outside-voice-unavailable: Codex auth missing] — proceeding with subagent only. Run `codex login` or set $CODEX_API_KEY to enable dual-voice review."
+  _OUTSIDE_VOICE_AVAILABLE=false
 else
-  _gstack_codex_version_check   # non-blocking warn if known-bad
-  _CODEX_AVAILABLE=true
+  _gstack_codex_version_check
+  _OUTSIDE_VOICE_AVAILABLE=true
 fi
 ```
 
-If `_CODEX_AVAILABLE=false`, all Phase 1-3.5 Codex voices below degrade to
-`[codex-unavailable]` in the degradation matrix. /autoplan completes with
-Claude subagent only — saves token spend on Codex prompts we can't use.
+If `_OUTSIDE_VOICE_AVAILABLE=false`, all outside-voice phases below degrade to
+`[outside-voice-unavailable]`. /autoplan still completes with the host-native
+subagent only — saves token spend on prompts we can't use.
 
 ---
 
@@ -1029,33 +1026,33 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 - Scope expansion: in blast radius + <1d CC → approve (P2). Outside → defer to TODOS.md (P3).
   Duplicates → reject (P4). Borderline (3-5 files) → mark TASTE DECISION.
 - All 10 review sections: run fully, auto-decide each issue, log every decision.
-- Dual voices: always run BOTH Claude subagent AND Codex if available (P6).
-  Run them sequentially in foreground. First the Claude subagent (Agent tool,
-  foreground — do NOT use run_in_background), then Codex (Bash). Both must
+- Dual voices: always run BOTH the host-native subagent AND the outside voice if available (P6).
+  Run them sequentially in foreground. First the subagent (Agent tool,
+  foreground — do NOT use run_in_background), then the outside voice (Bash). Both must
   complete before building the consensus table.
 
-  **Codex CEO voice** (via Bash):
+  **Codex outside voice** (via Bash):
   ```bash
   _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
   _gstack_codex_timeout_wrapper 600 codex exec "IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
 
-  You are a CEO/founder advisor reviewing a development plan.
-  Challenge the strategic foundations: Are the premises valid or assumed? Is this the
-  right problem to solve, or is there a reframing that would be 10x more impactful?
-  What alternatives were dismissed too quickly? What competitive or market risks are
-  unaddressed? What scope decisions will look foolish in 6 months? Be adversarial.
-  No compliments. Just the strategic blind spots.
-  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
+You are a CEO/founder advisor reviewing a development plan.
+Challenge the strategic foundations: Are the premises valid or assumed? Is this the
+right problem to solve, or is there a reframing that would be 10x more impactful?
+What alternatives were dismissed too quickly? What competitive or market risks are
+unaddressed? What scope decisions will look foolish in 6 months? Be adversarial.
+No compliments. Just the strategic blind spots.
+File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   _CODEX_EXIT=$?
   if [ "$_CODEX_EXIT" = "124" ]; then
     _gstack_codex_log_event "codex_timeout" "600"
     _gstack_codex_log_hang "autoplan" "0"
-    echo "[codex stalled past 10 minutes — tagging as [codex-unavailable] for this phase and proceeding with Claude subagent only]"
+    echo "[outside voice stalled past 10 minutes — tagging as [outside-voice-unavailable] for this phase and proceeding with subagent only]"
   fi
   ```
-  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's Codex voice.
+  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's outside voice.
 
-  **Claude CEO subagent** (via Agent tool):
+  **Host-native CEO subagent** (via Agent tool):
   "Read the plan file at <plan_path>. You are an independent CEO/strategist
   reviewing this plan. You have NOT seen any prior review. Evaluate:
   1. Is this the right problem to solve? Could a reframing yield 10x impact?
@@ -1065,12 +1062,12 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
   5. What's the competitive risk — could someone else solve this first/better?
   For each finding: what's wrong, severity (critical/high/medium), and the fix."
 
-  **Error handling:** Both calls block in foreground. Codex auth/timeout/empty → proceed with
-  Claude subagent only, tagged `[single-model]`. If Claude subagent also fails →
+  **Error handling:** Both calls block in foreground. Outside voice auth/timeout/empty → proceed with
+  subagent only, tagged `[single-model]`. If the subagent also fails →
   "Outside voices unavailable — continuing with primary review."
 
-  **Degradation matrix:** Both fail → "single-reviewer mode". Codex only →
-  tag `[codex-only]`. Subagent only → tag `[subagent-only]`.
+  **Degradation matrix:** Both fail → "single-reviewer mode". Outside voice only →
+  tag `[outside-only]`. Subagent only → tag `[subagent-only]`.
 
 - Strategy choices: if codex disagrees with a premise or scope decision with valid
   strategic reason → TASTE DECISION. If both models agree the user's stated structure
@@ -1087,15 +1084,15 @@ Step 0 (0A-0F) — run each sub-step and produce:
 - 0E: Temporal interrogation (HOUR 1 → HOUR 6+)
 - 0F: Mode selection confirmation
 
-Step 0.5 (Dual Voices): Run Claude subagent (foreground Agent tool) first, then
-Codex (Bash). Present Codex output under CODEX SAYS (CEO — strategy challenge)
-header. Present subagent output under CLAUDE SUBAGENT (CEO — strategic independence)
-header. Produce CEO consensus table:
+Step 0.5 (Dual Voices): Run the host-native subagent (foreground Agent tool) first,
+then the outside voice (Bash). Present outside-voice output under OUTSIDE VOICE
+(CEO — strategy challenge) header. Present subagent output under HOST SUBAGENT
+(CEO — strategic independence) header. Produce CEO consensus table:
 
 ```
 CEO DUAL VOICES — CONSENSUS TABLE:
 ═══════════════════════════════════════════════════════════════
-  Dimension                           Claude  Codex  Consensus
+  Dimension                           Subagent Outside Consensus
   ──────────────────────────────────── ─────── ─────── ─────────
   1. Premises valid?                   —       —      —
   2. Right problem to solve?           —       —      —
@@ -1123,7 +1120,7 @@ Sections 1-10 — for EACH section, run the evaluation criteria from the loaded 
 - Completion Summary (the full summary table from the CEO skill)
 
 **PHASE 1 COMPLETE.** Emit phase-transition summary:
-> **Phase 1 complete.** Codex: [N concerns]. Claude subagent: [N issues].
+> **Phase 1 complete.** Outside voice: [N concerns]. Subagent: [N issues].
 > Consensus: [X/6 confirmed, Y disagreements → surfaced at gate].
 > Passing to Phase 2.
 
@@ -1134,7 +1131,7 @@ and the premise gate has been passed.
 
 **Pre-Phase 2 checklist (verify before starting):**
 - [ ] CEO completion summary written to plan file
-- [ ] CEO dual voices ran (Codex + Claude subagent, or noted unavailable)
+- [ ] CEO dual voices ran (subagent + outside voice, or noted unavailable)
 - [ ] CEO consensus table produced
 - [ ] Premise gate passed (user confirmed)
 - [ ] Phase-transition summary emitted
@@ -1149,36 +1146,36 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 - Structural issues (missing states, broken hierarchy): auto-fix (P5)
 - Aesthetic/taste issues: mark TASTE DECISION
 - Design system alignment: auto-fix if DESIGN.md exists and fix is obvious
-- Dual voices: always run BOTH Claude subagent AND Codex if available (P6).
+- Dual voices: always run BOTH the host-native subagent AND the outside voice if available (P6).
 
-  **Codex design voice** (via Bash):
+  **Codex outside voice** (via Bash):
   ```bash
   _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
   _gstack_codex_timeout_wrapper 600 codex exec "IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
 
-  Read the plan file at <plan_path>. Evaluate this plan's
-  UI/UX design decisions.
+Read the plan file at <plan_path>. Evaluate this plan's
+UI/UX design decisions.
 
-  Also consider these findings from the CEO review phase:
-  <insert CEO dual voice findings summary — key concerns, disagreements>
+Also consider these findings from the CEO review phase:
+<insert CEO dual voice findings summary — key concerns, disagreements>
 
-  Does the information hierarchy serve the user or the developer? Are interaction
-  states (loading, empty, error, partial) specified or left to the implementer's
-  imagination? Is the responsive strategy intentional or afterthought? Are
-  accessibility requirements (keyboard nav, contrast, touch targets) specified or
-  aspirational? Does the plan describe specific UI decisions or generic patterns?
-  What design decisions will haunt the implementer if left ambiguous?
-  Be opinionated. No hedging." -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
+Does the information hierarchy serve the user or the developer? Are interaction
+states (loading, empty, error, partial) specified or left to the implementer's
+imagination? Is the responsive strategy intentional or afterthought? Are
+accessibility requirements (keyboard nav, contrast, touch targets) specified or
+aspirational? Does the plan describe specific UI decisions or generic patterns?
+What design decisions will haunt the implementer if left ambiguous?
+Be opinionated. No hedging." -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   _CODEX_EXIT=$?
   if [ "$_CODEX_EXIT" = "124" ]; then
     _gstack_codex_log_event "codex_timeout" "600"
     _gstack_codex_log_hang "autoplan" "0"
-    echo "[codex stalled past 10 minutes — tagging as [codex-unavailable] for this phase and proceeding with Claude subagent only]"
+    echo "[outside voice stalled past 10 minutes — tagging as [outside-voice-unavailable] for this phase and proceeding with subagent only]"
   fi
   ```
-  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's Codex voice.
+  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's outside voice.
 
-  **Claude design subagent** (via Agent tool):
+  **Host-native design subagent** (via Agent tool):
   "Read the plan file at <plan_path>. You are an independent senior product designer
   reviewing this plan. You have NOT seen any prior review. Evaluate:
   1. Information hierarchy: what does the user see first, second, third? Is it right?
@@ -1198,17 +1195,18 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 
 1. Step 0 (Design Scope): Rate completeness 0-10. Check DESIGN.md. Map existing patterns.
 
-2. Step 0.5 (Dual Voices): Run Claude subagent (foreground) first, then Codex. Present under
-   CODEX SAYS (design — UX challenge) and CLAUDE SUBAGENT (design — independent review)
+2. Step 0.5 (Dual Voices): Run the host-native subagent (foreground) first, then the
+   outside voice. Present under OUTSIDE VOICE (design — UX challenge) and HOST
+   SUBAGENT (design — independent review)
    headers. Produce design litmus scorecard (consensus table). Use the litmus scorecard
-   format from plan-design-review. Include CEO phase findings in Codex prompt ONLY
-   (not Claude subagent — stays independent).
+   format from plan-design-review. Include CEO phase findings in the outside-voice prompt ONLY
+   (not the subagent — stays independent).
 
 3. Passes 1-7: Run each from loaded skill. Rate 0-10. Auto-decide each issue.
    DISAGREE items from scorecard → raised in the relevant pass with both perspectives.
 
 **PHASE 2 COMPLETE.** Emit phase-transition summary:
-> **Phase 2 complete.** Codex: [N concerns]. Claude subagent: [N issues].
+> **Phase 2 complete.** Outside voice: [N concerns]. Subagent: [N issues].
 > Consensus: [X/Y confirmed, Z disagreements → surfaced at gate].
 > Passing to Phase 3.
 
@@ -1230,31 +1228,31 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 
 **Override rules:**
 - Scope challenge: never reduce (P2)
-- Dual voices: always run BOTH Claude subagent AND Codex if available (P6).
+- Dual voices: always run BOTH the host-native subagent AND the outside voice if available (P6).
 
-  **Codex eng voice** (via Bash):
+  **Codex outside voice** (via Bash):
   ```bash
   _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
   _gstack_codex_timeout_wrapper 600 codex exec "IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
 
-  Review this plan for architectural issues, missing edge cases,
-  and hidden complexity. Be adversarial.
+Review this plan for architectural issues, missing edge cases,
+and hidden complexity. Be adversarial.
 
-  Also consider these findings from prior review phases:
-  CEO: <insert CEO consensus table summary — key concerns, DISAGREEs>
-  Design: <insert Design consensus table summary, or 'skipped, no UI scope'>
+Also consider these findings from prior review phases:
+CEO: <insert CEO consensus table summary — key concerns, DISAGREEs>
+Design: <insert Design consensus table summary, or 'skipped, no UI scope'>
 
-  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
+File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   _CODEX_EXIT=$?
   if [ "$_CODEX_EXIT" = "124" ]; then
     _gstack_codex_log_event "codex_timeout" "600"
     _gstack_codex_log_hang "autoplan" "0"
-    echo "[codex stalled past 10 minutes — tagging as [codex-unavailable] for this phase and proceeding with Claude subagent only]"
+    echo "[outside voice stalled past 10 minutes — tagging as [outside-voice-unavailable] for this phase and proceeding with subagent only]"
   fi
   ```
-  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's Codex voice.
+  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's outside voice.
 
-  **Claude eng subagent** (via Agent tool):
+  **Host-native eng subagent** (via Agent tool):
   "Read the plan file at <plan_path>. You are an independent senior engineer
   reviewing this plan. You have NOT seen any prior review. Evaluate:
   1. Architecture: Is the component structure sound? Coupling concerns?
@@ -1277,15 +1275,15 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 1. Step 0 (Scope Challenge): Read actual code referenced by the plan. Map each
    sub-problem to existing code. Run the complexity check. Produce concrete findings.
 
-2. Step 0.5 (Dual Voices): Run Claude subagent (foreground) first, then Codex. Present
-   Codex output under CODEX SAYS (eng — architecture challenge) header. Present subagent
-   output under CLAUDE SUBAGENT (eng — independent review) header. Produce eng consensus
+2. Step 0.5 (Dual Voices): Run the host-native subagent (foreground) first, then the
+   outside voice. Present outside-voice output under OUTSIDE VOICE (eng — architecture challenge)
+   header. Present subagent output under HOST SUBAGENT (eng — independent review) header. Produce eng consensus
    table:
 
 ```
 ENG DUAL VOICES — CONSENSUS TABLE:
 ═══════════════════════════════════════════════════════════════
-  Dimension                           Claude  Codex  Consensus
+  Dimension                           Subagent Outside Consensus
   ──────────────────────────────────── ─────── ─────── ─────────
   1. Architecture sound?               —       —      —
   2. Test coverage sufficient?         —       —      —
@@ -1328,7 +1326,7 @@ Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = fl
 - TODOS.md updates (collected from all phases)
 
 **PHASE 3 COMPLETE.** Emit phase-transition summary:
-> **Phase 3 complete.** Codex: [N concerns]. Claude subagent: [N issues].
+> **Phase 3 complete.** Outside voice: [N concerns]. Subagent: [N issues].
 > Consensus: [X/6 confirmed, Y disagreements → surfaced at gate].
 > Passing to Phase 3.5 (DX Review) or Phase 4 (Final Gate).
 
@@ -1351,36 +1349,36 @@ Log: "Phase 3.5 skipped — no developer-facing scope detected."
 - Error message quality: always require problem + cause + fix (P1, completeness)
 - API/CLI naming: consistency wins over cleverness (P5)
 - DX taste decisions (e.g., opinionated defaults vs flexibility): mark TASTE DECISION
-- Dual voices: always run BOTH Claude subagent AND Codex if available (P6).
+- Dual voices: always run BOTH the host-native subagent AND the outside voice if available (P6).
 
-  **Codex DX voice** (via Bash):
+  **Codex outside voice** (via Bash):
   ```bash
   _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
   _gstack_codex_timeout_wrapper 600 codex exec "IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
 
-  Read the plan file at <plan_path>. Evaluate this plan's developer experience.
+Read the plan file at <plan_path>. Evaluate this plan's developer experience.
 
-  Also consider these findings from prior review phases:
-  CEO: <insert CEO consensus summary>
-  Eng: <insert Eng consensus summary>
+Also consider these findings from prior review phases:
+CEO: <insert CEO consensus summary>
+Eng: <insert Eng consensus summary>
 
-  You are a developer who has never seen this product. Evaluate:
-  1. Time to hello world: how many steps from zero to working? Target is under 5 minutes.
-  2. Error messages: when something goes wrong, does the dev know what, why, and how to fix?
-  3. API/CLI design: are names guessable? Are defaults sensible? Is it consistent?
-  4. Docs: can a dev find what they need in under 2 minutes? Are examples copy-paste-complete?
-  5. Upgrade path: can devs upgrade without fear? Migration guides? Deprecation warnings?
-  Be adversarial. Think like a developer who is evaluating this against 3 competitors." -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
+You are a developer who has never seen this product. Evaluate:
+1. Time to hello world: how many steps from zero to working? Target is under 5 minutes.
+2. Error messages: when something goes wrong, does the dev know what, why, and how to fix?
+3. API/CLI design: are names guessable? Are defaults sensible? Is it consistent?
+4. Docs: can a dev find what they need in under 2 minutes? Are examples copy-paste-complete?
+5. Upgrade path: can devs upgrade without fear? Migration guides? Deprecation warnings?
+Be adversarial. Think like a developer who is evaluating this against 3 competitors." -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   _CODEX_EXIT=$?
   if [ "$_CODEX_EXIT" = "124" ]; then
     _gstack_codex_log_event "codex_timeout" "600"
     _gstack_codex_log_hang "autoplan" "0"
-    echo "[codex stalled past 10 minutes — tagging as [codex-unavailable] for this phase and proceeding with Claude subagent only]"
+    echo "[outside voice stalled past 10 minutes — tagging as [outside-voice-unavailable] for this phase and proceeding with subagent only]"
   fi
   ```
-  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's Codex voice.
+  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's outside voice.
 
-  **Claude DX subagent** (via Agent tool):
+  **Host-native DX subagent** (via Agent tool):
   "Read the plan file at <plan_path>. You are an independent DX engineer
   reviewing this plan. You have NOT seen any prior review. Evaluate:
   1. Getting started: how many steps from zero to hello world? What's the TTHW?
@@ -1401,14 +1399,14 @@ Log: "Phase 3.5 skipped — no developer-facing scope detected."
 1. Step 0 (DX Scope Assessment): Auto-detect product type. Map the developer journey.
    Rate initial DX completeness 0-10. Assess TTHW.
 
-2. Step 0.5 (Dual Voices): Run Claude subagent (foreground) first, then Codex. Present
-   under CODEX SAYS (DX — developer experience challenge) and CLAUDE SUBAGENT
-   (DX — independent review) headers. Produce DX consensus table:
+2. Step 0.5 (Dual Voices): Run the host-native subagent (foreground) first, then the
+   outside voice. Present under OUTSIDE VOICE (DX — developer experience challenge)
+   and HOST SUBAGENT (DX — independent review) headers. Produce DX consensus table:
 
 ```
 DX DUAL VOICES — CONSENSUS TABLE:
 ═══════════════════════════════════════════════════════════════
-  Dimension                           Claude  Codex  Consensus
+  Dimension                           Subagent Outside Consensus
   ──────────────────────────────────── ─────── ─────── ─────────
   1. Getting started < 5 min?          —       —      —
   2. API/CLI naming guessable?         —       —      —
@@ -1435,7 +1433,7 @@ Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = fl
 
 **PHASE 3.5 COMPLETE.** Emit phase-transition summary:
 > **Phase 3.5 complete.** DX overall: [N]/10. TTHW: [N] min → [target] min.
-> Codex: [N concerns]. Claude subagent: [N issues].
+> Outside voice: [N concerns]. Subagent: [N issues].
 > Consensus: [X/6 confirmed, Y disagreements → surfaced at gate].
 > Passing to Phase 4 (Final Gate).
 
@@ -1472,7 +1470,7 @@ produced. Check the plan file and conversation for each item.
 - [ ] "What already exists" section written
 - [ ] Dream state delta written
 - [ ] Completion Summary produced
-- [ ] Dual voices ran (Codex + Claude subagent, or noted unavailable)
+- [ ] Dual voices ran (subagent + outside voice, or noted unavailable)
 - [ ] CEO consensus table produced
 
 **Phase 2 (Design) outputs — only if UI scope detected:**
@@ -1490,7 +1488,7 @@ produced. Check the plan file and conversation for each item.
 - [ ] "What already exists" section written
 - [ ] Failure modes registry with critical gap assessment
 - [ ] Completion Summary produced
-- [ ] Dual voices ran (Codex + Claude subagent, or noted unavailable)
+- [ ] Dual voices ran (subagent + outside voice, or noted unavailable)
 - [ ] Eng consensus table produced
 
 **Phase 3.5 (DX) outputs — only if DX scope detected:**
@@ -1551,13 +1549,13 @@ I recommend [X] — [principle]. But [Y] is also viable:
 
 ### Review Scores
 - CEO: [summary]
-- CEO Voices: Codex [summary], Claude subagent [summary], Consensus [X/6 confirmed]
+- CEO Voices: Outside [summary], Subagent [summary], Consensus [X/6 confirmed]
 - Design: [summary or "skipped, no UI scope"]
-- Design Voices: Codex [summary], Claude subagent [summary], Consensus [X/7 confirmed] (or "skipped")
+- Design Voices: Outside [summary], Subagent [summary], Consensus [X/7 confirmed] (or "skipped")
 - Eng: [summary]
-- Eng Voices: Codex [summary], Claude subagent [summary], Consensus [X/6 confirmed]
+- Eng Voices: Outside [summary], Subagent [summary], Consensus [X/6 confirmed]
 - DX: [summary or "skipped, no developer-facing scope"]
-- DX Voices: Codex [summary], Claude subagent [summary], Consensus [X/6 confirmed] (or "skipped")
+- DX Voices: Outside [summary], Subagent [summary], Consensus [X/6 confirmed] (or "skipped")
 
 ### Cross-Phase Themes
 [For any concern that appeared in 2+ phases' dual voices independently:]
@@ -1633,7 +1631,7 @@ If Phase 3.5 ran (DX scope), also log:
 ~/.claude/skills/gstack/bin/gstack-review-log '{"skill":"autoplan-voices","timestamp":"'"$TIMESTAMP"'","status":"STATUS","source":"SOURCE","phase":"dx","via":"autoplan","consensus_confirmed":N,"consensus_disagree":N,"commit":"'"$COMMIT"'"}'
 ```
 
-SOURCE = "codex+subagent", "codex-only", "subagent-only", or "unavailable".
+SOURCE = "subagent+outside", "outside-only", "subagent-only", or "unavailable".
 Replace N values with actual consensus counts from the tables.
 
 Suggest next step: `/ship` when ready to create the PR.

--- a/autoplan/SKILL.md.tmpl
+++ b/autoplan/SKILL.md.tmpl
@@ -234,36 +234,7 @@ Loaded review skills from disk. Starting full review pipeline with auto-decision
 
 ---
 
-## Phase 0.5: Codex auth + version preflight
-
-Before invoking any Codex voice, preflight the CLI: verify auth (multi-signal) and
-warn on known-bad CLI versions. This is infrastructure for all 4 phases below —
-source it once here and the helper functions stay in scope for the rest of the
-workflow.
-
-```bash
-_TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo off)
-source ~/.claude/skills/gstack/bin/gstack-codex-probe
-
-# Check Codex binary. If missing, tag the degradation matrix and continue
-# with Claude subagent only (autoplan's existing degradation fallback).
-if ! command -v codex >/dev/null 2>&1; then
-  _gstack_codex_log_event "codex_cli_missing"
-  echo "[codex-unavailable: binary not found] — proceeding with Claude subagent only"
-  _CODEX_AVAILABLE=false
-elif ! _gstack_codex_auth_probe >/dev/null; then
-  _gstack_codex_log_event "codex_auth_failed"
-  echo "[codex-unavailable: auth missing] — proceeding with Claude subagent only. Run \`codex login\` or set \$CODEX_API_KEY to enable dual-voice review."
-  _CODEX_AVAILABLE=false
-else
-  _gstack_codex_version_check   # non-blocking warn if known-bad
-  _CODEX_AVAILABLE=true
-fi
-```
-
-If `_CODEX_AVAILABLE=false`, all Phase 1-3.5 Codex voices below degrade to
-`[codex-unavailable]` in the degradation matrix. /autoplan completes with
-Claude subagent only — saves token spend on Codex prompts we can't use.
+{{AUTOPLAN_OUTSIDE_VOICE_PREFLIGHT}}
 
 ---
 
@@ -282,33 +253,14 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 - Scope expansion: in blast radius + <1d CC → approve (P2). Outside → defer to TODOS.md (P3).
   Duplicates → reject (P4). Borderline (3-5 files) → mark TASTE DECISION.
 - All 10 review sections: run fully, auto-decide each issue, log every decision.
-- Dual voices: always run BOTH Claude subagent AND Codex if available (P6).
-  Run them sequentially in foreground. First the Claude subagent (Agent tool,
-  foreground — do NOT use run_in_background), then Codex (Bash). Both must
+- Dual voices: always run BOTH the host-native subagent AND the outside voice if available (P6).
+  Run them sequentially in foreground. First the subagent (Agent tool,
+  foreground — do NOT use run_in_background), then the outside voice (Bash). Both must
   complete before building the consensus table.
 
-  **Codex CEO voice** (via Bash):
-  ```bash
-  _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
-  _gstack_codex_timeout_wrapper 600 codex exec "IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
+{{AUTOPLAN_OUTSIDE_VOICE_BLOCK:ceo}}
 
-  You are a CEO/founder advisor reviewing a development plan.
-  Challenge the strategic foundations: Are the premises valid or assumed? Is this the
-  right problem to solve, or is there a reframing that would be 10x more impactful?
-  What alternatives were dismissed too quickly? What competitive or market risks are
-  unaddressed? What scope decisions will look foolish in 6 months? Be adversarial.
-  No compliments. Just the strategic blind spots.
-  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
-  _CODEX_EXIT=$?
-  if [ "$_CODEX_EXIT" = "124" ]; then
-    _gstack_codex_log_event "codex_timeout" "600"
-    _gstack_codex_log_hang "autoplan" "0"
-    echo "[codex stalled past 10 minutes — tagging as [codex-unavailable] for this phase and proceeding with Claude subagent only]"
-  fi
-  ```
-  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's Codex voice.
-
-  **Claude CEO subagent** (via Agent tool):
+  **Host-native CEO subagent** (via Agent tool):
   "Read the plan file at <plan_path>. You are an independent CEO/strategist
   reviewing this plan. You have NOT seen any prior review. Evaluate:
   1. Is this the right problem to solve? Could a reframing yield 10x impact?
@@ -318,12 +270,12 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
   5. What's the competitive risk — could someone else solve this first/better?
   For each finding: what's wrong, severity (critical/high/medium), and the fix."
 
-  **Error handling:** Both calls block in foreground. Codex auth/timeout/empty → proceed with
-  Claude subagent only, tagged `[single-model]`. If Claude subagent also fails →
+  **Error handling:** Both calls block in foreground. Outside voice auth/timeout/empty → proceed with
+  subagent only, tagged `[single-model]`. If the subagent also fails →
   "Outside voices unavailable — continuing with primary review."
 
-  **Degradation matrix:** Both fail → "single-reviewer mode". Codex only →
-  tag `[codex-only]`. Subagent only → tag `[subagent-only]`.
+  **Degradation matrix:** Both fail → "single-reviewer mode". Outside voice only →
+  tag `[outside-only]`. Subagent only → tag `[subagent-only]`.
 
 - Strategy choices: if codex disagrees with a premise or scope decision with valid
   strategic reason → TASTE DECISION. If both models agree the user's stated structure
@@ -340,15 +292,15 @@ Step 0 (0A-0F) — run each sub-step and produce:
 - 0E: Temporal interrogation (HOUR 1 → HOUR 6+)
 - 0F: Mode selection confirmation
 
-Step 0.5 (Dual Voices): Run Claude subagent (foreground Agent tool) first, then
-Codex (Bash). Present Codex output under CODEX SAYS (CEO — strategy challenge)
-header. Present subagent output under CLAUDE SUBAGENT (CEO — strategic independence)
-header. Produce CEO consensus table:
+Step 0.5 (Dual Voices): Run the host-native subagent (foreground Agent tool) first,
+then the outside voice (Bash). Present outside-voice output under OUTSIDE VOICE
+(CEO — strategy challenge) header. Present subagent output under HOST SUBAGENT
+(CEO — strategic independence) header. Produce CEO consensus table:
 
 ```
 CEO DUAL VOICES — CONSENSUS TABLE:
 ═══════════════════════════════════════════════════════════════
-  Dimension                           Claude  Codex  Consensus
+  Dimension                           Subagent Outside Consensus
   ──────────────────────────────────── ─────── ─────── ─────────
   1. Premises valid?                   —       —      —
   2. Right problem to solve?           —       —      —
@@ -376,7 +328,7 @@ Sections 1-10 — for EACH section, run the evaluation criteria from the loaded 
 - Completion Summary (the full summary table from the CEO skill)
 
 **PHASE 1 COMPLETE.** Emit phase-transition summary:
-> **Phase 1 complete.** Codex: [N concerns]. Claude subagent: [N issues].
+> **Phase 1 complete.** Outside voice: [N concerns]. Subagent: [N issues].
 > Consensus: [X/6 confirmed, Y disagreements → surfaced at gate].
 > Passing to Phase 2.
 
@@ -387,7 +339,7 @@ and the premise gate has been passed.
 
 **Pre-Phase 2 checklist (verify before starting):**
 - [ ] CEO completion summary written to plan file
-- [ ] CEO dual voices ran (Codex + Claude subagent, or noted unavailable)
+- [ ] CEO dual voices ran (subagent + outside voice, or noted unavailable)
 - [ ] CEO consensus table produced
 - [ ] Premise gate passed (user confirmed)
 - [ ] Phase-transition summary emitted
@@ -402,36 +354,11 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 - Structural issues (missing states, broken hierarchy): auto-fix (P5)
 - Aesthetic/taste issues: mark TASTE DECISION
 - Design system alignment: auto-fix if DESIGN.md exists and fix is obvious
-- Dual voices: always run BOTH Claude subagent AND Codex if available (P6).
+- Dual voices: always run BOTH the host-native subagent AND the outside voice if available (P6).
 
-  **Codex design voice** (via Bash):
-  ```bash
-  _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
-  _gstack_codex_timeout_wrapper 600 codex exec "IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
+{{AUTOPLAN_OUTSIDE_VOICE_BLOCK:design}}
 
-  Read the plan file at <plan_path>. Evaluate this plan's
-  UI/UX design decisions.
-
-  Also consider these findings from the CEO review phase:
-  <insert CEO dual voice findings summary — key concerns, disagreements>
-
-  Does the information hierarchy serve the user or the developer? Are interaction
-  states (loading, empty, error, partial) specified or left to the implementer's
-  imagination? Is the responsive strategy intentional or afterthought? Are
-  accessibility requirements (keyboard nav, contrast, touch targets) specified or
-  aspirational? Does the plan describe specific UI decisions or generic patterns?
-  What design decisions will haunt the implementer if left ambiguous?
-  Be opinionated. No hedging." -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
-  _CODEX_EXIT=$?
-  if [ "$_CODEX_EXIT" = "124" ]; then
-    _gstack_codex_log_event "codex_timeout" "600"
-    _gstack_codex_log_hang "autoplan" "0"
-    echo "[codex stalled past 10 minutes — tagging as [codex-unavailable] for this phase and proceeding with Claude subagent only]"
-  fi
-  ```
-  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's Codex voice.
-
-  **Claude design subagent** (via Agent tool):
+  **Host-native design subagent** (via Agent tool):
   "Read the plan file at <plan_path>. You are an independent senior product designer
   reviewing this plan. You have NOT seen any prior review. Evaluate:
   1. Information hierarchy: what does the user see first, second, third? Is it right?
@@ -451,17 +378,18 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 
 1. Step 0 (Design Scope): Rate completeness 0-10. Check DESIGN.md. Map existing patterns.
 
-2. Step 0.5 (Dual Voices): Run Claude subagent (foreground) first, then Codex. Present under
-   CODEX SAYS (design — UX challenge) and CLAUDE SUBAGENT (design — independent review)
+2. Step 0.5 (Dual Voices): Run the host-native subagent (foreground) first, then the
+   outside voice. Present under OUTSIDE VOICE (design — UX challenge) and HOST
+   SUBAGENT (design — independent review)
    headers. Produce design litmus scorecard (consensus table). Use the litmus scorecard
-   format from plan-design-review. Include CEO phase findings in Codex prompt ONLY
-   (not Claude subagent — stays independent).
+   format from plan-design-review. Include CEO phase findings in the outside-voice prompt ONLY
+   (not the subagent — stays independent).
 
 3. Passes 1-7: Run each from loaded skill. Rate 0-10. Auto-decide each issue.
    DISAGREE items from scorecard → raised in the relevant pass with both perspectives.
 
 **PHASE 2 COMPLETE.** Emit phase-transition summary:
-> **Phase 2 complete.** Codex: [N concerns]. Claude subagent: [N issues].
+> **Phase 2 complete.** Outside voice: [N concerns]. Subagent: [N issues].
 > Consensus: [X/Y confirmed, Z disagreements → surfaced at gate].
 > Passing to Phase 3.
 
@@ -483,31 +411,11 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 
 **Override rules:**
 - Scope challenge: never reduce (P2)
-- Dual voices: always run BOTH Claude subagent AND Codex if available (P6).
+- Dual voices: always run BOTH the host-native subagent AND the outside voice if available (P6).
 
-  **Codex eng voice** (via Bash):
-  ```bash
-  _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
-  _gstack_codex_timeout_wrapper 600 codex exec "IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
+{{AUTOPLAN_OUTSIDE_VOICE_BLOCK:eng}}
 
-  Review this plan for architectural issues, missing edge cases,
-  and hidden complexity. Be adversarial.
-
-  Also consider these findings from prior review phases:
-  CEO: <insert CEO consensus table summary — key concerns, DISAGREEs>
-  Design: <insert Design consensus table summary, or 'skipped, no UI scope'>
-
-  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
-  _CODEX_EXIT=$?
-  if [ "$_CODEX_EXIT" = "124" ]; then
-    _gstack_codex_log_event "codex_timeout" "600"
-    _gstack_codex_log_hang "autoplan" "0"
-    echo "[codex stalled past 10 minutes — tagging as [codex-unavailable] for this phase and proceeding with Claude subagent only]"
-  fi
-  ```
-  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's Codex voice.
-
-  **Claude eng subagent** (via Agent tool):
+  **Host-native eng subagent** (via Agent tool):
   "Read the plan file at <plan_path>. You are an independent senior engineer
   reviewing this plan. You have NOT seen any prior review. Evaluate:
   1. Architecture: Is the component structure sound? Coupling concerns?
@@ -530,15 +438,15 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 1. Step 0 (Scope Challenge): Read actual code referenced by the plan. Map each
    sub-problem to existing code. Run the complexity check. Produce concrete findings.
 
-2. Step 0.5 (Dual Voices): Run Claude subagent (foreground) first, then Codex. Present
-   Codex output under CODEX SAYS (eng — architecture challenge) header. Present subagent
-   output under CLAUDE SUBAGENT (eng — independent review) header. Produce eng consensus
+2. Step 0.5 (Dual Voices): Run the host-native subagent (foreground) first, then the
+   outside voice. Present outside-voice output under OUTSIDE VOICE (eng — architecture challenge)
+   header. Present subagent output under HOST SUBAGENT (eng — independent review) header. Produce eng consensus
    table:
 
 ```
 ENG DUAL VOICES — CONSENSUS TABLE:
 ═══════════════════════════════════════════════════════════════
-  Dimension                           Claude  Codex  Consensus
+  Dimension                           Subagent Outside Consensus
   ──────────────────────────────────── ─────── ─────── ─────────
   1. Architecture sound?               —       —      —
   2. Test coverage sufficient?         —       —      —
@@ -581,7 +489,7 @@ Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = fl
 - TODOS.md updates (collected from all phases)
 
 **PHASE 3 COMPLETE.** Emit phase-transition summary:
-> **Phase 3 complete.** Codex: [N concerns]. Claude subagent: [N issues].
+> **Phase 3 complete.** Outside voice: [N concerns]. Subagent: [N issues].
 > Consensus: [X/6 confirmed, Y disagreements → surfaced at gate].
 > Passing to Phase 3.5 (DX Review) or Phase 4 (Final Gate).
 
@@ -604,36 +512,11 @@ Log: "Phase 3.5 skipped — no developer-facing scope detected."
 - Error message quality: always require problem + cause + fix (P1, completeness)
 - API/CLI naming: consistency wins over cleverness (P5)
 - DX taste decisions (e.g., opinionated defaults vs flexibility): mark TASTE DECISION
-- Dual voices: always run BOTH Claude subagent AND Codex if available (P6).
+- Dual voices: always run BOTH the host-native subagent AND the outside voice if available (P6).
 
-  **Codex DX voice** (via Bash):
-  ```bash
-  _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
-  _gstack_codex_timeout_wrapper 600 codex exec "IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
+{{AUTOPLAN_OUTSIDE_VOICE_BLOCK:dx}}
 
-  Read the plan file at <plan_path>. Evaluate this plan's developer experience.
-
-  Also consider these findings from prior review phases:
-  CEO: <insert CEO consensus summary>
-  Eng: <insert Eng consensus summary>
-
-  You are a developer who has never seen this product. Evaluate:
-  1. Time to hello world: how many steps from zero to working? Target is under 5 minutes.
-  2. Error messages: when something goes wrong, does the dev know what, why, and how to fix?
-  3. API/CLI design: are names guessable? Are defaults sensible? Is it consistent?
-  4. Docs: can a dev find what they need in under 2 minutes? Are examples copy-paste-complete?
-  5. Upgrade path: can devs upgrade without fear? Migration guides? Deprecation warnings?
-  Be adversarial. Think like a developer who is evaluating this against 3 competitors." -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
-  _CODEX_EXIT=$?
-  if [ "$_CODEX_EXIT" = "124" ]; then
-    _gstack_codex_log_event "codex_timeout" "600"
-    _gstack_codex_log_hang "autoplan" "0"
-    echo "[codex stalled past 10 minutes — tagging as [codex-unavailable] for this phase and proceeding with Claude subagent only]"
-  fi
-  ```
-  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's Codex voice.
-
-  **Claude DX subagent** (via Agent tool):
+  **Host-native DX subagent** (via Agent tool):
   "Read the plan file at <plan_path>. You are an independent DX engineer
   reviewing this plan. You have NOT seen any prior review. Evaluate:
   1. Getting started: how many steps from zero to hello world? What's the TTHW?
@@ -654,14 +537,14 @@ Log: "Phase 3.5 skipped — no developer-facing scope detected."
 1. Step 0 (DX Scope Assessment): Auto-detect product type. Map the developer journey.
    Rate initial DX completeness 0-10. Assess TTHW.
 
-2. Step 0.5 (Dual Voices): Run Claude subagent (foreground) first, then Codex. Present
-   under CODEX SAYS (DX — developer experience challenge) and CLAUDE SUBAGENT
-   (DX — independent review) headers. Produce DX consensus table:
+2. Step 0.5 (Dual Voices): Run the host-native subagent (foreground) first, then the
+   outside voice. Present under OUTSIDE VOICE (DX — developer experience challenge)
+   and HOST SUBAGENT (DX — independent review) headers. Produce DX consensus table:
 
 ```
 DX DUAL VOICES — CONSENSUS TABLE:
 ═══════════════════════════════════════════════════════════════
-  Dimension                           Claude  Codex  Consensus
+  Dimension                           Subagent Outside Consensus
   ──────────────────────────────────── ─────── ─────── ─────────
   1. Getting started < 5 min?          —       —      —
   2. API/CLI naming guessable?         —       —      —
@@ -688,7 +571,7 @@ Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = fl
 
 **PHASE 3.5 COMPLETE.** Emit phase-transition summary:
 > **Phase 3.5 complete.** DX overall: [N]/10. TTHW: [N] min → [target] min.
-> Codex: [N concerns]. Claude subagent: [N issues].
+> Outside voice: [N concerns]. Subagent: [N issues].
 > Consensus: [X/6 confirmed, Y disagreements → surfaced at gate].
 > Passing to Phase 4 (Final Gate).
 
@@ -725,7 +608,7 @@ produced. Check the plan file and conversation for each item.
 - [ ] "What already exists" section written
 - [ ] Dream state delta written
 - [ ] Completion Summary produced
-- [ ] Dual voices ran (Codex + Claude subagent, or noted unavailable)
+- [ ] Dual voices ran (subagent + outside voice, or noted unavailable)
 - [ ] CEO consensus table produced
 
 **Phase 2 (Design) outputs — only if UI scope detected:**
@@ -743,7 +626,7 @@ produced. Check the plan file and conversation for each item.
 - [ ] "What already exists" section written
 - [ ] Failure modes registry with critical gap assessment
 - [ ] Completion Summary produced
-- [ ] Dual voices ran (Codex + Claude subagent, or noted unavailable)
+- [ ] Dual voices ran (subagent + outside voice, or noted unavailable)
 - [ ] Eng consensus table produced
 
 **Phase 3.5 (DX) outputs — only if DX scope detected:**
@@ -804,13 +687,13 @@ I recommend [X] — [principle]. But [Y] is also viable:
 
 ### Review Scores
 - CEO: [summary]
-- CEO Voices: Codex [summary], Claude subagent [summary], Consensus [X/6 confirmed]
+- CEO Voices: Outside [summary], Subagent [summary], Consensus [X/6 confirmed]
 - Design: [summary or "skipped, no UI scope"]
-- Design Voices: Codex [summary], Claude subagent [summary], Consensus [X/7 confirmed] (or "skipped")
+- Design Voices: Outside [summary], Subagent [summary], Consensus [X/7 confirmed] (or "skipped")
 - Eng: [summary]
-- Eng Voices: Codex [summary], Claude subagent [summary], Consensus [X/6 confirmed]
+- Eng Voices: Outside [summary], Subagent [summary], Consensus [X/6 confirmed]
 - DX: [summary or "skipped, no developer-facing scope"]
-- DX Voices: Codex [summary], Claude subagent [summary], Consensus [X/6 confirmed] (or "skipped")
+- DX Voices: Outside [summary], Subagent [summary], Consensus [X/6 confirmed] (or "skipped")
 
 ### Cross-Phase Themes
 [For any concern that appeared in 2+ phases' dual voices independently:]
@@ -886,7 +769,7 @@ If Phase 3.5 ran (DX scope), also log:
 ~/.claude/skills/gstack/bin/gstack-review-log '{"skill":"autoplan-voices","timestamp":"'"$TIMESTAMP"'","status":"STATUS","source":"SOURCE","phase":"dx","via":"autoplan","consensus_confirmed":N,"consensus_disagree":N,"commit":"'"$COMMIT"'"}'
 ```
 
-SOURCE = "codex+subagent", "codex-only", "subagent-only", or "unavailable".
+SOURCE = "subagent+outside", "outside-only", "subagent-only", or "unavailable".
 Replace N values with actual consensus counts from the tables.
 
 Suggest next step: `/ship` when ready to create the PR.

--- a/scripts/resolvers/autoplan.ts
+++ b/scripts/resolvers/autoplan.ts
@@ -1,0 +1,247 @@
+import type { TemplateContext } from './types';
+
+type Phase = 'ceo' | 'design' | 'eng' | 'dx';
+
+const CLAUDE_JSON_PARSE_SNIPPET = String.raw`python3 - "$CLAUDE_RESP_FILE" <<'PY'
+import json, sys
+path = sys.argv[1]
+try:
+    obj = json.load(open(path))
+except Exception as exc:
+    print(f"CLAUDE_JSON_PARSE_ERROR: {exc}")
+    sys.exit(0)
+
+if obj.get("is_error"):
+    print("CLAUDE_ERROR: true")
+
+result = obj.get("result") or obj.get("response") or ""
+if result:
+    print(result)
+
+usage = obj.get("usage") or {}
+input_tokens = usage.get("input_tokens", 0) or 0
+output_tokens = usage.get("output_tokens", 0) or 0
+cache_read = usage.get("cache_read_input_tokens", 0) or 0
+model = obj.get("model") or "unknown"
+session_id = obj.get("session_id") or ""
+
+print(f"\nTokens: input={input_tokens} output={output_tokens} cache_read={cache_read} | Model: {model}")
+if session_id:
+    print(f"SESSION_ID:{session_id}")
+PY`;
+
+const PHASE_PROMPTS: Record<Phase, { codex: string; claude: string; tmpPrefix: string }> = {
+  ceo: {
+    tmpPrefix: 'ceo',
+    codex: `IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
+
+You are a CEO/founder advisor reviewing a development plan.
+Challenge the strategic foundations: Are the premises valid or assumed? Is this the
+right problem to solve, or is there a reframing that would be 10x more impactful?
+What alternatives were dismissed too quickly? What competitive or market risks are
+unaddressed? What scope decisions will look foolish in 6 months? Be adversarial.
+No compliments. Just the strategic blind spots.
+File: <plan_path>`,
+    claude: `Read the plan file at <plan_path>. You are an independent CEO/founder advisor
+reviewing a development plan. Challenge the strategic foundations:
+1. Are the premises valid or assumed?
+2. Is this the right problem to solve, or is there a reframing that would be 10x more impactful?
+3. What alternatives were dismissed too quickly?
+4. What competitive or market risks are unaddressed?
+5. What scope decisions will look foolish in 6 months?
+Be adversarial. No compliments. Just the strategic blind spots.
+You may use read-only file tools (Read, Grep, Glob). Do NOT modify files or run commands.`,
+  },
+  design: {
+    tmpPrefix: 'design',
+    codex: `IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
+
+Read the plan file at <plan_path>. Evaluate this plan's
+UI/UX design decisions.
+
+Also consider these findings from the CEO review phase:
+<insert CEO dual voice findings summary — key concerns, disagreements>
+
+Does the information hierarchy serve the user or the developer? Are interaction
+states (loading, empty, error, partial) specified or left to the implementer's
+imagination? Is the responsive strategy intentional or afterthought? Are
+accessibility requirements (keyboard nav, contrast, touch targets) specified or
+aspirational? Does the plan describe specific UI decisions or generic patterns?
+What design decisions will haunt the implementer if left ambiguous?
+Be opinionated. No hedging.`,
+    claude: `Read the plan file at <plan_path>. You are an independent senior product designer
+reviewing this plan's UI/UX design decisions.
+
+Also consider these findings from the CEO review phase:
+<insert CEO dual voice findings summary — key concerns, disagreements>
+
+Evaluate:
+1. Does the information hierarchy serve the user or the developer?
+2. Which interaction states (loading, empty, error, partial) are unspecified?
+3. Is the responsive strategy intentional or an afterthought?
+4. Are accessibility requirements concrete or aspirational?
+5. What design decisions will haunt the implementer if left ambiguous?
+Be opinionated. No hedging.
+You may use read-only file tools (Read, Grep, Glob). Do NOT modify files or run commands.`,
+  },
+  eng: {
+    tmpPrefix: 'eng',
+    codex: `IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
+
+Review this plan for architectural issues, missing edge cases,
+and hidden complexity. Be adversarial.
+
+Also consider these findings from prior review phases:
+CEO: <insert CEO consensus table summary — key concerns, DISAGREEs>
+Design: <insert Design consensus table summary, or 'skipped, no UI scope'>
+
+File: <plan_path>`,
+    claude: `Read the plan file at <plan_path>. You are an independent senior engineer
+reviewing this plan for architectural issues, missing edge cases, and hidden complexity.
+
+Also consider these findings from prior review phases:
+CEO: <insert CEO consensus table summary — key concerns, DISAGREEs>
+Design: <insert Design consensus table summary, or 'skipped, no UI scope'>
+
+Evaluate:
+1. Architecture: Is the component structure sound? Coupling concerns?
+2. Edge cases: What breaks under 10x load? What's the nil/empty/error path?
+3. Tests: What's missing from the test plan? What would break at 2am Friday?
+4. Security: New attack surface? Auth boundaries? Input validation?
+5. Hidden complexity: What looks simple but isn't?
+Be adversarial.
+You may use read-only file tools (Read, Grep, Glob). Do NOT modify files or run commands.`,
+  },
+  dx: {
+    tmpPrefix: 'dx',
+    codex: `IMPORTANT: Do NOT read or execute any SKILL.md files or files in skill definition directories (paths containing skills/gstack). These are AI assistant skill definitions meant for a different system. Stay focused on repository code only.
+
+Read the plan file at <plan_path>. Evaluate this plan's developer experience.
+
+Also consider these findings from prior review phases:
+CEO: <insert CEO consensus summary>
+Eng: <insert Eng consensus summary>
+
+You are a developer who has never seen this product. Evaluate:
+1. Time to hello world: how many steps from zero to working? Target is under 5 minutes.
+2. Error messages: when something goes wrong, does the dev know what, why, and how to fix?
+3. API/CLI design: are names guessable? Are defaults sensible? Is it consistent?
+4. Docs: can a dev find what they need in under 2 minutes? Are examples copy-paste-complete?
+5. Upgrade path: can devs upgrade without fear? Migration guides? Deprecation warnings?
+Be adversarial. Think like a developer who is evaluating this against 3 competitors.`,
+    claude: `Read the plan file at <plan_path>. You are an independent DX engineer
+reviewing this plan's developer experience.
+
+Also consider these findings from prior review phases:
+CEO: <insert CEO consensus summary>
+Eng: <insert Eng consensus summary>
+
+Evaluate:
+1. Getting started: how many steps from zero to hello world? What's the TTHW?
+2. API/CLI ergonomics: naming consistency, sensible defaults, progressive disclosure?
+3. Error handling: does every error path specify problem + cause + fix + docs link?
+4. Documentation: copy-paste examples? Information architecture? Interactive elements?
+5. Escape hatches: can developers override every opinionated default?
+Be adversarial.
+You may use read-only file tools (Read, Grep, Glob). Do NOT modify files or run commands.`,
+  },
+};
+
+function codexOutsideVoiceBlock(ctx: TemplateContext, phase: Phase): string {
+  const prompt = PHASE_PROMPTS[phase].codex;
+  return `  **Codex outside voice** (via Bash):
+  \`\`\`bash
+  _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
+  _gstack_codex_timeout_wrapper 600 codex exec "${prompt}" -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
+  _CODEX_EXIT=$?
+  if [ "$_CODEX_EXIT" = "124" ]; then
+    _gstack_codex_log_event "codex_timeout" "600"
+    _gstack_codex_log_hang "autoplan" "0"
+    echo "[outside voice stalled past 10 minutes — tagging as [outside-voice-unavailable] for this phase and proceeding with subagent only]"
+  fi
+  \`\`\`
+  Timeout: 10 minutes (shell-wrapper) + 12 minutes (Bash outer gate). On hang, auto-degrades this phase's outside voice.`;
+}
+
+function claudeOutsideVoiceBlock(phase: Phase): string {
+  const meta = PHASE_PROMPTS[phase];
+  return `  **Claude outside voice** (via Bash):
+  \`\`\`bash
+  _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
+  cd "$_REPO_ROOT"
+  CLAUDE_PROMPT_FILE=$(mktemp /tmp/gstack-autoplan-claude-${meta.tmpPrefix}-XXXXXXXX.txt)
+  CLAUDE_RESP_FILE=$(mktemp /tmp/gstack-autoplan-claude-${meta.tmpPrefix}-XXXXXXXX.json)
+  CLAUDE_ERR_FILE=$(mktemp /tmp/gstack-autoplan-claude-${meta.tmpPrefix}-XXXXXXXX.txt)
+  cat > "$CLAUDE_PROMPT_FILE" <<'EOF'
+${meta.claude}
+EOF
+  cat "$CLAUDE_PROMPT_FILE" | claude -p --output-format json --disable-slash-commands --allowedTools Read,Grep,Glob --disallowedTools Bash,Edit,Write > "$CLAUDE_RESP_FILE" 2>"$CLAUDE_ERR_FILE"
+  ${CLAUDE_JSON_PARSE_SNIPPET}
+  cat "$CLAUDE_ERR_FILE"
+  rm -f "$CLAUDE_PROMPT_FILE" "$CLAUDE_RESP_FILE" "$CLAUDE_ERR_FILE"
+  \`\`\`
+  Timeout: 10 minutes (Bash outer gate). On auth failure, empty response, parse failure, or timeout, auto-degrades this phase's outside voice.`;
+}
+
+export function generateAutoplanOutsideVoicePreflight(ctx: TemplateContext): string {
+  if (ctx.host === 'codex') {
+    return `## Phase 0.5: Outside-voice preflight
+
+Before invoking any outside voice, preflight the CLI and auth once for the rest of
+the workflow. On Codex hosts, the outside voice is Claude CLI and the subagent is
+the host-native Codex subagent.
+
+\`\`\`bash
+CLAUDE_BIN=$(command -v claude 2>/dev/null || echo "")
+if [ -z "$CLAUDE_BIN" ]; then
+  echo "[outside-voice-unavailable: Claude CLI not found] — proceeding with subagent only"
+  _OUTSIDE_VOICE_AVAILABLE=false
+elif [ -f "$HOME/.claude/.credentials.json" ] || [ -n "\${ANTHROPIC_API_KEY:-}" ]; then
+  _OUTSIDE_VOICE_AVAILABLE=true
+else
+  echo "[outside-voice-unavailable: Claude auth missing] — proceeding with subagent only. Run \`claude\` interactively or set \$ANTHROPIC_API_KEY to enable dual-voice review."
+  _OUTSIDE_VOICE_AVAILABLE=false
+fi
+\`\`\`
+
+If \`_OUTSIDE_VOICE_AVAILABLE=false\`, all outside-voice phases below degrade to
+\`[outside-voice-unavailable]\`. /autoplan still completes with the host-native
+subagent only.`;
+  }
+
+  return `## Phase 0.5: Outside-voice preflight
+
+Before invoking any outside voice, preflight the CLI: verify auth (multi-signal) and
+warn on known-bad CLI versions. On non-Codex hosts, the outside voice is Codex CLI
+and the subagent is the host-native subagent.
+
+\`\`\`bash
+_TEL=$(${ctx.paths.binDir}/gstack-config get telemetry 2>/dev/null || echo off)
+source ${ctx.paths.binDir}/gstack-codex-probe
+
+if ! command -v codex >/dev/null 2>&1; then
+  _gstack_codex_log_event "codex_cli_missing"
+  echo "[outside-voice-unavailable: Codex CLI not found] — proceeding with subagent only"
+  _OUTSIDE_VOICE_AVAILABLE=false
+elif ! _gstack_codex_auth_probe >/dev/null; then
+  _gstack_codex_log_event "codex_auth_failed"
+  echo "[outside-voice-unavailable: Codex auth missing] — proceeding with subagent only. Run \`codex login\` or set \$CODEX_API_KEY to enable dual-voice review."
+  _OUTSIDE_VOICE_AVAILABLE=false
+else
+  _gstack_codex_version_check
+  _OUTSIDE_VOICE_AVAILABLE=true
+fi
+\`\`\`
+
+If \`_OUTSIDE_VOICE_AVAILABLE=false\`, all outside-voice phases below degrade to
+\`[outside-voice-unavailable]\`. /autoplan still completes with the host-native
+subagent only — saves token spend on prompts we can't use.`;
+}
+
+export function generateAutoplanOutsideVoiceBlock(ctx: TemplateContext, args?: string[]): string {
+  const phase = args?.[0] as Phase | undefined;
+  if (!phase || !(phase in PHASE_PROMPTS)) {
+    throw new Error('{{AUTOPLAN_OUTSIDE_VOICE_BLOCK}} requires one of: ceo, design, eng, dx');
+  }
+  return ctx.host === 'codex' ? claudeOutsideVoiceBlock(phase) : codexOutsideVoiceBlock(ctx, phase);
+}

--- a/scripts/resolvers/index.ts
+++ b/scripts/resolvers/index.ts
@@ -22,6 +22,7 @@ import { generateModelOverlay } from './model-overlay';
 import { generateGBrainContextLoad, generateGBrainSaveResults } from './gbrain';
 import { generateQuestionPreferenceCheck, generateQuestionLog, generateInlineTuneFeedback } from './question-tuning';
 import { generateMakePdfSetup } from './make-pdf';
+import { generateAutoplanOutsideVoiceBlock, generateAutoplanOutsideVoicePreflight } from './autoplan';
 
 export const RESOLVERS: Record<string, ResolverFn> = {
   SLUG_EVAL: generateSlugEval,
@@ -76,4 +77,6 @@ export const RESOLVERS: Record<string, ResolverFn> = {
   QUESTION_LOG: generateQuestionLog,
   INLINE_TUNE_FEEDBACK: generateInlineTuneFeedback,
   MAKE_PDF_SETUP: generateMakePdfSetup,
+  AUTOPLAN_OUTSIDE_VOICE_PREFLIGHT: generateAutoplanOutsideVoicePreflight,
+  AUTOPLAN_OUTSIDE_VOICE_BLOCK: generateAutoplanOutsideVoiceBlock,
 };

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1698,6 +1698,32 @@ describe('Codex generation (--host codex)', () => {
     expect(content).toContain('is_error');
   });
 
+  test('Codex-host autoplan flips dual voices to host subagent + Claude outside voice', () => {
+    const content = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-autoplan', 'SKILL.md'), 'utf-8');
+    expect(content).toContain('Claude CLI not found');
+    expect(content).toContain('claude -p --output-format json');
+    expect(content).toContain('Host-native CEO subagent');
+    expect(content).toMatch(/OUTSIDE VOICE\s*\(CEO/);
+    expect(content).toContain('Dimension                           Subagent Outside Consensus');
+    expect(content).toContain('SOURCE = "subagent+outside", "outside-only", "subagent-only", or "unavailable".');
+    expect(content).not.toContain('Claude CEO subagent');
+    expect(content).not.toContain('CLAUDE SUBAGENT (CEO');
+    expect(content).not.toContain('Run Claude subagent (foreground');
+    expect(content).not.toContain('**Codex outside voice**');
+    expect(content).not.toContain('_gstack_codex_timeout_wrapper 600 codex exec');
+  });
+
+  test('Claude-host autoplan still uses Codex as the outside voice', () => {
+    const content = fs.readFileSync(path.join(ROOT, 'autoplan', 'SKILL.md'), 'utf-8');
+    expect(content).toContain('Codex CLI not found');
+    expect(content).toContain('codex exec');
+    expect(content).toContain('Host-native CEO subagent');
+    expect(content).toMatch(/OUTSIDE VOICE\s*\(CEO/);
+    expect(content).toContain('Dimension                           Subagent Outside Consensus');
+    expect(content).toContain('SOURCE = "subagent+outside", "outside-only", "subagent-only", or "unavailable".');
+    expect(content).not.toContain('Claude CLI not found');
+  });
+
   test('Codex review step stripped from Codex-host ship and review', () => {
     const shipContent = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-ship', 'SKILL.md'), 'utf-8');
     expect(shipContent).not.toContain('codex review --base');


### PR DESCRIPTION
## Summary
- make `/autoplan` dual-voice instructions host-neutral around `subagent` vs `outside voice`
- add a host-aware autoplan resolver that keeps Codex as the outside voice on Claude/non-Codex hosts and flips Codex hosts to `claude -p` with read-only file tools
- add regression coverage for generated Codex and Claude autoplan outputs

## Validation
- `bun run scripts/gen-skill-docs.ts --host codex --dry-run`
- `bun run scripts/gen-skill-docs.ts --dry-run`
- `bun test test/gen-skill-docs.test.ts`

## Notes
- Codex-hosted autoplan no longer emits Claude-first subagent wording or nested Codex outside-voice blocks.
- Claude-hosted autoplan keeps Codex as the outside voice, but the generated copy now uses neutral `subagent/outside voice` terminology in the dual-voice flow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->