### PR TITLE
fix(sync-gbrain): generate gbrain-valid source ids for repos with dots or long names

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -33,6 +33,7 @@ import { existsSync, statSync, mkdirSync, writeFileSync, readFileSync, unlinkSyn
 import { join, dirname } from "path";
 import { execSync, execFileSync, spawnSync } from "child_process";
 import { homedir } from "os";
+import { createHash } from "crypto";
 
 import { detectEngineTier, withErrorContext, canonicalizeRemote } from "../lib/gstack-memory-helpers";
 import { sourcePageCount } from "../lib/gbrain-sources";
@@ -158,20 +159,43 @@ function originUrl(): string | null {
 }
 
 /**
- * Derive a stable source id for the cwd code corpus. Pattern: `gstack-code-<slug>`,
- * where <slug> comes from canonicalizeRemote() then `/` → `-` (e.g.,
- * `github.com/garrytan/gstack` → `gstack-code-github-com-garrytan-gstack`).
+ * Derive a stable source id for the cwd code corpus. Pattern: `gstack-code-<slug>`.
  *
- * Falls back to `gstack-code-<basename(repo)>` when there is no origin (local repo).
+ * gbrain enforces source ids to be 1-32 lowercase alnum chars with optional interior
+ * hyphens. We use the last two segments of the canonical remote (org/repo) and skip
+ * the host — `github.com` etc. is the same for nearly every user and just eats budget.
+ * If the resulting id still exceeds 32 chars, we keep the tail (most distinctive end)
+ * and append a 6-char hash of the full slug for collision resistance.
+ *
+ * Falls back to the repo basename when there is no origin (local repo).
  */
 function deriveCodeSourceId(repoPath: string): string {
   const remote = canonicalizeRemote(originUrl());
   if (remote) {
-    return `gstack-code-${remote.replace(/[\/\s]+/g, "-").replace(/-+/g, "-")}`;
+    const segs = remote.split("/").filter(Boolean);
+    const slugSource = segs.slice(-2).join("-");
+    return constrainSourceId("gstack-code", slugSource);
   }
-  // Fallback for repos without a remote.
   const base = repoPath.split("/").pop() || "repo";
-  return `gstack-code-${base.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/-+/g, "-")}`;
+  return constrainSourceId("gstack-code", base);
+}
+
+/**
+ * Build a gbrain-valid source id (1-32 lowercase alnum + interior hyphens). Sanitizes
+ * `raw`, prefixes with `prefix`, and falls back to a hashed-tail form when total length
+ * would exceed 32 chars.
+ */
+function constrainSourceId(prefix: string, raw: string): string {
+  const MAX = 32;
+  const slug = raw.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  const full = `${prefix}-${slug}`;
+  if (full.length <= MAX) return full;
+  const hash = createHash("sha1").update(slug).digest("hex").slice(0, 6);
+  // Total budget: prefix + "-" + tail + "-" + hash
+  const tailBudget = MAX - prefix.length - 2 - hash.length;
+  if (tailBudget < 1) return `${prefix}-${hash}`;
+  const tail = slug.slice(-tailBudget).replace(/^-+|-+$/g, "");
+  return tail ? `${prefix}-${tail}-${hash}` : `${prefix}-${hash}`;
 }
 
 function gbrainAvailable(): boolean {

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -108,6 +108,47 @@ describe("gstack-gbrain-sync CLI", () => {
     rmSync(home, { recursive: true, force: true });
   });
 
+  it("derived source ids are gbrain-valid (≤32 chars, alnum + interior hyphens, no dots) for any remote", () => {
+    // gbrain enforces source ids to be 1-32 lowercase alnum chars with optional interior
+    // hyphens. Pre-fix, the slug came from canonicalizeRemote() with only `/` and
+    // whitespace stripped — leaving dots from hostnames (`github.com`) and no length cap.
+    // For `github.com/<org>/<repo>`, the id was `gstack-code-github.com-<org>-<repo>`,
+    // which fails validation on both counts. This test exercises the derivation against
+    // controlled remotes by spawning the CLI in a temp git repo.
+    const cases = [
+      "https://github.com/radubach/platform.git",      // dot in hostname, total > 32 with old slug
+      "git@github.com:garrytan/gstack.git",            // SCP-style remote
+      "https://gitlab.example.com/team/proj.git",      // multi-dot host, non-github
+      "https://github.com/some-very-long-org-name/some-very-long-repo-name.git", // forces hash-truncate
+    ];
+    const VALID_ID = /^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/;
+    for (const remote of cases) {
+      const home = makeTestHome();
+      const gstackHome = join(home, ".gstack");
+      mkdirSync(gstackHome, { recursive: true });
+      const repo = mkdtempSync(join(tmpdir(), "gstack-source-id-repo-"));
+      spawnSync("git", ["init", "--quiet", "-b", "main"], { cwd: repo });
+      spawnSync("git", ["remote", "add", "origin", remote], { cwd: repo });
+
+      const r = spawnSync("bun", [SCRIPT, "--dry-run", "--code-only", "--quiet"], {
+        encoding: "utf-8",
+        timeout: 60000,
+        cwd: repo,
+        env: { ...process.env, HOME: home, GSTACK_HOME: gstackHome },
+      });
+      expect(r.status).toBe(0);
+      const m = (r.stdout || "").match(/gbrain sources add (\S+)/);
+      expect(m).not.toBeNull();
+      const id = m![1];
+      expect(id.length).toBeLessThanOrEqual(32);
+      expect(id).toMatch(VALID_ID);
+      expect(id.startsWith("gstack-code-")).toBe(true);
+
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("dry-run does NOT acquire the lock file (lock is for write paths only)", () => {
     const home = makeTestHome();
     const gstackHome = join(home, ".gstack");


### PR DESCRIPTION
## Summary

`/sync-gbrain` failed for me on `github.com/radubach/platform` with:

```
ERR  code  source registration failed: gbrain sources add gstack-code-github.com-radubach-platform failed:
     Invalid source id "gstack-code-github.com-radubach-platform". Must be 1-32 lowercase alnum chars with
     optional interior hyphens (e.g. "wiki", "yc-media").
```

`deriveCodeSourceId` in `bin/gstack-gbrain-sync.ts:170` builds the id by taking
`canonicalizeRemote(originUrl())` and replacing only `/` and whitespace with `-`. That leaves
dots from hostnames (`github.com`) intact and applies no length cap, so any `github.com/<org>/<repo>`
produces `gstack-code-github.com-<org>-<repo>` (40 chars in my case) — both invalid.

## Fix

- **Drop the host segment.** `github.com-` is the same for nearly every user and just consumes the 32-char budget. Use only the last two path segments (org-repo).
- **Sanitize any remaining non-alnum to hyphens**, then collapse and trim leading/trailing hyphens.
- **Hash-truncate when org/repo names are long enough** to push past 32 chars: keep the tail of the slug (most distinctive end) and append a 6-char sha1 of the original slug for collision resistance.

Resulting ids for the cases I checked:

| Remote | Pre-fix id (invalid) | Post-fix id |
|---|---|---|
| `github.com/radubach/platform` | `gstack-code-github.com-radubach-platform` (40, has `.`) | `gstack-code-radubach-platform` (29) |
| `github.com/garrytan/gstack` | `gstack-code-github.com-garrytan-gstack` (38, has `.`) | `gstack-code-garrytan-gstack` (27) |
| `github.com/some-very-long-org-name/some-very-long-repo-name` | 60 chars, has `.` | `gstack-code-ong-repo-name-4cead7` (32) |

Verified by re-running `/sync-gbrain --full` on `radubach/platform`: code stage now registers and indexes (110 pages, 1396 chunks).

## Test Coverage

- New regression test in `test/gstack-gbrain-sync.test.ts` (`derived source ids are gbrain-valid…`) spawns the CLI inside temp git repos with four controlled remote shapes (dot in hostname, SCP-style, multi-dot host, long org/repo forcing hash-truncate). Asserts every derived id is ≤32 chars, matches the gbrain validator regex `^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$`, and starts with `gstack-code-`.
- I confirmed the test catches the original bug — reverting the fix produces `Expected: <= 32, Received: 40` on the first case.
- The existing `dry-run derives a stable source id from the canonical git remote` test still passes (same prefix/regex contract — its expected slug for the gstack repo just changed from `gstack-code-github-com-garrytan-gstack` to `gstack-code-garrytan-gstack`, both match the regex).

`bun test test/gstack-gbrain-sync.test.ts`: 14/14 pass (was 13).

## Notes

- The behavioral change is the slug shape (drops `github-com-` prefix, may add hash suffix for long names). Users whose previous registration was already failing — i.e., everyone with a hostname-dot or org/repo over the budget — get a working sync. Users on shorter names get a slightly shorter, equally stable id.
- No migration concern for IDs that previously *did* validate: the only way an old id could have validated was if it never contained the host segment (no fallback path produced one) — i.e., the no-remote `gstack-code-<basename>` branch, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->