### PR TITLE
fix(gbrain-sync): fold hostname into code-source id hash

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -32,7 +32,7 @@
 import { existsSync, statSync, mkdirSync, writeFileSync, readFileSync, unlinkSync, renameSync } from "fs";
 import { join, dirname } from "path";
 import { execSync, spawnSync } from "child_process";
-import { homedir } from "os";
+import { homedir, hostname } from "os";
 import { createHash } from "crypto";
 
 import { detectEngineTier, withErrorContext, canonicalizeRemote } from "../lib/gstack-memory-helpers";
@@ -159,30 +159,35 @@ function originUrl(): string | null {
 }
 
 /**
- * Derive a worktree-aware source id for the cwd code corpus.
+ * Derive a host- and worktree-aware source id for the cwd code corpus.
  *
- * Pattern: `gstack-code-<slug>-<pathhash8>` where slug comes from origin
- * (org/repo) and pathhash8 is the first 8 hex chars of sha1(absolute repo
- * path). The pathhash8 is what makes Conductor worktrees of the same repo
- * coexist as separate sources in the same gbrain DB instead of stomping on
- * each other.
+ * Pattern: `gstack-code-<slug>-<hostpathhash8>` where slug comes from origin
+ * (org/repo) and hostpathhash8 is the first 8 hex chars of
+ * sha1(`${hostname}::${absolute repo path}`). Folding hostname into the hash
+ * keeps Conductor worktrees of the same repo as distinct sources on one host
+ * AND keeps two machines that share an absolute layout (e.g. chezmoi-managed
+ * home dirs against a federated brain) from colliding on each other.
  *
  * Falls back to the repo basename when there is no origin (local repo).
+ *
+ * `GSTACK_HOSTNAME` env override is honored for deterministic tests; in
+ * production paths it is unset and `os.hostname()` is used.
  *
  * gbrain enforces source ids to be 1-32 lowercase alnum chars with
  * optional interior hyphens. `constrainSourceId` handles the 32-char cap
  * with a hashed-tail fallback when the combined slug exceeds budget.
  */
 function deriveCodeSourceId(repoPath: string): string {
-  const pathHash = createHash("sha1").update(repoPath).digest("hex").slice(0, 8);
+  const host = process.env.GSTACK_HOSTNAME || hostname();
+  const hostPathHash = createHash("sha1").update(`${host}::${repoPath}`).digest("hex").slice(0, 8);
   const remote = canonicalizeRemote(originUrl());
   if (remote) {
     const segs = remote.split("/").filter(Boolean);
     const slugSource = segs.slice(-2).join("-");
-    return constrainSourceId("gstack-code", `${slugSource}-${pathHash}`);
+    return constrainSourceId("gstack-code", `${slugSource}-${hostPathHash}`);
   }
   const base = repoPath.split("/").pop() || "repo";
-  return constrainSourceId("gstack-code", `${base}-${pathHash}`);
+  return constrainSourceId("gstack-code", `${base}-${hostPathHash}`);
 }
 
 /**

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, mkdirSync } from "fs";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, mkdirSync, chmodSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { spawnSync } from "child_process";
@@ -213,6 +213,62 @@ describe("gstack-gbrain-sync CLI", () => {
 
     rmSync(parent, { recursive: true, force: true });
     rmSync(home, { recursive: true, force: true });
+  });
+
+  it("derives distinct source ids for the same absolute path on different hosts", () => {
+    // Issue #1414: two machines with identical home-dir layouts (chezmoi-managed
+    // dotfiles, ansible-provisioned VMs) collide on the same source id when
+    // federated against a shared gbrain DB, because the pre-fix `pathHash` was
+    // sha1(absolute path) only — host-agnostic. Folding hostname into the hash
+    // key keeps them distinct. `GSTACK_HOSTNAME` env var is the test-only knob;
+    // production uses `os.hostname()`.
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const repo = mkdtempSync(join(tmpdir(), "gstack-host-collide-"));
+    spawnSync("git", ["init", "--quiet", "-b", "main"], { cwd: repo });
+    spawnSync("git", ["remote", "add", "origin", "https://github.com/example/multihost.git"], { cwd: repo });
+
+    // Dry-run still gates the code stage on `command -v gbrain`. Drop a no-op
+    // shim on PATH so the stage runs (we only assert the preview line, never
+    // invoke gbrain itself).
+    const bindir = mkdtempSync(join(tmpdir(), "gstack-host-collide-bin-"));
+    const shim = join(bindir, "gbrain");
+    writeFileSync(shim, "#!/bin/sh\nexit 0\n");
+    chmodSync(shim, 0o755);
+    const PATH = `${bindir}:${process.env.PATH || ""}`;
+
+    const runAs = (host: string) =>
+      spawnSync("bun", [SCRIPT, "--dry-run", "--code-only", "--quiet"], {
+        encoding: "utf-8",
+        timeout: 60000,
+        cwd: repo,
+        env: { ...process.env, HOME: home, GSTACK_HOME: gstackHome, GSTACK_HOSTNAME: host, PATH },
+      });
+
+    const a = runAs("machine-a");
+    const b = runAs("machine-b");
+    expect(a.status).toBe(0);
+    expect(b.status).toBe(0);
+    const idA = (a.stdout || "").match(/gbrain sources add (\S+)/)?.[1];
+    const idB = (b.stdout || "").match(/gbrain sources add (\S+)/)?.[1];
+    expect(idA).toBeTruthy();
+    expect(idB).toBeTruthy();
+    expect(idA).not.toBe(idB);
+    // Both still gbrain-valid.
+    const VALID_ID = /^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/;
+    expect(idA!).toMatch(VALID_ID);
+    expect(idB!).toMatch(VALID_ID);
+
+    // Same host + same path stays stable across invocations.
+    const a2 = runAs("machine-a");
+    expect(a2.status).toBe(0);
+    const idA2 = (a2.stdout || "").match(/gbrain sources add (\S+)/)?.[1];
+    expect(idA2).toBe(idA);
+
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+    rmSync(bindir, { recursive: true, force: true });
   });
 
   it("dry-run does NOT acquire the lock file (lock is for write paths only)", () => {


### PR DESCRIPTION
## Summary

- `deriveCodeSourceId` now keys its 8-char hash off `${hostname}::${absolute repo path}` instead of the path alone.
- Conductor worktrees on a single host stay distinct (path entropy unchanged within a host). Two machines with the same absolute layout against a federated brain stop colliding.
- One new test asserts distinct ids across simulated hostnames + stable id within the same host.

Fixes #1414.

## Why

`pathHash = sha1(repoPath).slice(0,8)` was a function of absolute filesystem path only. Two machines with identical home-dir layouts (chezmoi dotfiles, ansible-provisioned VMs, single-user multi-host fleets) produce identical source ids when both run against a shared brain DB. Last-writer-wins on `sources.local_path`; bare `gbrain sync` on the loser surfaces a cryptic `Not a git repository` against the cwd that *is* a git repo.

The v1.29.0.0 "Conductor worktrees of the same repo coexist as separate sources" promise holds within one host because Conductor worktrees live at different paths. It breaks across hosts because the path is the same on both.

## Fix

```ts
const host = process.env.GSTACK_HOSTNAME || hostname();
const hostPathHash = createHash("sha1")
  .update(`${host}::${repoPath}`)
  .digest("hex")
  .slice(0, 8);
```

`os.hostname()` is the cheapest stable host identifier that works on every platform without a privileged read. `/etc/machine-id` is stabler across rename but Linux-specific. `GSTACK_HOSTNAME` is a test-only knob; production leaves it unset.

## Migration

Legacy path-only-hashed sources age out naturally. In-place migration would force a brain-wide rewrite for a minority workflow; the existing `deriveLegacyCodeSourceId` orphan-cleanup pattern can pick them up in a follow-up if a one-shot rewrite is preferred.

Out of scope: the TODOS.md P3 entry about cross-remote-host collisions (`github.com/acme/foo` vs `gitlab.com/acme/foo` on the same machine). Different axis.

## Tests

`test/gstack-gbrain-sync.test.ts` case `derives distinct source ids for the same absolute path on different hosts`:

- Same temp repo + same remote + same cwd, `GSTACK_HOSTNAME=machine-a` vs `GSTACK_HOSTNAME=machine-b` → distinct gbrain-valid ids.
- Same host + same path across two invocations → identical id.
- No-op `gbrain` shim is dropped on PATH so the dry-run code stage runs.

```bash
bun test test/gstack-gbrain-sync.test.ts -t "distinct source ids"
# 1 pass, 0 fail
```

Rest of file matches the pre-existing baseline on `upstream/main` (10 fail locally because `gbrain` CLI is not installed in this environment; unchanged by this diff).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->