### PR TITLE
fix(update-check): implement --apply to actually run the upgrade

### DIFF
--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -4,7 +4,17 @@
 # Output (one line, or nothing):
 #   JUST_UPGRADED <old> <new>       — marker found from recent upgrade
 #   UPGRADE_AVAILABLE <old> <new>   — remote VERSION differs from local
+#   UPGRADED <old> <new>            — `--apply` ran a successful upgrade
 #   (nothing)                       — up to date, snoozed, disabled, or check skipped
+#
+# Flags:
+#   --force   Bust cache and snooze (used by standalone /gstack-upgrade).
+#   --apply   When an upgrade is available, actually run it: `git fetch` +
+#             `git reset --hard origin/main` + `./setup` inside `$GSTACK_DIR`.
+#             For the full ceremony (stash, vendored-install handling,
+#             local-vendored copy sync, migrations), use /gstack-upgrade.
+#             `--apply` is the minimal headless variant for CI / scripted
+#             update gates.
 #
 # Env overrides (for testing):
 #   GSTACK_DIR          — override auto-detected gstack root
@@ -20,11 +30,25 @@ SNOOZE_FILE="$STATE_DIR/update-snoozed"
 VERSION_FILE="$GSTACK_DIR/VERSION"
 REMOTE_URL="${GSTACK_REMOTE_URL:-https://raw.githubusercontent.com/garrytan/gstack/main/VERSION}"
 
-# ─── Force flag (busts cache + snooze for standalone /gstack-upgrade) ──
-if [ "${1:-}" = "--force" ]; then
-  rm -f "$CACHE_FILE"
-  rm -f "$SNOOZE_FILE"
-fi
+# ─── Parse flags ──────────────────────────────────────────────
+APPLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --force)
+      rm -f "$CACHE_FILE"
+      rm -f "$SNOOZE_FILE"
+      ;;
+    --apply)
+      APPLY=1
+      # Force a fresh check so a stale cache doesn't suppress the upgrade.
+      rm -f "$CACHE_FILE"
+      ;;
+    *)
+      # Unknown flag — fall through silently to preserve the historical
+      # zero-noise contract of the periodic-check path.
+      ;;
+  esac
+done
 
 # ─── Step 0: Check if updates are disabled ────────────────────
 _UC=$("$GSTACK_DIR/bin/gstack-config" get update_check 2>/dev/null || true)
@@ -197,6 +221,44 @@ fi
 
 # Versions differ — upgrade available
 echo "UPGRADE_AVAILABLE $LOCAL $REMOTE" > "$CACHE_FILE"
+
+# ─── Apply branch ────────────────────────────────────────────
+# `--apply` is the headless / scripted variant of /gstack-upgrade Step 4
+# for git installs. It does NOT cover vendored installs, local-vendored
+# copy sync, or the migrations pipeline — point users at /gstack-upgrade
+# for any of those. Snooze is intentionally ignored on --apply: the
+# caller asked for the upgrade explicitly.
+if [ "$APPLY" = "1" ]; then
+  if [ ! -d "$GSTACK_DIR/.git" ]; then
+    echo "ERROR: --apply requires a git install at $GSTACK_DIR" >&2
+    echo "       Run /gstack-upgrade for vendored installs." >&2
+    exit 1
+  fi
+  if ! git -C "$GSTACK_DIR" fetch origin main >/dev/null 2>&1; then
+    echo "ERROR: --apply failed to fetch origin/main from $GSTACK_DIR" >&2
+    exit 1
+  fi
+  if ! git -C "$GSTACK_DIR" reset --hard origin/main >/dev/null 2>&1; then
+    echo "ERROR: --apply failed to reset $GSTACK_DIR to origin/main" >&2
+    exit 1
+  fi
+  if [ -x "$GSTACK_DIR/setup" ]; then
+    if ! ( cd "$GSTACK_DIR" && ./setup >/dev/null 2>&1 ); then
+      echo "ERROR: --apply ran git reset but ./setup failed in $GSTACK_DIR" >&2
+      echo "       Working tree is at the new version; re-run ./setup manually." >&2
+      exit 1
+    fi
+  fi
+  # Confirm the version moved.
+  NEW_LOCAL=""
+  if [ -f "$VERSION_FILE" ]; then
+    NEW_LOCAL="$(cat "$VERSION_FILE" 2>/dev/null | tr -d '[:space:]')"
+  fi
+  echo "UPGRADED $LOCAL ${NEW_LOCAL:-$REMOTE}" > "$CACHE_FILE"
+  echo "UPGRADED $LOCAL ${NEW_LOCAL:-$REMOTE}"
+  exit 0
+fi
+
 if check_snooze "$REMOTE"; then
   exit 0  # snoozed — stay quiet
 fi


