### PR TITLE
fix(token-registry): UTF-8 byte-length short-circuit before timingSafeEqual

### DIFF
--- a/browse/src/token-registry.ts
+++ b/browse/src/token-registry.ts
@@ -155,7 +155,20 @@ export function getRootToken(): string {
 }
 
 export function isRootToken(token: string): boolean {
-  return token === rootToken;
+  // Constant-time compare so a tunnel-reachable caller who can provoke an
+  // isRootToken() call (e.g., via the 403 "root over tunnel" rejection path)
+  // can't measure byte-by-byte string-compare timing to recover the token.
+  // Compare UTF-8 byte lengths (not JS string length) before timingSafeEqual,
+  // which throws on length-mismatched buffers. A multibyte input whose JS
+  // string length matches rootToken but whose UTF-8 byte length differs must
+  // return false on the auth path, not error out.
+  if (!rootToken) return false;
+  const tokenBytes = Buffer.byteLength(token, 'utf8');
+  const rootBytes = Buffer.byteLength(rootToken, 'utf8');
+  if (tokenBytes !== rootBytes) return false;
+  const a = Buffer.from(token, 'utf8');
+  const b = Buffer.from(rootToken, 'utf8');
+  return crypto.timingSafeEqual(a, b);
 }
 
 function generateToken(prefix: string): string {

--- a/browse/test/token-registry.test.ts
+++ b/browse/test/token-registry.test.ts
@@ -28,6 +28,39 @@ describe('token-registry', () => {
       expect(info!.scopes).toEqual(['read', 'write', 'admin', 'meta', 'control']);
       expect(info!.rateLimit).toBe(0);
     });
+
+    // Regression: the previous fix did a JS string-length short-circuit before
+    // crypto.timingSafeEqual, but the buffers passed in are UTF-8. A multibyte
+    // input with matching string length but mismatched byte length would slip
+    // past the check and crash inside timingSafeEqual. Auth path must return
+    // false, not error.
+    it('returns false for a multibyte token whose string length matches but UTF-8 byte length differs', () => {
+      // 'root-token-for-tests' is 20 ASCII chars (20 bytes).
+      // 'é'.repeat(20) is 20 chars but 40 UTF-8 bytes.
+      const multibyte = 'é'.repeat(20);
+      expect(multibyte.length).toBe('root-token-for-tests'.length);
+      expect(Buffer.byteLength(multibyte, 'utf8')).not.toBe(
+        Buffer.byteLength('root-token-for-tests', 'utf8'),
+      );
+      expect(() => isRootToken(multibyte)).not.toThrow();
+      expect(isRootToken(multibyte)).toBe(false);
+    });
+
+    it('returns false for a token that differs only in length (same prefix)', () => {
+      expect(isRootToken('root-token-for-tests-extra')).toBe(false);
+      expect(isRootToken('root-token-for-test')).toBe(false);
+    });
+
+    it('returns false for a same-length token that differs only in the last byte', () => {
+      const expected = 'root-token-for-tests';
+      const wrong = expected.slice(0, -1) + (expected.endsWith('x') ? 'y' : 'x');
+      expect(wrong.length).toBe(expected.length);
+      expect(isRootToken(wrong)).toBe(false);
+    });
+
+    it('returns false for the empty string even when root is set', () => {
+      expect(isRootToken('')).toBe(false);
+    });
   });
 
   describe('createToken', () => {


### PR DESCRIPTION
Follow-up to #1171 (closed). That patch had a subtle bug Codex caught during pre-landing review:

`Buffer.from(token)` defaults to UTF-8, so a token whose JS string length matches `rootToken` but whose UTF-8 byte length differs (e.g. `"é".repeat(20)` is 20 chars but 40 bytes vs a 20-byte ASCII root) slipped past the length check and crashed inside `crypto.timingSafeEqual` because the buffers were different sizes. Since `isRootToken()` is on the auth path, malformed multibyte input would throw rather than cleanly 401/403.

## Fix
Option (a) from your comment: compare `Buffer.byteLength(token, 'utf8')` against `Buffer.byteLength(rootToken, 'utf8')` before calling `timingSafeEqual`, and build the comparison buffers with explicit `'utf8'` encoding. No exception-control-flow on the auth path.

```ts
if (!rootToken) return false;
const tokenBytes = Buffer.byteLength(token, 'utf8');
const rootBytes  = Buffer.byteLength(rootToken, 'utf8');
if (tokenBytes !== rootBytes) return false;
const a = Buffer.from(token, 'utf8');
const b = Buffer.from(rootToken, 'utf8');
return crypto.timingSafeEqual(a, b);
```

## Regression tests
Four cases in `browse/test/token-registry.test.ts`:

1. **Multibyte input with matching JS string length but differing UTF-8 byte length** (the actual bug). Asserts `not.toThrow()` AND `false`. Without the fix this throws `RangeError: Input buffers must have the same byte length`.
2. **Differing-length tokens** (covers the short-circuit branch).
3. **Same-length differ-by-last-byte** (covers the `timingSafeEqual` branch, ensures we don't regress to `===`-style short-circuit).
4. **Empty string when root is set** (early-return guard).

## Verified
- Branched off current `main` (`5d4fe7d`, v1.31.0.0), not the closed PR's branch.
- `bun test browse/test/token-registry.test.ts` passes 49 / 49.
- One commit, fix + tests together, no churn elsewhere.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->