### PR TITLE
feat(nim): Add NVIDIA NIM integration skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Invoke them by name (e.g., `/office-hours`).
 |-------|-------------|
 | `/review` | Pre-landing PR review. Finds bugs that pass CI but break in prod. |
 | `/codex` | Second opinion via OpenAI Codex. Review, challenge, or consult modes. |
+| `/nim` | Route through NVIDIA NIM instead of Anthropic. Use your own models. |
 | `/investigate` | Systematic root-cause debugging. No fixes without investigation. |
 | `/design-review` | Live-site visual audit + fix loop with atomic commits. |
 | `/design-shotgun` | Generate multiple AI design variants, comparison board, iterate. |

--- a/nim/SKILL.md
+++ b/nim/SKILL.md
@@ -2,65 +2,88 @@
 
 > Route current task through NVIDIA NIM instead of Anthropic
 
-Use this when you want to use your own NIM models (via OpenClaude proxy) instead of Claude Code's default Anthropic models.
+Use this when you want to use your own NIM models instead of Claude Code's default Anthropic models.
 
 ## When
 
-- **Cost savings**: You're running on your own GPU/API
-- **Privacy**: Don't want to send data to Anthropic  
-- **Specific models**: Use NIM-only models (GLM, Llama, Vision)
+- **Cost savings**: Your GPU / API (not per-token)
+- **Privacy**: Data stays local, not sent to Anthropic  
+- **Specific models**: Use NIM-exclusive models (GLM, Llama, Vision)
 - **Testing**: Compare NIM vs Claude outputs
+- **Custom models**: Fine-tuned or private models
 
-## Setup Required
+## Setup (One-Time)
 
 ```bash
-# One-time setup
+# Clone OpenClaude
 git clone https://github.com/Hanishchow/OpenClaude.git ~/OpenClaude
 cd ~/OpenClaude
+
+# Add your NVIDIA API key
+cp config/env.example config/.env
+# Edit .env and add: NVIDIA_NIM_API_KEY=your-key
+
+# Start the proxy
 ./scripts/start.sh
 
-# Test it works
-~/OpenClaude/cli/nim-chat.sh "test"
+# Test
+~/OpenClaude/cli/nim-chat.sh "hello"
 ```
 
-## How It Works
+Get your free NVIDIA API key at: https://build.nvidia.com/settings/api-keys
 
-1. Routes through local proxy at `localhost:8082`
-2. Proxy forwards to NVIDIA NIM (`integrate.api.nvidia.com`)
-3. Response streaming returned in SSE format
+## Architecture
+
+```
+Claude Code → OpenClaude Proxy (localhost:8082) → NVIDIA NIM → Your Models
+```
 
 ## Models Available
 
 | Model | Best For |
 |-------|----------|
-| `z-ai/glm-4.7` | General chat |
+| `z-ai/glm-4.7` | General chat (default) |
 | `meta/llama-3.1-70b-instruct` | Fast responses |
-| `deepseek-ai/deepseek-coder-v2` | Code/debug tasks |
+| `deepseek-ai/deepseek-coder-v2` | Code, debugging |
 | `nvidia/vision` | Image understanding |
 
-## Workflow
+## Usage
 
-1. Activate this skill: `@nim`
-2. Your task will be routed through NIM instead of Anthropic
-3. See the response in your terminal
+```bash
+# Chat with NIM
+~/OpenClaude/cli/nim-chat.sh "Your prompt"
 
-## Requirements
+# Auto-route to best model
+~/OpenClaude/cli/nim-route.sh "description"
 
-- NVIDIA API key (https://build.nvidia.com/settings/api-keys)
-- OpenClaude proxy running (`./scripts/start.sh`)
-- Or use existing CLI: `~/OpenClaude/cli/nim-chat.sh "prompt"`
+# List available models
+~/OpenClaude/cli/nim-models.sh
 
-## Notes
-
-- **Slow first start**: Proxy cold-starts ~5s
-- **Response quality**: May differ from Claude
-- **Tool support**: Limited vs Claude (no computer use, etc.)
-- **Streaming**: Responses stream in real-time
-
-## Examples
-
+# Or use the skill in Claude Code:
+@nim Explain quantum computing
 ```
