### PR TITLE
fix: gstack-memory-ingest calls non-existent `gbrain put_page` CLI verb

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -763,23 +763,41 @@ function gbrainPutPage(page: PageRecord): { ok: boolean; error?: string } {
   if (!gbrainAvailable()) {
     return { ok: false, error: "gbrain CLI not in PATH" };
   }
+  // gbrain CLI verb is `put <slug>`; it does NOT accept --title / --type /
+  // --tags flags. (`put_page` is the MCP tool name, not the CLI subcommand.)
+  // Inject title/type/tags into the YAML frontmatter that page.body already
+  // begins with so gbrain's frontmatter parser picks them up.
+  let body = page.body;
+  if (body.startsWith("---\n")) {
+    const end = body.indexOf("\n---\n", 4);
+    if (end > 0) {
+      const inject = [
+        `title: ${JSON.stringify(page.title)}`,
+        `type: ${page.type}`,
+        `tags:`,
+        ...page.tags.map((t) => `  - ${t}`),
+      ].join("\n");
+      body = body.slice(0, end) + "\n" + inject + body.slice(end);
+    }
+  }
   try {
-    const args = [
-      "put_page",
-      "--slug", page.slug,
-      "--title", page.title,
-      "--type", page.type,
-      "--tags", page.tags.join(","),
-    ];
-    execFileSync("gbrain", args, {
-      input: page.body,
+    execFileSync("gbrain", ["put", page.slug], {
+      input: body,
       encoding: "utf-8",
-      timeout: 30000,
+      // Bumped from 30s: auto-link reconciliation on dense transcripts hits
+      // 30s once the brain has a few hundred existing pages.
+      timeout: 60000,
+      // Bumped from default 1MB: without this, gbrain's actual stderr gets
+      // truncated and callers see only "Command failed:" with no detail.
+      maxBuffer: 16 * 1024 * 1024,
       stdio: ["pipe", "pipe", "pipe"],
     });
     return { ok: true };
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } catch (err: any) {
+    const stderr = err?.stderr?.toString?.() ?? "";
+    const stdout = err?.stdout?.toString?.() ?? "";
+    const detail = stderr || stdout || (err instanceof Error ? err.message : String(err));
+    return { ok: false, error: detail.split("\n")[0].slice(0, 300) };
   }
 }
 


### PR DESCRIPTION
## Symptom

`/setup-gbrain` Step 7.5 (transcript & memory ingest gate) writes 0 pages on a clean install. With `--quiet` removed, every page errors with:

```
Unknown command: put_page
Run gbrain --help for available commands.
```

## Root cause

`bin/gstack-memory-ingest.ts:767-779` shells out via:

```ts
const args = ["put_page", "--slug", page.slug, "--title", page.title,
              "--type", page.type, "--tags", page.tags.join(",")];
execFileSync("gbrain", args, { input: page.body, ... });
```

The `gbrain` CLI (v0.18+ through current v0.26.7) does not expose a `put_page` subcommand. The verb is `gbrain put <slug>` and it accepts only `<slug>` positionally plus content via stdin or `--content`. There is no `--title`, `--type`, or `--tags` flag on the CLI. `put_page` is the MCP tool name; this looks like confusion between the MCP and CLI surfaces.

```
$ gbrain put --help
Usage: gbrain put <slug> [options]
Options:
  <slug>     Page slug (required)
  --content  Full markdown content with YAML frontmatter (required)
```

## Repro (current main)

```bash
bun bin/gstack-memory-ingest.ts --bulk --include-unattributed --limit 1
```

Result: `written: 0, failed: 1`.

Confirmed on a clean install with gbrain v0.26.7 + gstack v1.26.3.0.

## Fix

`gbrain put` reads tags/title/type from YAML frontmatter, so:

1. Switch to the correct CLI verb (`put` instead of `put_page`).
2. Inject `title`, `type`, `tags` into the frontmatter that `buildTranscriptPage` / `buildArtifactPage` already produce, instead of passing them as CLI flags.

Bundled ergonomic improvements in the same function:

- `timeout: 30000 -> 60000`. Auto-link reconciliation on dense transcripts hits 30s once the brain has a few hundred existing pages; the original limit caused timeouts in real backfills.
- `maxBuffer: 16 MB`. Without this, Node truncates gbrain's stderr at the default 1 MB and callers see only `Command failed:` with no detail. Cost real debugging time on this very bug.
- Surface stderr/stdout in the returned error message instead of the bare exception, for the same reason.

## Tests

- `bun test test/gstack-memory-ingest.test.ts` -> 15/15 pass
- `bun test` on the three test files touching this code path (`gstack-memory-ingest`, `gstack-memory-helpers`, `skill-validation`) -> 362/362 pass

Validated end-to-end on a real machine: 122 Claude Code transcripts + 108 Codex transcripts written cleanly with this patch (via a temporary one-off wrapper that exercises the same `gbrain put` codepath this PR introduces).

## Versions

- gstack: v1.26.3.0 (current main, db9447c3)
- gbrain: v0.26.7
- Bun: 1.3.12
- macOS arm64
- Affects every release since v1.26.0.0 (where transcript ingest landed)