### PR TITLE
fix(setup): symlink skill bin/ dirs so PreToolUse hooks resolve

### DIFF
--- a/setup
+++ b/setup
@@ -577,6 +577,18 @@ link_claude_skill_dirs() {
         if [ -e "$target/sections" ] || [ -L "$target/sections" ]; then rm -rf "$target/sections"; fi
         _link_or_copy "$gstack_dir/$dir_name/sections" "$target/sections"
       fi
+      # Also link bin/ when the source skill ships one. PreToolUse hook
+      # frontmatter references $CLAUDE_SKILL_DIR/bin/<script>; without
+      # this link those paths resolve to a non-existent target and the
+      # hook silently no-ops (issue #1459). Same fix applies to every
+      # skill that publishes scripts -- freeze, careful, browse, etc.
+      # Routes through _link_or_copy so Windows installs without
+      # Developer Mode get a directory copy instead of a frozen symlink.
+      if [ -d "$gstack_dir/$dir_name/bin" ]; then
+        if [ -L "$target/bin" ]; then rm "$target/bin"; fi
+        if [ -e "$target/bin" ] && [ ! -L "$target/bin" ]; then rm -rf "$target/bin"; fi
+        _link_or_copy "$gstack_dir/$dir_name/bin" "$target/bin"
+      fi
       linked+=("$link_name")
     fi
   done


### PR DESCRIPTION
## Summary

Resolves §1 of #1459 (\`/freeze\` enforcement chain). Companion defects §2 / §3 are intentionally out of scope.

\`link_claude_skill_dirs\` previously only symlinked \`SKILL.md\` into the top-level skill directory, leaving \`bin/\` behind. PreToolUse hook frontmatter references \`\\$CLAUDE_SKILL_DIR/bin/<script>\`; with no symlink the path resolves to a non-existent target and the hook silently no-ops. The same defect affects every skill that ships scripts — \`freeze\`, \`careful\`, \`browse\`, etc.

## What changes

In \`setup\`'s \`link_claude_skill_dirs\` function, after the existing \`SKILL.md\` symlink:

\`\`\`bash
if [ -d \"\\$gstack_dir/\\$dir_name/bin\" ]; then
  if [ -L \"\\$target/bin\" ]; then rm \"\\$target/bin\"; fi
  if [ -e \"\\$target/bin\" ] && [ ! -L \"\\$target/bin\" ]; then rm -rf \"\\$target/bin\"; fi
  ln -snf \"\\$gstack_dir/\\$dir_name/bin\" \"\\$target/bin\"
fi
\`\`\`

Idempotent (rm + \`ln -snf\`) and tolerant of a prior real-directory entry at the target path so re-installs over an older copy upgrade cleanly.

## Out of scope (explicitly)

Defects §2 (registering PreToolUse hooks in user \`~/.claude/settings.json\`) and §3 are out of scope. Both touch user-global state on behalf of \`./setup\` and deserve a separate design call — happy to follow up if you want me to take §2 next.

## Test plan

- [x] \`bash -n setup\` — script syntax clean.
- [x] Diff is one block inside \`link_claude_skill_dirs\`; no other code paths touched.