### PR TITLE
feat(hosts): add GitHub Copilot CLI as 11th supported host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/gstack-global-discover
 .openclaw/
 .hermes/
 .gbrain/
+.copilot/
 .context/
 extension/.auth.json
 # xterm assets are vendored from npm at build time; not source-of-truth.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These are conversational skills. Your OpenClaw agent runs them directly via chat
 
 ### Other AI Agents
 
-gstack works on 10 AI coding agents, not just Claude. Setup auto-detects which
+gstack works on 11 AI coding agents, not just Claude. Setup auto-detects which
 agents you have installed:
 
 ```bash
@@ -121,9 +121,41 @@ Or target a specific agent with `./setup --host <name>`:
 | Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |
 | Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |
 | GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |
+| GitHub Copilot CLI | `--host copilot` | `~/.copilot/skills/gstack-*/` |
 
 **Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).
 It's one TypeScript config file, zero code changes.
+
+### GitHub Copilot CLI
+
+The standalone `copilot` binary (GA February 2026, separate from the older
+`gh copilot` extension) auto-discovers skills from `~/.copilot/skills/`.
+
+```bash
+# 1. Install Copilot CLI if you haven't already
+npm install -g @github/copilot
+# or: brew install copilot, winget install GitHub.CopilotCLI
+
+# 2. Install gstack
+git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack
+cd ~/gstack && ./setup --host copilot
+
+# 3. Verify
+copilot
+> /skills list
+```
+
+Each gstack skill becomes a slash command in your Copilot session: `/gstack-review`,
+`/gstack-cso`, `/gstack-office-hours`, `/gstack-ship`, etc.
+
+**v1 scope notes** — these orchestration features are suppressed in the v1 Copilot
+build because they embed Claude-specific Agent dispatch syntax that doesn't
+translate cleanly: `REVIEW_ARMY` (parallel specialist dispatch), `ADVERSARIAL_STEP`
+(adversarial reviewer), `DESIGN_OUTSIDE_VOICES` (design committee). These can be
+re-enabled in a follow-up after validating Copilot CLI's `task` tool semantics
+with real sessions. The core sprint methodology (`/gstack-review`, `/gstack-ship`,
+`/gstack-investigate`, `/gstack-cso`, `/gstack-office-hours`, etc.) works as
+designed.
 
 ## See it work
 
@@ -342,6 +374,7 @@ rm -rf ~/.codex/skills/gstack* 2>/dev/null
 rm -rf ~/.factory/skills/gstack* 2>/dev/null
 rm -rf ~/.kiro/skills/gstack* 2>/dev/null
 rm -rf ~/.openclaw/skills/gstack* 2>/dev/null
+rm -rf ~/.copilot/skills/gstack* 2>/dev/null
 
 # 6. Remove temp files
 rm -f /tmp/gstack-* 2>/dev/null

--- a/bin/gstack-uninstall
+++ b/bin/gstack-uninstall
@@ -10,8 +10,9 @@
 #   ~/.claude/skills/gstack       — global Claude skill install (git clone or vendored)
 #   ~/.claude/skills/{skill}      — per-skill symlinks created by setup
 #   ~/.codex/skills/gstack*       — Codex skill install + per-skill symlinks
-#   ~/.factory/skills/gstack*     — Factory Droid skill install + per-skill symlinks
-#   ~/.kiro/skills/gstack*        — Kiro skill install + per-skill symlinks
+#   ~/.factory/skills/gstack*     - Factory Droid skill install + per-skill symlinks
+#   ~/.kiro/skills/gstack*        - Kiro skill install + per-skill symlinks
+#   ~/.copilot/skills/gstack*     - GitHub Copilot CLI skill install + per-skill symlinks
 #   ~/.gstack/                    — global state (config, analytics, sessions, projects,
 #                                   repos, installation-id, browse error logs)
 #   .claude/skills/gstack*        — project-local skill install (--local installs)
@@ -66,6 +67,7 @@ if [ "$FORCE" -eq 0 ]; then
   [ -d "$HOME/.codex/skills" ] && echo "  ~/.codex/skills/gstack*"
   [ -d "$HOME/.factory/skills" ] && echo "  ~/.factory/skills/gstack*"
   [ -d "$HOME/.kiro/skills" ] && echo "  ~/.kiro/skills/gstack*"
+  [ -d "$HOME/.copilot/skills" ] && echo "  ~/.copilot/skills/gstack*"
   [ "$KEEP_STATE" -eq 0 ] && [ -d "$STATE_DIR" ] && echo "  $STATE_DIR"
 
   if [ -n "$_GIT_ROOT" ]; then
@@ -188,6 +190,16 @@ if [ -d "$KIRO_SKILLS" ]; then
     [ -e "$_ITEM" ] || [ -L "$_ITEM" ] || continue
     rm -rf "$_ITEM"
     REMOVED+=("kiro/$(basename "$_ITEM")")
+  done
+fi
+
+# ─── Remove Copilot CLI skills ──────────────────────────────
+COPILOT_SKILLS="$HOME/.copilot/skills"
+if [ -d "$COPILOT_SKILLS" ]; then
+  for _ITEM in "$COPILOT_SKILLS"/gstack*; do
+    [ -e "$_ITEM" ] || [ -L "$_ITEM" ] || continue
+    rm -rf "$_ITEM"
+    REMOVED+=("copilot/$(basename "$_ITEM")")
   done
 fi
 

--- a/docs/COPILOT.md
+++ b/docs/COPILOT.md
@@ -1,0 +1,147 @@
+# GitHub Copilot CLI integration
+
+gstack ships first-class support for the standalone GitHub Copilot CLI
+(`copilot` binary, GA February 2026). This document describes the integration
+in detail; see the README for the quick install steps.
+
+## Why a dedicated host
+
+Before April 24, 2026, Copilot CLI auto-loaded skills from `~/.claude/`,
+which let users run gstack via the existing Claude install. **As of v1.0.36
+(April 24, 2026) Copilot CLI no longer reads `~/.claude/`** (see the
+[Copilot CLI changelog](https://docs.github.com/copilot/changelog/copilot-cli)).
+That means a dedicated host install is required to use gstack with Copilot.
+
+The `--host copilot` flag wires gstack into Copilot's official skill location:
+`~/.copilot/skills/<skill-name>/SKILL.md`. Each gstack skill becomes a
+`/skill-name` slash command that Copilot auto-discovers via `/skills list`.
+
+## Install
+
+```bash
+# 1. Install Copilot CLI
+npm install -g @github/copilot
+# or: brew install copilot
+# or: winget install GitHub.CopilotCLI
+# or: curl -fsSL https://aka.ms/copilot-cli-install.sh | sh
+
+# 2. Install gstack
+git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack
+cd ~/gstack && ./setup --host copilot
+
+# 3. Verify in Copilot
+copilot
+> /skills list                # should show 43 gstack-* skills
+> /gstack-review              # try a skill
+```
+
+`./setup --host auto` also works — auto-detection runs `command -v copilot`
+and installs gstack for Copilot if the binary is on `$PATH`.
+
+## What gets installed
+
+- **`~/.copilot/skills/gstack/`** - runtime root with symlinks to `bin/`,
+  `browse/dist/`, `design/dist/`, `ETHOS.md`, `gstack-upgrade/`, `qa/`,
+  `review/specialists/`, etc.
+- **`~/.copilot/skills/gstack-<skill>/`** - one symlinked skill directory
+  per gstack skill (43 in the v1 build), each containing the host-adapted
+  `SKILL.md`. Copilot auto-discovers these and exposes each as a slash
+  command at session start.
+
+## Tool-name translation
+
+Copilot CLI uses a different tool catalog than Claude Code. The host config
+rewrites Claude tool references in skill content to their Copilot equivalents:
+
+| Claude Code     | Copilot CLI |
+|-----------------|-------------|
+| Bash            | bash        |
+| Read            | view        |
+| Write           | create      |
+| Edit            | edit        |
+| Agent           | task        |
+| Grep            | grep        |
+| Glob            | glob        |
+| AskUserQuestion | ask_user    |
+
+See the official Copilot CLI tool docs at
+<https://docs.github.com/copilot/concepts/agents/about-copilot-cli> for the
+full catalog including `/fleet`, `web_search`, `web_fetch`, MCP integration,
+and per-tool approval flow.
+
+## v1 scope
+
+The following gstack orchestration features are **suppressed** in the v1
+Copilot host because they embed Claude-specific Agent dispatch syntax
+(`subagent_type` parameter) that Copilot's `task` tool doesn't accept:
+
+- `REVIEW_ARMY` (parallel specialist dispatch in `/gstack-review`)
+- `ADVERSARIAL_STEP` (adversarial reviewer in `/gstack-review`)
+- `DESIGN_OUTSIDE_VOICES` (parallel design committee in design skills)
+
+Two skills are also **skipped** as they're not portable to Copilot:
+
+- `codex` - Claude wrapper around the `codex exec` binary
+- `pair-agent` - depends on Claude streaming semantics
+
+The core sprint methodology works as designed:
+
+- `/gstack-review` (without parallel specialists - sequential review still works)
+- `/gstack-ship`, `/gstack-investigate`, `/gstack-cso`, `/gstack-office-hours`
+- `/gstack-autoplan` (with sequential review pipeline)
+- `/gstack-plan-ceo-review`, `/gstack-plan-eng-review`, `/gstack-plan-design-review`
+- `/gstack-retro`, `/gstack-canary`, `/gstack-health`, `/gstack-learn`
+- ... and 30+ more
+
+These suppressions can be re-enabled in a follow-up after validating
+Copilot CLI's `task` tool semantics with real sessions.
+
+## Custom instructions
+
+Copilot CLI auto-loads custom instructions from several locations
+(see [Copilot CLI custom instructions docs](https://docs.github.com/copilot/how-tos/copilot-cli/customize-copilot/add-custom-instructions)):
+
+- `$HOME/.copilot/copilot-instructions.md` (personal, all sessions)
+- `<repo>/.github/copilot-instructions.md` (project-wide)
+- `<repo>/AGENTS.md`, `<repo>/CLAUDE.md`, `<repo>/GEMINI.md` (also auto-loaded)
+- `<repo>/.github/instructions/**/*.instructions.md` (scoped to file globs)
+
+gstack respects all of these. CLAUDE.md is intentionally **not** rewritten
+to AGENTS.md by the host config: gstack templates use CLAUDE.md as state
+storage (skill routing, state hooks, telemetry), and Copilot CLI reads both.
+
+## Uninstall
+
+`bin/gstack-uninstall` includes Copilot CLI cleanup. To remove manually:
+
+```bash
+rm -rf ~/.copilot/skills/gstack*
+```
+
+## Troubleshooting
+
+### `copilot` command not found
+
+Install via `npm install -g @github/copilot` (or `brew install copilot` /
+`winget install GitHub.CopilotCLI`). The standalone Copilot CLI is **not**
+the same as the older `gh copilot` extension; gstack auto-detection looks
+for the `copilot` binary specifically.
+
+### Skills not showing in `/skills list`
+
+1. Confirm install: `ls ~/.copilot/skills/` should show `gstack-*` directories.
+2. Reload skills inside Copilot: `/skills reload`.
+3. Check `SKILL.md` is present in each skill dir:
+   `ls ~/.copilot/skills/gstack-review/SKILL.md`.
+
+### A skill mentions "Agent tool" or "Bash tool"
+
+Tool name rewrites cover the documented patterns (`use the X tool`,
+`the X tool`, bare `X tool`). If you find a leak, please file an issue at
+<https://github.com/garrytan/gstack/issues> with the skill name and the
+exact phrase - it just needs another rewrite rule.
+
+### Want the orchestration features back
+
+Track the follow-up work to enable `REVIEW_ARMY`, `ADVERSARIAL_STEP`, and
+`DESIGN_OUTSIDE_VOICES` for Copilot at <https://github.com/garrytan/gstack/issues/393>.

--- a/hosts/copilot.ts
+++ b/hosts/copilot.ts
@@ -1,0 +1,90 @@
+import type { HostConfig } from '../scripts/host-config';
+
+/**
+ * GitHub Copilot CLI host configuration.
+ *
+ * Copilot CLI is the standalone `copilot` binary (GA February 2026), separate
+ * from the older `gh copilot` extension. It auto-discovers personal skills from
+ * `~/.copilot/skills/<name>/SKILL.md` and exposes each as a `/skill-name` slash
+ * command. As of v1.0.36 (April 24, 2026) it no longer loads `~/.claude/`
+ * skills, so a dedicated host install is required.
+ *
+ * Refs:
+ *   - https://docs.github.com/copilot/concepts/agents/about-copilot-cli
+ *   - https://docs.github.com/copilot/how-tos/copilot-cli/customize-copilot/add-skills
+ */
+const copilot: HostConfig = {
+  name: 'copilot',
+  displayName: 'GitHub Copilot CLI',
+  cliCommand: 'copilot',
+  cliAliases: [],
+
+  globalRoot: '.copilot/skills/gstack',
+  localSkillRoot: '.copilot/skills/gstack',
+  hostSubdir: '.copilot',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: null,
+  },
+
+  generation: {
+    generateMetadata: false,
+    // codex skill is a Claude wrapper around `codex exec`; not portable to Copilot.
+    // pair-agent depends on Claude streaming semantics that Copilot doesn't expose.
+    skipSkills: ['codex', 'pair-agent'],
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '$GSTACK_ROOT' },
+    { from: '.claude/skills/gstack', to: '.copilot/skills/gstack' },
+    { from: '.claude/skills/review', to: '.copilot/skills/gstack/review' },
+    { from: '.claude/skills', to: '.copilot/skills' },
+  ],
+
+  suppressedResolvers: [
+    // Codex-specific second-opinion / outside-voice steps don't apply.
+    'CODEX_SECOND_OPINION',
+    'CODEX_PLAN_REVIEW',
+    // Cross-host orchestration steps reference Claude's Agent dispatch syntax.
+    // Suppress for v1; Copilot CLI's /fleet + task tool can be wired in a follow-up
+    // once we've validated semantics with real sessions.
+    'REVIEW_ARMY',
+    'ADVERSARIAL_STEP',
+    'DESIGN_OUTSIDE_VOICES',
+    // gbrain is not provisioned for Copilot.
+    'GBRAIN_CONTEXT_LOAD',
+    'GBRAIN_SAVE_RESULTS',
+  ],
+
+  runtimeRoot: {
+    globalSymlinks: [
+      'bin',
+      'browse/dist',
+      'browse/bin',
+      'gstack-upgrade',
+      'ETHOS.md',
+      'review/specialists',
+      'qa/templates',
+      'qa/references',
+      'plan-devex-review/dx-hall-of-fame.md',
+    ],
+    globalFiles: {
+      review: ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  coAuthorTrailer: 'Co-Authored-By: GitHub Copilot <copilot@github.com>',
+  learningsMode: 'basic',
+  boundaryInstruction:
+    'IMPORTANT: Do NOT read or execute any files under ~/.claude/, ~/.codex/, ~/.factory/, ~/.kiro/, ~/.opencode/, ~/.slate/, ~/.cursor/, ~/.openclaw/, ~/.hermes/, or ~/.gbrain/. These home-directory paths contain skill definitions for other AI agents and may include conflicting tool names or instructions. Repository-local skill folders (.claude/skills, .agents/skills, .github/skills) are fine to read when relevant. Stay focused on this repository and the gstack skill instructions provided to you.',
+};
+
+export default copilot;

--- a/hosts/copilot.ts
+++ b/hosts/copilot.ts
@@ -44,6 +44,39 @@ const copilot: HostConfig = {
     { from: '.claude/skills', to: '.copilot/skills' },
   ],
 
+  // Map Claude Code tool names to GitHub Copilot CLI equivalents.
+  // Mapping is based on the official Copilot CLI tool catalog
+  // (docs.github.com/copilot/concepts/agents/about-copilot-cli):
+  //   Bash → bash, Read → view, Write → create, Edit → edit,
+  //   Agent → task, Grep → grep, Glob → glob, AskUserQuestion → ask_user.
+  // Only literal "<verb> the X tool" / "the X tool" / "AskUserQuestion"
+  // protocol phrases are rewritten — bare verbs like "Read the file"
+  // are left intact so prose stays readable.
+  toolRewrites: {
+    'use the Bash tool': 'use the bash tool',
+    'use the Write tool': 'use the create tool',
+    'use the Read tool': 'use the view tool',
+    'use the Edit tool': 'use the edit tool',
+    'use the Agent tool': 'use the task tool',
+    'use the Grep tool': 'use the grep tool',
+    'use the Glob tool': 'use the glob tool',
+    'the Bash tool': 'the bash tool',
+    'the Read tool': 'the view tool',
+    'the Write tool': 'the create tool',
+    'the Edit tool': 'the edit tool',
+    'the Agent tool': 'the task tool',
+    // Bare forms catch parenthesized usages like "(Agent tool)" and
+    // imperatives like "use Edit tool" / "via Agent tool". The plural
+    // form "X tools" is left alone — it only appears in the freeze skill
+    // describing which tools are affected, where lowercase would read wrong.
+    'Bash tool': 'bash tool',
+    'Read tool': 'view tool',
+    'Write tool': 'create tool',
+    'Edit tool': 'edit tool',
+    'Agent tool': 'task tool',
+    AskUserQuestion: 'ask_user',
+  },
+
   suppressedResolvers: [
     // Codex-specific second-opinion / outside-voice steps don't apply.
     'CODEX_SECOND_OPINION',

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,10 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import copilot from './copilot';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, copilot];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, copilot };

--- a/setup
+++ b/setup
@@ -24,6 +24,8 @@ FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
 OPENCODE_SKILLS="$HOME/.config/opencode/skills"
 OPENCODE_GSTACK="$OPENCODE_SKILLS/gstack"
+COPILOT_SKILLS="$HOME/.copilot/skills"
+COPILOT_GSTACK="$COPILOT_SKILLS/gstack"
 
 IS_WINDOWS=0
 case "$(uname -s)" in
@@ -43,7 +45,7 @@ TEAM_MODE=0
 NO_TEAM_MODE=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, copilot, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -56,7 +58,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|opencode|auto) ;;
+  claude|codex|kiro|factory|opencode|copilot|auto) ;;
   openclaw)
     echo ""
     echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
@@ -91,7 +93,7 @@ case "$HOST" in
     echo "GBrain setup and brain skills ship from the GBrain repo."
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, copilot, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -155,14 +157,16 @@ INSTALL_CODEX=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
 INSTALL_OPENCODE=0
+INSTALL_COPILOT=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
   command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
+  command -v copilot >/dev/null 2>&1 && INSTALL_COPILOT=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ] && [ "$INSTALL_COPILOT" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
@@ -175,6 +179,8 @@ elif [ "$HOST" = "factory" ]; then
   INSTALL_FACTORY=1
 elif [ "$HOST" = "opencode" ]; then
   INSTALL_OPENCODE=1
+elif [ "$HOST" = "copilot" ]; then
+  INSTALL_COPILOT=1
 fi
 
 migrate_direct_codex_install() {
@@ -318,6 +324,16 @@ if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
     cd "$SOURCE_GSTACK_DIR"
     bun install --frozen-lockfile 2>/dev/null || bun install
     bun run gen:skill-docs --host opencode
+  )
+fi
+
+# 1e. Generate .copilot/ GitHub Copilot CLI skill docs
+if [ "$INSTALL_COPILOT" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .copilot/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun install --frozen-lockfile 2>/dev/null || bun install
+    bun run gen:skill-docs --host copilot
   )
 fi
 
@@ -763,6 +779,91 @@ link_opencode_skill_dirs() {
   fi
 }
 
+create_copilot_runtime_root() {
+  local gstack_dir="$1"
+  local copilot_gstack="$2"
+  local copilot_dir="$gstack_dir/.copilot/skills"
+
+  if [ -L "$copilot_gstack" ]; then
+    rm -f "$copilot_gstack"
+  elif [ -d "$copilot_gstack" ] && [ "$copilot_gstack" != "$gstack_dir" ]; then
+    rm -rf "$copilot_gstack"
+  fi
+
+  mkdir -p "$copilot_gstack" "$copilot_gstack/browse" "$copilot_gstack/design" "$copilot_gstack/gstack-upgrade" "$copilot_gstack/review" "$copilot_gstack/qa" "$copilot_gstack/plan-devex-review"
+
+  if [ -f "$copilot_dir/gstack/SKILL.md" ]; then
+    ln -snf "$copilot_dir/gstack/SKILL.md" "$copilot_gstack/SKILL.md"
+  fi
+  if [ -d "$gstack_dir/bin" ]; then
+    ln -snf "$gstack_dir/bin" "$copilot_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    ln -snf "$gstack_dir/browse/dist" "$copilot_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    ln -snf "$gstack_dir/browse/bin" "$copilot_gstack/browse/bin"
+  fi
+  if [ -d "$gstack_dir/design/dist" ]; then
+    ln -snf "$gstack_dir/design/dist" "$copilot_gstack/design/dist"
+  fi
+  if [ -f "$copilot_dir/gstack-upgrade/SKILL.md" ]; then
+    ln -snf "$copilot_dir/gstack-upgrade/SKILL.md" "$copilot_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      ln -snf "$gstack_dir/review/$f" "$copilot_gstack/review/$f"
+    fi
+  done
+  if [ -d "$gstack_dir/review/specialists" ]; then
+    ln -snf "$gstack_dir/review/specialists" "$copilot_gstack/review/specialists"
+  fi
+  if [ -d "$gstack_dir/qa/templates" ]; then
+    ln -snf "$gstack_dir/qa/templates" "$copilot_gstack/qa/templates"
+  fi
+  if [ -d "$gstack_dir/qa/references" ]; then
+    ln -snf "$gstack_dir/qa/references" "$copilot_gstack/qa/references"
+  fi
+  if [ -f "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" ]; then
+    ln -snf "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" "$copilot_gstack/plan-devex-review/dx-hall-of-fame.md"
+  fi
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    ln -snf "$gstack_dir/ETHOS.md" "$copilot_gstack/ETHOS.md"
+  fi
+}
+
+link_copilot_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local copilot_dir="$gstack_dir/.copilot/skills"
+  local linked=()
+
+  if [ ! -d "$copilot_dir" ]; then
+    echo "  Generating .copilot/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host copilot )
+  fi
+
+  if [ ! -d "$copilot_dir" ]; then
+    echo "  warning: .copilot/skills/ generation failed - run 'bun run gen:skill-docs --host copilot' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$copilot_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
 # 4. Install for Claude (default)
 SKILLS_BASENAME="$(basename "$INSTALL_SKILLS_DIR")"
 SKILLS_PARENT_BASENAME="$(basename "$(dirname "$INSTALL_SKILLS_DIR")")"
@@ -933,6 +1034,16 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   echo "gstack ready (opencode)."
   echo "  browse: $BROWSE_BIN"
   echo "  opencode skills: $OPENCODE_SKILLS"
+fi
+
+# 6d. Install for GitHub Copilot CLI
+if [ "$INSTALL_COPILOT" -eq 1 ]; then
+  mkdir -p "$COPILOT_SKILLS"
+  create_copilot_runtime_root "$SOURCE_GSTACK_DIR" "$COPILOT_GSTACK"
+  link_copilot_skill_dirs "$SOURCE_GSTACK_DIR" "$COPILOT_SKILLS"
+  echo "gstack ready (copilot)."
+  echo "  browse: $BROWSE_BIN"
+  echo "  copilot skills: $COPILOT_SKILLS"
 fi
 
 # 7. Create .agents/ sidecar symlinks for the real Codex skill target.

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2243,16 +2243,17 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('rm -f "$target"');
   });
 
-  test('setup supports --host auto|claude|codex|kiro|opencode', () => {
+  test('setup supports --host auto|claude|codex|kiro|opencode|copilot', () => {
     expect(setupContent).toContain('--host');
-    expect(setupContent).toContain('claude|codex|kiro|factory|opencode|auto');
+    expect(setupContent).toContain('claude|codex|kiro|factory|opencode|copilot|auto');
   });
 
-  test('auto mode detects claude, codex, kiro, and opencode binaries', () => {
+  test('auto mode detects claude, codex, kiro, opencode, and copilot binaries', () => {
     expect(setupContent).toContain('command -v claude');
     expect(setupContent).toContain('command -v codex');
     expect(setupContent).toContain('command -v kiro-cli');
     expect(setupContent).toContain('command -v opencode');
+    expect(setupContent).toContain('command -v copilot');
   });
 
   // T1: Sidecar skip guard — prevents .agents/skills/gstack from being linked as a skill
@@ -2283,6 +2284,18 @@ describe('setup script validation', () => {
     expect(setupContent).toContain('INSTALL_OPENCODE=');
     expect(setupContent).toContain('OPENCODE_SKILLS="$HOME/.config/opencode/skills"');
     expect(setupContent).toContain('OPENCODE_GSTACK="$OPENCODE_SKILLS/gstack"');
+  });
+
+  test('setup supports --host copilot with install section and Copilot CLI skill path vars', () => {
+    expect(setupContent).toContain('INSTALL_COPILOT=');
+    expect(setupContent).toContain('COPILOT_SKILLS="$HOME/.copilot/skills"');
+    expect(setupContent).toContain('COPILOT_GSTACK="$COPILOT_SKILLS/gstack"');
+  });
+
+  test('setup installs Copilot CLI skills into a nested gstack runtime root', () => {
+    expect(setupContent).toContain('create_copilot_runtime_root');
+    expect(setupContent).toContain('.copilot/skills');
+    expect(setupContent).toContain('link_copilot_skill_dirs');
   });
 
   test('setup installs OpenCode skills into a nested gstack runtime root', () => {

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -30,8 +30,8 @@ const ROOT = path.resolve(import.meta.dir, '..');
 // ─── hosts/index.ts ─────────────────────────────────────────
 
 describe('hosts/index.ts', () => {
-  test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+  test('ALL_HOST_CONFIGS has 11 hosts', () => {
+    expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {


### PR DESCRIPTION
## What

Adds **GitHub Copilot CLI** as the 11th supported host in gstack, following the declarative `ADDING_A_HOST.md` pattern. Closes the gap that opened in Copilot CLI v1.0.36 (Apr 24, 2026) when `~/.claude/` skills stopped being auto-loaded.

After this PR, users on the standalone `copilot` CLI can:

```bash
./setup --host copilot
copilot
> /skills list   # all 43 gstack skills, namespaced as /gstack-*
```

## Why

- **Issue #393** has 18 hearts asking for this.
- **PR #1044** (sumitgogia, declarative pattern, also targets Copilot CLI) has been quiet for 5+ weeks; I left a coordination comment on it (https://github.com/garrytan/gstack/pull/1044#issuecomment-4360673314) before opening this one. Credit to that prior work for setting the declarative direction.
- Copilot CLI now requires its own host root (`~/.copilot/skills/`) and rewrites Claude tool names to its own (Read -> view, Write -> create, Bash -> bash, Agent -> task, etc.).

## How (4 commits, ~450 lines, 9 files)

1. **`feat(hosts): add GitHub Copilot CLI as 11th supported host`**
   - New `hosts/copilot.ts` declarative `HostConfig`
   - Registers in `hosts/index.ts`, bumps host count assertion (10 -> 11)
   - `cliCommand: 'copilot'` (the standalone npm `@github/copilot` binary, not the older `gh copilot` extension)
   - `globalRoot: '.copilot/skills/gstack'`, `localSkillRoot: '.copilot/skills'`
   - `frontmatter` allowlist of `{name, description}` (strips Claude's `allowed-tools` array which Copilot's `shell` field would reject)
   - `skipSkills: ['codex', 'pair-agent']` (codex is a Claude wrapper around `codex exec`; pair-agent depends on Claude streaming)
   - `suppressedResolvers`: REVIEW_ARMY, ADVERSARIAL_STEP, DESIGN_OUTSIDE_VOICES, CODEX_SECOND_OPINION, CODEX_PLAN_REVIEW, GBRAIN_* (these expand to Claude `subagent_type` blocks that don't translate)
   - `boundaryInstruction` scoped to FOREIGN home dirs only (`~/.claude`, `~/.codex`, etc.); the repo-local `.claude/skills/` is allowed since Copilot officially reads it.

2. **`feat(hosts): add tool name rewrites for Copilot CLI compatibility`**
   - Comprehensive `toolRewrites` covers 3 patterns per tool: `use the X tool`, `the X tool`, bare `X tool` (catches `(Read tool)`, `(via Agent tool)` parenthesized usages).
   - Mapping: Bash -> bash, Read -> view, Write -> create, Edit -> edit, Agent -> task, Grep -> grep, Glob -> glob, AskUserQuestion -> ask_user.
   - WebSearch is intentionally **not** rewritten (semantically wrong: `web_fetch` retrieves URLs, not searches).
   - Verified post-rewrite: zero `Read tool|Write tool|Bash tool|Agent tool|...` substrings remain in the generated 47k-line `~/.copilot/skills/` tree.

3. **`feat(setup): add --host copilot install support`**
   - `--host copilot` validation, `INSTALL_COPILOT` plumbing, generation step (1e), helper functions `create_copilot_runtime_root` + `link_copilot_skill_dirs`, install dispatcher block (6d).
   - Mirrors the opencode pattern exactly.
   - Verified end-to-end: `./setup --host copilot` linked 43 skills into `~/.copilot/skills/`; `copilot` then shows them under `/skills list`.

4. **`docs(copilot): README install section, gstack-uninstall coverage, docs/COPILOT.md`**
   - README: bumps host count, adds Copilot row to the host table, adds dedicated install subsection (npm/brew/winget) with v1 scope notes.
   - `bin/gstack-uninstall`: adds `~/.copilot/skills/gstack*` to the cleanup block and confirmation prompt (mirrors Kiro).
   - `docs/COPILOT.md`: integration guide with tool-name translation table, v1 scope rationale, custom-instructions location matrix, troubleshooting.

## Differences vs PR #1044

I learned from #1044's groundwork; here are the deltas:

| Concern | #1044 | This PR |
|---|---|---|
| `cliAliases` | `['gh']` | none (the `gh copilot` extension is a different product; this is the standalone `copilot` binary) |
| Tool rewrites | 2 patterns | 3 patterns (adds bare `X tool` to catch `(Read tool)` parenthesized refs) |
| `pair-agent` | not skipped | skipped (depends on Claude streaming) |
| Orchestration resolvers (REVIEW_ARMY etc.) | inherited verbatim | `suppressedResolvers` (Claude `subagent_type` syntax doesn't run on Copilot) |
| `WebSearch` | rewritten to `web_fetch` | intentionally left alone (semantic mismatch) |
| `localSkillRoot` | `.github/skills/gstack` | `.copilot/skills` (avoids creating tracked-by-default git noise; Copilot reads `.copilot/skills/` natively) |
| Branch base | ~32 commits behind main | rebased on current `main` |

## Validation

- `bun run scripts/host-config-export.ts validate` -> "All 11 configs valid"
- `bun test test/host-config.test.ts test/gen-skill-docs.test.ts` -> 455 tests, 0 fail, 5623 expects
- `bun test` (full suite) -> 2217 pass / 8 fail. The 8 failures are pre-existing baseline (doc-inventory cross-check for AGENTS.md/skills.md, ship-version-sync VERSION/pkg drift, `read_secret_to_env` var-name validation, port-detection race tests). **Zero regressions.**
- Real install: `./setup --host copilot` -> 43 skills linked into `~/.copilot/skills/`; `copilot` -> `/skills list` shows them.
- `bun run gen:skill-docs --host all` -> 47074 lines, 541k tokens, no host-specific errors.

## v1 scope (intentional)

This PR ships a focused v1. The following are deferred to a follow-up once Copilot CLI's orchestration story matures:

- Skipped: `/codex`, `/pair-agent` (Claude-streaming-specific).
- Suppressed orchestration resolvers (`/review`, `/qa`, `/plan-*-review`, `/cso`, `/design-*`, `/setup-gbrain`) still install but the Claude `subagent_type` blocks are stripped, so they run as single-pass sessions instead of fan-out reviews. `docs/COPILOT.md` documents this and points users to the Claude or Codex hosts if they need the multi-agent reviews.

## Test plan for reviewers

```bash
git fetch origin pull/<this-pr>/head:copilot-pr && git checkout copilot-pr
bun install
bun test                         # confirm same 8 baseline failures, no new ones
bun run scripts/host-config-export.ts validate   # 11 configs valid
./setup --host copilot           # if you have Copilot CLI installed
ls ~/.copilot/skills/            # 43 entries
copilot                          # then /skills list
```

## Acknowledgements

- Issue #393 reporter and the 5+ commenters who kept the demand visible.
- @sumitgogia for #1044, which validated the declarative direction; if you'd prefer to land this on top of #1044 rebased, I'm happy to coordinate.
- @ridermw for #396 / #487, which clarified the path/tool-name space.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->