### PR TITLE
fix: support cursor host in setup

### DIFF
--- a/setup
+++ b/setup
@@ -20,6 +20,8 @@ INSTALL_SKILLS_DIR="$(dirname "$INSTALL_GSTACK_DIR")"
 BROWSE_BIN="$SOURCE_GSTACK_DIR/browse/dist/browse"
 CODEX_SKILLS="$HOME/.codex/skills"
 CODEX_GSTACK="$CODEX_SKILLS/gstack"
+CURSOR_SKILLS="$HOME/.cursor/skills"
+CURSOR_GSTACK="$CURSOR_SKILLS/gstack"
 FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
 OPENCODE_SKILLS="$HOME/.config/opencode/skills"
@@ -43,7 +45,7 @@ TEAM_MODE=0
 NO_TEAM_MODE=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, cursor, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -56,7 +58,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|opencode|auto) ;;
+  claude|codex|cursor|kiro|factory|opencode|auto) ;;
   openclaw)
     echo ""
     echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
@@ -91,7 +93,7 @@ case "$HOST" in
     echo "GBrain setup and brain skills ship from the GBrain repo."
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, cursor, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -152,23 +154,27 @@ fi
 # For auto: detect which agents are installed
 INSTALL_CLAUDE=0
 INSTALL_CODEX=0
+INSTALL_CURSOR=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
 INSTALL_OPENCODE=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
+  command -v cursor >/dev/null 2>&1 && INSTALL_CURSOR=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
   command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_CURSOR" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
   INSTALL_CLAUDE=1
 elif [ "$HOST" = "codex" ]; then
   INSTALL_CODEX=1
+elif [ "$HOST" = "cursor" ]; then
+  INSTALL_CURSOR=1
 elif [ "$HOST" = "kiro" ]; then
   INSTALL_KIRO=1
 elif [ "$HOST" = "factory" ]; then
@@ -318,6 +324,15 @@ if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
     cd "$SOURCE_GSTACK_DIR"
     bun install --frozen-lockfile 2>/dev/null || bun install
     bun run gen:skill-docs --host opencode
+  )
+fi
+
+if [ "$INSTALL_CURSOR" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .cursor/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun install --frozen-lockfile 2>/dev/null || bun install
+    bun run gen:skill-docs --host cursor
   )
 fi
 
@@ -562,6 +577,41 @@ create_agents_sidecar() {
   done
 }
 
+create_cursor_sidecar() {
+  local repo_root="$1"
+  local cursor_gstack="$repo_root/.cursor/skills/gstack"
+  local cursor_dir="$repo_root/.cursor/skills"
+
+  for stale in browse review qa; do
+    if [ -L "$cursor_gstack/$stale" ]; then
+      rm -f "$cursor_gstack/$stale"
+    fi
+  done
+
+  mkdir -p "$cursor_gstack" "$cursor_gstack/browse" "$cursor_gstack/gstack-upgrade" "$cursor_gstack/review"
+
+  if [ -d "$SOURCE_GSTACK_DIR/bin" ]; then
+    ln -snf "$SOURCE_GSTACK_DIR/bin" "$cursor_gstack/bin"
+  fi
+  if [ -d "$SOURCE_GSTACK_DIR/browse/dist" ]; then
+    ln -snf "$SOURCE_GSTACK_DIR/browse/dist" "$cursor_gstack/browse/dist"
+  fi
+  if [ -d "$SOURCE_GSTACK_DIR/browse/bin" ]; then
+    ln -snf "$SOURCE_GSTACK_DIR/browse/bin" "$cursor_gstack/browse/bin"
+  fi
+  if [ -f "$cursor_dir/gstack-upgrade/SKILL.md" ]; then
+    ln -snf "$cursor_dir/gstack-upgrade/SKILL.md" "$cursor_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$SOURCE_GSTACK_DIR/review/$f" ]; then
+      ln -snf "$SOURCE_GSTACK_DIR/review/$f" "$cursor_gstack/review/$f"
+    fi
+  done
+  if [ -f "$SOURCE_GSTACK_DIR/ETHOS.md" ]; then
+    ln -snf "$SOURCE_GSTACK_DIR/ETHOS.md" "$cursor_gstack/ETHOS.md"
+  fi
+}
+
 # ─── Helper: create a minimal ~/.codex/skills/gstack runtime root ───────────
 # Codex scans ~/.codex/skills recursively. Exposing the whole repo here causes
 # duplicate skills because source SKILL.md files and generated Codex skills are
