### PR TITLE
fix(learnings): accept investigation entries

### DIFF
--- a/bin/gstack-learnings-log
+++ b/bin/gstack-learnings-log
@@ -19,7 +19,7 @@ let j;
 try { j = JSON.parse(raw); } catch { process.stderr.write('gstack-learnings-log: invalid JSON, skipping\n'); process.exit(1); }
 
 // Field validation: type must be from allowed list
-const ALLOWED_TYPES = ['pattern', 'pitfall', 'preference', 'architecture', 'tool', 'operational'];
+const ALLOWED_TYPES = ['pattern', 'pitfall', 'preference', 'architecture', 'tool', 'operational', 'investigation'];
 if (!j.type || !ALLOWED_TYPES.includes(j.type)) {
   process.stderr.write('gstack-learnings-log: invalid type \"' + (j.type || '') + '\", must be one of: ' + ALLOWED_TYPES.join(', ') + '\n');
   process.exit(1);

--- a/test/learnings.test.ts
+++ b/test/learnings.test.ts
@@ -75,6 +75,27 @@ describe('gstack-learnings-log', () => {
     expect(parsed.confidence).toBe(8);
   });
 
+  test('accepts investigation learnings with affected files', () => {
+    const input = JSON.stringify({
+      skill: 'investigate',
+      type: 'investigation',
+      key: 'root-cause-key',
+      insight: 'Root cause summary',
+      confidence: 9,
+      source: 'observed',
+      files: ['affected/file1.ts', 'affected/file2.ts'],
+    });
+    const result = runLog(input);
+    expect(result.exitCode).toBe(0);
+
+    const f = findLearningsFile();
+    expect(f).not.toBeNull();
+    const parsed = JSON.parse(fs.readFileSync(f!, 'utf-8').trim());
+    expect(parsed.skill).toBe('investigate');
+    expect(parsed.type).toBe('investigation');
+    expect(parsed.files).toEqual(['affected/file1.ts', 'affected/file2.ts']);
+  });
+
   test('auto-injects timestamp when ts is missing', () => {
     const input = '{"skill":"review","type":"pattern","key":"ts-test","insight":"test","confidence":5,"source":"observed"}';
     runLog(input);


### PR DESCRIPTION
Fixes #1423

## Summary
- add `investigation` to the learnings logger type allowlist
- cover the `/investigate` learning payload shape, including affected files

## Testing
- `bun test test/learnings.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->