### PR TITLE
fix(skill-check): honor primary host skipSkills in Templates check

### DIFF
--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -10,6 +10,7 @@
 
 import { validateSkill } from '../test/helpers/skill-parser';
 import { discoverTemplates, discoverSkillFiles } from './discover-skills';
+import { claude as PRIMARY_HOST } from '../hosts/index';
 import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
@@ -64,15 +65,25 @@ for (const file of SKILL_FILES) {
 
 console.log('\n  Templates:');
 const TEMPLATES = discoverTemplates(ROOT);
+// Repo-root SKILL.md outputs reflect what the primary host (claude) generates.
+// If a skill is in claude's skipSkills (e.g. the `/claude` outside-voice skill
+// is intentionally not bundled into the Claude host), its generated file is
+// expected to be absent — flagging it as missing here is a false positive.
+const PRIMARY_SKIP_SKILLS = new Set(PRIMARY_HOST.generation?.skipSkills ?? []);
 
 for (const { tmpl, output } of TEMPLATES) {
   const tmplPath = path.join(ROOT, tmpl);
   const outPath = path.join(ROOT, output);
+  const skillDir = output.includes('/') ? output.split('/')[0] : '';
   if (!fs.existsSync(tmplPath)) {
     console.log(`  \u26a0\ufe0f  ${output.padEnd(30)} — no template`);
     continue;
   }
   if (!fs.existsSync(outPath)) {
+    if (skillDir && PRIMARY_SKIP_SKILLS.has(skillDir)) {
+      console.log(`  -  ${output.padEnd(30)} — skipped per ${PRIMARY_HOST.name} host config`);
+      continue;
+    }
     hasErrors = true;
     console.log(`  \u274c ${output.padEnd(30)} — generated file missing! Run: bun run gen:skill-docs`);
     continue;


### PR DESCRIPTION
## Summary

`scripts/skill-check.ts` Templates section flags `claude/SKILL.md` as `❌ generated file missing!` and exits 1, even though `hosts/claude.ts` has `generation.skipSkills: ['claude']` and `gen-skill-docs.ts` correctly skips generating it. This is an inconsistency between the generator (honors skipSkills) and the checker (doesn't).

## Root cause

`scripts/gen-skill-docs.ts:510-516` already filters skills by `skipSkills`/`includeSkills` per the current host config — so `claude/SKILL.md` never gets generated for the Claude host.

`scripts/skill-check.ts:75-79` iterates `discoverTemplates(ROOT)` and naively checks `fs.existsSync(outPath)` without consulting any host config. Result: the legitimately-skipped `claude/SKILL.md` shows up as a hard failure, killing `bun run skill:check` with exit 1.

## Fix

Import the primary host (`claude`) and check its `skipSkills` set before flagging missing outputs. The change mirrors the existing logic in `gen-skill-docs.ts` so check and generation stay aligned.

11 added lines in `scripts/skill-check.ts`. No behavior change when `skipSkills` is empty (the default for most hosts) or when a missing output is unrelated to skipSkills.

## Test plan

Pre-patch (with default `hosts/claude.ts` `skipSkills: ['claude']`):
```
$ bun run gen:skill-docs       # claude/SKILL.md correctly NOT generated
$ bun run skill:check
…
  ❌ claude/SKILL.md                — generated file missing! Run: bun run gen:skill-docs
…
error: script "skill:check" exited with code 1
$ echo $?
1
```

Post-patch:
```
$ bun run skill:check
…
  -  claude/SKILL.md                — skipped per claude host config
…
$ echo $?
0
```

All other checks remain unchanged.

## Notes

Spotted while running `/gstack-upgrade` on a fresh clone after v1.31.1.0 — the upgrade itself succeeded cleanly (binaries rebuilt, 338 tests pass), but `bun run skill:check` exited 1 on the cosmetic claude/SKILL.md false positive. No functional impact for users, but the check should be self-consistent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->