@@ -605,6 +655,44 @@ create_codex_runtime_root() {
   # ETHOS.md — referenced by "Search Before Building" in all skill preambles
   if [ -f "$gstack_dir/ETHOS.md" ]; then
     ln -snf "$gstack_dir/ETHOS.md" "$codex_gstack/ETHOS.md"
+  fi
+}
+
+create_cursor_runtime_root() {
+  local gstack_dir="$1"
+  local cursor_gstack="$2"
+  local cursor_dir="$gstack_dir/.cursor/skills"
+
+  if [ -L "$cursor_gstack" ]; then
+    rm -f "$cursor_gstack"
+  elif [ -d "$cursor_gstack" ] && [ "$cursor_gstack" != "$gstack_dir" ]; then
+    rm -rf "$cursor_gstack"
+  fi
+
+  mkdir -p "$cursor_gstack" "$cursor_gstack/browse" "$cursor_gstack/gstack-upgrade" "$cursor_gstack/review"
+
+  if [ -f "$cursor_dir/gstack/SKILL.md" ]; then
+    ln -snf "$cursor_dir/gstack/SKILL.md" "$cursor_gstack/SKILL.md"
+  fi
+  if [ -d "$gstack_dir/bin" ]; then
+    ln -snf "$gstack_dir/bin" "$cursor_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    ln -snf "$gstack_dir/browse/dist" "$cursor_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    ln -snf "$gstack_dir/browse/bin" "$cursor_gstack/browse/bin"
+  fi
+  if [ -f "$cursor_dir/gstack-upgrade/SKILL.md" ]; then
+    ln -snf "$cursor_dir/gstack-upgrade/SKILL.md" "$cursor_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      ln -snf "$gstack_dir/review/$f" "$cursor_gstack/review/$f"
+    fi
+  done
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    ln -snf "$gstack_dir/ETHOS.md" "$cursor_gstack/ETHOS.md"
   fi
 }
 
