### PR TITLE
fix(gbrain-sync): cut source-id slugs on hyphen boundaries

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -179,7 +179,14 @@ function deriveCodeSourceId(repoPath: string): string {
   if (remote) {
     const segs = remote.split("/").filter(Boolean);
     const slugSource = segs.slice(-2).join("-");
-    return constrainSourceId("gstack-code", `${slugSource}-${pathHash}`);
+    const fullId = constrainSourceId("gstack-code", `${slugSource}-${pathHash}`);
+    // If the org+repo+pathhash fits cleanly (suffix preserved), use it.
+    if (fullId.endsWith(`-${pathHash}`)) return fullId;
+    // Otherwise drop the org prefix and retry with just repo+pathhash so the
+    // repo name stays readable. If that still doesn't fit, constrainSourceId
+    // falls back to a deterministic hash-only form.
+    const repoOnly = segs[segs.length - 1] || "repo";
+    return constrainSourceId("gstack-code", `${repoOnly}-${pathHash}`);
   }
   const base = repoPath.split("/").pop() || "repo";
   return constrainSourceId("gstack-code", `${base}-${pathHash}`);
@@ -210,6 +217,10 @@ function deriveLegacyCodeSourceId(repoPath: string): string {
  * Build a gbrain-valid source id (1-32 lowercase alnum + interior hyphens). Sanitizes
  * `raw`, prefixes with `prefix`, and falls back to a hashed-tail form when total length
  * would exceed 32 chars.
+ *
+ * Truncation cuts on hyphen boundaries (whole-word units) from the right, never
+ * mid-word. Inputs like "drummerms-av-sow-wiz-skill-270c0001" produce
+ * "${prefix}-270c0001-<hash>", not "${prefix}-kill-270c0001-<hash>".
  */
 function constrainSourceId(prefix: string, raw: string): string {
   const MAX = 32;
@@ -228,7 +239,20 @@ function constrainSourceId(prefix: string, raw: string): string {
   // Total budget: prefix + "-" + tail + "-" + hash
   const tailBudget = MAX - prefix.length - 2 - hash.length;
   if (tailBudget < 1) return `${prefix}-${hash}`;
-  const tail = slug.slice(-tailBudget).replace(/^-+|-+$/g, "");
+  // Cut on hyphen boundaries instead of mid-word. Walk tokens from the right,
+  // accumulating until adding the next token would exceed tailBudget. This
+  // preserves readable suffixes (pathhash, repo name) and avoids embarrassing
+  // mid-word artifacts like "skill" → "kill".
+  const tokens = slug.split("-").filter(Boolean);
+  const kept: string[] = [];
+  let len = 0;
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const add = kept.length === 0 ? tokens[i].length : tokens[i].length + 1;
+    if (len + add > tailBudget) break;
+    kept.unshift(tokens[i]);
+    len += add;
+  }
+  const tail = kept.join("-");
   return tail ? `${prefix}-${tail}-${hash}` : `${prefix}-${hash}`;
 }
 


### PR DESCRIPTION
## Summary

`constrainSourceId` in `bin/gstack-gbrain-sync.ts` truncates long slugs with `slug.slice(-tailBudget)`, which cuts mid-word when the budget boundary lands inside a hyphen-separated token. For a repo where `prefix-org-repo-pathhash` exceeds the 32-char source-id cap, this produces visible artifacts like:

| Input | Before | After |
|---|---|---|
| `drummerms-av-sow-wiz-skill-270c0001` (from `github.com/Drummerms/av-sow-wiz-skill`) | `gstack-code-kill-270c0001-c32152` | `gstack-code-270c0001-050d83` |

The `kill` substring is `skill` chopped at the 13-char tail boundary. Beyond the cosmetic problem, it surfaces in user-visible citations and source listings.

## What changes

Two small edits, both in `bin/gstack-gbrain-sync.ts`:

1. **`constrainSourceId`** — walk hyphen-separated tokens from the right, accumulating whole tokens until adding the next would exceed `tailBudget`. When no token fits, falls through to the existing `${prefix}-${hash}` form. Pure refactor of the truncation step; no API change.

2. **`deriveCodeSourceId`** — when the full `prefix-org-repo-pathhash` triggers truncation (suffix no longer ends with `-${pathHash}`), retry with `prefix-repo-pathhash` (drop the org). Keeps the repo name readable in cases where dropping the org alone is enough to fit. Falls through to `constrainSourceId` either way.

## What's out of scope

The deeper constraint is gbrain's 32-char source-id cap. For mid-length org+repo combinations, even `repo-pathhash` doesn't fit — this PR's fallback produces `gstack-code-270c0001-050d83` for the example above, which is deterministic + clean but loses the repo name in the ID. Raising the gbrain cap (e.g. to 64) would let `gstack-code-av-sow-wiz-skill-270c0001` (37 chars) resolve fully. That's a gbrain-side change not bundled here.

## Test plan

- [x] `bun run bin/gstack-gbrain-sync.ts --dry-run` against `av-sow-wiz-skill` produces `gstack-code-270c0001-050d83` instead of `gstack-code-kill-270c0001-c32152`
- [x] Short repo names unaffected (org+repo+pathhash fits without truncation → same output as before)
- [ ] Unit tests for `constrainSourceId` if the maintainer wants them — happy to add in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gstack/pr/1481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->