### PR TITLE
fix(codex): surface non-zero exits so wrappers stop reading as silent stalls

### DIFF
--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -949,6 +949,13 @@ if [ "$_CODEX_EXIT" = "124" ]; then
   _gstack_codex_log_event "codex_timeout" "330"
   _gstack_codex_log_hang "review" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
   echo "Codex stalled past 5.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+elif [ "$_CODEX_EXIT" != "0" ]; then
+  # Surface non-zero exits (parse errors, arg-shape breaks, etc.) so the
+  # calling agent doesn't read "no output" as a silent model/API stall and
+  # burn 30-60min misdiagnosing it. See #1327.
+  echo "[codex exit $_CODEX_EXIT] $(head -1 "$TMPERR" 2>/dev/null || echo "no stderr captured")"
+  head -20 "$TMPERR" 2>/dev/null | sed 's/^/  /' || true
+  _gstack_codex_log_event "codex_nonzero_exit" "review:$_CODEX_EXIT"
 fi
 ```
 
@@ -1187,6 +1194,12 @@ if [ "$_CODEX_EXIT" = "124" ]; then
   _gstack_codex_log_event "codex_timeout" "600"
   _gstack_codex_log_hang "challenge" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
   echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+elif [ "$_CODEX_EXIT" != "0" ]; then
+  # Surface non-zero exits so the calling agent doesn't read "no output" as
+  # a silent model/API stall. See #1327.
+  echo "[codex exit $_CODEX_EXIT] $(head -1 "$TMPERR" 2>/dev/null || echo "no stderr captured")"
+  head -20 "$TMPERR" 2>/dev/null | sed 's/^/  /' || true
+  _gstack_codex_log_event "codex_nonzero_exit" "challenge:$_CODEX_EXIT"
 fi
 # Fix 2: surface auth errors from captured stderr instead of dropping them
 if grep -qiE "auth|login|unauthorized" "$TMPERR" 2>/dev/null; then
@@ -1334,6 +1347,12 @@ if [ "$_CODEX_EXIT" = "124" ]; then
   _gstack_codex_log_event "codex_timeout" "600"
   _gstack_codex_log_hang "consult" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
   echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+elif [ "$_CODEX_EXIT" != "0" ]; then
+  # Surface non-zero exits so the calling agent doesn't read "no output" as
+  # a silent model/API stall. See #1327.
+  echo "[codex exit $_CODEX_EXIT] $(head -1 "$TMPERR" 2>/dev/null || echo "no stderr captured")"
+  head -20 "$TMPERR" 2>/dev/null | sed 's/^/  /' || true
+  _gstack_codex_log_event "codex_nonzero_exit" "consult:$_CODEX_EXIT"
 fi
 ```
 
@@ -1356,6 +1375,12 @@ if [ "$_CODEX_EXIT" = "124" ]; then
   _gstack_codex_log_event "codex_timeout" "600"
   _gstack_codex_log_hang "consult-resume" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
   echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+elif [ "$_CODEX_EXIT" != "0" ]; then
+  # Surface non-zero exits so the calling agent doesn't read "no output" as
+  # a silent model/API stall. See #1327.
+  echo "[codex exit $_CODEX_EXIT] $(head -1 "$TMPERR" 2>/dev/null || echo "no stderr captured")"
+  head -20 "$TMPERR" 2>/dev/null | sed 's/^/  /' || true
+  _gstack_codex_log_event "codex_nonzero_exit" "consult-resume:$_CODEX_EXIT"
 fi
 
 5. Capture session ID from the streamed output. The parser prints `SESSION_ID:<id>`

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -175,6 +175,13 @@ if [ "$_CODEX_EXIT" = "124" ]; then
   _gstack_codex_log_event "codex_timeout" "330"
   _gstack_codex_log_hang "review" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
   echo "Codex stalled past 5.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+elif [ "$_CODEX_EXIT" != "0" ]; then
