### PR TITLE
fix(setup): clarify Hermes host banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Or target a specific agent with `./setup --host <name>`:
 | Factory Droid | `--host factory` | `~/.factory/skills/gstack-*/` |
 | Slate | `--host slate` | `~/.slate/skills/gstack-*/` |
 | Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |
-| Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |
+| Hermes | `--host hermes` | Prints integration instructions; `bun run gen:skill-docs --host hermes` writes `.hermes/skills/` |
 | GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |
 
 **Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).

--- a/setup
+++ b/setup
@@ -71,12 +71,17 @@ case "$HOST" in
     exit 0 ;;
   hermes)
     echo ""
-    echo "Hermes integration uses the same model as OpenClaw — Hermes spawns"
+    echo "Hermes integration uses the same model as OpenClaw: Hermes spawns"
     echo "Claude Code sessions, and gstack provides methodology artifacts."
+    echo ""
+    echo "./setup --host hermes does not install files into Hermes today."
+    echo "It only prints integration instructions."
     echo ""
     echo "To integrate gstack with Hermes:"
     echo "  1. Tell your Hermes agent: 'install gstack for hermes'"
-    echo "  2. Or generate artifacts: bun run gen:skill-docs --host hermes"
+    echo "  2. Or generate reviewable artifacts locally:"
+    echo "     bun run gen:skill-docs --host hermes"
+    echo "     This writes .hermes/skills/ in this checkout."
     echo ""
     exit 0 ;;
   gbrain)

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2275,6 +2275,19 @@ describe('setup script validation', () => {
     expect(setupContent).toContain('claude|codex|kiro|factory|opencode|auto');
   });
 
+  test('Hermes host banner is explicit that setup is not an installer', () => {
+    const hermesStart = setupContent.indexOf('  hermes)');
+    const hermesEnd = setupContent.indexOf('  gbrain)', hermesStart);
+    expect(hermesStart).toBeGreaterThan(-1);
+    expect(hermesEnd).toBeGreaterThan(hermesStart);
+
+    const hermesBlock = setupContent.slice(hermesStart, hermesEnd);
+    expect(hermesBlock).toContain('./setup --host hermes does not install files into Hermes today.');
+    expect(hermesBlock).toContain('It only prints integration instructions.');
+    expect(hermesBlock).toContain('bun run gen:skill-docs --host hermes');
+    expect(hermesBlock).toContain('This writes .hermes/skills/ in this checkout.');
+  });
+
   test('auto mode detects claude, codex, kiro, and opencode binaries', () => {
     expect(setupContent).toContain('command -v claude');
     expect(setupContent).toContain('command -v codex');


### PR DESCRIPTION
Fixes #1201

## Summary
- Clarifies that `./setup --host hermes` is an instruction banner, not a host-side installer.
- Points users at `bun run gen:skill-docs --host hermes` for reviewable `.hermes/skills/` artifacts.
- Updates the README host table so it no longer promises `~/.hermes/skills/gstack-*/` installation.
- Adds a regression test for the Hermes banner wording.

## Verification
- `bun test test/gen-skill-docs.test.ts --test-name-pattern "Hermes host banner"`
- `bash -n setup`
- `./setup --host hermes` shows the banner and exits 0