@@ -696,6 +784,38 @@ create_opencode_runtime_root() {
   fi
   if [ -f "$gstack_dir/ETHOS.md" ]; then
     ln -snf "$gstack_dir/ETHOS.md" "$opencode_gstack/ETHOS.md"
+  fi
+}
+
+link_cursor_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local cursor_dir="$gstack_dir/.cursor/skills"
+  local linked=()
+
+  if [ ! -d "$cursor_dir" ]; then
+    echo "  Generating .cursor/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host cursor )
+  fi
+
+  if [ ! -d "$cursor_dir" ]; then
+    echo "  warning: .cursor/skills/ generation failed — run 'bun run gen:skill-docs --host cursor' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$cursor_dir"/*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
   fi
 }
 
@@ -859,6 +979,15 @@ if [ "$INSTALL_CODEX" -eq 1 ]; then
   log "  codex skills: $CODEX_SKILLS"
 fi
 
+if [ "$INSTALL_CURSOR" -eq 1 ]; then
+  mkdir -p "$CURSOR_SKILLS"
+  create_cursor_runtime_root "$SOURCE_GSTACK_DIR" "$CURSOR_GSTACK"
+  link_cursor_skill_dirs "$SOURCE_GSTACK_DIR" "$CURSOR_SKILLS"
+  echo "gstack ready (cursor)."
+  echo "  browse: $BROWSE_BIN"
+  echo "  cursor skills: $CURSOR_SKILLS"
+fi
+
 # 6. Install for Kiro CLI (copy from .agents/skills, rewrite paths)
 if [ "$INSTALL_KIRO" -eq 1 ]; then
   KIRO_SKILLS="$HOME/.kiro/skills"
@@ -940,6 +1069,9 @@ fi
 # so the runtime assets must live there for both global and repo-local installs.
 if [ "$INSTALL_CODEX" -eq 1 ]; then
   create_agents_sidecar "$SOURCE_GSTACK_DIR"
+fi
+if [ "$INSTALL_CURSOR" -eq 1 ]; then
+  create_cursor_sidecar "$SOURCE_GSTACK_DIR"
 fi
 
 # 8. Run pending version migrations


### PR DESCRIPTION
## Summary

This PR makes the documented `./setup --host cursor` install path work as a first-class host install.

The README already lists Cursor as supported and documents skills installing under `~/.cursor/skills/gstack-*/`, but the setup script rejected `cursor` during host validation with:

```text
Unknown --host value: cursor
```

That made the documented install path unusable even though the repo already has Cursor host generation config in `hosts/cursor.ts`.

Related issues:
- Fixes #1269
- Addresses the same failure reported in #872

## What changed

- Added `cursor` to the accepted `--host` values and error messages.
- Added Cursor install flags and path constants:
  - `~/.cursor/skills`
  - `~/.cursor/skills/gstack`
- Added optional auto-detection via `command -v cursor`, while preserving the existing fallback behavior when no hosts are detected.
- Generate Cursor-specific skill docs with `bun run gen:skill-docs --host cursor` when Cursor install is selected.
- Added a minimal Cursor runtime root at `~/.cursor/skills/gstack` with only runtime assets and root skill files:
  - `bin`
  - `browse/dist`
  - `browse/bin`
  - selected `review/*.md` runtime files
  - `ETHOS.md`
  - root `SKILL.md`
  - `gstack-upgrade/SKILL.md`
- Added `link_cursor_skill_dirs()` to link generated Cursor skills from `.cursor/skills/gstack-*` into `~/.cursor/skills/`.
- Added a repo-local `.cursor/skills/gstack` sidecar for generated Cursor skills, matching the existing runtime-root pattern while avoiding recursive duplicate skill discovery.

A key detail here is that Cursor installs now use the Cursor-generated skill docs, not Codex-generated docs. I checked this carefully because Codex docs set defaults like `~/.codex/skills/gstack`; Cursor skills need their preamble and repo-local fallback to resolve through `~/.cursor/skills/gstack` and `.cursor/skills/gstack`.

## Why this shape

Cursor's skill layout is very close to the existing generated-host flow, but it needs its own install target and generated host output. The implementation follows the same setup-script structure already used by Codex, Factory, and OpenCode:

- one `INSTALL_CURSOR` flag
- one runtime-root creation helper
- one generated-skill linking helper
- one install block
- one sidecar setup path for generated skills

The runtime root intentionally does not symlink the entire `review/` or `qa/` directories, because those source directories contain `SKILL.md` files. Exposing them through the runtime root could create duplicate skill discovery. Instead, the installer links only the runtime markdown files that skills read directly.

## Local verification

Verified on my laptop from this repo checkout.

Commands run:

```bash
bash -n setup
GSTACK_SKIP_COREUTILS=1 ./setup --host cursor
GSTACK_SKIP_COREUTILS=1 ./setup --host auto
```

Manual install checks:

```bash
ls -la ~/.cursor/skills/
ls -la ~/.cursor/skills/gstack/
```

Additional checks performed:

- Confirmed `./setup --host cursor` exits successfully and prints `gstack ready (cursor).`
- Confirmed `~/.cursor/skills` contains the generated `gstack-*` skill links.
- Confirmed 45 `gstack-*` Cursor skill directories are present.
- Confirmed every installed Cursor skill has a `SKILL.md`.
- Confirmed installed Cursor skill links point to `.cursor/skills/...`, not `.agents/skills/...`.
- Confirmed a generated Cursor skill preamble resolves to `~/.cursor/skills/gstack` and repo-local `.cursor/skills/gstack`, not Codex paths.
- Confirmed runtime assets exist under `~/.cursor/skills/gstack`:
  - `bin`
  - `browse/dist`
  - `browse/bin`
  - `review/checklist.md`
  - `review/design-checklist.md`
  - `review/greptile-triage.md`
  - `review/TODOS-format.md`
  - `ETHOS.md`
  - `SKILL.md`
  - `gstack-upgrade/SKILL.md`
- Confirmed there is no duplicate `review/SKILL.md` or `qa/SKILL.md` exposed under the global runtime root.
- Confirmed there is no duplicate `review/SKILL.md` or `qa/SKILL.md` exposed under the repo-local `.cursor/skills/gstack` runtime sidecar.
- Confirmed `./setup --host auto` still runs successfully.

## Notes

I did not add Slate support here. This PR is intentionally scoped to the documented Cursor install path and the open Cursor setup issue.