### PR TITLE
fix(brain-allowlist): include root-level design + test-plan docs in artifacts sync

### DIFF
--- a/bin/gstack-artifacts-init
+++ b/bin/gstack-artifacts-init
@@ -227,6 +227,9 @@ projects/*/ceo-plans/*.md
 projects/*/ceo-plans/*/*.md
 projects/*/designs/*.md
 projects/*/designs/*/*.md
+projects/*/*-design-*.md
+projects/*/*-eng-review-test-plan-*.md
+projects/*/*-test-plan-*.md
 projects/*/timeline.jsonl
 retros/*.md
 developer-profile.json
@@ -247,6 +250,9 @@ cat > "$GSTACK_HOME/.brain-privacy-map.json" <<'EOF'
   {"pattern": "projects/*/ceo-plans/*/*.md", "class": "artifact"},
   {"pattern": "projects/*/designs/*.md", "class": "artifact"},
   {"pattern": "projects/*/designs/*/*.md", "class": "artifact"},
+  {"pattern": "projects/*/*-design-*.md", "class": "artifact"},
+  {"pattern": "projects/*/*-eng-review-test-plan-*.md", "class": "artifact"},
+  {"pattern": "projects/*/*-test-plan-*.md", "class": "artifact"},
   {"pattern": "retros/*.md", "class": "artifact"},
   {"pattern": "builder-journey.md", "class": "artifact"},
   {"pattern": "projects/*/timeline.jsonl", "class": "behavioral"},


### PR DESCRIPTION
## Summary

Fixes #1452: `gstack-artifacts-init` writes a `.brain-allowlist` that covers `projects/*/designs/*.md` and `projects/*/ceo-plans/*.md`, but several skills land their output at the **project root**, not in those subdirectories:

| Skill | Actual write path | Source |
|---|---|---|
| `/office-hours` Builder/Startup | `projects/{slug}/{user}-{branch}-design-{datetime}.md` | `office-hours/SKILL.md.tmpl:519` |
| `/plan-eng-review` | `projects/{slug}/{user}-{branch}-eng-review-test-plan-{datetime}.md` | `plan-eng-review/SKILL.md.tmpl:85-86` |
| `/autoplan` (test plan) | `projects/{slug}/{user}-{branch}-test-plan-{datetime}.md` | `autoplan/SKILL.md.tmpl:525` |

Cross-skill readers (`plan-ceo-review`, `plan-eng-review`, `autoplan`) glob these at the project root via `projects/$SLUG/*-design-*.md`, so the write paths are authoritative; the allowlist is the inconsistent piece. With `artifacts_sync_mode=full`, `gstack-brain-sync` silently skips all three doc types, breaking the cross-machine ceo-plan -> design chain.

## Change

Add three root-anchored glob patterns to **both**:

1. `.brain-allowlist` (so `gstack-brain-sync` includes them):
   ```
   projects/*/*-design-*.md
   projects/*/*-eng-review-test-plan-*.md
   projects/*/*-test-plan-*.md
   ```
2. `.brain-privacy-map.json` (same patterns, `class: "artifact"`, mirroring the existing `designs/` entries).

Glob `*` does not match path separators, so the new patterns do not conflict with the existing `projects/*/designs/*.md` or `projects/*/ceo-plans/*.md` entries.

Per the issue author's recommendation, the alternative (canonicalizing skill write paths under `designs/`) would break the existing cross-skill readers. The allowlist fix is the lower-risk path.

## Files

- `bin/gstack-artifacts-init` — allowlist + privacy-map block, 6 added lines, no removals.

## Test plan

- [ ] Run `bash -n bin/gstack-artifacts-init` (verified locally — syntax OK)
- [ ] Parse the embedded `.brain-privacy-map.json` (verified locally — valid JSON)
- [ ] `bun test test/brain-sync.test.ts` — existing tests verify file existence only, not pattern contents, so the diff is non-breaking
- [ ] On a fresh setup: run `/office-hours`, then `gstack-brain-sync --once`, confirm the root-level `*-design-*.md` is enqueued and pushed
- [ ] Existing `designs/*.md` and `ceo-plans/*.md` paths continue to sync as before