### PR TITLE
fix: add fail-fast probe for base branch in ship step 12

### DIFF
--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -2371,6 +2371,11 @@ already knows. A good test: would this insight save time in a future session? If
 **Idempotency check:** Before bumping, classify the state by comparing `VERSION` against the base branch AND against `package.json`'s `version` field. Four states: FRESH (do bump), ALREADY_BUMPED (skip bump), DRIFT_STALE_PKG (sync pkg only, no re-bump), DRIFT_UNEXPECTED (stop and ask).
 
 ```bash
+if ! git rev-parse --verify origin/<base> >/dev/null 2>&1; then
+  echo "ERROR: Unable to resolve origin/<base>. Run 'git fetch origin' or verify the base branch exists."
+  exit 1
+fi
+
 BASE_VERSION=$(git show origin/<base>:VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "0.0.0.0")
 CURRENT_VERSION=$(cat VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "0.0.0.0")
 [ -z "$BASE_VERSION" ] && BASE_VERSION="0.0.0.0"

--- a/ship/SKILL.md.tmpl
+++ b/ship/SKILL.md.tmpl
@@ -406,6 +406,11 @@ For each comment in `comments`:
 **Idempotency check:** Before bumping, classify the state by comparing `VERSION` against the base branch AND against `package.json`'s `version` field. Four states: FRESH (do bump), ALREADY_BUMPED (skip bump), DRIFT_STALE_PKG (sync pkg only, no re-bump), DRIFT_UNEXPECTED (stop and ask).
 
 ```bash
+if ! git rev-parse --verify origin/<base> >/dev/null 2>&1; then
+  echo "ERROR: Unable to resolve origin/<base>. Run 'git fetch origin' or verify the base branch exists."
+  exit 1
+fi
+
 BASE_VERSION=$(git show origin/<base>:VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "0.0.0.0")
 CURRENT_VERSION=$(cat VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "0.0.0.0")
 [ -z "$BASE_VERSION" ] && BASE_VERSION="0.0.0.0"


### PR DESCRIPTION
/ship Step 12 currently computes `BASE_VERSION` with:

```bash
BASE_VERSION=$(git show origin/<base>:VERSION ... || echo "0.0.0.0")
```

If origin/<base> is missing/unfetched/unresolvable (offline, detached HEAD, misconfigured remotes, etc.), the command fails and /ship silently falls back to 0.0.0.0, which can produce an incorrect version bump baseline.

### What changed
Added a fail-fast guard before reading origin/<base>:VERSION:
git rev-parse --verify origin/<base> must succeed, otherwise /ship prints a clear error and exits.
Left the existing parsing/trimming logic intact for the happy path.
Regenerated skill docs after updating the .tmpl file.

### Why this is better
Avoids silently selecting an invalid baseline (0.0.0.0) that can cause version drift.
Produces an actionable error message that tells the user how to fix it (git fetch origin / verify base branch).

### Testing
bun test
bun run gen:skill-docs --host all

This addresses the TODO item: “/ship Step 12 BASE_VERSION silent fallback to 0.0.0.0 when git show fails”.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->