### PR TITLE
feat(browse): add --navigate flag to download for browser-triggered file downloads

### DIFF
--- a/browse/src/commands.ts
+++ b/browse/src/commands.ts
@@ -134,7 +134,7 @@ export const COMMAND_DESCRIPTIONS: Record<string, { category: string; descriptio
   'dialog-accept': { category: 'Interaction', description: 'Auto-accept next alert/confirm/prompt. Optional text is sent as the prompt response', usage: 'dialog-accept [text]' },
   'dialog-dismiss': { category: 'Interaction', description: 'Auto-dismiss next dialog' },
   // Data extraction
-  'download': { category: 'Extraction', description: 'Download URL or media element to disk using browser cookies', usage: 'download <url|@ref> [path] [--base64]' },
+  'download': { category: 'Extraction', description: 'Download URL or media element to disk using browser cookies. Use --navigate for URLs that trigger browser downloads (CDN redirects, Content-Disposition, DDoS-Guard protected sites)', usage: 'download <url|@ref> [path] [--base64] [--navigate]' },
   'scrape':   { category: 'Extraction', description: 'Bulk download all media from page. Writes manifest.json', usage: 'scrape <images|videos|media> [--selector sel] [--dir path] [--limit N]' },
   'archive':  { category: 'Extraction', description: 'Save complete page as MHTML via CDP', usage: 'archive [path]' },
   // Visual

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -1137,9 +1137,10 @@ export async function handleWriteCommand(
     }
 
     case 'download': {
-      if (args.length === 0) throw new Error('Usage: download <url|@ref> [path] [--base64]');
+      if (args.length === 0) throw new Error('Usage: download <url|@ref> [path] [--base64] [--navigate]');
       const isBase64 = args.includes('--base64');
-      const filteredArgs = args.filter(a => a !== '--base64');
+      const useNavigate = args.includes('--navigate');
+      const filteredArgs = args.filter(a => a !== '--base64' && a !== '--navigate');
       let url = filteredArgs[0];
       const outputPath = filteredArgs[1];
 
@@ -1200,6 +1201,61 @@ export async function handleWriteCommand(
         if (!match) throw new Error('Failed to decode blob data');
         contentType = match[1];
         buffer = Buffer.from(match[2], 'base64');
+      } else if (useNavigate) {
+        // Strategy 2: Navigate to URL and capture browser-triggered download.
+        // This handles URLs that trigger file downloads via redirects,
+        // Content-Disposition headers, or CDN chains that fail with
+        // page.request.fetch() (e.g. DDoS-Guard protected sites, Anna's
+        // Archive fast downloads, CDN redirect chains).
+        await validateNavigationUrl(url);
+        const downloadPromise = page.waitForEvent('download', { timeout: 60000 });
+        // Use goto with 'commit' wait — the page may redirect to trigger
+        // the download, so 'domcontentloaded' may never fire.
+        page.goto(url, { waitUntil: 'commit', timeout: 30000 }).catch(() => {
+          // Navigation may "fail" because the response is a download,
+          // not a page. This is expected — the download event handles it.
+        });
+        const download = await downloadPromise;
+        const failure = await download.failure();
+        if (failure) {
+          throw new Error(`Download failed: ${failure}`);
+        }
+        // Save to temp location first, then read into buffer
+        const tempPath = path.join(TEMP_DIR, `browse-nav-download-${Date.now()}`);
+        await download.saveAs(tempPath);
+        buffer = fs.readFileSync(tempPath);
+        // Try to infer content type from suggested filename
+        const suggested = download.suggestedFilename();
+        if (suggested) {
+          const extMatch = suggested.match(/\.([a-z0-9]+)$/i);
+          if (extMatch) {
+            const extLower = extMatch[1].toLowerCase();
+            const mimeMap: Record<string, string> = {
+              epub: 'application/epub+zip', pdf: 'application/pdf',
+              zip: 'application/zip', gz: 'application/gzip',
+              mp3: 'audio/mpeg', mp4: 'video/mp4',
+              jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
+              txt: 'text/plain', html: 'text/html', json: 'application/json',
+            };
+            contentType = mimeMap[extLower] || 'application/octet-stream';
+          }
+        }
+        // Clean up temp file if we're going to write elsewhere
+        if (outputPath || isBase64) {
+          try { fs.unlinkSync(tempPath); } catch { /* ignore */ }
+        } else {
+          // If no output path specified, rename temp file
+          const ext = contentType.split(';')[0].includes('/')
+            ? mimeToExt(contentType.split(';')[0].trim())
+            : '.bin';
+          const finalPath = path.join(TEMP_DIR, `browse-download-${Date.now()}${ext}`);
+          fs.renameSync(tempPath, finalPath);
+          const sizeKB = Math.round(buffer.length / 1024);
+          return `Downloaded: ${finalPath} (${sizeKB}KB, ${contentType.split(';')[0].trim()})${suggested ? ` [${suggested}]` : ''}`;
+        }
+        if (buffer.length > 200 * 1024 * 1024) {
+          throw new Error('File too large (>200MB).');
+        }
       } else {
         // Strategy 1: Direct URL via page.request.fetch().
         // Gate the URL through the same validator `goto` uses. Without


### PR DESCRIPTION
## Problem

The `download` command uses `page.request.fetch()` which creates a separate HTTP request outside the browser context. This fails for URLs that trigger actual browser downloads via:

- **Content-Disposition headers** — server says "download this file"
- **CDN redirect chains** — DDoS-Guard → CDN redirect that requires browser cookies
- **Cross-origin redirects** — CORS blocks `fetch()` but browser navigation works

Concrete example: Anna's Archive fast downloads. The browser can login, get auth cookies, and navigate to a download URL — but `page.request.fetch()` can't follow the redirect chain through DDoS-Guard. The `goto` command says "Download is starting" but the file is never persisted.

## Solution

New `--navigate` flag on the `download` command:

```bash
browse download "https://example.com/file.epub" /tmp/book.epub --navigate
```

When `--navigate` is set, instead of `page.request.fetch()`, the command:
1. Sets up `page.waitForEvent("download")` listener
2. Calls `page.goto(url)` with `waitUntil: "commit"` (since the page may redirect to trigger the download)
3. Captures the Playwright `Download` object
4. Calls `download.saveAs(path)` to persist the file
5. Infers content type from the suggested filename

This uses the browser's native download handling, which includes all cookies, proxy settings, and TLS fingerprint — exactly what sites like Anna's Archive, DDoS-Guard-protected CDNs, and authenticated download portals require.

## Usage

```bash
# Old behavior (direct fetch, still default):
browse download "https://cdn.example.com/file.pdf" /tmp/file.pdf

# New: browser-triggered download:
browse download "https://protected-site.com/download/abc123" /tmp/file.epub --navigate

# Works with --base64 too:
browse download "https://protected-site.com/download/abc123" --navigate --base64
```

## Testing

Tested end-to-end with Anna's Archive fast downloads through NordVPN SOCKS proxy:
- Login via form → auth cookies set
- `download --navigate` → file captured and saved
- 4.1MB EPUB validated

## Changes

- `browse/src/write-commands.ts`: Added `--navigate` strategy (Strategy 2) to `download` command
- `browse/src/commands.ts`: Updated help text to document `--navigate` flag

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->