### PR TITLE
Fix gstack-memory-ingest for gbrain >=0.18 `put` rename

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -765,7 +765,7 @@ function gbrainPutPage(page: PageRecord): { ok: boolean; error?: string } {
   }
   try {
     const args = [
-      "put_page",
+      "put",
       "--slug", page.slug,
       "--title", page.title,
       "--type", page.type,


### PR DESCRIPTION
Closes #1346.

## Summary

gbrain `0.18` renamed the page-write subcommand from `put_page` to `put` (same flags, same stdin body contract). `gstack-memory-ingest` still calls `gbrain put_page ...`, so on any gbrain `>=0.18` every ingest fails with `Unknown command: put_page` and nothing lands in the brain. One-line fix in the args array at `bin/gstack-memory-ingest.ts:768`.

## Repro (before this PR)

```
$ gbrain --version
gbrain 0.18.2
$ bun run bin/gstack-memory-ingest.ts --incremental --limit 1 2>&1 | tail -3
[put-error] ...: Command failed: gbrain put_page --slug ... --type ...
Unknown command: put_page
```

## Test plan

- [ ] Run `gstack-memory-ingest --limit 1` against gbrain 0.18.2 and confirm the page lands (`gbrain get <slug>` returns it).
- [ ] Sanity check on gbrain `<=0.17` if still supported — though `put` is the canonical name in current help output, it may be a hard cut. If older gbrain support is required, the right shape is a version probe; happy to extend if maintainers prefer.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->