### PR TITLE
fix(gbrain-install): skip postinstall scripts on Windows MSYS/Cygwin

### DIFF
--- a/bin/gstack-gbrain-install
+++ b/bin/gstack-gbrain-install
@@ -131,9 +131,24 @@ if $DRY_RUN; then
 fi
 
 # --- install + link ---
+# On Windows MSYS/Cygwin shells, bun's postinstall scripts (notably gbrain's
+# native-bindings setup) fail to parse path arguments correctly and abort
+# `bun install` with a non-zero exit. The package itself installs fine
+# without scripts, so detect Windows and pass --ignore-scripts there. The
+# `bun link` step below is unaffected.
+IS_WINDOWS=0
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT) IS_WINDOWS=1 ;;
+esac
+
 if ! $VALIDATE_ONLY; then
-  log "running bun install in $INSTALL_DIR"
-  ( cd "$INSTALL_DIR" && bun install --silent )
+  if [ "$IS_WINDOWS" -eq 1 ]; then
+    log "running bun install --ignore-scripts in $INSTALL_DIR (Windows shell detected)"
+    ( cd "$INSTALL_DIR" && bun install --silent --ignore-scripts )
+  else
+    log "running bun install in $INSTALL_DIR"
+    ( cd "$INSTALL_DIR" && bun install --silent )
+  fi
   log "running bun link in $INSTALL_DIR"
   ( cd "$INSTALL_DIR" && bun link --silent )
 fi


### PR DESCRIPTION
## Summary

Fixes #1271 (quirk 1): `gstack-gbrain-install` aborts on Windows MSYS/Cygwin shells because `bun install` runs gbrain's native postinstall script, which mis-parses Windows-style path arguments and exits non-zero. The package itself installs cleanly without scripts, so this PR detects Windows shells (`uname -s` matches `MINGW*|MSYS*|CYGWIN*|Windows_NT`) and passes `--ignore-scripts` to `bun install` on those platforms only. macOS and Linux paths are untouched.

The follow-up `bun link` step is unaffected by `--ignore-scripts` (link runs its own lifecycle), so the resulting `gbrain` CLI on PATH still works as before. D19 PATH-shadow validation downstream of the install also continues to apply unchanged.

## Scope

- One file: `bin/gstack-gbrain-install`
- One concern: Windows shell detection + conditional flag
- No behavior change for macOS / Linux

Issue #1271 lists three quirks; this PR addresses only quirk 1. The remaining two (path normalization in `~/.bashrc` append, and ttyd/screen probe on Git-bash) are out of scope here.

## Test plan

- [ ] macOS shell: `bash bin/gstack-gbrain-install --dry-run` still prints expected plan (no change)
- [ ] macOS shell: full install path still runs `bun install --silent` (no `--ignore-scripts`)
- [ ] Simulate MSYS by spoofing `uname -s`: confirm `bun install --silent --ignore-scripts` branch is taken
- [ ] Bash `-n` syntax check passes (verified locally)