### PR TITLE
fix: make gbrain full sync source-aware

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -7,7 +7,8 @@
  *   1. Code (current repo)         → `gbrain sources add` (idempotent via
  *                                    lib/gbrain-sources.ts) + `gbrain sync
  *                                    --strategy code` (incremental) or
- *                                    `gbrain reindex-code --yes` (--full).
+ *                                    `gbrain sync --full --strategy code`
+ *                                    (--full first-run/full refresh).
  *                                    NEVER `gbrain import` (markdown only).
  *   2. Transcripts + curated memory → gstack-memory-ingest (typed put_page)
  *   3. Curated artifacts to git    → gstack-brain-sync (existing pipeline)
@@ -33,6 +34,7 @@ import { existsSync, statSync, mkdirSync, writeFileSync, readFileSync, unlinkSyn
 import { join, dirname } from "path";
 import { execSync, execFileSync, spawnSync } from "child_process";
 import { homedir } from "os";
+import { createHash } from "crypto";
 
 import { detectEngineTier, withErrorContext, canonicalizeRemote } from "../lib/gstack-memory-helpers";
 import { sourcePageCount } from "../lib/gbrain-sources";
@@ -43,6 +45,8 @@ type Mode = "incremental" | "full" | "dry-run";
 
 interface CliArgs {
   mode: Mode;
+  /** True when --full was requested, even if --dry-run later changes mode to dry-run. */
+  full: boolean;
   quiet: boolean;
   noCode: boolean;
   noMemory: boolean;
@@ -83,7 +87,7 @@ function printUsage(): void {
 
 Modes:
   --incremental        Default. mtime fast-path; ~50ms steady-state.
-  --full               First-run; full walk + reindex. Honest ~25-35 min for big Macs (ED2).
+  --full               First-run/full refresh; source-aware code sync. Honest ~25-35 min for big Macs (ED2).
   --dry-run            Preview what would sync; no writes anywhere.
 
 Options:
@@ -102,6 +106,7 @@ Each stage failure is non-fatal; subsequent stages still run.
 function parseArgs(): CliArgs {
   const args = process.argv.slice(2);
   let mode: Mode = "incremental";
+  let full = false;
   let quiet = false;
   let noCode = false;
   let noMemory = false;
@@ -111,8 +116,8 @@ function parseArgs(): CliArgs {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     switch (a) {
-      case "--incremental": mode = "incremental"; break;
-      case "--full": mode = "full"; break;
+      case "--incremental": mode = "incremental"; full = false; break;
+      case "--full": mode = "full"; full = true; break;
       case "--dry-run": mode = "dry-run"; break;
       case "--quiet": quiet = true; break;
       case "--no-code": noCode = true; break;
@@ -134,7 +139,7 @@ function parseArgs(): CliArgs {
     }
   }
 
-  return { mode, quiet, noCode, noMemory, noBrainSync, codeOnly };
+  return { mode, full, quiet, noCode, noMemory, noBrainSync, codeOnly };
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -158,20 +163,22 @@ function originUrl(): string | null {
 }
 
 /**
- * Derive a stable source id for the cwd code corpus. Pattern: `gstack-code-<slug>`,
- * where <slug> comes from canonicalizeRemote() then `/` → `-` (e.g.,
- * `github.com/garrytan/gstack` → `gstack-code-github-com-garrytan-gstack`).
- *
- * Falls back to `gstack-code-<basename(repo)>` when there is no origin (local repo).
+ * Derive a stable source id for the cwd code corpus. gbrain limits source ids
+ * to 32 lowercase alnum/hyphen chars, so keep the human slug short and append
+ * a deterministic hash to avoid collisions across owners/remotes.
  */
 function deriveCodeSourceId(repoPath: string): string {
   const remote = canonicalizeRemote(originUrl());
-  if (remote) {
-    return `gstack-code-${remote.replace(/[\/\s]+/g, "-").replace(/-+/g, "-")}`;
-  }
-  // Fallback for repos without a remote.
-  const base = repoPath.split("/").pop() || "repo";
-  return `gstack-code-${base.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/-+/g, "-")}`;
+  const rawSlug = (remote ? remote.split("/").slice(-2).join("-") : repoPath.split("/").pop() || "repo")
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "") || "repo";
+  const hash = createHash("sha1").update(remote || repoPath).digest("hex").slice(0, 6);
+  const prefix = "gstack-code-";
+  const maxSlugLen = 32 - prefix.length - 1 - hash.length;
+  const slug = rawSlug.slice(0, maxSlugLen).replace(/-$/g, "") || "repo";
+  return `${prefix}${slug}-${hash}`;
 }
 
 function gbrainAvailable(): boolean {
@@ -245,12 +252,15 @@ function runCodeImport(args: CliArgs): StageResult {
   const sourceId = deriveCodeSourceId(root);
 
   if (args.mode === "dry-run") {
+    const syncPreview = args.full
+      ? `gbrain sync --full --strategy code --source ${sourceId}`
+      : `gbrain sync --strategy code --source ${sourceId}`;
     return {
       name: "code",
       ran: false,
       ok: true,
       duration_ms: 0,
-      summary: `would: gbrain sources add ${sourceId} --path ${root} --federated; gbrain sync --strategy code --source ${sourceId}`,
+      summary: `would: gbrain sources add ${sourceId} --path ${root} --federated; ${syncPreview}`,
       detail: { source_id: sourceId, source_path: root, status: "skipped" },
     };
   }
@@ -276,9 +286,10 @@ function runCodeImport(args: CliArgs): StageResult {
     };
   }
 
-  // Step 2: Run sync or reindex.
-  const syncArgs = args.mode === "full"
-    ? ["reindex-code", "--source", sourceId, "--yes"]
+  // Step 2: Run source-aware sync. `reindex-code` only re-embeds already
+  // imported code pages; it is not a first-run import path.
+  const syncArgs = args.full
+    ? ["sync", "--full", "--strategy", "code", "--source", sourceId]
     : ["sync", "--strategy", "code", "--source", sourceId];
 
   const syncResult = spawnSync("gbrain", syncArgs, {

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -714,7 +714,7 @@ search over Grep.
 
 **Architecture (post-codex review):** This skill uses gbrain v0.20.0+'s
 **native code surfaces** (`gbrain sources add`, `gbrain sync --strategy code`,
-`gbrain reindex-code`, `gbrain code-def/code-refs/code-callers/code-callees`).
+`gbrain sync --full --strategy code`, `gbrain code-def/code-refs/code-callers/code-callees`).
 It does NOT use `gbrain import` (that path is for markdown directories).
 It does NOT touch `~/.gstack/` indexing (the existing `gstack-gbrain-source-wireup`
 owns that — never double-store).
@@ -725,7 +725,7 @@ When the user types `/sync-gbrain`, run this skill. Argument modes (parsed by
 the skill itself, not a dispatcher binary):
 
 - `/sync-gbrain` — incremental sync (default; mtime fast-path; ~50ms steady-state)
-- `/sync-gbrain --full` — full code reindex via `gbrain reindex-code` (~25-35 min on a big repo)
+- `/sync-gbrain --full` — full source-aware code sync via `gbrain sync --full --strategy code` (~25-35 min on a big repo)
 - `/sync-gbrain --code-only` — only run the code stage; skip memory + brain-sync
 - `/sync-gbrain --dry-run` — preview what would sync; no writes anywhere
 - `/sync-gbrain --no-memory` / `--no-brain-sync` — selectively skip stages
@@ -795,7 +795,7 @@ echo "cwd source: $SOURCE_ID, page_count: $PAGES"
 If `PAGES` is 0 or empty AND the user did NOT pass `--no-code` AND mode was
 not `--full`, AskUserQuestion via the format in the preamble:
 
-> D1 — This repo has 0 indexed pages in gbrain. Run a full code reindex now?
+> D1 — This repo has 0 indexed pages in gbrain. Run a full code sync now?
 >
 > ELI10: gbrain hasn't indexed this repo's code yet. The semantic search
 > tools (`gbrain search`, `code-def`, `code-refs`) will return nothing

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -36,7 +36,7 @@ search over Grep.
 
 **Architecture (post-codex review):** This skill uses gbrain v0.20.0+'s
 **native code surfaces** (`gbrain sources add`, `gbrain sync --strategy code`,
-`gbrain reindex-code`, `gbrain code-def/code-refs/code-callers/code-callees`).
+`gbrain sync --full --strategy code`, `gbrain code-def/code-refs/code-callers/code-callees`).
 It does NOT use `gbrain import` (that path is for markdown directories).
 It does NOT touch `~/.gstack/` indexing (the existing `gstack-gbrain-source-wireup`
 owns that — never double-store).
@@ -47,7 +47,7 @@ When the user types `/sync-gbrain`, run this skill. Argument modes (parsed by
 the skill itself, not a dispatcher binary):
 
 - `/sync-gbrain` — incremental sync (default; mtime fast-path; ~50ms steady-state)
-- `/sync-gbrain --full` — full code reindex via `gbrain reindex-code` (~25-35 min on a big repo)
+- `/sync-gbrain --full` — full source-aware code sync via `gbrain sync --full --strategy code` (~25-35 min on a big repo)
 - `/sync-gbrain --code-only` — only run the code stage; skip memory + brain-sync
 - `/sync-gbrain --dry-run` — preview what would sync; no writes anywhere
 - `/sync-gbrain --no-memory` / `--no-brain-sync` — selectively skip stages
@@ -117,7 +117,7 @@ echo "cwd source: $SOURCE_ID, page_count: $PAGES"
 If `PAGES` is 0 or empty AND the user did NOT pass `--no-code` AND mode was
 not `--full`, AskUserQuestion via the format in the preamble:
 
-> D1 — This repo has 0 indexed pages in gbrain. Run a full code reindex now?
+> D1 — This repo has 0 indexed pages in gbrain. Run a full code sync now?
 >
 > ELI10: gbrain hasn't indexed this repo's code yet. The semantic search
 > tools (`gbrain search`, `code-def`, `code-refs`) will return nothing

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -92,6 +92,18 @@ describe("gstack-gbrain-sync CLI", () => {
     rmSync(home, { recursive: true, force: true });
   });
 
+  it("--full --dry-run with --code-only uses source-aware sync, not reindex-code", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+
+    const r = runScript(["--full", "--dry-run", "--code-only", "--quiet"], { HOME: home, GSTACK_HOME: gstackHome });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("gbrain sync --full --strategy code");
+    expect(r.stdout).not.toContain("reindex-code");
+    rmSync(home, { recursive: true, force: true });
+  });
+
   it("dry-run derives a stable source id from the canonical git remote", () => {
     // The source id pattern is `gstack-code-<canonicalized-remote>`. For this
     // repo (github.com/garrytan/gstack), the slug should appear in the dry-run


### PR DESCRIPTION
## Summary
- Preserve `--full` intent through dry-run mode in `gstack-gbrain-sync`.
- Preview and execute full code sync with `gbrain sync --full --strategy code --source ...`.
- Avoid using `gbrain reindex-code` for first/full code imports.
- Update `/sync-gbrain` docs/templates and add regression coverage.

## Test plan
- `bun test ./test/gstack-gbrain-sync.test.ts`
- Local smoke: `bun run bin/gstack-gbrain-sync.ts --full --dry-run --code-only --quiet`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->