### PR TITLE
fix(v1.27 migration): qualify repo with owner so gh rename actually runs

### DIFF
--- a/gstack-upgrade/migrations/v1.27.0.0.sh
+++ b/gstack-upgrade/migrations/v1.27.0.0.sh
@@ -184,19 +184,42 @@ if ! journal_done "gh_repo_renamed"; then
   case "$HOST" in
     github)
       if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-        # Idempotent: if new name already exists, treat as success.
-        if gh repo view "$NEW_REPO_NAME" >/dev/null 2>&1; then
-          echo "    repo already named $NEW_REPO_NAME on GitHub — no-op" >&2
+        # `gh repo rename --repo` and `gh repo edit` both require the
+        # "[HOST/]OWNER/REPO" form. Passing a bare repo name (as earlier
+        # versions of this migration did) fails with:
+        #   expected the "[HOST/]OWNER/REPO" format, got "<name>"
+        # Resolve the authenticated user's login and qualify both names.
+        GH_OWNER=$(gh api user --jq .login 2>/dev/null || echo "")
+        if [ -z "$GH_OWNER" ]; then
+          echo "    WARNING: could not resolve gh authenticated user — skipping rename" >&2
+          echo "    manual: gh repo rename $NEW_REPO_NAME --repo <owner>/$OLD_REPO_NAME --yes" >&2
           mark_done "gh_repo_renamed"
         else
-          if gh repo rename "$NEW_REPO_NAME" --repo "$OLD_REPO_NAME" --yes 2>/dev/null \
-              || gh repo edit "$OLD_REPO_NAME" --name "$NEW_REPO_NAME" 2>/dev/null; then
-            echo "    renamed on GitHub" >&2
+          OLD_QUALIFIED="${GH_OWNER}/${OLD_REPO_NAME}"
+          NEW_QUALIFIED="${GH_OWNER}/${NEW_REPO_NAME}"
+          # Idempotent: if new name already exists, treat as success.
+          if gh repo view "$NEW_QUALIFIED" >/dev/null 2>&1; then
+            echo "    repo already named $NEW_REPO_NAME on GitHub — no-op" >&2
             mark_done "gh_repo_renamed"
           else
-            echo "    WARNING: gh rename failed (repo may not exist or permission denied)" >&2
-            echo "    skipping step 1; subsequent steps still run" >&2
-            mark_done "gh_repo_renamed"
+            RENAME_ERR=""
+            RENAME_ERR2=""
+            RENAME_OK=0
+            if RENAME_ERR=$(gh repo rename "$NEW_REPO_NAME" --repo "$OLD_QUALIFIED" --yes 2>&1); then
+              RENAME_OK=1
+            elif RENAME_ERR2=$(gh repo edit "$OLD_QUALIFIED" --name "$NEW_REPO_NAME" 2>&1); then
+              RENAME_OK=1
+            fi
+            if [ "$RENAME_OK" = "1" ]; then
+              echo "    renamed on GitHub" >&2
+              mark_done "gh_repo_renamed"
+            else
+              echo "    WARNING: gh rename failed for $OLD_QUALIFIED" >&2
+              [ -n "$RENAME_ERR" ] && echo "      gh repo rename: $RENAME_ERR" >&2
+              [ -n "$RENAME_ERR2" ] && echo "      gh repo edit:   $RENAME_ERR2" >&2
+              echo "    skipping step 1; subsequent steps still run" >&2
+              mark_done "gh_repo_renamed"
+            fi
           fi
         fi
       else

--- a/test/migrations-v1.27.0.0.test.ts
+++ b/test/migrations-v1.27.0.0.test.ts
@@ -27,11 +27,20 @@ function makeFakeGh(opts: { authStatus?: 'ok' | 'fail'; renameSucceeds?: boolean
 echo "gh $@" >> "${callLog}"
 case "$1" in
   auth) ${authStatus === 'ok' ? 'exit 0' : 'exit 1'} ;;
+  api)
+    # gh api user --jq .login → print authenticated login
+    shift
+    if [ "\${1:-}" = "user" ]; then
+      echo "testuser"
+      exit 0
+    fi
+    exit 0
+    ;;
   repo)
     shift
     case "$1" in
       view)
-        # gh repo view <name>
+        # gh repo view <owner/name> | <name>
         shift
         ${alreadyRenamed ? `if echo "$@" | grep -q gstack-artifacts; then exit 0; else exit 1; fi` : `exit 1`}
         ;;


### PR DESCRIPTION
## Summary

The `v1.27.0.0` migration (gstack-brain → gstack-artifacts rename) silently fails to rename users' GitHub repos because it passes a bare repo name to `gh repo rename --repo` and `gh repo edit`, both of which require the `[HOST/]OWNER/REPO` form.

```
$ gh repo rename gstack-artifacts-Brandon --repo gstack-brain-Brandon --yes
expected the "[HOST/]OWNER/REPO" format, got "gstack-brain-Brandon"
```

Because stderr was suppressed with `2>/dev/null`, this surfaced only as the generic warning `gh rename failed (repo may not exist or permission denied)` — misdirecting users who actually have `ADMIN` on the repo. The step is then `mark_done`'d, so a second `/gstack-upgrade` run does not retry. The local pointer at `~/.gstack-artifacts-remote.txt` ends up referencing a repo that doesn't exist on GitHub until the user notices.

I hit this today upgrading from v1.26.4.0 → v1.32.0.0 on a fully-authenticated `gh` with ADMIN on the legacy `gstack-brain-$USER` repo.

## What this PR changes

- Resolve the authenticated user's login via `gh api user --jq .login`.
- Qualify both the existing-name check (`gh repo view`) and the rename/edit invocations with `$OWNER/$REPO`.
- Capture stderr from each attempt so the warning prints the real `gh` error instead of a generic guess.
- Extend the fake `gh` mock in `test/migrations-v1.27.0.0.test.ts` so existing tests still drive the rename path with the new `gh api user` call.

No behavior change for users where the migration would already be a no-op (`gh` unauthenticated, repo already at the new name, or no legacy state).

## Test plan

- [x] `bun test test/migrations-v1.27.0.0.test.ts` — 11/11 passing locally
- [x] `bash -n gstack-upgrade/migrations/v1.27.0.0.sh` — clean
- [x] Manually re-ran corrected command on my repo (`gh repo rename gstack-artifacts-Brandon --repo agile-operators/gstack-brain-Brandon --yes`) — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->