+  # Surface non-zero exits (parse errors, arg-shape breaks, etc.) so the
+  # calling agent doesn't read "no output" as a silent model/API stall and
+  # burn 30-60min misdiagnosing it. See #1327.
+  echo "[codex exit $_CODEX_EXIT] $(head -1 "$TMPERR" 2>/dev/null || echo "no stderr captured")"
+  head -20 "$TMPERR" 2>/dev/null | sed 's/^/  /' || true
+  _gstack_codex_log_event "codex_nonzero_exit" "review:$_CODEX_EXIT"
 fi
 ```
 
@@ -329,6 +336,12 @@ if [ "$_CODEX_EXIT" = "124" ]; then
   _gstack_codex_log_event "codex_timeout" "600"
   _gstack_codex_log_hang "challenge" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
   echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+elif [ "$_CODEX_EXIT" != "0" ]; then
+  # Surface non-zero exits so the calling agent doesn't read "no output" as
+  # a silent model/API stall. See #1327.
+  echo "[codex exit $_CODEX_EXIT] $(head -1 "$TMPERR" 2>/dev/null || echo "no stderr captured")"
+  head -20 "$TMPERR" 2>/dev/null | sed 's/^/  /' || true
+  _gstack_codex_log_event "codex_nonzero_exit" "challenge:$_CODEX_EXIT"
 fi
 # Fix 2: surface auth errors from captured stderr instead of dropping them
 if grep -qiE "auth|login|unauthorized" "$TMPERR" 2>/dev/null; then
@@ -476,6 +489,12 @@ if [ "$_CODEX_EXIT" = "124" ]; then
   _gstack_codex_log_event "codex_timeout" "600"
   _gstack_codex_log_hang "consult" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
   echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+elif [ "$_CODEX_EXIT" != "0" ]; then
+  # Surface non-zero exits so the calling agent doesn't read "no output" as
+  # a silent model/API stall. See #1327.
+  echo "[codex exit $_CODEX_EXIT] $(head -1 "$TMPERR" 2>/dev/null || echo "no stderr captured")"
+  head -20 "$TMPERR" 2>/dev/null | sed 's/^/  /' || true
+  _gstack_codex_log_event "codex_nonzero_exit" "consult:$_CODEX_EXIT"
 fi
 ```
 
@@ -498,6 +517,12 @@ if [ "$_CODEX_EXIT" = "124" ]; then
   _gstack_codex_log_event "codex_timeout" "600"
   _gstack_codex_log_hang "consult-resume" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
   echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+elif [ "$_CODEX_EXIT" != "0" ]; then
+  # Surface non-zero exits so the calling agent doesn't read "no output" as
+  # a silent model/API stall. See #1327.
+  echo "[codex exit $_CODEX_EXIT] $(head -1 "$TMPERR" 2>/dev/null || echo "no stderr captured")"
+  head -20 "$TMPERR" 2>/dev/null | sed 's/^/  /' || true
+  _gstack_codex_log_event "codex_nonzero_exit" "consult-resume:$_CODEX_EXIT"
 fi
 
 5. Capture session ID from the streamed output. The parser prints `SESSION_ID:<id>`


### PR DESCRIPTION
## Summary

Fixes #1327.

The \`/codex\` Review, Challenge, Consult, and Consult-resume wrappers all inspect \`_CODEX_EXIT\` for the 124 timeout sentinel only. Any other non-zero exit — parse error from a Codex CLI breaking arg change (exit 2), auth failure that didn't match the existing auth-text regex, network drop returning a partial frame — gets swallowed. The calling agent sees empty stdout, indistinguishable from a model API stall, and proceeds to misdiagnose for 30-60min before someone checks \`\$TMPERR\` by hand.

The reporter's CLAUDE.md #54f from claude-teams-bot makes the same observation across ~5 hits in one week: *"Don't trust silent-stall framing... it's exit non-zero with empty stdout, swallowed by a wrapper that only handles the timeout exit code."*

## Approach

Add an \`elif != "0"\` branch to each of the four wrappers (Review, Challenge, Consult new-session, Consult-resume). On a non-zero non-timeout exit, the wrapper now:

- Prints \`[codex exit <code>] <first stderr line>\` so the calling agent has an immediate, structured diagnostic line.
- Prints the first 20 lines of \`\$TMPERR\` indented two spaces so the full parse error / arg-shape rejection is right there in the conversation, not hidden in a temp file.
- Logs \`codex_nonzero_exit:<mode>:<exit_code>\` via the existing telemetry helper so this becomes queryable, distinct from \`codex_timeout\`.

Behavior on success (exit 0) and timeout (exit 124) is unchanged — the existing branches still fire first. Auth-error detection in the Challenge wrapper (\`grep -qiE "auth|login|unauthorized" "\$TMPERR"\`) also still fires unchanged; the new branch sits between the timeout branch and the auth branch and doesn't shadow either.

## Defensive, not curative

This is the layer the reporter explicitly framed as separate from #1209's curative fix for the specific parse-error trigger: even after #1209 lands, future Codex CLI arg-shape breaks will keep masquerading as silent stalls until/unless someone manually inspects the captured stderr. Both fixes are complementary; this one is the cheaper of the two and self-corrects on the next regression.

## Files

- \`codex/SKILL.md.tmpl\` — canonical source. Four \`elif != "0"\` branches added next to the existing \`if = "124"\` checks (Review @ 178, Challenge @ 336, Consult @ 489, Consult-resume @ 517).
- \`codex/SKILL.md\` — generated mirror, same four edits applied so the PR is self-consistent without requiring the reviewer to run \`bun run gen:skill-docs\` to inspect the output.

Both files are kept in sync per the \`SKILL.md workflow\` section of CLAUDE.md.

## Validation

- \`bash -n\` on the embedded blocks — clean (the wrappers are markdown code fences but each block is a self-contained bash snippet that runs fine when extracted).
- No \`bun test\` runner available locally; the change is additive (new elif branch only; no existing branch touched) so the existing skill-validation suite should remain green.

Fixes #1327

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->