-@nim Explain quantum computing simply
-@nim Write a Python function for Fibonacci
-@nim Compare this code to NIM vs Claude output
+
+## Comparison
+
+| Feature | Claude (Anthropic) | NIM (This) |
+|---------|-------------------|-------------|
+| Cost | Per-token | Your GPU/API |
+| Privacy | Sends to cloud | Local option |
+| Models | Claude only | Any NIM model |
+| Tools | Full support | Limited |
+| Speed | Fast | Depends on GPU |
+
+## Troubleshooting
+
+**Proxy not running:**
+```bash
+~/OpenClaude/scripts/start.sh
 ```
+
+**API key issues:**
+- Get key from https://build.nvidia.com/settings/api-keys
+- Add to ~/OpenClaude/config/.env
+
+**Model not found:**
+- Some models require acceptance on NVIDIA build
+- Check available models: ~/OpenClaude/cli/nim-models.sh

--- a/nim/SKILL.md
+++ b/nim/SKILL.md
@@ -1,0 +1,66 @@
+# @nim
+
+> Route current task through NVIDIA NIM instead of Anthropic
+
+Use this when you want to use your own NIM models (via OpenClaude proxy) instead of Claude Code's default Anthropic models.
+
+## When
+
+- **Cost savings**: You're running on your own GPU/API
+- **Privacy**: Don't want to send data to Anthropic  
+- **Specific models**: Use NIM-only models (GLM, Llama, Vision)
+- **Testing**: Compare NIM vs Claude outputs
+
+## Setup Required
+
+```bash
+# One-time setup
+git clone https://github.com/Hanishchow/OpenClaude.git ~/OpenClaude
+cd ~/OpenClaude
+./scripts/start.sh
+
+# Test it works
+~/OpenClaude/cli/nim-chat.sh "test"
+```
+
+## How It Works
+
+1. Routes through local proxy at `localhost:8082`
+2. Proxy forwards to NVIDIA NIM (`integrate.api.nvidia.com`)
+3. Response streaming returned in SSE format
+
+## Models Available
+
+| Model | Best For |
+|-------|----------|
+| `z-ai/glm-4.7` | General chat |
+| `meta/llama-3.1-70b-instruct` | Fast responses |
+| `deepseek-ai/deepseek-coder-v2` | Code/debug tasks |
+| `nvidia/vision` | Image understanding |
+
+## Workflow
+
+1. Activate this skill: `@nim`
+2. Your task will be routed through NIM instead of Anthropic
+3. See the response in your terminal
+
+## Requirements
+
+- NVIDIA API key (https://build.nvidia.com/settings/api-keys)
+- OpenClaude proxy running (`./scripts/start.sh`)
+- Or use existing CLI: `~/OpenClaude/cli/nim-chat.sh "prompt"`
+
+## Notes
+
+- **Slow first start**: Proxy cold-starts ~5s
+- **Response quality**: May differ from Claude
+- **Tool support**: Limited vs Claude (no computer use, etc.)
+- **Streaming**: Responses stream in real-time
+
+## Examples
+
+```
+@nim Explain quantum computing simply
+@nim Write a Python function for Fibonacci
+@nim Compare this code to NIM vs Claude output
+```

--- a/nim/env.example
+++ b/nim/env.example
@@ -1,0 +1,19 @@
+# OpenClaude Environment Configuration
+# Copy this file to config/.env and add your API keys
+
+# Required: Your NVIDIA API key
+# Get it from https://build.nvidia.com/settings/api-keys
+NVIDIA_NIM_API_KEY=your_nvidia_api_key_here
+
+# Optional: NIM endpoint (default: NVIDIA hosted)
+# For local NIM: http://localhost:8000/v1
+NIM_BASE_URL=https://integrate.api.nvidia.com/v1
+
+# Optional: Free Claude Code proxy port
+FCC_PORT=8082
+
+# Optional: Maximum tokens to generate
+MAX_TOKENS=4096
+
+# Optional: Default model
+NIM_MODEL=claude-sonnet-4-20250514

--- a/nim/nim-chat.sh
+++ b/nim/nim-chat.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+#
+# OpenClaude CLI - Chat with NIM models
+#
+# Usage: nim-chat.sh "Your prompt here"
+#
+
+set -euo pipefail
+
+# Load config
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Source config if exists
+if [ -f "$PROJECT_ROOT/config/.env" ]; then
+  set -a
+  source "$PROJECT_ROOT/config/.env"
+  set +a
+fi
+
+# Defaults
+FCC_URL="${FCC_URL:-http://127.0.0.1:8082}"
+FCC_PORT="${FCC_PORT:-8082}"
+NIM_API_KEY="${NVIDIA_NIM_API_KEY:-}"
+NIM_BASE_URL="${NIM_BASE_URL:-https://integrate.api.nvidia.com/v1}"
+MODEL="${NIM_MODEL:-claude-sonnet-4-20250514}"
+MAX_TOKENS="${MAX_TOKENS:-4096}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+  echo -e "${GREEN}[INFO]${NC} $*"
+}
+
+log_error() {
+  echo -e "${RED}[ERROR]${NC} $*" >&2
+}
+
+log_warn() {
+  echo -e "${YELLOW}[WARN]${NC} $*"
+}
+
+check_dependencies() {
+  local missing=()
+  
+  for cmd in curl jq; do
+    if ! command -v "$cmd" &> /dev/null; then
+      missing+=("$cmd")
+    fi
+  done
+  
+  if [ ${#missing[@]} -gt 0 ]; then
+    log_error "Missing dependencies: ${missing[*]}"
+    log_error "Install with: apt install curl jq"
+    exit 1
+  fi
+}
+
+check_fcc_running() {
+  if ! curl -s --max-time 2 "$FCC_URL/health" &> /dev/null; then
+    log_error "OpenClaude proxy not running at $FCC_URL"
+    log_error "Start with: ./scripts/start.sh"
+    exit 1
+  fi
+}
+
+check_config() {
+  if [ -z "$NIM_API_KEY" ]; then
+    log_error "NVIDIA_NIM_API_KEY not set"
+    log_error "Copy config/env.example to config/.env and add your API key"
+    exit 1
+  fi
+}
+
+start_fcc() {
+  if curl -s --max-time 2 "$FCC_URL/health" &> /dev/null; then
+    log_info "OpenClaude proxy already running"
+    return 0
+  fi
+  
+  log_info "Starting OpenClaude proxy..."
+  cd "$PROJECT_ROOT"
+  
+  # Check for virtual environment
+  if [ -d ".venv" ]; then
+    source .venv/bin/activate
+  fi
+  
+  # Start in background
+  nohup uvicorn server:app --host 127.0.0.1 --port "$FCC_PORT" &> /tmp/fcc.log 2>&1 &
+  local fcc_pid=$!
+  
+  # Wait for startup
+  local retries=10
+  while [ $retries -gt 0 ]; do
+    if curl -s --max-time 2 "$FCC_URL/health" &> /dev/null; then
+      log_info "OpenClaude proxy started (PID: $fcc_pid)"
+      return 0
+    fi
+    sleep 1
+    ((retries--))
+  done
+  
+  log_error "Failed to start OpenClaude proxy"
+  log_error "Check /tmp/fcc.log for details"
+  exit 1
+}
+
+send_message() {
+  local prompt="$1"
+  
+  curl -s -N -X POST "$FCC_URL/v1/messages" \
+    -H "Content-Type: application/json" \
+    -H "x-provider: nvidia_nim" \
+    -d "{
+      \"model\": \"$MODEL\",
+      \"messages\": [{\"role\": \"user\", \"content\": \"$prompt\"}],
+      \"max_tokens\": $MAX_TOKENS,
+      \"stream\": true
+    }" 2>&1 | while IFS= read -r line; do
+      # Parse SSE events
+      if echo "$line" | grep -q '^data:'; then
+        local data
+        data=$(echo "$line" | sed 's/^data: //')
+        local type
+        type=$(echo "$data" | jq -r '.type' 2>/dev/null)
+        
+        case "$type" in
+          "text_delta")
+            echo "$data" | jq -r '.delta.text // empty' 2>/dev/null
+            ;;
+          "content_block_delta")
+            local content_type
+            content_type=$(echo "$data" | jq -r '.delta.type' 2>/dev/null)
+            if [ "$content_type" = "thinking_delta" ]; then
+              # Skip thinking for cleaner output
+              :
+            else
+              echo "$data" | jq -r '.delta.text // empty' 2>/dev/null
+            fi
+            ;;
+          "message_start"|"content_block_start"|"content_block_stop"|"message_delta"|"message_stop")
+            # Skip metadata
+            ;;
+        esac
+      fi
+    done
+}
+
+show_help() {
+  cat << EOF
+OpenClaude - Chat with NIM models via Claude Code proxy
+
+Usage: $(basename "$0") [OPTIONS] "Your prompt"
+
+Options:
+  -m, --model MODEL    Model to use (default: $MODEL)
+  -t, --tokens N       Max tokens (default: $MAX_TOKENS)
+  -s, --stream         Enable streaming output
+  -h, --help          Show this help
+  -s, --start         Start the proxy first
+
+Examples:
+  $(basename "$0") "Say hello"
+  $(basename "$0") -m z-ai/glm-4.7 "Explain quantum computing"
+  $(basename "$0") --start "What is the weather?"
+
+EOF
+}
+
+main() {
+  local start_first=false
+  local custom_model=""
+  local custom_tokens=""
+  
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        show_help
+        exit 0
+        ;;
+      -s|--start)
+        start_first=true
+        shift
+        ;;
+      -m|--model)
+        custom_model="$2"
+        shift 2
+        ;;
+      -t|--tokens)
+        custom_tokens="$2"
+        shift 2
+        ;;
+      -*)
+        log_error "Unknown option: $1"
+        show_help
+        exit 1
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  
+  local prompt="${1:-}"
+  
+  if [ -z "$prompt" ]; then
+    log_error "Please provide a prompt"
+    show_help
+    exit 1
+  fi
+  
+  # Apply overrides
+  [ -n "$custom_model" ] && MODEL="$custom_model"
+  [ -n "$custom_tokens" ] && MAX_TOKENS="$custom_tokens"
+  
+  # Setup
+  check_dependencies
+  check_config
+  
+  if [ "$start_first" = true ]; then
+    start_fcc
+  else
+    check_fcc_running
+  fi
+  
+  # Send message
+  send_message "$prompt"
+}
+
+main "$@"

