### PR TITLE
fix: add missing lastConsoleFlushed declaration in browse server

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -324,6 +324,7 @@ const DIALOG_LOG_PATH = config.dialogLog;
 // terminal-agent.ts; chat queue + per-tab agent multiplexing are no
 // longer needed.
 
+let lastConsoleFlushed = 0;
 let lastNetworkFlushed = 0;
 let lastDialogFlushed = 0;
 let flushInProgress = false;


### PR DESCRIPTION
`lastConsoleFlushed` is referenced in `flushBuffers()` (line 337) but was never declared. `lastNetworkFlushed` and `lastDialogFlushed` were declared at line 327, but `lastConsoleFlushed` was omitted. This causes a `ReferenceError: lastConsoleFlushed is not defined` that spams the browse daemon console in an infinite loop, making the terminal unusable.

One-line fix: add `let lastConsoleFlushed = 0;` alongside the other flush counters.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->