### PR TITLE
fix(browser): add --no-sandbox for root user on Linux/WSL2

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -182,10 +182,11 @@ export class BrowserManager {
     const launchArgs: string[] = [];
     let useHeadless = true;
 
-    // Docker/CI: Chromium sandbox requires unprivileged user namespaces which
-    // are typically disabled in containers. Detect container environment and
-    // add --no-sandbox automatically.
-    if (process.env.CI || process.env.CONTAINER) {
+    // Docker/CI/root: Chromium sandbox requires unprivileged user namespaces which
+    // are typically disabled in containers and are never available for the root
+    // user on Linux. Detect all three cases and add --no-sandbox automatically.
+    const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+    if (process.env.CI || process.env.CONTAINER || isRoot) {
       launchArgs.push('--no-sandbox');
     }
 


### PR DESCRIPTION
Fixes #1364.

When running as root on Linux or WSL2, Chromium exits immediately because its sandbox can't initialize for the root user. `browser-manager.ts` already skips the sandbox under `CI` and `CONTAINER`, but root was missing from that check.

## Change

```typescript
// before
if (process.env.CI || process.env.CONTAINER) {
  launchArgs.push('--no-sandbox');
}

// after
const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
if (process.env.CI || process.env.CONTAINER || isRoot) {
  launchArgs.push('--no-sandbox');
}
```

The `typeof process.getuid === 'function'` guard keeps this safe on Windows where `getuid` is not defined.

## Test

```bash
# Before fix (as root, WSL2)
B=~/.claude/skills/gstack/browse/dist/browse
$B goto https://example.com
# [browse] FATAL: Chromium process crashed or was killed. Server exiting.

# After fix
$B goto https://example.com
# Navigated to https://example.com (200)
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->