--- a/nim/nim-models.sh
+++ b/nim/nim-models.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# OpenClaude - List available NIM models
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Source config
+if [ -f "$PROJECT_ROOT/config/.env" ]; then
+  set -a
+  source "$PROJECT_ROOT/config/.env"
+  set +a
+fi
+
+NIM_BASE_URL="${NIM_BASE_URL:-https://integrate.api.nvidia.com/v1}"
+NIM_API_KEY="${NVIDIA_NIM_API_KEY:-}"
+
+if [ -z "$NIM_API_KEY" ]; then
+  echo "Error: NVIDIA_NIM_API_KEY not set"
+  echo "Copy config/env.example to config/.env and add your API key"
+  exit 1
+fi
+
+echo "Fetching available models..."
+echo ""
+
+curl -s "$NIM_BASE_URL/models" \
+  -H "Authorization: Bearer $NIM_API_KEY" \
+  -H "Content-Type: application/json" 2>/dev/null | jq -r '.data[]?.id // .models[]?.id' 2>/dev/null | grep -v "^$" | head -20 || echo "Error fetching models. Check your API key."

--- a/nim/nim-route.sh
+++ b/nim/nim-route.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# OpenClaude - Route to optimal NIM model
+#
+# Usage: nim-route.sh "description of task"
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Source config if exists
+if [ -f "$PROJECT_ROOT/config/.env" ]; then
+  set -a
+  source "$PROJECT_ROOT/config/.env"
+  set +a
+fi
+
+NIM_BASE_URL="${NIM_BASE_URL:-https://integrate.api.nvidia.com/v1}"
+NIM_API_KEY="${NVIDIA_NIM_API_KEY:-}"
+
+show_help() {
+  cat << EOF
+OpenClaude Model Router
+
+Usage: $(basename "$0") "description of task"
+
+Routes to optimal model based on task complexity:
+- vision: Image understanding (screenshots, diagrams)
+- fast: Simple tasks (< 200 chars)
+- deep: Complex reasoning (> 2000 chars or debug/complex)
+
+Models available:
+- meta/llama-3.1-70b-instruct (fast)
+- nvidia/vision (vision)
+- deepseek-ai/deepseek-coder-v2 (deep)
+
+EOF
+}
+
+route_model() {
+  local prompt="$1"
+  local len=$(echo "$prompt" | wc -c)
+  
+  # Vision tasks
+  if echo "$prompt" | grep -qiE "image|screenshot|photo| picture|vision|diagram|chart|graph"; then
+    echo "nvidia/vision"
+    return
+  fi
+  
+  # Deep reasoning
+  if [ "$len" -gt 2000 ]; then
+    echo "deepseek-ai/deepseek-coder-v2"
+    return
+  fi
+  
+  if echo "$prompt" | grep -qiE "debug|complex|architect|design|analyze|explain.*detailed"; then
+    echo "deepseek-ai/deepseek-coder-v2"
+    return
+  fi
+  
+  # Fast/simple
+  echo "meta/llama-3.1-70b-instruct"
+}
+
+# Parse arguments
+case "${1:-}" in
+  -h|--help|"")
+    show_help
+    exit 0
+    ;;
+  *)
+    route_model "$1"
+    ;;
+esac

