### PR TITLE
security: gate domain-skill auto-promote on classifier_score > 0

### DIFF
--- a/browse/src/domain-skills.ts
+++ b/browse/src/domain-skills.ts
@@ -291,8 +291,20 @@ export async function writeSkill(input: WriteSkillInput): Promise<DomainSkillRow
  *
  * Auto-promote logic:
  *   - increment use_count
- *   - if use_count >= PROMOTE_THRESHOLD AND flag_count == 0 → state:active
- *   - else stay quarantined with updated counter
+ *   - if use_count >= PROMOTE_THRESHOLD AND flag_count == 0 AND L4 has scored
+ *     the body (classifier_score > 0) → state:active
+ *   - else stay quarantined with updated counter; user must run
+ *     `domain-skill promote-to-global` manually
+ *
+ * The classifier_score > 0 gate is load-bearing: handleSave currently writes
+ * classifier_score=0 with the comment "L4 deferred to load-time / sidebar-agent
+ * fills this in on first prompt-injection load," but sidebar-agent was ripped
+ * (CLAUDE.md "Sidebar architecture") and nothing else updates the score, so
+ * skills authored via the production path never had their body scanned by L4.
+ * Without this gate, three benign uses promote any quarantined skill — including
+ * one written under the influence of a poisoned page — into the prompt context
+ * for every subsequent visit. The gate re-opens automatically the day L4 is
+ * rewired and writeSkill / recordSkillUse start receiving non-zero scores.
  */
 export async function recordSkillUse(host: string, projectSlug: string, classifierFlagged: boolean): Promise<DomainSkillRow | null> {
   const normalized = normalizeHost(host);
@@ -303,7 +315,12 @@ export async function recordSkillUse(host: string, projectSlug: string, classifi
   const useCount = current.use_count + 1;
   const flagCount = current.flag_count + (classifierFlagged ? 1 : 0);
   let state: SkillState = current.state;
-  if (state === 'quarantined' && useCount >= PROMOTE_THRESHOLD && flagCount === 0) {
+  if (
+    state === 'quarantined' &&
+    useCount >= PROMOTE_THRESHOLD &&
+    flagCount === 0 &&
+    current.classifier_score > 0
+  ) {
     state = 'active';
   }
   const updated: DomainSkillRow = {

--- a/browse/test/domain-skills-storage.test.ts
+++ b/browse/test/domain-skills-storage.test.ts
@@ -106,6 +106,31 @@ describe('domain-skills: state machine (T6)', () => {
       })
     ).rejects.toThrow(/classifier flagged/);
   });
+
+  // domain-skill-commands.ts:140 (handleSave) writes classifier_score=0 with
+  // the comment "L4 deferred to load-time" — but sidebar-agent (the deferred
+  // scanner) was ripped per CLAUDE.md "Sidebar architecture." Without an
+  // explicit gate, three benign uses promote any quarantined skill, including
+  // one authored under a poisoned page, into prompt context permanently.
+  it('does NOT auto-promote when classifier_score is 0 (production handleSave shape)', async () => {
+    const m = await freshImport();
+    await m.writeSkill({
+      host: 'linkedin.com',
+      body: '# LinkedIn',
+      projectSlug: 'test-slug',
+      source: 'agent',
+      classifierScore: 0, // matches domain-skill-commands.ts:140 production path
+    });
+    const after3 = await m.recordSkillUse('linkedin.com', 'test-slug', false);
+    await m.recordSkillUse('linkedin.com', 'test-slug', false);
+    const final = await m.recordSkillUse('linkedin.com', 'test-slug', false);
+    expect(after3?.state).toBe('quarantined');
+    expect(final?.state).toBe('quarantined');
+    expect(final?.use_count).toBe(3);
+    // readSkill returns null for quarantined skills — they don't fire.
+    const read = await m.readSkill('linkedin.com', 'test-slug');
+    expect(read).toBeNull();
+  });
 });
 
 describe('domain-skills: scope shadowing (T4)', () => {


### PR DESCRIPTION
## Summary

`browse/src/domain-skill-commands.ts:140` (handleSave) writes `classifier_score: 0` with the inline comment *"L4 deferred to load-time / sidebar-agent fills this in on first prompt-injection load."* But CLAUDE.md "Sidebar architecture" documents that `sidebar-agent.ts` was ripped, and grepping `browse/src/` for callers of `recordSkillUse(..., classifierFlagged: true)` (or any caller of `recordSkillUse` outside `domain-skills.ts` itself) returns zero hits.

Net effect: every quarantined skill that survives three benign `recordSkillUse(..., false)` calls auto-promotes to `active` (`domain-skills.ts:297-308`) and lands in prompt context wrapped as UNTRUSTED on every subsequent visit to that host. The L4 score that was supposed to gate the promotion was never written — the production save path puts 0 on disk and nothing later updates it.

## Threat model

A domain-skill body authored by an agent under the influence of a poisoned page would lose its auto-promote barrier after three uses. The exploit isn't single-step but the bar is N=3 prompt-injection-shaped uses on a hostile page, which is well within reach. Note that the new `window.gstackInjectToTerminal` PTY path (per CLAUDE.md "Sidebar architecture" / "Cross-pane PTY injection") runs no L1-L3 either, so page-derived text reaches the live `claude` REPL with no scan; a tampered domain-skill widens that surface across every later visit.

## Fix

One condition added to the auto-promote gate in `recordSkillUse`:

```ts
if (state === 'quarantined' && useCount >= PROMOTE_THRESHOLD &&
    flagCount === 0 && current.classifier_score > 0) {
  state = 'active';
}
```

`classifier_score` is set once at `writeSkill` and never updated. Production saves it as 0 (`handleSave`), so the gate stays closed. Existing tests that explicitly pass `classifierScore: 0.1` still auto-promote — the auto-promote path is preserved for the day L4 is rewired.

Manual promotion via `domain-skill promote-to-global` is unaffected (it goes through `promoteToGlobal` which has its own state-machine guard at line 337+).

## Test

New regression case `does NOT auto-promote when classifier_score is 0 (production handleSave shape)` plants a skill with `classifierScore: 0` (matches `domain-skill-commands.ts:140`), runs three uses without flag, asserts the skill stays `quarantined` and `readSkill` returns `null`.

```
$ bun test browse/test/domain-skills-storage.test.ts
 15 pass
 0 fail
 36 expect() calls
```

Negative control: stash the patch, run the same test, it fails with `Received: "active"`. Restore the patch, it passes.

## Test plan

- [x] `bun test browse/test/domain-skills-storage.test.ts` green (15/15)
- [x] Negative control: revert fix, new test fails with `Received: "active"` (verified)
- [x] Existing auto-promote tests (which pass `classifierScore: 0.1`) still pass — auto-promote behavior is preserved for the day L4 returns
- [x] `promoteToGlobal` (manual promote path) untouched

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->