### PR TITLE
fix(memory-ingest): strip NUL bytes from transcript body before put

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -819,6 +819,11 @@ function gbrainPutPage(page: PageRecord): { ok: boolean; error?: string } {
       body,
     ].join("\n");
   }
+  // Strip NUL bytes — Postgres rejects 0x00 in UTF-8 text columns. Some Claude
+  // Code transcripts contain NUL inside user-pasted content or tool output, and
+  // surfacing those as `internal_error: invalid byte sequence` from the brain
+  // is unhelpful when we can sanitize at write time.
+  body = body.replace(/ /g, "");
   try {
     execFileSync("gbrain", ["put", page.slug], {
       input: body,


### PR DESCRIPTION
## Summary

`gstack-memory-ingest` builds a rendered transcript body, then calls `gbrain put` over stdin. When the body contains a NUL byte (`0x00` / ` `), Postgres rejects it with `invalid byte sequence for encoding "UTF8": 0x00`, which surfaces from the brain server as an opaque `internal_error`. The error is then truncated by `gbrainPutPage` to the first 300 chars of the first line, hiding the root cause.

NUL bytes show up in the wild from user-pasted binary blobs, terminal escape sequences, screen-recorder output, and the like — anything that landed in a `## User` or `## Assistant` section of a Claude Code transcript.

This sanitizes at write time, one line + a comment block, in `bin/gstack-memory-ingest.ts` right before the `execFileSync("gbrain", ["put", ...])` call. The regex matches a literal NUL character (`/ /g`).

## Repro before this fix

A first-run `--bulk` ingest of ~86 transcripts on a fresh thin-client setup fails some of them with:

```
[put-error] transcripts/claude-code/_unattributed/...: Remote tool put_page failed: {
```

…and the truncated error hides the actual root cause. Adding a temporary stderr-dump to `gbrainPutPage` surfaces the real message:

```json
{"error":"internal_error","message":"invalid byte sequence for encoding \"UTF8\": 0x00"}
```

In my case, 2 of 86 transcripts had user-pasted content with embedded NULs. The 1-line strip fixes it cleanly without touching anything else in the pipeline.

## After this fix

```
$ bun bin/gstack-memory-ingest.ts --incremental
[1] transcripts/claude-code/_unattributed/2026-04-30-0f15bc90-57a
[2] transcripts/claude-code/_unattributed/2026-04-30-5d3bf8aa-6cd
Ingest pass complete (incremental):
  written:               2
  failed:                0
```

## Test plan
- [x] Manual: ingested 86 transcripts (2 of which contained NULs) on a fresh thin-client setup → 86/86 written, 0 failed
- [ ] Unit test: not added — happy to add one if you want, but I didn't see existing in-process unit tests on `gbrainPutPage` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->