### PR TITLE
fix(gbrain-sync): append .gbrain-source to consumer repo's .gitignore after successful attach

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -408,6 +408,27 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
     };
   }
 
+  // Append .gbrain-source to the consumer repo's .gitignore so the per-worktree
+  // pin file doesn't leak across branches or get committed accidentally.
+  // The v1.29.0.0 changelog promised this but only added it to gstack's own
+  // .gitignore; this adds it to the consuming repo as well. Idempotent.
+  try {
+    const gitignorePath = join(root, ".gitignore");
+    let existing = "";
+    try {
+      existing = readFileSync(gitignorePath, "utf-8");
+    } catch {
+      // No .gitignore yet — we'll create one with just this entry.
+    }
+    if (!existing.split("\n").some((line) => line.trim() === ".gbrain-source")) {
+      const sep = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+      writeFileSync(gitignorePath, existing + sep + ".gbrain-source\n");
+    }
+  } catch (e) {
+    // Non-fatal — unwritable .gitignore is unusual but shouldn't abort the sync.
+    console.warn("[gstack-gbrain-sync] warning: could not update .gitignore:", (e as Error).message);
+  }
+
   return {
     name: "code",
     ran: true,


### PR DESCRIPTION
… after attach

## Summary

Fixes #1384

The v1.29.0.0 changelog promised:
> `.gbrain-source` added to `.gitignore` so per-worktree pin doesn't leak across branches.

However, the shipped code only added `.gbrain-source` to **gstack's own** `.gitignore` — not to the **consumer repo's** `.gitignore`. This PR fixes that gap.

## Root Cause

In `bin/gstack-gbrain-sync.ts`, after `gbrain sources attach <id>` succeeds, the `.gbrain-source` pin file is written to the consumer repo's root. The v1.29.0.0 implementation correctly hashes by path to give each worktree a unique source ID, but it never appended `.gbrain-source` to the consumer repo's `.gitignore`.

Without this gitignore entry, the pin file shows up as an untracked file and can be accidentally committed (via `git add -A`, pre-commit hooks, etc.), causing it to propagate to other branches and worktrees — silently overriding their per-worktree pin on next `git pull`.

## Fix

After a successful `gbrain sources attach`, append `.gbrain-source` to `<root>/.gitignore` if not already present. The operation is:

- **Idempotent** — checks for existing entry before writing
- - **Safe** — wrapped in try/catch; a non-writable `.gitignore` logs a warning and continues (never aborts the sync)
- - **Minimal** — only appends the one line; creates the file if it doesn't exist yet
- - **Correct newline handling** — adds a newline separator if the existing file doesn't end with one
## Before / After

```bash
# Before v1.29.0.0 fix + this PR:
cd ~/myrepo && /sync-gbrain
git status
# → Untracked files:
#     .gbrain-source
grep '.gbrain-source' .gitignore || echo "MISSING"
# → MISSING

# After this PR:
cd ~/myrepo && /sync-gbrain
grep '.gbrain-source' .gitignore
# → .gbrain-source      ← correctly added
git status
# → nothing to commit (pin file is ignored)
```

## Why this matters for Conductor users

Conductor users run `/sync-gbrain` in multiple sibling worktrees of the same repo+branch. Each worktree correctly gets a different path-hash source ID (per v1.29.0.0), but if either pin gets committed, `git pull` in the sibling overwrites the local pin and routes gbrain queries to the wrong worktree's code source. This is exactly the failure mode the changelog claimed to prevent.

Single-worktree users aren't badly affected but still benefit from a clean `git status`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->