### PR TITLE
security: pass cwd to git via execFileSync, not interpolation through /bin/sh

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -632,9 +632,16 @@ function extractContentText(rec: any): string {
 function resolveGitRemote(cwd: string): string {
   if (!cwd) return "";
   try {
-    const out = execSync(`git -C ${JSON.stringify(cwd)} remote get-url origin 2>/dev/null`, {
+    // execFileSync (no shell) so `cwd` cannot trigger command substitution.
+    // Transcript JSONL records are an untrusted surface (a poisoned `.cwd`
+    // value containing `"$(...)"` survived `JSON.stringify` interpolation
+    // into a `/bin/sh -c` context, since JSON quoting does not escape `$`
+    // or backticks). Mirrors the execFileSync pattern this module already
+    // uses for `gbrainAvailable()` (line 762) and `gbrainPutPage()` (line 816).
+    const out = execFileSync("git", ["-C", cwd, "remote", "get-url", "origin"], {
       encoding: "utf-8",
       timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
     });
     return canonicalizeRemote(out.trim());
   } catch {

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -205,6 +205,52 @@ describe("gstack-memory-ingest state file", () => {
   });
 });
 
+// ── Security: cwd in transcript JSONL must not reach a shell ─────────────
+
+describe("gstack-memory-ingest security: untrusted cwd cannot trigger shell substitution", () => {
+  it("does not invoke /bin/sh when a transcript record contains $() in cwd", () => {
+    // Transcript JSONL is an untrusted surface — a record's `.cwd` value
+    // can be set by anyone who can write to ~/.claude/projects (cross-machine
+    // share, prompt-injection appending to the active session log, etc.).
+    // resolveGitRemote() must use execFileSync, not execSync with template
+    // interpolation, or `cwd="$(...)"` triggers command substitution under
+    // /bin/sh -c on the next ingest run.
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+
+    const markerDir = mkdtempSync(join(tmpdir(), "gstack-mi-cwd-marker-"));
+    const marker = join(markerDir, "PWNED");
+    // Plain $(...) — what an attacker would write into a transcript record.
+    // execFileSync passes this verbatim to git as a -C argument; execSync
+    // (the prior code path) wrapped it in a /bin/sh -c template that ran
+    // the substitution.
+    const malicious = "$(touch " + marker + ")";
+
+    const record = JSON.stringify({
+      type: "user",
+      uuid: "11111111-1111-1111-1111-111111111111",
+      sessionId: "abc",
+      cwd: malicious,
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: "hi" },
+    });
+    writeClaudeCodeSession(home, "-tmp-target", "abc", record + "\n");
+
+    const r = runScript(["--incremental", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      GSTACK_MEMORY_INGEST_NO_WRITE: "1",
+    });
+
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(marker)).toBe(false);
+
+    rmSync(home, { recursive: true, force: true });
+    rmSync(markerDir, { recursive: true, force: true });
+  });
+});
+
 // ── Transcript parser via re-import of the source module ───────────────────
 
 describe("internal: parseTranscriptJsonl + buildTranscriptPage shape", () => {


### PR DESCRIPTION
## Summary

`bin/gstack-memory-ingest.ts:632-643` ran:

```ts
execSync(`git -C ${JSON.stringify(cwd)} remote get-url origin 2>/dev/null`, ...)
```

`JSON.stringify` escapes `"` and `\` but not `$` or backticks, so a `cwd` of `"$(touch /tmp/marker)"` survives JSON quoting and detonates under `/bin/sh`'s command-substitution-inside-double-quotes.

`cwd` originates from transcript JSONL records under `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl` and `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`. The walker grabs the first `.cwd` it sees per session — agent transcripts are an explicit untrusted surface in the gstack threat model, which is what the L1-L6 sidebar security stack exists for.

Two pivots above the local same-uid bar:

- **Prompt-injection-to-shell.** A single line appended to the active session log via prompt injection turns the next `/sync-gbrain` into RCE under the user's uid (HOME, ssh keys, ngrok creds, gbrain bearers, etc.).
- **Cross-machine transcript share.** A colleague's `.claude/projects` snippet untar'd into a peer's HOME (a documented gbrain dogfooding pattern) → RCE on first sync.

`gstack-memory-ingest --incremental` is stage 2 of `gstack-gbrain-sync.ts:runMemoryIngest` (lines 407-433), so any `/sync-gbrain` run triggers it.

## Fix

Swap the one `execSync` for `execFileSync("git", ["-C", cwd, "remote", "get-url", "origin"], ...)`. No shell, argv passed directly to git. The same module already uses `execFileSync` for `gbrainAvailable()` (line 755) and `gbrainPutPage()` (line 816) — this single `execSync` was the outlier.

## Test

New regression test `gstack-memory-ingest security: untrusted cwd cannot trigger shell substitution` plants a Claude-Code-shaped JSONL with `cwd="$(touch <marker>)"` and asserts the marker file is not created after `--incremental --quiet`.

```
$ bun test test/gstack-memory-ingest.test.ts
 18 pass
 0 fail
 53 expect() calls
```

Negative control: stash the patch, run the same test, it fails (marker file gets created on disk). Restore the patch, it passes.

## Test plan

- [x] `bun test test/gstack-memory-ingest.test.ts` green (18/18)
- [x] Negative control: revert fix, security test fails with the marker file created (verified)
- [x] Existing tests unaffected (every other test passes both before and after the fix)
