### PR TITLE
codex: add verify mode + Claude-skepticism preamble (v1.1.0)

### DIFF
--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: codex
-version: 1.0.0
+version: 1.1.0
 description: |
-  OpenAI Codex CLI wrapper — three modes. Code review: independent diff review via
-  codex review with pass/fail gate. Challenge: adversarial mode that tries to break
-  your code. Consult: ask codex anything with session continuity for follow-ups.
-  The "200 IQ autistic developer" second opinion. Use when asked to "codex review",
-  "codex challenge", "ask codex", "second opinion", or "consult codex".
+  OpenAI Codex CLI wrapper — four modes. Code review: independent diff review
+  with pass/fail gate, Claude-skepticism preamble. Challenge: adversarial mode
+  that tries to break your code. Consult: ask codex anything with session
+  continuity. Verify: audit a recommendation Claude gave you, independently —
+  closes the 2026-05-09 ShipStation-class failure path. Use when asked to
+  "codex review", "codex challenge", "codex verify", "ask codex", "second
+  opinion", or "consult codex".
 allowed-tools:
   - Bash
   - Read
@@ -251,6 +253,53 @@ assumptions, catches things you might miss. Present its output faithfully, not s
 
 ---
 
+## Claude Code Trust Boundaries
+
+The /codex skill exists because Claude Code has a documented failure mode of
+making confident, plausible-sounding claims about third-party systems without
+verifying them against documentation. On 2026-05-09 Claude recommended clicking
+ShipStation's "Send Notifications" button as "the preferred path" for replaying
+WooCommerce shipnotify webhooks. The button does not replay webhooks — it
+re-sends ShipStation's own branded shipping confirmation emails. 814 customers
+received duplicate emails for orders shipped weeks earlier. Source: button-label
+inference, no doc verification.
+
+When constructing any codex prompt — Review, Challenge, Consult, or Verify —
+prepend the following SKEPTICISM PREAMBLE verbatim:
+
+────────────────────────────────────────────────────────────────────
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+────────────────────────────────────────────────────────────────────
+
+---
+
 ## Step 0: Check codex binary
 
 ```bash
@@ -269,7 +318,8 @@ Parse the user's input to determine which mode to run:
 
 1. `/codex review` or `/codex review <instructions>` — **Review mode** (Step 2A)
 2. `/codex challenge` or `/codex challenge <focus>` — **Challenge mode** (Step 2B)
-3. `/codex` with no arguments — **Auto-detect:**
+3. `/codex verify` or `/codex verify <pasted recommendation>` — **Verify mode** (Step 2D)
+4. `/codex` with no arguments — **Auto-detect:**
    - Check for a diff (with fallback if origin isn't available):
      `git diff origin/<base> --stat 2>/dev/null | tail -1 || git diff <base> --stat 2>/dev/null | tail -1`
    - If a diff exists, use AskUserQuestion:
@@ -277,48 +327,90 @@ Parse the user's input to determine which mode to run:
      Codex detected changes against the base branch. What should it do?
      A) Review the diff (code review with pass/fail gate)
      B) Challenge the diff (adversarial — try to break it)
-     C) Something else — I'll provide a prompt
+     C) Verify a recommendation Claude gave me (paste it next)
+     D) Something else — I'll provide a prompt
      ```
    - If no diff, check for plan files scoped to the current project:
      `ls -t ~/.claude/plans/*.md 2>/dev/null | xargs grep -l "$(basename $(pwd))" 2>/dev/null | head -1`
      If no project-scoped match, fall back to: `ls -t ~/.claude/plans/*.md 2>/dev/null | head -1`
      but warn the user: "Note: this plan may be from a different project."
    - If a plan file exists, offer to review it
-   - Otherwise, ask: "What would you like to ask Codex?"
-4. `/codex <anything else>` — **Consult mode** (Step 2C), where the remaining text is the prompt
+   - Otherwise, ask: "Did you want to verify a recommendation Claude gave you, or ask Codex something else?"
+5. `/codex <anything else>` — **Consult mode** (Step 2C), where the remaining text is the prompt
 
 ---
 
 ## Step 2A: Review Mode
 
-Run Codex code review against the current branch diff.
+Run Codex code review against the current branch diff, with the SKEPTICISM PREAMBLE prepended.
 
-1. Create temp files for output capture:
+1. Create temp files:
 ```bash
+TMPPROMPT=$(mktemp /tmp/codex-prompt-XXXXXX.txt)
 TMPERR=$(mktemp /tmp/codex-err-XXXXXX.txt)
 ```
 
-2. Run the review (5-minute timeout):
+2. Write the assembled prompt (preamble + review body) to the temp file. Substitute
+   `<base>` with the detected base branch before writing. Use a single-quoted heredoc
+   since the SKEPTICISM PREAMBLE contains no shell variables that need expansion:
 ```bash
-codex review --base <base> -c 'model_reasoning_effort="xhigh"' --enable web_search_cached 2>"$TMPERR"
+cat > "$TMPPROMPT" <<'EOF_PREAMBLE'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+
+Now perform code review on the diff against the base branch. Apply P1/P2
+markers per existing convention, plus the additions from the preamble above.
+EOF_PREAMBLE
 ```
 
-Use `timeout: 300000` on the Bash call. If the user provided custom instructions
-(e.g., `/codex review focus on security`), pass them as the prompt argument:
+If the user provided custom instructions (e.g., `/codex review focus on security`),
+append them after the body — they never replace the preamble:
 ```bash
-codex review "focus on security" --base <base> -c 'model_reasoning_effort="xhigh"' --enable web_search_cached 2>"$TMPERR"
+printf '\n\nAdditional user focus: %s\n' "$USER_FOCUS" >> "$TMPPROMPT"
 ```
 
-3. Capture the output. Then parse cost from stderr:
+3. Run the review via stdin (5-minute timeout). `codex review` accepts `-` to read
+   prompt from stdin:
+```bash
+codex review - --base <base> -c 'model_reasoning_effort="xhigh"' --enable web_search_cached 2>"$TMPERR" < "$TMPPROMPT"
+```
+
+4. Capture the output. Then parse cost from stderr:
 ```bash
 grep "tokens used" "$TMPERR" 2>/dev/null || echo "tokens: unknown"
 ```
 
