### PR TITLE
fix(gemini-adapter): detect new ~/.gemini/oauth_creds.json auth path

### DIFF
--- a/test/helpers/providers/gemini.ts
+++ b/test/helpers/providers/gemini.ts
@@ -22,8 +22,10 @@ export class GeminiAdapter implements ProviderAdapter {
     if (res.status !== 0) {
       return { ok: false, reason: 'gemini CLI not found on PATH. Install per https://github.com/google-gemini/gemini-cli' };
     }
-    const cfgDir = path.join(os.homedir(), '.config', 'gemini');
-    const hasCfg = fs.existsSync(cfgDir);
+    const legacyCfgDir = path.join(os.homedir(), '.config', 'gemini');
+    const newCfgDir = path.join(os.homedir(), '.gemini');
+    const newOauth = path.join(newCfgDir, 'oauth_creds.json');
+    const hasCfg = fs.existsSync(legacyCfgDir) || fs.existsSync(newOauth);
     const hasKey = !!process.env.GOOGLE_API_KEY;
     if (!hasCfg && !hasKey) {
       return { ok: false, reason: 'No Gemini auth found. Log in via `gemini login` or export GOOGLE_API_KEY.' };


### PR DESCRIPTION
## Summary

`gemini-cli >=0.30` stores OAuth credentials at `~/.gemini/oauth_creds.json` instead of the legacy `~/.config/gemini/` directory. The benchmark adapter's availability check still only looks at the legacy path, so users who have authenticated with a recent gemini-cli see `NOT READY — No Gemini auth found` even though the CLI itself works fine.

This patch accepts either path, so older and newer installs both succeed.

## Repro before fix

```
$ gemini   # cached credentials load fine
$ ~/.claude/skills/gstack/bin/gstack-model-benchmark --prompt unused --models gemini --dry-run
  gemini: NOT READY — No Gemini auth found.
```

`~/.config/gemini/` does not exist; `~/.gemini/oauth_creds.json` does.

## After fix

```
  gemini: OK
```

Verified end-to-end with a real benchmark run (gpt + gemini, 11.5s, no auth errors).

## Test plan

- [x] Dry-run shows `gemini: OK` on a host with only `~/.gemini/oauth_creds.json`
- [x] Real benchmark run completes without auth errors
- [ ] Verify legacy `~/.config/gemini/` path still detected (unchanged code path; trusting OR semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->