### PR TITLE
fix: use anon key in update-check (least-privilege alignment with tel…

### DIFF
--- a/supabase/functions/update-check/index.ts
+++ b/supabase/functions/update-check/index.ts
@@ -18,9 +18,12 @@ Deno.serve(async (req) => {
       return new Response(CURRENT_VERSION, { status: 200 });
     }
 
+    // Use anon key — the service role key bypasses RLS and is over-privileged
+    // for a public endpoint that only needs INSERT on update_checks.
+    // (Same rationale as telemetry-ingest; see that function's comments.)
     const supabase = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+      Deno.env.get("SUPABASE_ANON_KEY") ?? ""
     );
 
     // Log the update check (fire-and-forget)


### PR DESCRIPTION
## Problem

`update-check` uses `SUPABASE_SERVICE_ROLE_KEY` to INSERT into `update_checks`.
The service role key bypasses Row Level Security and grants unrestricted DB access.

`telemetry-ingest` (same project) already identifies this as an anti-pattern:

> "The service role key bypasses Row Level Security (RLS) and grants full unrestricted database access — wildly over-privileged for a public telemetry endpoint that only needs INSERT on two tables. The anon key + properly configured RLS INSERT policies is correct."

The `update_checks` table already has the correct RLS policy:

```sql
ALTER TABLE update_checks ENABLE ROW LEVEL SECURITY;
CREATE POLICY "anon_insert_only" ON update_checks FOR INSERT WITH CHECK (true);
```

So the anon key works. The service role key is unnecessary.

## Fix

```diff
- Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+ Deno.env.get("SUPABASE_ANON_KEY") ?? ""
```

1 file, +4 -1 (3 lines are the added comment explaining the rationale).

## Why this matters

If a future vulnerability in this edge function (or Supabase SDK) allows query manipulation, the blast radius with the service role key is the entire database. With the anon key, RLS constrains damage to INSERT-only on `update_checks`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->