### PR TITLE
feat(browse): add geolocation CDP override methods to allowlist

### DIFF
--- a/browse/src/cdp-allowlist.ts
+++ b/browse/src/cdp-allowlist.ts
@@ -155,6 +155,25 @@ export const CDP_ALLOWLIST: ReadonlyArray<CdpAllowEntry> = Object.freeze([
     output: 'trusted',
     justification: 'UA override on the active tab. NOTE: changes affect future requests; fine for tests.',
   },
+  {
+    domain: 'Emulation',
+    method: 'setGeolocationOverride',
+    scope: 'tab',
+    output: 'trusted',
+    justification: 'Geolocation override on the active tab. Same threat profile as setDeviceMetricsOverride: pure input, no data exfiltration. Enables GPS testing.',
+  },
+  {
+    domain: 'Emulation',
+    method: 'clearGeolocationOverride',
+    scope: 'tab',
+    output: 'trusted',
+    justification: 'Clear geolocation override. Mirrors clearDeviceMetricsOverride for cleanup symmetry.',
+  },
+  // NOTE: Browser.grantPermissions is intentionally NOT added here. It is a
+  // browser-scope CDP method that cannot be forwarded through the page-level
+  // CDPSession that the browse bridge uses. Geolocation testing requires either
+  // a Playwright script (which grants permissions at context creation) or a
+  // future browser-scope CDP routing path in the bridge.
   // ─── Page capture (output, not navigation) ─────────────────
   {
     domain: 'Page',


### PR DESCRIPTION
## Summary

Adds `Emulation.setGeolocationOverride` and `Emulation.clearGeolocationOverride` to the CDP allowlist, enabling GPS/geolocation coordinate simulation via the browse daemon.

## Why

Testing location-aware web apps (maps, GPS trackers, proximity search) currently requires a separate Playwright script because the browse daemon blocks all CDP methods by default (deny-default posture). Geolocation override has the same threat profile as the already-allowed `Emulation.setDeviceMetricsOverride`: pure input to the active tab, no data exfiltration surface.

## What changed

- `browse/src/cdp-allowlist.ts` — added 2 entries under the Emulation section:
  - `Emulation.setGeolocationOverride` (tab, trusted) — sets geolocation coordinates for the active tab
  - `Emulation.clearGeolocationOverride` (tab, trusted) — clears the override, mirrors `clearDeviceMetricsOverride`
- Added a NOTE documenting that `Browser.grantPermissions` cannot work through the page-scoped CDPSession and needs a separate browser-scope routing path in the future

## Usage

```bash
# Set geolocation to London
$B cdp Emulation.setGeolocationOverride '{"latitude":51.5074,"longitude":-0.1278,"accuracy":10}'

# Clear override
$B cdp Emulation.clearGeolocationOverride '{}'
```

## Known limitation

Full end-to-end GPS testing (permission grant + coordinate override) still requires either:
1. A Playwright script that creates a context with `permissions: ['geolocation']` and `geolocation: {...}`, or
2. A future browser-scope CDP routing path in the bridge that can forward `Browser.grantPermissions`

The `setGeolocationOverride` alone overrides coordinates when geolocation permission is already granted (e.g., after user interaction or via a Playwright-launched context).

## Testing

All 6 existing CDP allowlist tests pass (199 expect calls). No new tests needed — existing test suite validates that every entry has required fields, no duplicates exist, and the deny-default posture is maintained.

```
bun test browse/test/cdp-allowlist.test.ts
 6 pass  0 fail  199 expect() calls
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->