### PR TITLE
test: bump remaining claude-opus-4-6 → 4-7 references

### DIFF
--- a/test/helpers/eval-store.ts
+++ b/test/helpers/eval-store.ts
@@ -68,7 +68,7 @@ export interface EvalTestEntry {
   last_tool_call?: string;    // e.g. "Write(review-output.md)"
 
   // Model + timing diagnostics (added for Sonnet/Opus split)
-  model?: string;                // e.g. 'claude-sonnet-4-6' or 'claude-opus-4-6'
+  model?: string;                // e.g. 'claude-sonnet-4-6' or 'claude-opus-4-7'
   first_response_ms?: number;    // time from spawn to first NDJSON line
   max_inter_turn_ms?: number;    // peak latency between consecutive tool calls
 

--- a/test/skill-e2e-design.test.ts
+++ b/test/skill-e2e-design.test.ts
@@ -103,7 +103,7 @@ Write DESIGN.md and CLAUDE.md (or update it) in the working directory.`,
       timeout: 360_000,
       testName: 'design-consultation-core',
       runId,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
     });
 
     logCost('/design-consultation core', result);
@@ -227,7 +227,7 @@ Skip research. Skip font preview. Skip any AskUserQuestion calls — this is non
       timeout: 360_000,
       testName: 'design-consultation-existing',
       runId,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
     });
 
     logCost('/design-consultation existing', result);

--- a/test/skill-e2e-plan.test.ts
+++ b/test/skill-e2e-plan.test.ts
@@ -82,7 +82,7 @@ Focus on reviewing the plan content: architecture, error handling, security, and
       timeout: 360_000,
       testName: 'plan-ceo-review',
       runId,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
     });
 
     logCost('/plan-ceo-review', result);
@@ -167,7 +167,7 @@ Focus on reviewing the plan content: architecture, error handling, security, and
       timeout: 360_000,
       testName: 'plan-ceo-review-selective',
       runId,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
     });
 
     logCost('/plan-ceo-review (SELECTIVE)', result);
@@ -233,7 +233,7 @@ Write your expansion proposals to ${planDir}/proposals.md with ONLY the proposal
       timeout: 360_000,
       testName: 'plan-ceo-review-expansion-energy',
       runId,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
     });
 
     logCost('/plan-ceo-review (EXPANSION ENERGY)', result);
@@ -333,7 +333,7 @@ Focus on architecture, code quality, tests, and performance sections.`,
       timeout: 360_000,
       testName: 'plan-eng-review',
       runId,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
     });
 
     logCost('/plan-eng-review', result);
@@ -459,7 +459,7 @@ Write your review to ${planDir}/review-output.md`,
       timeout: 360_000,
       testName: 'plan-eng-review-artifact',
       runId,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
     });
 
     logCost('/plan-eng-review artifact', result);
@@ -679,7 +679,7 @@ This review report at the bottom of the plan is the MOST IMPORTANT deliverable o
       timeout: 360_000,
       testName: 'plan-review-report',
       runId,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
     });
 
     logCost('/plan-eng-review report', result);

--- a/test/skill-e2e-qa-bugs.test.ts
+++ b/test/skill-e2e-qa-bugs.test.ts
@@ -100,7 +100,7 @@ CRITICAL RULES:
       timeout: 300_000,
       testName: `qa-${label}`,
       runId,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
     });
 
     logCost(`/qa ${label}`, result);

--- a/test/skill-e2e-review.test.ts
+++ b/test/skill-e2e-review.test.ts
@@ -514,7 +514,7 @@ Analyze the git history and produce the narrative report as described in the SKI
       timeout: 300_000,
       testName: 'retro',
       runId,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
     });
 
     logCost('/retro', result);

--- a/test/skill-e2e-workflow.test.ts
+++ b/test/skill-e2e-workflow.test.ts
@@ -503,7 +503,7 @@ Write the full output (including the GATE verdict) to ${codexDir}/codex-output.m
       timeout: 300_000,
       testName: 'codex-review',
       runId,
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
     });
 
     logCost('/codex review', result);


### PR DESCRIPTION
## Summary

Found 11 leftover `claude-opus-4-6` references across 6 test files after the v1.x migration to `claude-opus-4-7`. Bumping for consistency with the rest of the suite (`test/helpers/providers/claude.ts`, `test/helpers/pricing.ts`, and the dedicated `test/skill-e2e-opus-47.test.ts` already use `4-7`).

Files touched:

- `test/helpers/eval-store.ts` (1 — comment example)
- `test/skill-e2e-design.test.ts` (2)
- `test/skill-e2e-plan.test.ts` (5, including `plan-ceo-review-expansion-energy` added in 1.27.x)
- `test/skill-e2e-qa-bugs.test.ts` (1)
- `test/skill-e2e-review.test.ts` (1)
- `test/skill-e2e-workflow.test.ts` (1)

`grep -rn 'claude-opus-4-6' test/` returns zero matches after this patch.

## Test plan

- [x] `grep -rn 'claude-opus-4-6' test/` → no results
- [x] `git diff --stat` shows only the 12 line-level swaps in 6 files
- [ ] CI passes on the bumped suite (the test logic is unchanged — only the model identifier in the runner config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->