### PR TITLE
fix(browse): auto-detect Linux AppArmor userns restriction so sandbox works on stock Ubuntu/Pi OS

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -16,6 +16,7 @@
  */
 
 import { chromium, type Browser, type BrowserContext, type BrowserContextOptions, type Page, type Locator, type Cookie } from 'playwright';
+import { readFileSync } from 'node:fs';
 import { addConsoleEntry, addNetworkEntry, addDialogEntry, networkBuffer, type DialogEntry } from './buffers';
 import { validateNavigationUrl } from './url-validation';
 import { TabSession, type RefEntry } from './tab-session';
@@ -185,7 +186,24 @@ export class BrowserManager {
     // Docker/CI: Chromium sandbox requires unprivileged user namespaces which
     // are typically disabled in containers. Detect container environment and
     // add --no-sandbox automatically.
-    if (process.env.CI || process.env.CONTAINER) {
+    //
+    // Linux AppArmor: Ubuntu 23.10+ ships with
+    // kernel.apparmor_restrict_unprivileged_userns=1 by default, which blocks
+    // Chromium's userns sandbox even outside containers. Detect this kernel-
+    // level restriction so headless browse works on stock Ubuntu desktops and
+    // Raspberry Pi OS without manual env tricks.
+    //
+    // BROWSE_NO_SANDBOX=1 lets users force-disable the sandbox explicitly.
+    let needsNoSandbox = !!(process.env.CI || process.env.CONTAINER || process.env.BROWSE_NO_SANDBOX);
+    if (!needsNoSandbox && process.platform === 'linux') {
+      try {
+        const v = readFileSync('/proc/sys/kernel/apparmor_restrict_unprivileged_userns', 'utf8').trim();
+        if (v === '1') needsNoSandbox = true;
+      } catch {
+        // /proc file absent or unreadable → assume sandbox is fine
+      }
+    }
+    if (needsNoSandbox) {
       launchArgs.push('--no-sandbox');
     }
 


### PR DESCRIPTION
## Summary

- Detect Linux AppArmor userns restriction so headless `browse` works on stock Ubuntu desktops and Raspberry Pi OS without env tricks
- Add explicit `BROWSE_NO_SANDBOX=1` override
- Existing `CI` / `CONTAINER` detection unchanged
- macOS / Windows behavior unchanged

## Why

Ubuntu 23.10+ ships with `kernel.apparmor_restrict_unprivileged_userns=1` enabled by default, which blocks Chromium's user-namespace sandbox even outside containers. On these hosts (and on Raspberry Pi OS for the same reason), running `browse` from a normal user shell fails:

```
[browse] Server failed to start:
[browse] Failed to start: launch: Target page, context or browser has been closed
Browser logs:
Chromium sandboxing failed!
================================
To avoid the sandboxing issue, do either of the following:
  - (preferred): Configure your environment to support sandboxing
  - (alternative): Launch Chromium without sandbox using 'chromiumSandbox: false' option
================================
```

Today the workarounds are all bad:
- `CI=1 browse status` — misleading, this isn't CI
- `CONTAINER=1 browse status` — misleading, this isn't a container
- `sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0` — weakens host security

This PR auto-detects the kernel restriction by reading `/proc/sys/kernel/apparmor_restrict_unprivileged_userns` and adds `--no-sandbox` only when it's `1`. Adds `BROWSE_NO_SANDBOX=1` for users who want explicit control.

## What changed

`browse/src/browser-manager.ts:185-204` (+19 lines, -1 line):

- `import { readFileSync } from 'node:fs'`
- New `BROWSE_NO_SANDBOX` env override
- Linux-only `/proc` read, gated on `process.platform === 'linux'`, wrapped in `try/catch` so missing/unreadable `/proc` files silently fall through to the existing behavior

## Test plan

- [x] Ubuntu 25.10 / Raspberry Pi 5 / kernel `6.17.0-1011-raspi`: `browse status` reports healthy and `browse goto https://example.com` returns 200 / `browse js document.title` returns "Example Domain", all without `CI=1` or `CONTAINER=1`
- [ ] macOS: unchanged — `process.platform === 'linux'` gate skips the new code path
- [ ] Windows: unchanged — same gate
- [ ] Linux without AppArmor restriction (`apparmor_restrict_unprivileged_userns=0` or file missing): unchanged — sandbox stays enabled
- [ ] Container without `CONTAINER=1` env: unchanged — falls through to userns sandbox check (unaffected by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->