### PR TITLE
fix(browse): add --disable-dev-shm-usage and --no-sandbox to Chromium launch args

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -194,16 +194,15 @@ export class BrowserManager {
     // Extensions only work in headed mode, so we use an off-screen window.
     const extensionsDir = process.env.BROWSE_EXTENSIONS_DIR;
     const { STEALTH_LAUNCH_ARGS } = await import('./stealth');
-    const launchArgs: string[] = [...STEALTH_LAUNCH_ARGS];
+    const launchArgs: string[] = [
+      ...STEALTH_LAUNCH_ARGS,
+      '--disable-dev-shm-usage',
+      '--no-sandbox',
+    ];
     let useHeadless = true;
 
     // Docker/CI: Chromium sandbox requires unprivileged user namespaces which
-    // are typically disabled in containers. Detect container environment and
-    // add --no-sandbox automatically.
-    if (process.env.CI || process.env.CONTAINER) {
-      launchArgs.push('--no-sandbox');
-    }
-
+    // are typically disabled in containers. --no-sandbox already added above.
     if (extensionsDir) {
       launchArgs.push(
         `--disable-extensions-except=${extensionsDir}`,
@@ -276,6 +275,8 @@ export class BrowserManager {
     const extensionPath = this.findExtensionPath();
     const launchArgs = [
       '--hide-crash-restore-bubble',
+      '--disable-dev-shm-usage',
+      '--no-sandbox',
       // Anti-bot-detection: remove the navigator.webdriver flag that Playwright sets.
       // Sites like Google and NYTimes check this to block automation browsers.
       '--disable-blink-features=AutomationControlled',


### PR DESCRIPTION
## Problem

WSL2 and Docker containers often lack /dev/shm (shared memory) and unprivileged user namespaces. Chromium requires both to function correctly in multi-step browsing (chain commands, goto→js, goto→screenshot).

**Without these flags:**
- Individual browse commands work (goto, status)
- Multi-step operations hang/timeout (chain, goto→js, goto→screenshot)

**Root cause:** Chromium's CDP communication stalls when /dev/shm is insufficient, causing page.evaluate() and other IPC operations to hang indefinitely. The daemon starts and accepts connections, but any JS evaluation after navigation to a local SPA page hangs.

## Fix

Add `--disable-dev-shm-usage` and `--no-sandbox` as default arguments in both `launch()` and `launchCDP()` methods, instead of conditionally adding `--no-sandbox` only in CI/CONTAINER environments.

**Changes in browse/src/browser-manager.ts:**
1. `launch()` method: inject both flags into launchArgs at initialization
2. `launchCDP()` method: same flags added to the CDP launch args array

## Verification

Tested on WSL2 (Ubuntu 22.04) with a local React SPA at localhost:18081:

**Before fix:**
```
$B goto localhost:18081 → ✓ 200 
$B js "document.title" → ✗ HANG
$B chain → ✗ 30s timeout
```

**After fix:**
```
echo 'goto http://localhost:18081 | status | js "document.title" | console --errors | network' | $B chain
→ [goto] Navigated to http://localhost:18081 (200)
→ [status] Status: healthy, URL: http://localhost:18081/
→ [js] MemoryCenter - AI Brain Console
→ [console] (errors captured correctly)
→ [network] 5 static assets, all 200
```

Public URLs (example.com) were not affected but continue to work correctly after the change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->