### PR TITLE
docs: align prompt-injection thresholds in CLAUDE.md and ARCHITECTURE.md to security.ts (v1.6.4.0 catch-up)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -156,7 +156,7 @@ The Chrome sidebar agent has tools (Bash, Read, Glob, Grep, WebFetch) and reads 
 
 4. **L5 canary token (`browse/src/security.ts`).** A random token injected into the system prompt at session start. Rolling-buffer detection across `text_delta` and `input_json_delta` streams catches the token if it shows up anywhere in Claude's output, tool arguments, URLs, or file writes. Deterministic BLOCK — if the token leaks, the attacker convinced Claude to reveal the system prompt, and the session ends.
 
-5. **L6 ensemble combiner (`combineVerdict`).** BLOCK requires agreement from two ML classifiers at >= `WARN` (0.60), not a single confident hit. This is the Stack Overflow instruction-writing false-positive mitigation. On tool-output scans, single-layer high confidence BLOCKs directly — the content wasn't user-authored, so the FP concern doesn't apply.
+5. **L6 ensemble combiner (`combineVerdict`).** BLOCK requires agreement from two ML classifiers at >= `WARN` (0.75), not a single confident hit. This is the Stack Overflow instruction-writing false-positive mitigation. On tool-output scans, single-layer high confidence BLOCKs directly — the content wasn't user-authored, so the FP concern doesn't apply.
 
 **Critical constraint:** `security-classifier.ts` runs only in the sidebar-agent process, never in the compiled browse binary. `@huggingface/transformers` v4 requires `onnxruntime-node`, which fails `dlopen` from Bun compile's temp extract directory. Only the pure-string pieces (canary inject/check, verdict combiner, attack log, status) are in `security.ts`, which is safe to import from `server.ts`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,8 +287,12 @@ for `server.ts`. See `~/.gstack/projects/garrytan-gstack/ceo-plans/2026-04-19-pr
 
 **Thresholds** (in `security.ts`):
 - `BLOCK: 0.85` — single-layer score that would cause BLOCK if cross-confirmed
-- `WARN: 0.60` — cross-confirm threshold. When L4 AND L4b both >= 0.60 → BLOCK
+- `WARN: 0.75` — cross-confirm threshold. When L4 AND L4b both >= 0.75 → BLOCK
 - `LOG_ONLY: 0.40` — gates transcript classifier (skip Haiku when all layers < 0.40)
+- `SOLO_CONTENT_BLOCK: 0.92` — single-layer threshold for label-less content classifiers
+  (testsavant, deberta). Intentionally higher than `BLOCK` because these layers can't
+  distinguish "this is an injection" from "this looks like phishing aimed at the user."
+  The transcript classifier keeps a separate, label-gated solo path at `BLOCK` (0.85).
 
 **Ensemble rule:** BLOCK only when the ML content classifier AND the transcript
 classifier both report >= WARN. Single-layer high confidence degrades to WARN —


### PR DESCRIPTION
## Summary

CLAUDE.md and ARCHITECTURE.md were missed when `WARN` was bumped 0.60 → 0.75 in d75402bb (v1.6.4.0, #1135). `browse/src/security.ts:37` has `WARN: 0.75` and `BROWSER.md:743` was updated alongside that commit; `CLAUDE.md:290` and `ARCHITECTURE.md:159` still read `0.60`.

This PR brings the two stale docs in line with the source-of-truth and the sister doc that was already updated. Also adds the `SOLO_CONTENT_BLOCK: 0.92` entry to CLAUDE.md (already in `security.ts:50` and `BROWSER.md:745`, missing from CLAUDE.md's threshold table).

**No code change. No behavior change. Pure doc-vs-code alignment.**

## What's actually true

`browse/src/security.ts:35-51` is authoritative:

~~~ts
export const THRESHOLDS = {
  BLOCK: 0.85,
  WARN: 0.75,
  LOG_ONLY: 0.40,
  SOLO_CONTENT_BLOCK: 0.92,
} as const;
~~~

The v1.6.4.0 commit message stated the change directly:

> "THRESHOLDS.WARN bumped 0.60 → 0.75 — borderline fires drop out of the 2-of-N ensemble pool."

## Why this matters

- CLAUDE.md is project-binding and read by both human contributors and AI agents grounded in it. An agent quoting CLAUDE.md will tell users the cross-confirm threshold is `0.60` — wrong by 20% on a security-critical number.
- ARCHITECTURE.md is the canonical system-design doc; operators reading it to debug or tune the security stack get the wrong mental model of when ensemble cross-confirm fires.
- The `SOLO_CONTENT_BLOCK: 0.92` entry is the floor that prevents `testsavant` / `deberta` from solo-firing on phishing-flavored benign content. Operators who don't know it exists can't reason about why a high single-layer score didn't `BLOCK`.

## Verification

~~~
$ grep -n "WARN" browse/src/security.ts CLAUDE.md ARCHITECTURE.md BROWSER.md
browse/src/security.ts:37:  WARN: 0.75,
CLAUDE.md:290:- WARN: 0.75 — cross-confirm threshold ...        # was 0.60
ARCHITECTURE.md:159:...two ML classifiers at >= WARN (0.75)...  # was (0.60)
BROWSER.md:743:- WARN: 0.75 — cross-confirm threshold ...       # already correct
~~~

All four sources now agree.

## Files changed

- `CLAUDE.md` — fix `WARN: 0.60` → `0.75` (line 290), add `SOLO_CONTENT_BLOCK: 0.92` row with the FP-floor rationale.
- `ARCHITECTURE.md` — fix inline `WARN (0.60)` → `(0.75)` (line 159).

## Test plan

- [x] `grep "0\.60\|0\.75"` across `CLAUDE.md`, `ARCHITECTURE.md`, `BROWSER.md`, and `security.ts` shows all four files agree on `0.75`.
- [x] No code paths touched; no test runs needed.

## How this was found

Surfaced by a multi-artifact audit that fused CLAUDE.md, ARCHITECTURE.md, BROWSER.md, and the security source. The drift is invisible from any single file — each looks self-consistent — but emerges when you cross-check the three docs against the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)