### PR TITLE
docs(codex): rename Step 0 to avoid collision with platform-detect prelude

### DIFF
--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -792,7 +792,7 @@ assumptions, catches things you might miss. Present its output faithfully, not s
 
 ---
 
-## Step 0: Check codex binary
+## Step 0.4: Check codex binary
 
 ```bash
 CODEX_BIN=$(which codex 2>/dev/null || echo "")

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -39,7 +39,7 @@ assumptions, catches things you might miss. Present its output faithfully, not s
 
 ---
 
-## Step 0: Check codex binary
+## Step 0.4: Check codex binary
 
 ```bash
 CODEX_BIN=$(which codex 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

`codex/SKILL.md` had two `## Step 0:` H2 headings sitting back-to-back: the platform-detect prelude (`## Step 0: Detect platform and base branch`, injected via `scripts/resolvers/utility.ts`) and the codex skill's own `## Step 0: Check codex binary` from `codex/SKILL.md.tmpl:42`. An agent reading the skill in order hits both with no clear cue which to follow.

## Why this matters

[#1388](https://github.com/garrytan/gstack/issues/1388) reports the collision and proposes three options (`Step 0a/0b`, merge, or relabel one as `Step 0.5`). The `Step 0.5` option is taken, so this PR uses the next free fractional slot.

## Changes

Renamed `codex/SKILL.md.tmpl:42` from `## Step 0: Check codex binary` to `## Step 0.4: Check codex binary`. The new label slots between the prelude (`Step 0`) and the existing `Step 0.5: Auth probe + version check` / `Step 0.6: Resolve portable roots` sections, so reading order stays correct and no downstream renumbering is needed.

After the rename, `codex/SKILL.md` has exactly one `## Step 0:` heading: the platform-detect prelude at line 746.

## Testing

- `bun test test/skill-validation.test.ts` -> 327 pass
- `bun test test/gen-skill-docs.test.ts` -> 378 pass, 1 unrelated pre-existing fail (`package.json version matches VERSION file` `package.json` is at 1.29.0.0 vs `VERSION` 1.30.0.0; not touched by this PR)
- `grep -n '^## Step 0' codex/SKILL.md` returns only the prelude

Closes #1388

AI was used for assistance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->