### PR TITLE
feat: add Devin as a supported host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/gstack-global-discover
 .openclaw/
 .hermes/
 .gbrain/
+.devin/
 .context/
 extension/.auth.json
 # xterm assets are vendored from npm at build time; not source-of-truth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ gstack/
 │   ├── codex.ts, factory.ts, kiro.ts  # Existing hosts
 │   ├── opencode.ts, slate.ts, cursor.ts, openclaw.ts  # IDE hosts
 │   ├── hermes.ts, gbrain.ts  # Agent runtime hosts
+│   ├── devin.ts  # Cognition Devin
 │   └── index.ts     # Registry: exports all, derives Host type
 ├── scripts/         # Build + DX tooling
 │   ├── gen-skill-docs.ts  # Template → SKILL.md generator (config-driven)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These are conversational skills. Your OpenClaw agent runs them directly via chat
 
 ### Other AI Agents
 
-gstack works on 10 AI coding agents, not just Claude. Setup auto-detects which
+gstack works on 11 AI coding agents, not just Claude. Setup auto-detects which
 agents you have installed:
 
 ```bash
@@ -121,6 +121,7 @@ Or target a specific agent with `./setup --host <name>`:
 | Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |
 | Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |
 | GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |
+| Devin | `--host devin` | `~/.devin/skills/gstack-*/` |
 
 **Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).
 It's one TypeScript config file, zero code changes.

--- a/docs/ADDING_A_HOST.md
+++ b/docs/ADDING_A_HOST.md
@@ -1,7 +1,7 @@
 # Adding a New Host to gstack
 
 gstack uses a declarative host config system. Each supported AI coding agent
-(Claude, Codex, Factory, Kiro, OpenCode, Slate, Cursor, OpenClaw) is defined
+(Claude, Codex, Factory, Kiro, OpenCode, Slate, Cursor, OpenClaw, Devin) is defined
 as a typed TypeScript config object. Adding a new host means creating one file
 and re-exporting it. Zero code changes to the generator, setup, or tooling.
 
@@ -17,6 +17,7 @@ hosts/
 ├── slate.ts         # Slate (Random Labs)
 ├── cursor.ts        # Cursor
 ├── openclaw.ts      # OpenClaw (hybrid: config + adapter)
+├── devin.ts         # Cognition Devin
 └── index.ts         # Registry: imports all, derives Host type
 ```
 
@@ -97,11 +98,11 @@ import myhost from './myhost';
 
 // Add to ALL_HOST_CONFIGS array:
 export const ALL_HOST_CONFIGS: HostConfig[] = [
-  claude, codex, factory, kiro, opencode, slate, cursor, openclaw, myhost
+  claude, codex, factory, kiro, opencode, slate, cursor, openclaw, devin, myhost
 ];
 
 // Add to re-exports:
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, myhost };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, devin, myhost };
 ```
 
 ### 3. Add to .gitignore

--- a/hosts/devin.ts
+++ b/hosts/devin.ts
@@ -1,0 +1,49 @@
+import type { HostConfig } from '../scripts/host-config';
+
+const devin: HostConfig = {
+  name: 'devin',
+  displayName: 'Devin',
+  cliCommand: 'devin',
+  cliAliases: [],
+
+  globalRoot: '.devin/skills/gstack',
+  localSkillRoot: '.devin/skills/gstack',
+  hostSubdir: '.devin',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: null,
+  },
+
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.devin/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.devin/skills/gstack' },
+    { from: '.claude/skills', to: '.devin/skills' },
+  ],
+
+  suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
+
+  runtimeRoot: {
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalFiles: {
+      'review': ['checklist.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  coAuthorTrailer: 'Co-Authored-By: Devin <devin@cognition.ai>',
+  learningsMode: 'basic',
+};
+
+export default devin;

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,10 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import devin from './devin';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, devin];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, devin };

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2916,7 +2916,7 @@ describe('plan-mode-info resolver (handshake-replacement)', () => {
     // Non-Claude hosts render to hostSubdirs (.agents/, .openclaw/, etc). The
     // plan-mode-info resolver has no host-scoping — all hosts get the new
     // section, none get the old handshake. Scan all candidate host dirs.
-    const hostDirs = ['.agents', '.openclaw', '.opencode', '.factory', '.hermes', '.kiro', '.cursor', '.slate'];
+    const hostDirs = ['.agents', '.openclaw', '.opencode', '.factory', '.hermes', '.kiro', '.cursor', '.slate', '.devin'];
     let checked = 0;
     for (const host of hostDirs) {
       const skillsRoot = path.join(ROOT, host, 'skills');

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -22,6 +22,7 @@ import {
   slate,
   cursor,
   openclaw,
+  devin,
 } from '../hosts/index';
 import { HOST_PATHS } from '../scripts/resolvers/types';
 
@@ -30,8 +31,8 @@ const ROOT = path.resolve(import.meta.dir, '..');
 // ─── hosts/index.ts ─────────────────────────────────────────
 
 describe('hosts/index.ts', () => {
-  test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+  test('ALL_HOST_CONFIGS has 11 hosts', () => {
+    expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {
@@ -53,6 +54,7 @@ describe('hosts/index.ts', () => {
     expect(slate.name).toBe('slate');
     expect(cursor.name).toBe('cursor');
     expect(openclaw.name).toBe('openclaw');
+    expect(devin.name).toBe('devin');
   });
 
   test('getHostConfig returns correct config', () => {


### PR DESCRIPTION
## Summary

- Adds Cognition Devin as the 11th supported AI coding agent via the declarative host config system.
- Pure config addition: new `hosts/devin.ts` + registry/test/doc updates, zero generator changes.
- Generates 49 SKILL.md outputs under `.devin/skills/gstack-*/` with no `.claude/skills` path leakage.

## Changes

- `hosts/devin.ts` — new config (cursor/slate-pattern). `cliCommand: 'devin'`, paths `~/.devin/skills/gstack`, basic learnings, Devin co-author trailer.
- `hosts/index.ts` — devin import + `ALL_HOST_CONFIGS` + re-export.
- `.gitignore` — adds `.devin/`.
- `README.md` — count 10 → 11, install table row.
- `CLAUDE.md` — host tree note.
- `docs/ADDING_A_HOST.md` — supported-host list updated.
- `test/host-config.test.ts` — count 10 → 11, devin import + name check.
- `test/gen-skill-docs.test.ts` — `.devin` in `hostDirs` for cross-host handshake-absence check.

## Test plan

- [x] `bun run scripts/host-config-export.ts validate` → "All 11 configs valid"
- [x] `bun run gen:skill-docs --host devin` → 49 SKILL.md generated, no `.claude/skills` leakage
- [x] `bun run gen:skill-docs --host all` → all hosts regenerate clean
- [x] `bun test test/host-config.test.ts` → 73 pass
- [x] `bun test test/gen-skill-docs.test.ts` → 380 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->