### PR TITLE
fix(gstack-gbrain-detect): include 'url' in Tier 1 $mtype case for Streamable HTTP MCP

### DIFF
--- a/bin/gstack-gbrain-detect
+++ b/bin/gstack-gbrain-detect
@@ -110,8 +110,8 @@ if command -v claude >/dev/null 2>&1; then
       mcommand=$(echo "$mcp_get_json" | jq -r '.command // empty' 2>/dev/null)
       murl=$(echo "$mcp_get_json" | jq -r '.url // empty' 2>/dev/null)
       case "$mtype" in
-        http|sse) gbrain_mcp_mode="remote-http" ;;
-        stdio)    gbrain_mcp_mode="local-stdio" ;;
+        url|http|sse) gbrain_mcp_mode="remote-http" ;;
+        stdio)        gbrain_mcp_mode="local-stdio" ;;
         *)
           # Newer claude versions may emit just url + command; infer.
           if [ -n "$murl" ]; then gbrain_mcp_mode="remote-http"


### PR DESCRIPTION
## Problem

`bin/gstack-gbrain-detect` runs a 3-tier fallback to determine `gbrain_mcp_mode`. **Tier 1** calls `claude mcp get gbrain --json` and matches `$mtype`:

```sh
case "$mtype" in
  http|sse) gbrain_mcp_mode="remote-http" ;;
  stdio)    gbrain_mcp_mode="local-stdio" ;;
  *)
    # Newer claude versions may emit just url + command; infer.
    if [ -n "$murl" ]; then gbrain_mcp_mode="remote-http"
    elif [ -n "$mcommand" ]; then gbrain_mcp_mode="local-stdio"
    fi ;;
esac
```

**Tier 3** (`~/.claude.json` jq fallback) — and every `SKILL.md` preamble that documents the same logic — correctly match `url|http|sse`:

```sh
case "$mtype" in
  url|http|sse) gbrain_mcp_mode="remote-http" ;;
  stdio)        gbrain_mcp_mode="local-stdio" ;;
  ...
esac
```

Anthropic's "Streamable HTTP" MCP transport reports `type: "url"`. When `claude mcp get gbrain --json` returns `{"type": "url", ...}` without a top-level `url` field (some claude CLI versions omit it when the URL is implicit in the config), Tier 1 falls through to `*`, sees `$murl` is empty, and returns `none`. Tier 3 — looking at the *same* `~/.claude.json` — would correctly say `remote-http`.

So the detect script's output can disagree with what the SKILL.md preambles tell skills to expect, and `/setup-gbrain` (and any downstream skill that branches on `gbrain_mcp_mode`) can misread the current mode.

## Fix

Add `url` to the Tier 1 case branch, matching Tier 3 and the SKILL.md preambles. The `stdio` arm is re-aligned in the same case block to keep the visual columns intact (cosmetic only):

```diff
       case "$mtype" in
-        http|sse) gbrain_mcp_mode="remote-http" ;;
-        stdio)    gbrain_mcp_mode="local-stdio" ;;
+        url|http|sse) gbrain_mcp_mode="remote-http" ;;
+        stdio)        gbrain_mcp_mode="local-stdio" ;;
         *)
```

Diff is +2/-2 lines, fully scoped to `bin/gstack-gbrain-detect`.

## Test plan

- [x] `bash -n bin/gstack-gbrain-detect` — clean parse.
- [x] Tier 3 in the same file (line 146) and `SKILL.md` preambles already match `url|http|sse`, so this PR brings Tier 1 in line with established convention rather than introducing a new behavior.
- [ ] `gstack-gbrain-detect | jq .gbrain_mcp_mode` against an Anthropic CLI configured with the `url` transport — best verified by maintainer with a real claude install.

## Discovery context

Found while reconciling DuReef's vendored `gstack` mirror at `db9447c3` (which predates the 3-tier detect block) against upstream HEAD `443bde05`. The Tier 1 / Tier 3 mismatch was visible immediately because Tier 3 was already correct in the same file.

Companion DuReef-side bookkeeping: [DuReef/workspace#49](https://github.com/DuReef/workspace/pull/49) — read-only watch entry in our `PORT-CANDIDATES.md` so reviewers know to refuse this regression on the next `chore(inspiration)` sync if this upstream PR isn't merged first.

## Out of scope

- No `VERSION` / `CHANGELOG.md` bump (left to maintainer's release cadence).
- No tests added — Tier 1 needs a real claude CLI fixture; the existing 3-tier defense-in-depth chain (commented "Fallback chain logged because if Anthropic moves the file or renames keys, the third tier breaks silently; the first two tiers should catch it") is the live test surface.
- No related changes to `gstack-gbrain-sync.ts`'s lock keepalive (filed separately as a sibling PR).

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->