-4. Determine gate verdict by checking the review output for critical findings.
+5. Determine gate verdict by checking the review output for critical findings.
    If the output contains `[P1]` — the gate is **FAIL**.
    If no `[P1]` markers are found (only `[P2]` or no findings) — the gate is **PASS**.
 
-5. Present the output:
+6. Present the output:
 
 ```
 CODEX SAYS (code review):
@@ -334,7 +426,7 @@ or
 GATE: FAIL (N critical findings)
 ```
 
-6. **Cross-model comparison:** If `/review` (Claude's own review) was already run
+7. **Cross-model comparison:** If `/review` (Claude's own review) was already run
    earlier in this conversation, compare the two sets of findings:
 
 ```
@@ -343,9 +435,19 @@ CROSS-MODEL ANALYSIS:
   Only Codex found: [findings unique to Codex]
   Only Claude found: [findings unique to Claude's /review]
   Agreement rate: X% (N/M total unique findings overlap)
+
+EXTERNAL-SYSTEM DISAGREEMENTS (if any):
+  When Codex and Claude disagree on a claim about a third-party UI/API/plugin/
+  vendor system, surface the disagreement with:
+    "Codex contradicts Claude on <claim>. Codex cites: <doc URL>. Claude's
+     reasoning was: <quote>."
+  Per the SKEPTICISM PREAMBLE, the user should default to Codex's verdict
+  unless they produce explicit contradicting evidence (a fetched doc URL or
+  verified test result). This rule is stated once in the preamble; this
+  section just makes the disagreement findable.
 ```
 
-7. Persist the review result:
+8. Persist the review result:
 ```bash
 ~/.claude/skills/gstack/bin/gstack-review-log '{"skill":"codex-review","timestamp":"TIMESTAMP","status":"STATUS","gate":"GATE","findings":N}'
 ```
@@ -353,9 +455,9 @@ CROSS-MODEL ANALYSIS:
 Substitute: TIMESTAMP (ISO 8601), STATUS ("clean" if PASS, "issues_found" if FAIL),
 GATE ("pass" or "fail"), findings (count of [P1] + [P2] markers).
 
-8. Clean up temp files:
+9. Clean up temp files:
 ```bash
-rm -f "$TMPERR"
+rm -f "$TMPPROMPT" "$TMPERR"
 ```
 
 ---
@@ -365,18 +467,91 @@ rm -f "$TMPERR"
 Codex tries to break your code — finding edge cases, race conditions, security holes,
 and failure modes that a normal review would miss.
 
-1. Construct the adversarial prompt. If the user provided a focus area
-(e.g., `/codex challenge security`), include it:
-
-Default prompt (no focus):
-"Review the changes on this branch against the base branch. Run `git diff origin/<base>` to see the diff. Your job is to find ways this code will fail in production. Think like an attacker and a chaos engineer. Find edge cases, race conditions, security holes, resource leaks, failure modes, and silent data corruption paths. Be adversarial. Be thorough. No compliments — just the problems."
-
-With focus (e.g., "security"):
-"Review the changes on this branch against the base branch. Run `git diff origin/<base>` to see the diff. Focus specifically on SECURITY. Your job is to find every way an attacker could exploit this code. Think about injection vectors, auth bypasses, privilege escalation, data exposure, and timing attacks. Be adversarial."
-
-2. Run codex exec with **JSONL output** to capture reasoning traces and tool calls (5-minute timeout):
+1. Create a temp file:
 ```bash
-codex exec "<prompt>" -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>/dev/null | python3 -c "
+TMPPROMPT=$(mktemp /tmp/codex-prompt-XXXXXX.txt)
+```
+
+2. Write the assembled prompt (preamble + adversarial body) to the temp file.
+   Substitute `<base>` with the actual detected base branch before writing.
+
+   Default prompt (no focus):
+```bash
+cat > "$TMPPROMPT" <<'EOF_PREAMBLE'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+
+Now: review the changes on this branch against the base branch. Run `git diff origin/<base>` to see the diff. Your job is to find ways this code will fail in production. Think like an attacker and a chaos engineer. Find edge cases, race conditions, security holes, resource leaks, failure modes, and silent data corruption paths. Be adversarial. Be thorough. No compliments — just the problems.
+EOF_PREAMBLE
+```
+
+   With a user-specified focus (e.g., "security") — substitute `<FOCUS_AREA>` and
+   `<base>` with their actual values before writing:
+```bash
+cat > "$TMPPROMPT" <<'EOF_PREAMBLE'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+
+Now: review the changes on this branch against the base branch. Run `git diff origin/<base>` to see the diff. Focus specifically on <FOCUS_AREA>. Your job is to find every way an attacker could exploit this code. Think about injection vectors, auth bypasses, privilege escalation, data exposure, and timing attacks. Be adversarial.
+EOF_PREAMBLE
+```
+
+3. Run codex exec with **JSONL output** via stdin (5-minute timeout). `codex exec`
+   accepts `-` to read prompt from stdin:
+```bash
+codex exec - -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>/dev/null < "$TMPPROMPT" | python3 -c "
 import sys, json
 for line in sys.stdin:
     line = line.strip()
@@ -407,7 +582,12 @@ for line in sys.stdin:
 This parses codex's JSONL events to extract reasoning traces, tool calls, and the final
 response. The `[codex thinking]` lines show what codex reasoned through before its answer.
 
-3. Present the full streamed output:
+4. Clean up:
+```bash
+rm -f "$TMPPROMPT"
+```
+
+5. Present the full streamed output:
 
 ```
 CODEX SAYS (adversarial challenge):
@@ -437,6 +617,7 @@ B) Start a new conversation
 
 2. Create temp files:
 ```bash
+TMPPROMPT=$(mktemp /tmp/codex-prompt-XXXXXX.txt)
 TMPRESP=$(mktemp /tmp/codex-resp-XXXXXX.txt)
 TMPERR=$(mktemp /tmp/codex-err-XXXXXX.txt)
 ```
@@ -448,20 +629,91 @@ ls -t ~/.claude/plans/*.md 2>/dev/null | xargs grep -l "$(basename $(pwd))" 2>/d
 ```
 If no project-scoped match, fall back to `ls -t ~/.claude/plans/*.md 2>/dev/null | head -1`
 but warn: "Note: this plan may be from a different project — verify before sending to Codex."
-Read the plan file and prepend the persona to the user's prompt:
-"You are a brutally honest technical reviewer. Review this plan for: logical gaps and
+
+4. Assemble the prompt with the SKEPTICISM PREAMBLE prepended and write to the temp file.
+
+   For **plan review**, read the plan content and include it in the prompt:
+```bash
+cat > "$TMPPROMPT" <<'EOF_PREAMBLE'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+
+You are a brutally honest technical reviewer. Review this plan for: logical gaps and
 unstated assumptions, missing error handling or edge cases, overcomplexity (is there a
 simpler approach?), feasibility risks (what could go wrong?), and missing dependencies
 or sequencing issues. Be direct. Be terse. No compliments. Just the problems.
 
 THE PLAN:
-<plan content>"
+<plan content>
+EOF_PREAMBLE
+```
 
-4. Run codex exec with **JSONL output** to capture reasoning traces (5-minute timeout):
+   For **general consult**, write the preamble then append the user's prompt:
+```bash
+cat > "$TMPPROMPT" <<'EOF_PREAMBLE'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+EOF_PREAMBLE
+printf '\n\n%s\n' "$USER_PROMPT" >> "$TMPPROMPT"
+```
+
+5. Run codex exec with **JSONL output** via stdin (5-minute timeout):
 
 For a **new session:**
 ```bash
-codex exec "<prompt>" -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" | python3 -c "
+codex exec - -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" < "$TMPPROMPT" | python3 -c "
 import sys, json
 for line in sys.stdin:
     line = line.strip()
@@ -494,12 +746,12 @@ for line in sys.stdin:
 
 For a **resumed session** (user chose "Continue"):
 ```bash
-codex exec resume <session-id> "<prompt>" -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" | python3 -c "
+codex exec resume <session-id> - -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" < "$TMPPROMPT" | python3 -c "
 <same python streaming parser as above>
 "
 ```
 
-5. Capture session ID from the streamed output. The parser prints `SESSION_ID:<id>`
+6. Capture session ID from the streamed output. The parser prints `SESSION_ID:<id>`
    from the `thread.started` event. Save it for follow-ups:
 ```bash
 mkdir -p .context
@@ -507,7 +759,7 @@ mkdir -p .context
 Save the session ID printed by the parser (the line starting with `SESSION_ID:`)
 to `.context/codex-session-id`.
 
-6. Present the full streamed output:
+7. Present the full streamed output:
 
 ```
 CODEX SAYS (consult):
@@ -518,9 +770,180 @@ Tokens: N | Est. cost: ~$X.XX
 Session saved — run /codex again to continue this conversation.
 ```
 
-7. After presenting, note any points where Codex's analysis differs from your own
+8. After presenting, note any points where Codex's analysis differs from your own
    understanding. If there is a disagreement, flag it:
    "Note: Claude Code disagrees on X because Y."
+
+9. Clean up:
+```bash
+rm -f "$TMPPROMPT" "$TMPRESP" "$TMPERR"
+```
+
+---
+
+## Step 2D: Verify Mode
+
+The user pastes a recommendation Claude gave them. Codex independently verifies
+each factual claim about external systems against documentation.
+
+1. **Get the payload.** If the user invoked `/codex verify` with no payload,
+   emit a literal text prompt: "Paste the recommendation you want verified.
+   When you're done, send it. (No length limit — write to a file if it's
+   very long.)" Then wait for the next user message. Do NOT use
+   AskUserQuestion here — it's wrong for free-text paste of unbounded length.
+   The next user message becomes `$RECOMMENDATION_TEXT`.
+
+2. **Empty-payload guard.** If `$RECOMMENDATION_TEXT` after trimming is empty,
+   short-circuit:
+```bash
+echo "$RECOMMENDATION_TEXT" | tr -d '[:space:]'
+```
+   Output: `GATE: PASS — no recommendation provided, nothing to verify.`
+   Skip the Codex call entirely. Do NOT attempt to detect "no external-system
+   claims" in non-empty payloads — let Codex decide. The cost of one Codex call
+   on genuinely trivial input is acceptable; misclassifying a real claim as
+   "doesn't need checking" is exactly the failure mode this mode defends against.
+
+3. **Build the prompt via tempfile** (avoids shell escaping, EOF-collision, and
+   Windows command-line length limits):
+```bash
+TMPPROMPT=$(mktemp /tmp/codex-verify-prompt-XXXXXX.txt)
+TMPRECOMMEND=$(mktemp /tmp/codex-verify-rec-XXXXXX.txt)
+TMPERR=$(mktemp /tmp/codex-verify-err-XXXXXX.txt)
+
+# Write the user's pasted recommendation raw — no shell expansion.
+printf '%s' "$RECOMMENDATION_TEXT" > "$TMPRECOMMEND"
+
+# Build the verify prompt. Single-quoted heredoc — no $ expansion.
+cat > "$TMPPROMPT" <<'EOF_VERIFY_PROMPT'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+
+The file at the path provided below contains a recommendation generated by
+Claude Code (an LLM). The user is considering acting on it. Your job is
+independent verification.
+
+Begin by reading the recommendation: use your file-read or shell tool to
+`cat` the file at the path listed at the end of this prompt.
+
+For every factual claim in the recommendation that touches an external
+system (third-party UI button, API endpoint, plugin behavior, vendor
+configuration, SaaS dashboard semantic, button label meaning, webhook
+behavior, payment gateway behavior, email send behavior), produce one
+verification entry in this exact format:
+
+  CLAIM: <quote the specific claim>
+  CITATION: <fetched documentation URL, or DOC_NOT_FOUND>
+  VERDICT: <VERIFIED | UNVERIFIED | WRONG | DOC_NOT_FOUND>
+  REASONING: <one sentence on why this verdict>
+  P1: <YES if VERDICT is UNVERIFIED, WRONG, or DOC_NOT_FOUND AND the action
+   would affect live customers, orders, payments, or data; otherwise NO>
+
+After listing all verification entries, output exactly one GATE line:
+  GATE: PASS  — only if every claim is VERIFIED with a non-DOC_NOT_FOUND citation.
+  GATE: FAIL — N P1 findings.
+
+Hard rule: PASS-by-omission is not allowed. If you found no claims to
+check, output `GATE: PASS — no external-system claims found.` instead.
+
+RECOMMENDATION FILE PATH:
+EOF_VERIFY_PROMPT
+
+# Append the file path outside the heredoc — so it expands correctly and
+# a future EOF_VERIFY_PROMPT in user content can't break the heredoc.
+printf '%s\n' "$TMPRECOMMEND" >> "$TMPPROMPT"
+```
+
+4. **Run codex exec via stdin** (5-minute timeout):
+```bash
+codex exec - -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" < "$TMPPROMPT" | python3 -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    try:
+        obj = json.loads(line)
+        t = obj.get('type','')
+        if t == 'item.completed' and 'item' in obj:
+            item = obj['item']
+            itype = item.get('type','')
+            text = item.get('text','')
+            if itype == 'reasoning' and text:
+                print(f'[codex thinking] {text}')
+                print()
+            elif itype == 'agent_message' and text:
+                print(text)
+            elif itype == 'command_execution':
+                cmd = item.get('command','')
+                if cmd: print(f'[codex ran] {cmd}')
+        elif t == 'turn.completed':
+            usage = obj.get('usage',{})
+            tokens = usage.get('input_tokens',0) + usage.get('output_tokens',0)
+            if tokens: print(f'\ntokens used: {tokens}')
+    except: pass
+"
+```
+
+5. **Parse the GATE line and present output:**
+
+```
+CODEX SAYS (verify):
+════════════════════════════════════════════════════════════
+<full output, verbatim — includes [codex thinking] traces and all CLAIM/
+ CITATION/VERDICT/REASONING/P1 entries>
+════════════════════════════════════════════════════════════
+GATE: FAIL — N P1 findings. DO NOT ACT ON THE RECOMMENDATION AS WRITTEN.
+Tokens: N | Est. cost: ~$X.XX
+```
+
+or:
+
+```
+GATE: PASS — all external-system claims verified with citations.
+```
+
+6. **Persist the verify result:**
+```bash
+~/.claude/skills/gstack/bin/gstack-review-log '{"skill":"codex-verify","timestamp":"TIMESTAMP","status":"STATUS","gate":"GATE","findings":N}'
+```
+
+Substitute: TIMESTAMP (ISO 8601), STATUS ("clean" if PASS, "issues_found" if FAIL),
+GATE ("pass" or "fail"), findings (count of P1 entries).
+
+7. **Clean up:**
+```bash
+rm -f "$TMPPROMPT" "$TMPRECOMMEND" "$TMPERR"
+```
+
+8. **No session continuity for verify.** Unlike Step 2C (Consult), verify is
+   one-shot. If a follow-up verify is needed for a related claim, the user
+   re-invokes `/codex verify` with new payload.
 
 ---
 
@@ -572,3 +995,6 @@ If token count is not available, display: `Tokens: unknown`
 - **5-minute timeout** on all Bash calls to codex (`timeout: 300000`).
 - **No double-reviewing.** If the user already ran `/review`, Codex provides a second
   independent opinion. Do not re-run Claude Code's own review.
+- **Skepticism preamble is mandatory.** Every codex prompt — Review, Challenge,
+  Consult, Verify — must prepend the SKEPTICISM PREAMBLE block from the
+  "Claude Code Trust Boundaries" section. No exceptions.

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -1,12 +1,14 @@
 ---
 name: codex
-version: 1.0.0
+version: 1.1.0
 description: |
-  OpenAI Codex CLI wrapper — three modes. Code review: independent diff review via
-  codex review with pass/fail gate. Challenge: adversarial mode that tries to break
-  your code. Consult: ask codex anything with session continuity for follow-ups.
-  The "200 IQ autistic developer" second opinion. Use when asked to "codex review",
-  "codex challenge", "ask codex", "second opinion", or "consult codex".
+  OpenAI Codex CLI wrapper — four modes. Code review: independent diff review
+  with pass/fail gate, Claude-skepticism preamble. Challenge: adversarial mode
+  that tries to break your code. Consult: ask codex anything with session
+  continuity. Verify: audit a recommendation Claude gave you, independently —
+  closes the 2026-05-09 ShipStation-class failure path. Use when asked to
+  "codex review", "codex challenge", "codex verify", "ask codex", "second
+  opinion", or "consult codex".
 allowed-tools:
   - Bash
   - Read
@@ -30,6 +32,53 @@ assumptions, catches things you might miss. Present its output faithfully, not s
 
 ---
 
+## Claude Code Trust Boundaries
+
+The /codex skill exists because Claude Code has a documented failure mode of
+making confident, plausible-sounding claims about third-party systems without
+verifying them against documentation. On 2026-05-09 Claude recommended clicking
+ShipStation's "Send Notifications" button as "the preferred path" for replaying
+WooCommerce shipnotify webhooks. The button does not replay webhooks — it
+re-sends ShipStation's own branded shipping confirmation emails. 814 customers
+received duplicate emails for orders shipped weeks earlier. Source: button-label
+inference, no doc verification.
+
+When constructing any codex prompt — Review, Challenge, Consult, or Verify —
+prepend the following SKEPTICISM PREAMBLE verbatim:
+
+────────────────────────────────────────────────────────────────────
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+────────────────────────────────────────────────────────────────────
+
+---
+
 ## Step 0: Check codex binary
 
 ```bash
@@ -48,7 +97,8 @@ Parse the user's input to determine which mode to run:
 
 1. `/codex review` or `/codex review <instructions>` — **Review mode** (Step 2A)
 2. `/codex challenge` or `/codex challenge <focus>` — **Challenge mode** (Step 2B)
-3. `/codex` with no arguments — **Auto-detect:**
+3. `/codex verify` or `/codex verify <pasted recommendation>` — **Verify mode** (Step 2D)
+4. `/codex` with no arguments — **Auto-detect:**
    - Check for a diff (with fallback if origin isn't available):
      `git diff origin/<base> --stat 2>/dev/null | tail -1 || git diff <base> --stat 2>/dev/null | tail -1`
    - If a diff exists, use AskUserQuestion:
@@ -56,48 +106,90 @@ Parse the user's input to determine which mode to run:
      Codex detected changes against the base branch. What should it do?
      A) Review the diff (code review with pass/fail gate)
      B) Challenge the diff (adversarial — try to break it)
-     C) Something else — I'll provide a prompt
+     C) Verify a recommendation Claude gave me (paste it next)
+     D) Something else — I'll provide a prompt
      ```
    - If no diff, check for plan files scoped to the current project:
      `ls -t ~/.claude/plans/*.md 2>/dev/null | xargs grep -l "$(basename $(pwd))" 2>/dev/null | head -1`
      If no project-scoped match, fall back to: `ls -t ~/.claude/plans/*.md 2>/dev/null | head -1`
      but warn the user: "Note: this plan may be from a different project."
    - If a plan file exists, offer to review it
-   - Otherwise, ask: "What would you like to ask Codex?"
-4. `/codex <anything else>` — **Consult mode** (Step 2C), where the remaining text is the prompt
+   - Otherwise, ask: "Did you want to verify a recommendation Claude gave you, or ask Codex something else?"
+5. `/codex <anything else>` — **Consult mode** (Step 2C), where the remaining text is the prompt
 
 ---
 
 ## Step 2A: Review Mode
 
-Run Codex code review against the current branch diff.
+Run Codex code review against the current branch diff, with the SKEPTICISM PREAMBLE prepended.
 
-1. Create temp files for output capture:
+1. Create temp files:
 ```bash
+TMPPROMPT=$(mktemp /tmp/codex-prompt-XXXXXX.txt)
 TMPERR=$(mktemp /tmp/codex-err-XXXXXX.txt)
 ```
 
-2. Run the review (5-minute timeout):
+2. Write the assembled prompt (preamble + review body) to the temp file. Substitute
+   `<base>` with the detected base branch before writing. Use a single-quoted heredoc
+   since the SKEPTICISM PREAMBLE contains no shell variables that need expansion:
 ```bash
-codex review --base <base> -c 'model_reasoning_effort="xhigh"' --enable web_search_cached 2>"$TMPERR"
+cat > "$TMPPROMPT" <<'EOF_PREAMBLE'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+
+Now perform code review on the diff against the base branch. Apply P1/P2
+markers per existing convention, plus the additions from the preamble above.
+EOF_PREAMBLE
 ```
 
-Use `timeout: 300000` on the Bash call. If the user provided custom instructions
-(e.g., `/codex review focus on security`), pass them as the prompt argument:
+If the user provided custom instructions (e.g., `/codex review focus on security`),
+append them after the body — they never replace the preamble:
 ```bash
-codex review "focus on security" --base <base> -c 'model_reasoning_effort="xhigh"' --enable web_search_cached 2>"$TMPERR"
+printf '\n\nAdditional user focus: %s\n' "$USER_FOCUS" >> "$TMPPROMPT"
 ```
 
-3. Capture the output. Then parse cost from stderr:
+3. Run the review via stdin (5-minute timeout). `codex review` accepts `-` to read
+   prompt from stdin:
+```bash
+codex review - --base <base> -c 'model_reasoning_effort="xhigh"' --enable web_search_cached 2>"$TMPERR" < "$TMPPROMPT"
+```
+
+4. Capture the output. Then parse cost from stderr:
 ```bash
 grep "tokens used" "$TMPERR" 2>/dev/null || echo "tokens: unknown"
 ```
 
-4. Determine gate verdict by checking the review output for critical findings.
+5. Determine gate verdict by checking the review output for critical findings.
    If the output contains `[P1]` — the gate is **FAIL**.
    If no `[P1]` markers are found (only `[P2]` or no findings) — the gate is **PASS**.
 
-5. Present the output:
+6. Present the output:
 
 ```
 CODEX SAYS (code review):
@@ -113,7 +205,7 @@ or
 GATE: FAIL (N critical findings)
 ```
 
-6. **Cross-model comparison:** If `/review` (Claude's own review) was already run
+7. **Cross-model comparison:** If `/review` (Claude's own review) was already run
    earlier in this conversation, compare the two sets of findings:
 
 ```
@@ -122,9 +214,19 @@ CROSS-MODEL ANALYSIS:
   Only Codex found: [findings unique to Codex]
   Only Claude found: [findings unique to Claude's /review]
   Agreement rate: X% (N/M total unique findings overlap)
+
+EXTERNAL-SYSTEM DISAGREEMENTS (if any):
+  When Codex and Claude disagree on a claim about a third-party UI/API/plugin/
+  vendor system, surface the disagreement with:
+    "Codex contradicts Claude on <claim>. Codex cites: <doc URL>. Claude's
+     reasoning was: <quote>."
+  Per the SKEPTICISM PREAMBLE, the user should default to Codex's verdict
+  unless they produce explicit contradicting evidence (a fetched doc URL or
+  verified test result). This rule is stated once in the preamble; this
+  section just makes the disagreement findable.
 ```
 
-7. Persist the review result:
+8. Persist the review result:
 ```bash
 ~/.claude/skills/gstack/bin/gstack-review-log '{"skill":"codex-review","timestamp":"TIMESTAMP","status":"STATUS","gate":"GATE","findings":N}'
 ```
@@ -132,9 +234,9 @@ CROSS-MODEL ANALYSIS:
 Substitute: TIMESTAMP (ISO 8601), STATUS ("clean" if PASS, "issues_found" if FAIL),
 GATE ("pass" or "fail"), findings (count of [P1] + [P2] markers).
 
-8. Clean up temp files:
+9. Clean up temp files:
 ```bash
-rm -f "$TMPERR"
+rm -f "$TMPPROMPT" "$TMPERR"
 ```
 
 ---
@@ -144,18 +246,91 @@ rm -f "$TMPERR"
 Codex tries to break your code — finding edge cases, race conditions, security holes,
 and failure modes that a normal review would miss.
 
-1. Construct the adversarial prompt. If the user provided a focus area
-(e.g., `/codex challenge security`), include it:
-
-Default prompt (no focus):
-"Review the changes on this branch against the base branch. Run `git diff origin/<base>` to see the diff. Your job is to find ways this code will fail in production. Think like an attacker and a chaos engineer. Find edge cases, race conditions, security holes, resource leaks, failure modes, and silent data corruption paths. Be adversarial. Be thorough. No compliments — just the problems."
-
-With focus (e.g., "security"):
-"Review the changes on this branch against the base branch. Run `git diff origin/<base>` to see the diff. Focus specifically on SECURITY. Your job is to find every way an attacker could exploit this code. Think about injection vectors, auth bypasses, privilege escalation, data exposure, and timing attacks. Be adversarial."
-
-2. Run codex exec with **JSONL output** to capture reasoning traces and tool calls (5-minute timeout):
+1. Create a temp file:
 ```bash
-codex exec "<prompt>" -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>/dev/null | python3 -c "
+TMPPROMPT=$(mktemp /tmp/codex-prompt-XXXXXX.txt)
+```
+
+2. Write the assembled prompt (preamble + adversarial body) to the temp file.
+   Substitute `<base>` with the actual detected base branch before writing.
+
+   Default prompt (no focus):
+```bash
+cat > "$TMPPROMPT" <<'EOF_PREAMBLE'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+
+Now: review the changes on this branch against the base branch. Run `git diff origin/<base>` to see the diff. Your job is to find ways this code will fail in production. Think like an attacker and a chaos engineer. Find edge cases, race conditions, security holes, resource leaks, failure modes, and silent data corruption paths. Be adversarial. Be thorough. No compliments — just the problems.
+EOF_PREAMBLE
+```
+
+   With a user-specified focus (e.g., "security") — substitute `<FOCUS_AREA>` and
+   `<base>` with their actual values before writing:
+```bash
+cat > "$TMPPROMPT" <<'EOF_PREAMBLE'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+
+Now: review the changes on this branch against the base branch. Run `git diff origin/<base>` to see the diff. Focus specifically on <FOCUS_AREA>. Your job is to find every way an attacker could exploit this code. Think about injection vectors, auth bypasses, privilege escalation, data exposure, and timing attacks. Be adversarial.
+EOF_PREAMBLE
+```
+
+3. Run codex exec with **JSONL output** via stdin (5-minute timeout). `codex exec`
+   accepts `-` to read prompt from stdin:
+```bash
+codex exec - -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>/dev/null < "$TMPPROMPT" | python3 -c "
 import sys, json
 for line in sys.stdin:
     line = line.strip()
@@ -186,7 +361,12 @@ for line in sys.stdin:
 This parses codex's JSONL events to extract reasoning traces, tool calls, and the final
 response. The `[codex thinking]` lines show what codex reasoned through before its answer.
 
-3. Present the full streamed output:
+4. Clean up:
+```bash
+rm -f "$TMPPROMPT"
+```
+
+5. Present the full streamed output:
 
 ```
 CODEX SAYS (adversarial challenge):
@@ -216,6 +396,7 @@ B) Start a new conversation
 
 2. Create temp files:
 ```bash
+TMPPROMPT=$(mktemp /tmp/codex-prompt-XXXXXX.txt)
 TMPRESP=$(mktemp /tmp/codex-resp-XXXXXX.txt)
 TMPERR=$(mktemp /tmp/codex-err-XXXXXX.txt)
 ```
@@ -227,20 +408,91 @@ ls -t ~/.claude/plans/*.md 2>/dev/null | xargs grep -l "$(basename $(pwd))" 2>/d
 ```
 If no project-scoped match, fall back to `ls -t ~/.claude/plans/*.md 2>/dev/null | head -1`
 but warn: "Note: this plan may be from a different project — verify before sending to Codex."
-Read the plan file and prepend the persona to the user's prompt:
-"You are a brutally honest technical reviewer. Review this plan for: logical gaps and
+
+4. Assemble the prompt with the SKEPTICISM PREAMBLE prepended and write to the temp file.
+
+   For **plan review**, read the plan content and include it in the prompt:
+```bash
+cat > "$TMPPROMPT" <<'EOF_PREAMBLE'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+
+You are a brutally honest technical reviewer. Review this plan for: logical gaps and
 unstated assumptions, missing error handling or edge cases, overcomplexity (is there a
 simpler approach?), feasibility risks (what could go wrong?), and missing dependencies
 or sequencing issues. Be direct. Be terse. No compliments. Just the problems.
 
 THE PLAN:
-<plan content>"
+<plan content>
+EOF_PREAMBLE
+```
 
-4. Run codex exec with **JSONL output** to capture reasoning traces (5-minute timeout):
+   For **general consult**, write the preamble then append the user's prompt:
+```bash
+cat > "$TMPPROMPT" <<'EOF_PREAMBLE'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+EOF_PREAMBLE
+printf '\n\n%s\n' "$USER_PROMPT" >> "$TMPPROMPT"
+```
+
+5. Run codex exec with **JSONL output** via stdin (5-minute timeout):
 
 For a **new session:**
 ```bash
-codex exec "<prompt>" -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" | python3 -c "
+codex exec - -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" < "$TMPPROMPT" | python3 -c "
 import sys, json
 for line in sys.stdin:
     line = line.strip()
@@ -273,12 +525,12 @@ for line in sys.stdin:
 
 For a **resumed session** (user chose "Continue"):
 ```bash
-codex exec resume <session-id> "<prompt>" -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" | python3 -c "
+codex exec resume <session-id> - -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" < "$TMPPROMPT" | python3 -c "
 <same python streaming parser as above>
 "
 ```
 
-5. Capture session ID from the streamed output. The parser prints `SESSION_ID:<id>`
+6. Capture session ID from the streamed output. The parser prints `SESSION_ID:<id>`
    from the `thread.started` event. Save it for follow-ups:
 ```bash
 mkdir -p .context
@@ -286,7 +538,7 @@ mkdir -p .context
 Save the session ID printed by the parser (the line starting with `SESSION_ID:`)
 to `.context/codex-session-id`.
 
-6. Present the full streamed output:
+7. Present the full streamed output:
 
 ```
 CODEX SAYS (consult):
@@ -297,9 +549,180 @@ Tokens: N | Est. cost: ~$X.XX
 Session saved — run /codex again to continue this conversation.
 ```
 
-7. After presenting, note any points where Codex's analysis differs from your own
+8. After presenting, note any points where Codex's analysis differs from your own
    understanding. If there is a disagreement, flag it:
    "Note: Claude Code disagrees on X because Y."
+
+9. Clean up:
+```bash
+rm -f "$TMPPROMPT" "$TMPRESP" "$TMPERR"
+```
+
+---
+
+## Step 2D: Verify Mode
+
+The user pastes a recommendation Claude gave them. Codex independently verifies
+each factual claim about external systems against documentation.
+
+1. **Get the payload.** If the user invoked `/codex verify` with no payload,
+   emit a literal text prompt: "Paste the recommendation you want verified.
+   When you're done, send it. (No length limit — write to a file if it's
+   very long.)" Then wait for the next user message. Do NOT use
+   AskUserQuestion here — it's wrong for free-text paste of unbounded length.
+   The next user message becomes `$RECOMMENDATION_TEXT`.
+
+2. **Empty-payload guard.** If `$RECOMMENDATION_TEXT` after trimming is empty,
+   short-circuit:
+```bash
+echo "$RECOMMENDATION_TEXT" | tr -d '[:space:]'
+```
+   Output: `GATE: PASS — no recommendation provided, nothing to verify.`
+   Skip the Codex call entirely. Do NOT attempt to detect "no external-system
+   claims" in non-empty payloads — let Codex decide. The cost of one Codex call
+   on genuinely trivial input is acceptable; misclassifying a real claim as
+   "doesn't need checking" is exactly the failure mode this mode defends against.
+
+3. **Build the prompt via tempfile** (avoids shell escaping, EOF-collision, and
+   Windows command-line length limits):
+```bash
+TMPPROMPT=$(mktemp /tmp/codex-verify-prompt-XXXXXX.txt)
+TMPRECOMMEND=$(mktemp /tmp/codex-verify-rec-XXXXXX.txt)
+TMPERR=$(mktemp /tmp/codex-verify-err-XXXXXX.txt)
+
+# Write the user's pasted recommendation raw — no shell expansion.
+printf '%s' "$RECOMMENDATION_TEXT" > "$TMPRECOMMEND"
+
+# Build the verify prompt. Single-quoted heredoc — no $ expansion.
+cat > "$TMPPROMPT" <<'EOF_VERIFY_PROMPT'
+SKEPTICISM PREAMBLE — read first.
+
+The artifact you are reviewing was authored or recommended by Claude Code, an
+LLM with a documented history of confident-but-unverified claims about
+third-party systems. Treat every claim about external systems with extreme
+skepticism.
+
+Specifically flag as P1:
+1. ANY claim about a third-party UI button, API endpoint, plugin behavior,
+   vendor configuration, or SaaS dashboard semantic that is NOT accompanied by
+   a documentation URL. Claude inferring behavior from a label is NOT
+   sufficient; demand a fetched-this-session doc URL.
+2. ANY recommendation for a bulk action (>1 record) that does NOT specify a
+   single-item test as a hard prerequisite. Format expected: "Test on <single
+   record id> first. Watch for <observable signal>. Confirm <expected result>.
+   Then proceed to bulk."
+3. ANY assertion about external behavior using confidence-language without
+   evidence: "should work", "the preferred path", "the cleanest approach",
+   "typically does X", "I believe", "go ahead and click", "recommended". When
+   these phrases appear with respect to an unverified third-party action, P1.
+4. ANY change that touches files served at public URLs, renames directories,
+   modifies URLs, or changes plugin/theme behavior in WordPress contexts
+   without a database reference check (l1o_posts, l1o_postmeta, l1o_options).
+
+Default verdict on disagreement: when codex's analysis contradicts Claude's
+claim about an external system, codex's verdict wins unless the user produces
+explicit evidence (a fetched doc URL or verified test result) supporting
+Claude.
+
+The file at the path provided below contains a recommendation generated by
+Claude Code (an LLM). The user is considering acting on it. Your job is
+independent verification.
+
+Begin by reading the recommendation: use your file-read or shell tool to
+`cat` the file at the path listed at the end of this prompt.
+
+For every factual claim in the recommendation that touches an external
+system (third-party UI button, API endpoint, plugin behavior, vendor
+configuration, SaaS dashboard semantic, button label meaning, webhook
+behavior, payment gateway behavior, email send behavior), produce one
+verification entry in this exact format:
+
+  CLAIM: <quote the specific claim>
+  CITATION: <fetched documentation URL, or DOC_NOT_FOUND>
+  VERDICT: <VERIFIED | UNVERIFIED | WRONG | DOC_NOT_FOUND>
+  REASONING: <one sentence on why this verdict>
+  P1: <YES if VERDICT is UNVERIFIED, WRONG, or DOC_NOT_FOUND AND the action
+   would affect live customers, orders, payments, or data; otherwise NO>
+
+After listing all verification entries, output exactly one GATE line:
+  GATE: PASS  — only if every claim is VERIFIED with a non-DOC_NOT_FOUND citation.
+  GATE: FAIL — N P1 findings.
+
+Hard rule: PASS-by-omission is not allowed. If you found no claims to
+check, output `GATE: PASS — no external-system claims found.` instead.
+
+RECOMMENDATION FILE PATH:
+EOF_VERIFY_PROMPT
+
+# Append the file path outside the heredoc — so it expands correctly and
+# a future EOF_VERIFY_PROMPT in user content can't break the heredoc.
+printf '%s\n' "$TMPRECOMMEND" >> "$TMPPROMPT"
+```
+
+4. **Run codex exec via stdin** (5-minute timeout):
+```bash
+codex exec - -s read-only -c 'model_reasoning_effort="xhigh"' --enable web_search_cached --json 2>"$TMPERR" < "$TMPPROMPT" | python3 -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    try:
+        obj = json.loads(line)
+        t = obj.get('type','')
+        if t == 'item.completed' and 'item' in obj:
+            item = obj['item']
+            itype = item.get('type','')
+            text = item.get('text','')
+            if itype == 'reasoning' and text:
+                print(f'[codex thinking] {text}')
+                print()
+            elif itype == 'agent_message' and text:
+                print(text)
+            elif itype == 'command_execution':
+                cmd = item.get('command','')
+                if cmd: print(f'[codex ran] {cmd}')
+        elif t == 'turn.completed':
+            usage = obj.get('usage',{})
+            tokens = usage.get('input_tokens',0) + usage.get('output_tokens',0)
+            if tokens: print(f'\ntokens used: {tokens}')
+    except: pass
+"
+```
+
+5. **Parse the GATE line and present output:**
+
+```
+CODEX SAYS (verify):
+════════════════════════════════════════════════════════════
+<full output, verbatim — includes [codex thinking] traces and all CLAIM/
+ CITATION/VERDICT/REASONING/P1 entries>
+════════════════════════════════════════════════════════════
+GATE: FAIL — N P1 findings. DO NOT ACT ON THE RECOMMENDATION AS WRITTEN.
+Tokens: N | Est. cost: ~$X.XX
+```
+
+or:
+
+```
+GATE: PASS — all external-system claims verified with citations.
+```
+
+6. **Persist the verify result:**
+```bash
+~/.claude/skills/gstack/bin/gstack-review-log '{"skill":"codex-verify","timestamp":"TIMESTAMP","status":"STATUS","gate":"GATE","findings":N}'
+```
+
+Substitute: TIMESTAMP (ISO 8601), STATUS ("clean" if PASS, "issues_found" if FAIL),
+GATE ("pass" or "fail"), findings (count of P1 entries).
+
+7. **Clean up:**
+```bash
+rm -f "$TMPPROMPT" "$TMPRECOMMEND" "$TMPERR"
+```
+
+8. **No session continuity for verify.** Unlike Step 2C (Consult), verify is
+   one-shot. If a follow-up verify is needed for a related claim, the user
+   re-invokes `/codex verify` with new payload.
 
 ---
 
@@ -351,3 +774,6 @@ If token count is not available, display: `Tokens: unknown`
 - **5-minute timeout** on all Bash calls to codex (`timeout: 300000`).
 - **No double-reviewing.** If the user already ran `/review`, Codex provides a second
   independent opinion. Do not re-run Claude Code's own review.
+- **Skepticism preamble is mandatory.** Every codex prompt — Review, Challenge,
+  Consult, Verify — must prepend the SKEPTICISM PREAMBLE block from the
+  "Claude Code Trust Boundaries" section. No exceptions.


### PR DESCRIPTION
## Summary

- **New `/codex verify` mode (Step 2D):** User pastes a Claude recommendation; Codex independently fact-checks every external-system claim (third-party UI buttons, API endpoints, plugin behavior, SaaS dashboard semantics) against documentation. Returns structured CLAIM/CITATION/VERDICT/REASONING/P1 entries and a single GATE: PASS/FAIL gate.
- **SKEPTICISM PREAMBLE injected into all existing modes:** Review, Challenge, and Consult prompts now prepend a trust-boundary preamble that instructs Codex to flag as P1: unverified third-party claims, bulk actions without single-item test prerequisites, confidence-language without evidence, and WordPress URL changes without DB checks.
- **Stdin prompt delivery:** All modes now write prompts to tempfiles and pass them via stdin (`codex review - < file`, `codex exec - < file`) instead of positional args or heredocs, eliminating shell-escaping, EOF-collision, and Windows command-line length issues.
- **Version bump:** 1.0.0 → 1.1.0. Frontmatter description updated to "four modes."
- **New "Claude Code Trust Boundaries" section** documents the 2026-05-09 incident and the SKEPTICISM PREAMBLE so future maintainers understand why this skill is configured the way it is.

## Incident context

On 2026-05-09, Claude Code recommended clicking ShipStation's "Send Notifications" button as "the preferred path" for replaying WooCommerce shipnotify webhooks. That button does not replay webhooks — it re-sends ShipStation's own branded shipping confirmation emails. 814 customers received duplicate "your package has shipped" emails for orders shipped weeks earlier. Source: label-based inference, no doc verification. `/codex verify` with that recommendation would have returned GATE: FAIL.

## Pre-flight checks (confirmed before editing)

- `codex review --help`: accepts `-` for stdin read. No `--prompt-file` flag. **Using stdin.**
- `codex exec --help`: accepts `-` for stdin read. No `--prompt-file` flag. **Using stdin.**
- `python3`: available at `/c/Users/clydl/AppData/Roaming/Python/Python314/Scripts/python3`
- `gen:skill-docs`: located at `~/.claude/skills/gstack/package.json` — `bun run gen:skill-docs`

## Test plan

- [x] `bun run gen:skill-docs` ran cleanly — `codex/SKILL.md` regenerated (1000 lines)
- [x] All 9 design changes verified present in generated SKILL.md (version, Trust Boundaries section, SKEPTICISM PREAMBLE in Steps 2A/2B/2C, Step 2D, verify in Step 1 detection, stdin approach, mandatory preamble rule)
- [ ] **Smoke test (manual, requires live session):** `/codex verify "I recommend clicking ShipStation's Send Notifications button to replay shipnotify webhooks. This is the preferred path."` → expect GATE: FAIL, P1: YES
- [ ] **Heredoc-collision test (manual):** `/codex verify` with payload containing `EOF_VERIFY_PROMPT` on its own line → expect normal completion (tempfile approach immune)
- [ ] **Empty-payload test (manual):** `/codex verify ""` → expect GATE: PASS, no Codex call

## Notes

- `python3` portability on Windows: existing issue inherited by Step 2D (not introduced here). Portable fallback (`python3 || python || py -3`) is a follow-up item.
- On Windows, `read-only` sandbox mode may block PowerShell. Existing pattern from Steps 2B/2C is preserved in Step 2D. Verify mode uses `read-only`; if Windows issues arise, bump to `workspace-write` as done elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->