### PR TITLE
feat: implement HostConfig for Pi Agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/gstack-global-discover
 .openclaw/
 .hermes/
 .gbrain/
+.pi/
 .context/
 extension/.auth.json
 # xterm assets are vendored from npm at build time; not source-of-truth.

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -66,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, pi };

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,10 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import pi from './pi';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, pi];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(

--- a/hosts/pi.ts
+++ b/hosts/pi.ts
@@ -21,6 +21,7 @@ const pi: HostConfig = {
   pathRewrites: [
     { from: '~/.claude/skills/gstack', to: '~/.pi/agent/skills/gstack' },
     { from: '.claude/skills/gstack', to: '.pi/agent/skills/gstack' },
+    { from: '.claude/skills/review', to: '.pi/agent/skills/gstack/review' },
     { from: '.claude/skills', to: '.pi/agent/skills' },
   ],
   // Define runtime root and install strategy based on Pi's structure

--- a/hosts/pi.ts
+++ b/hosts/pi.ts
@@ -1,0 +1,38 @@
+import type { HostConfig } from '../scripts/host-config';
+
+const pi: HostConfig = {
+  name: 'pi',
+  displayName: 'Pi Agent',
+  cliCommand: 'pi',
+  cliAliases: [],
+  globalRoot: '.pi/agent/skills/gstack',
+  localSkillRoot: '.pi/agent/skills/gstack',
+  hostSubdir: '.pi',
+  usesEnvVars: true,
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: null,
+  },
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],
+  },
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.pi/agent/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.pi/agent/skills/gstack' },
+    { from: '.claude/skills', to: '.pi/agent/skills' },
+  ],
+  // Define runtime root and install strategy based on Pi's structure
+  runtimeRoot: {
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalFiles: { 'review': ['checklist.md', 'TODOS-format.md'] },
+  },
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+  learningsMode: 'basic',
+};
+
+export default pi;

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -31,7 +31,7 @@ const ROOT = path.resolve(import.meta.dir, '..');
 
 describe('hosts/index.ts', () => {
   test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+    expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -30,7 +30,7 @@ const ROOT = path.resolve(import.meta.dir, '..');
 // ─── hosts/index.ts ─────────────────────────────────────────
 
 describe('hosts/index.ts', () => {
-  test('ALL_HOST_CONFIGS has 10 hosts', () => {
+  test('ALL_HOST_CONFIGS has 11 hosts', () => {
     expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 


### PR DESCRIPTION
This PR adds formal host support for the **Pi Agent** (`@mariozechner/pi-coding-agent`) within the GStack framework. Following the guidelines in `docs/ADDING_A_HOST.md`, this integration allows Pi Agent users to leverage GStack's multi-persona agentic workflows.

#### Key Changes:
*   **Host Configuration**: Created `hosts/pi.ts` to define the `HostConfig` for Pi, mapping global and local skill roots to `~/.pi/agent/skills/gstack`.
*   **Registry Integration**: Added and exported the Pi host configuration in `hosts/index.ts`.
*   **Ignore List**: Updated `.gitignore` to exclude the `.pi/` directory to prevent tracking generated skill artifacts.
*   **Test Coverage**: Updated `test/host-config.test.ts` to include validation for the new Pi host configuration.

#### Verification:
The following local validations were performed using **Bun** to ensure framework stability:
1.  **Schema Validation**: Ran `bun run scripts/host-config-export.ts validate` to confirm the configuration matches the expected interface.
2.  **Doc Generation**: Verified `bun run gen:skill-docs --host pi` successfully generates host-specific skill documentation.
3.  **Unit Tests**: Executed `bun test test/host-config.test.ts` and `bun test test/gen-skill-docs.test.ts` with all tests passing.

Close #1288 .

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->