--- a/nim/start.sh
+++ b/nim/start.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+#
+# OpenClaude - Start the proxy
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+LOG_FILE="/tmp/openclaude.log"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[OpenClaude]${NC} $*"; }
+warn() { echo -e "${YELLOW}[OpenClaude]${NC} $*"; }
+error() { echo -e "${RED}[OpenClaude]${NC} $*" >&2; }
+
+setup() {
+  cd "$PROJECT_ROOT"
+  
+  # Check Python
+  if ! command -v python3 &> /dev/null; then
+    error "Python 3 not found"
+    exit 1
+  fi
+  
+  # Check for uv
+  if command -v uv &> /dev/null; then
+    if [ ! -d ".venv" ]; then
+      log "Creating virtual environment..."
+      uv venv
+    fi
+  else
+    warn "uv not found, using system Python"
+  fi
+  
+  # Install dependencies
+  if [ -d ".venv" ]; then
+    log "Installing dependencies..."
+    source .venv/bin/activate
+    uv pip install -e . 2>/dev/null || pip install -e . 2>/dev/null || true
+  fi
+}
+
+start() {
+  cd "$PROJECT_ROOT"
+  
+  # Check if already running
+  if curl -s --max-time 2 http://127.0.0.1:8082/health &> /dev/null; then
+    log "Proxy already running on http://127.0.0.1:8082"
+    return 0
+  fi
+  
+  # Load env
+  if [ -f ".env" ]; then
+    set -a
+    source .env
+    set +a
+  fi
+  
+  # Start proxy
+  log "Starting OpenClaude proxy..."
+  
+  if [ -d ".venv" ]; then
+    source .venv/bin/activate
+  fi
+  
+  nohup uvicorn server:app --host 127.0.0.1 --port 8082 &>> "$LOG_FILE" 2>&1 &
+  local pid=$!
+  
+  # Wait for startup
+  local retries=15
+  while [ $retries -gt 0 ]; do
+    if curl -s --max-time 2 http://127.0.0.1:8082/health &> /dev/null; then
+      log "Proxy started (PID: $pid)"
+      log "Health: http://127.0.0.1:8082/health"
+      log "API: http://127.0.0.1:8082/v1/messages"
+      return 0
+    fi
+    sleep 1
+    ((retries--))
+  done
+  
+  error "Failed to start proxy"
+  error "Check $LOG_FILE for details"
+  tail -20 "$LOG_FILE"
+  exit 1
+}
+
+stop() {
+  local pid
+  pid=$(pgrep -f "uvicorn server:app" | head -1)
+  
+  if [ -n "$pid" ]; then
+    log "Stopping proxy (PID: $pid)..."
+    kill "$pid" 2>/dev/null || true
+    sleep 1
+    log "Proxy stopped"
+  else
+    warn "Proxy not running"
+  fi
+}
+
+status() {
+  if curl -s --max-time 2 http://127.0.0.1:8082/health &> /dev/null; then
+    log "Proxy running on http://127.0.0.1:8082"
+    curl -s http://127.0.0.1:8082/health | jq -r '.status, .version' 2>/dev/null || echo "Status: healthy"
+    return 0
+  else
+    error "Proxy not running"
+    return 1
+  fi
+}
+
+restart() {
+  stop
+  sleep 1
+  start
+}
+
+case "${1:-start}" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart)
+    restart
+    ;;
+  status)
+    status
+    ;;
+  setup)
+    setup
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status|setup}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Add @nim skill to route Claude Code through NVIDIA NIM instead of Anthropic.

## Changes

- New `@nim` skill for NIM routing
- CLI tools: nim-chat.sh, nim-route.sh, nim-models.sh
- Support for z-ai/glm-4.7, llama, deepseek, vision models

## Why

- Cost savings (use your own GPU/API)
- Privacy (don't send data to Anthropic)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->