### PR TITLE
fix: Korean/CJK IME input and rendering in Sidebar Terminal

### DIFF
--- a/browse/src/terminal-agent.ts
+++ b/browse/src/terminal-agent.ts
@@ -361,8 +361,26 @@ function buildServer() {
         // Binary input. Lazy-spawn claude on the first byte.
         if (!session.spawned) {
           session.spawned = true;
+          // UTF-8 boundary detection to prevent splitting multi-byte characters (issue #1272).
+          // Buffer incomplete UTF-8 sequences until the next chunk completes them.
+          let leftover = Buffer.alloc(0);
           const proc = spawnClaude(session.cols, session.rows, (chunk) => {
-            try { ws.sendBinary(chunk); } catch {}
+            const combined = Buffer.concat([leftover, Buffer.from(chunk)]);
+            // Find the last index where a UTF-8 codepoint ends. Look back at most 3 bytes.
+            let safeEnd = combined.length;
+            for (let i = combined.length - 1; i >= Math.max(0, combined.length - 3); i--) {
+              const b = combined[i];
+              if ((b & 0x80) === 0) { safeEnd = i + 1; break; }              // ASCII
+              if ((b & 0xC0) === 0x80) continue;                             // continuation byte
+              const expected = (b & 0xE0) === 0xC0 ? 2 : (b & 0xF0) === 0xE0 ? 3 : 4;
+              safeEnd = (combined.length - i >= expected) ? combined.length : i;
+              break;
+            }
+            const flush = combined.slice(0, safeEnd);
+            leftover = combined.slice(safeEnd);
+            if (flush.length) {
+              try { ws.sendBinary(flush); } catch {}
+            }
           });
           if (!proc) {
             try {

--- a/extension/sidepanel-terminal.js
+++ b/extension/sidepanel-terminal.js
@@ -154,7 +154,7 @@
   function ensureXterm() {
     if (term) return;
     term = new Terminal({
-      fontFamily: '"JetBrains Mono", "SF Mono", Menlo, monospace',
+      fontFamily: '"JetBrains Mono", "SF Mono", Menlo, "Noto Sans Mono CJK KR", "Malgun Gothic", monospace',
       fontSize: 13,
       theme: { background: '#0a0a0a', foreground: '#e5e5e5' },
       cursorBlink: true,
@@ -196,7 +196,25 @@
     });
     ro.observe(els.mount);
 
+    // IME composition handling for Korean/CJK input (issue #1272).
+    // Suppress partial jamo during composition; only send the final
+    // composed string on compositionend. Without this, Korean IME
+    // sends fragmented input or doubles characters.
+    let composing = false;
+    const ta = term.textarea;
+    if (ta) {
+      ta.addEventListener('compositionstart', () => { composing = true; });
+      ta.addEventListener('compositionend', (e) => {
+        composing = false;
+        if (e.data && ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(new TextEncoder().encode(e.data));
+        }
+      });
+    }
+
+
     term.onData((data) => {
+      if (composing) return;  // suppress partial input events during IME composition
       if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send(new TextEncoder().encode(data));
       }

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -38,7 +38,7 @@
 
   /* Typography */
   --font-system: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  --font-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', 'Noto Sans Mono CJK KR', 'Malgun Gothic', monospace;
 
   /* Radius */
   --radius-sm: 4px;


### PR DESCRIPTION
## Summary

Fixes #1272 - Korean/CJK IME input and rendering issues in Sidebar Terminal

Special thanks to @ldybob for the excellent root cause analysis and proposed solutions.

## Problem

The Sidebar Terminal had **three separate Korean/CJK bugs**:

1. **IME Input**: Korean text typed via IME composition was not reaching the PTY correctly
2. **Font Rendering**: Korean characters appeared fragmented or overlapping due to missing CJK font fallbacks
3. **UTF-8 Splitting**: Multi-byte UTF-8 characters were being split across WebSocket chunks, causing garbled output

## Changes

### Bug 1: IME Composition Handling
- Added `compositionstart`/`compositionend` event listeners in `extension/sidepanel-terminal.js`
- Suppresses partial jamo fragments during composition
- Only sends the final composed string on `compositionend`
- Prevents doubled or fragmented input

### Bug 2a: CJK Font Fallback
- Updated `fontFamily` in `extension/sidepanel-terminal.js` to include `"Noto Sans Mono CJK KR"` and `"Malgun Gothic"`
- Updated `--font-mono` CSS variable in `extension/sidepanel.css` with the same fonts
- Ensures consistent cell-width calculations for Korean characters
- Prevents character overlap and cursor misalignment

### Bug 2b: UTF-8 Boundary Detection
- Added buffering logic in `browse/src/terminal-agent.ts` to prevent splitting multi-byte UTF-8 characters
- Detects UTF-8 sequence boundaries and buffers incomplete sequences until the next chunk
- Follows the same pattern as PR #1007 which fixed the `sidebar-agent` path
- Extends the fix to the `terminal-agent` path (which was missed in #1007)

## Testing

✅ Korean input via IME now works correctly  
✅ Korean output renders without garbled characters  
✅ English input/output still works as expected  
✅ Cursor positioning is correct for mixed English/Korean text

## Impact

This fix enables Korean and other CJK developers using gstack on WSL2/Windows to fully use the Sidebar Terminal in their native language. Both input and output now work correctly.