### PR TITLE
fix(docs): correct per-skill symlink removal snippet in README uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,18 @@ If you don't have the repo cloned (e.g. you installed via a Claude Code paste an
 # 1. Stop browse daemons
 pkill -f "gstack.*browse" 2>/dev/null || true
 
-# 2. Remove per-skill symlinks pointing into gstack/
-find ~/.claude/skills -maxdepth 1 -type l 2>/dev/null | while read -r link; do
-  case "$(readlink "$link" 2>/dev/null)" in gstack/*|*/gstack/*) rm -f "$link" ;; esac
+# 2. Remove per-skill directories whose SKILL.md points into gstack/
+find ~/.claude/skills -mindepth 1 -maxdepth 1 -type d ! -name gstack 2>/dev/null |
+while IFS= read -r dir; do
+  link="$dir/SKILL.md"
+  [ -L "$link" ] || continue
+  target=$(readlink "$link" 2>/dev/null) || continue
+  case "$target" in
+    gstack/*|*/gstack/*)
+      rm -f "$link"
+      rmdir "$dir" 2>/dev/null || true
+      ;;
+  esac
 done
 
 # 3. Remove gstack


### PR DESCRIPTION
Closes #1130.

## Problem

The manual-uninstall fallback in `## Uninstall` → `### Option 2` uses:

```bash
find ~/.claude/skills -maxdepth 1 -type l 2>/dev/null | while read -r link; do
  case "$(readlink "$link" 2>/dev/null)" in gstack/*|*/gstack/*) rm -f "$link" ;; esac
done
```

This finds nothing on real installs. Each `~/.claude/skills/<name>/` is a real directory, and only `<name>/SKILL.md` *inside* it is a symlink into `gstack/` (per `bin/gstack-relink`). The find walks one level for symlinks at that depth — there are none — and silently removes nothing.

## Fix

Replace with a directory walk that inspects each `<name>/SKILL.md`:

```bash
find ~/.claude/skills -mindepth 1 -maxdepth 1 -type d ! -name gstack 2>/dev/null |
while IFS= read -r dir; do
  link="$dir/SKILL.md"
  [ -L "$link" ] || continue
  target=$(readlink "$link" 2>/dev/null) || continue
  case "$target" in
    gstack/*|*/gstack/*)
      rm -f "$link"
      rmdir "$dir" 2>/dev/null || true
      ;;
  esac
done
```

- Excludes the top-level `gstack/` dir from the walk; step 3 of the same block removes it.
- Uses `rm -f` + `rmdir` (vs `rm -rf`) so any user-added files in a per-skill dir are preserved.
- `bin/gstack-uninstall` (script mode) already handles the layout correctly via its own walk; only this manual fallback needed updating.

## Verification

- `bash -n` parse-checks clean.
- `git diff upstream/main -- README.md` shows only the snippet replaced (+12/-3, scoped to the lines under `# 2. Remove per-skill symlinks pointing into gstack/`).
