### PR TITLE
fix(browse): declare lastConsoleFlushed to restore console-log persistence

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -324,6 +324,7 @@ const DIALOG_LOG_PATH = config.dialogLog;
 // terminal-agent.ts; chat queue + per-tab agent multiplexing are no
 // longer needed.
 
+let lastConsoleFlushed = 0;
 let lastNetworkFlushed = 0;
 let lastDialogFlushed = 0;
 let flushInProgress = false;

--- a/browse/test/server-flush-trackers.test.ts
+++ b/browse/test/server-flush-trackers.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression: flushBuffers state-tracker declaration audit.
+ *
+ * `flushBuffers()` (server.ts) maintains per-buffer cursors so it only
+ * appends *new* entries to each on-disk log on every interval tick:
+ *
+ *   const newConsoleCount  = consoleBuffer.totalAdded  - lastConsoleFlushed;
+ *   const newNetworkCount  = networkBuffer.totalAdded  - lastNetworkFlushed;
+ *   const newDialogCount   = dialogBuffer.totalAdded   - lastDialogFlushed;
+ *
+ * The trackers must be declared with `let X = 0;` at module scope so the
+ * subtraction returns a real number on the first tick. If a tracker is
+ * referenced inside flushBuffers but never declared at module scope, the
+ * interval throws `ReferenceError: X is not defined` every second — the
+ * throw is swallowed by the catch at the bottom of flushBuffers (logged
+ * as `[browse] Buffer flush failed: <name> is not defined`), the
+ * corresponding on-disk log file is *never written*, and the regression
+ * is silent in production.
+ *
+ * This source-level guard catches that exact class of regression — a
+ * future flush-perf refactor that adds a fourth buffer cursor (or a
+ * future contributor that copy-pastes the `last*Flushed` pattern without
+ * the matching declaration) will fail this test before it ships.
+ *
+ * Pattern matches `terminal-agent.test.ts` and `dual-listener.test.ts`:
+ * read source as text, assert an invariant, no daemon required.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+
+const SERVER_TS = readFileSync(
+  path.resolve(import.meta.dir, '../src/server.ts'),
+  'utf-8',
+);
+
+describe('server.ts — flushBuffers tracker declarations', () => {
+  test('every `last*Flushed` tracker referenced inside flushBuffers is declared at module scope', () => {
+    // Locate the flushBuffers function body. The function is `async function
+    // flushBuffers() { ... }` — match through the closing brace at the start
+    // of a line (one-level-deep function in the file).
+    const fnMatch = SERVER_TS.match(
+      /async function flushBuffers\([^)]*\)[^{]*\{([\s\S]*?)\n\}/,
+    );
+    expect(fnMatch, 'flushBuffers function not found in server.ts').not.toBeNull();
+    const body = fnMatch![1]!;
+
+    // Pull every identifier matching the `lastXxxFlushed` cursor pattern.
+    const trackerMatches = [...body.matchAll(/\blast([A-Z]\w+)Flushed\b/g)];
+    const trackers = Array.from(new Set(trackerMatches.map((m) => `last${m[1]}Flushed`)));
+
+    expect(
+      trackers.length,
+      'flushBuffers should reference at least one last*Flushed tracker',
+    ).toBeGreaterThan(0);
+
+    for (const tracker of trackers) {
+      // Module-level `let X = 0;` declaration (not inside a function body).
+      // Anchored start-of-line to avoid matching nested re-declarations or
+      // string literals.
+      const declared = new RegExp(
+        `(?:^|\\n)let\\s+${tracker}\\s*=\\s*0\\s*;`,
+      ).test(SERVER_TS);
+      expect(
+        declared,
+        `\`${tracker}\` is referenced inside flushBuffers but never declared at module scope ` +
+          `with \`let ${tracker} = 0;\` — the interval will throw ReferenceError every tick ` +
+          `and the corresponding on-disk log will never be written`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`flushBuffers()` (server.ts:331) maintains a per-buffer cursor for console / network / dialog so it only appends *new* entries to each on-disk log on every interval tick. The console cursor is referenced + assigned in the function body — but the matching `let lastConsoleFlushed = 0;` declaration is missing. Only the network and dialog siblings are declared at lines 327-328.

Result: every 1-second `flushBuffers` tick (line 376) throws `ReferenceError: lastConsoleFlushed is not defined`, gets swallowed by the catch at line 369 (`[browse] Buffer flush failed: …`), and the console branch's append never runs. **`browse-console.log` is never written in any production deployment since this regressed.**

## Root cause

Regression introduced by [`1a100a2a`](https://github.com/garrytan/gstack/commit/1a100a2a) "fix: eliminate duplicate command sets in chain, improve flush perf and type safety" — the flush refactor switched from `Bun.write` to `fs.appendFileSync` and added the `lastConsoleFlushed` cursor pattern alongside its network/dialog siblings, but missed the matching `let` declaration. Tests don't currently exercise `flushBuffers`, so the regression shipped silently.

## How it surfaced

Found while stress-testing the daemon with 15 concurrent CLIs against cold state. The race surfaced this in one spawned daemon's stderr:

```
[browse] Buffer flush failed: lastConsoleFlushed is not defined
[browse] Buffer flush failed: lastConsoleFlushed is not defined
…repeated every second indefinitely
```

Verified by running the daemon against a real `file://` page with `console.log` events:
- in-memory `./browse console` correctly returns the captured entries
- `.gstack/browse-console.log` is **never created on disk**

After the fix, the same flow produces a 163-byte log file with the expected entries.

## Fix

```diff
+let lastConsoleFlushed = 0;
 let lastNetworkFlushed = 0;
 let lastDialogFlushed = 0;
 let flushInProgress = false;
```

One line. Same pattern as the existing siblings.

## Regression test

Added `browse/test/server-flush-trackers.test.ts` — a source-level guard following the [`terminal-agent.test.ts`](browse/test/terminal-agent.test.ts) and [`dual-listener.test.ts`](browse/test/dual-listener.test.ts) pattern (read source as text, assert invariant, no daemon required).

The test extracts every `last*Flushed` identifier referenced inside `flushBuffers()` and asserts each one has a matching `let X = 0;` declaration at module scope. Catches the exact regression class — any future flush-perf refactor that adds a fourth buffer cursor (or copy-pastes the pattern without the matching declaration) will fail this before it ships.

The failure message is intentionally specific so a future contributor sees the fix path without reading the test:

> `\`lastConsoleFlushed\` is referenced inside flushBuffers but never declared at module scope with \`let lastConsoleFlushed = 0;\` — the interval will throw ReferenceError every tick and the corresponding on-disk log will never be written`

## Test plan

- [x] New regression test fails on current `main` (verified before the fix), passes with the fix
- [x] `bun test browse/test/server-flush-trackers.test.ts` — 1 pass / 0 fail
- [x] `bun run build` — clean rebuild of all binaries
- [x] Manual smoke — spawn daemon → `goto file://` page with `console.log` → wait 4s for flush interval → `.gstack/browse-console.log` now exists with the expected entries (163 bytes vs zero file before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->