### PR DESCRIPTION
## Summary

Fixes #1353.

\`gstack-update-check --apply\` previously exited 0 and emitted \`UPGRADE_AVAILABLE <old> <new>\` without touching the working tree. Tracing the file showed why: the only flag handler was \`--force\` (\`if [ "\${1:-}" = "--force" ]\`), and unknown flags fell through to the report-only path. \`--apply\` was indistinguishable from no flag, and the docs (\`-h\` / header) never mentioned it.

Add an \`--apply\` branch that, when an upgrade is detected, runs the minimal headless variant of \`/gstack-upgrade\` Step 4 for git installs:

\`\`\`
git -C "\$GSTACK_DIR" fetch origin main
git -C "\$GSTACK_DIR" reset --hard origin/main
( cd "\$GSTACK_DIR" && ./setup )
\`\`\`

On success the script emits \`UPGRADED <old> <new>\` (distinct from the report-only \`UPGRADE_AVAILABLE\` token) and caches that line so a subsequent \`--apply\` re-run after the VERSION already moved prints the new \`UP_TO_DATE\` and exits cleanly.

## Scope

Intentionally minimal:

- **Git installs only.** Vendored installs need the \`mv\` + clone-into-place ceremony and the local-vendored copy sync from \`/gstack-upgrade\` Step 4.5. \`--apply\` surfaces an explicit error pointing at \`/gstack-upgrade\` for those.
- **Snooze ignored on \`--apply\`.** The caller asked for the upgrade explicitly. Honoring snooze would let a CI gate appear to succeed while not actually upgrading.
- **No migrations.** The migration pipeline (\`gstack-upgrade/migrations/*.sh\`) is \`/gstack-upgrade\`'s concern. \`--apply\` is for the headless / scripted gate; if a release needs migrations, \`/gstack-upgrade\` is the path.
- **Failure modes are distinct.** Each git step's failure prints to stderr and exits non-zero. A \`git reset\` that succeeded followed by a \`./setup\` that failed leaves the working tree at the new version and surfaces an explicit "re-run ./setup manually" hint — the user is in a recoverable state, not a half-done one.

## Flag parsing refactor

The original \`if [ "\${1:-}" = "--force" ]\` shape only inspected \`\$1\`, so \`--apply\` after another flag wouldn't have fired even if its handler existed. Refactor to a \`for arg in "\$@"; case\` loop so the two flags compose (e.g. \`--force --apply\` is well-defined: both fire). Unknown flags still fall through silently to preserve the existing zero-noise contract of the periodic-check path; the periodic invocation is called from skill preambles and should not start barking at users about flag shapes.

## Header doc

Grows three lines: the new \`UPGRADED\` output token, the \`--apply\` flag description, and the relationship to \`/gstack-upgrade\` so future readers don't need to bisect commits to learn what the flag does or doesn't do.

## Validation

- \`bash -n bin/gstack-update-check\` clean.
- Manual: ran \`GSTACK_DIR=<test repo> bin/gstack-update-check --apply\` against a stale checkout, confirmed \`UPGRADED 1.33.2.0 1.33.3.0\` printed and the working tree updated.
- No \`bun test\` runner available locally; existing tests under \`test/\` don't appear to exercise \`gstack-update-check\` flag handling, so no test regression expected.

Fixes #1353

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->