### PR TITLE
fix(gstack-paths): add --get <key> so /codex skips eval-tilde footgun

### DIFF
--- a/bin/gstack-paths
+++ b/bin/gstack-paths
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 # gstack-paths — output portable state-root paths for skill bash blocks
-# Usage: eval "$(gstack-paths)"  → sets GSTACK_STATE_ROOT, PLAN_ROOT, TMP_ROOT
-# Or:    gstack-paths            → prints GSTACK_STATE_ROOT=... etc.
+# Usage: eval "$(gstack-paths)"        → sets GSTACK_STATE_ROOT, PLAN_ROOT, TMP_ROOT
+#        gstack-paths                  → prints GSTACK_STATE_ROOT=... etc.
+#        gstack-paths --get <key>      → prints a single resolved path (no KEY= prefix)
+#                                         where <key> is state-root | plan-root | tmp-root
+#
+# The --get form was added so callers can use `PLAN_ROOT=$(gstack-paths --get plan-root)`
+# instead of `eval "$(gstack-paths)"`. The eval form trips Claude Code's PreToolUse
+# bash AST parser (tilde inside $() inside double-quoted eval arg = "Unhandled node
+# type: string"), forcing manual approval on every skill that needs portable roots.
+# See issue #1329 Pattern 2.
 #
 # Resolves three roots with explicit fallback chains so skills work the same
 # whether installed as a Claude Code plugin (CLAUDE_PLUGIN_DATA / CLAUDE_PLANS_DIR
@@ -17,6 +25,27 @@
 # shell-special characters if env vars contain them. Skills should always quote
 # expansions ("$GSTACK_STATE_ROOT", not $GSTACK_STATE_ROOT).
 set -u
+
+# Parse optional --get <key> selector.
+_get_key=""
+case "${1:-}" in
+  --help|-h)
+    sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  --get)
+    if [ -z "${2:-}" ]; then
+      echo "gstack-paths: --get requires a key (state-root|plan-root|tmp-root)" >&2
+      exit 1
+    fi
+    _get_key="$2"
+    ;;
+  "" ) ;;  # bare invocation — backward-compatible default output
+  *)
+    echo "gstack-paths: unknown argument '$1' (expected --get <key>)" >&2
+    exit 1
+    ;;
+esac
 
 # State root: where gstack writes projects/, sessions/, analytics/.
 if [ -n "${GSTACK_HOME:-}" ]; then
@@ -56,6 +85,18 @@ fi
 # will discover that on their own write attempt. Don't fail the eval here.
 mkdir -p "$_tmp_root" 2>/dev/null || true
 
-echo "GSTACK_STATE_ROOT=$_state_root"
-echo "PLAN_ROOT=$_plan_root"
-echo "TMP_ROOT=$_tmp_root"
+if [ -n "$_get_key" ]; then
+  case "$_get_key" in
+    state-root) echo "$_state_root" ;;
+    plan-root)  echo "$_plan_root" ;;
+    tmp-root)   echo "$_tmp_root" ;;
+    *)
+      echo "gstack-paths: unknown key '$_get_key' (expected state-root|plan-root|tmp-root)" >&2
+      exit 1
+      ;;
+  esac
+else
+  echo "GSTACK_STATE_ROOT=$_state_root"
+  echo "PLAN_ROOT=$_plan_root"
+  echo "TMP_ROOT=$_tmp_root"
+fi

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -872,8 +872,13 @@ This keeps the skill working whether installed as a Claude Code plugin
 (`CLAUDE_PLANS_DIR` set), a global `~/.claude/skills/gstack/` install, or a CI
 container where `HOME` may be unset and `/tmp` may be read-only.
 
+`--get <key>` is preferred over `eval "$(...)"` here: the eval form trips Claude
+Code's bash AST parser (tilde inside `$()` inside double-quoted eval arg) and
+forces a manual confirmation on every run. Issue #1329 Pattern 2.
+
 ```bash
-eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+PLAN_ROOT=$(~/.claude/skills/gstack/bin/gstack-paths --get plan-root)
+TMP_ROOT=$(~/.claude/skills/gstack/bin/gstack-paths --get tmp-root)
 ```
 
 After this, every subsequent bash block in this skill uses `"$PLAN_ROOT"` and

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -98,8 +98,13 @@ This keeps the skill working whether installed as a Claude Code plugin
 (`CLAUDE_PLANS_DIR` set), a global `~/.claude/skills/gstack/` install, or a CI
 container where `HOME` may be unset and `/tmp` may be read-only.
 
+`--get <key>` is preferred over `eval "$(...)"` here: the eval form trips Claude
+Code's bash AST parser (tilde inside `$()` inside double-quoted eval arg) and
+forces a manual confirmation on every run. Issue #1329 Pattern 2.
+
 ```bash
-eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+PLAN_ROOT=$(~/.claude/skills/gstack/bin/gstack-paths --get plan-root)
+TMP_ROOT=$(~/.claude/skills/gstack/bin/gstack-paths --get tmp-root)
 ```
 
 After this, every subsequent bash block in this skill uses `"$PLAN_ROOT"` and

--- a/test/gstack-paths.test.ts
+++ b/test/gstack-paths.test.ts
@@ -98,4 +98,61 @@ describe('gstack-paths', () => {
       expect(line).toMatch(/^[A-Z_]+=.*/);
     }
   });
+
+  // --- --get <key> CLI form (issue #1329 Pattern 2) ---
+
+  function runGet(env: Record<string, string | undefined>, args: string[]): { stdout: string; stderr: string; status: number } {
+    const r = spawnSync('bash', [BIN, ...args], {
+      env: { PATH: process.env.PATH, USERPROFILE: '', ...env } as Record<string, string>,
+      encoding: 'utf-8',
+    });
+    return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status ?? -1 };
+  }
+
+  describe('--get <key>', () => {
+    test('--get state-root prints just the resolved state root (no KEY= prefix)', () => {
+      const r = runGet({ HOME: '/tmp/myhome' }, ['--get', 'state-root']);
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('/tmp/myhome/.gstack');
+      expect(r.stdout).not.toContain('=');
+    });
+
+    test('--get plan-root respects the GSTACK_PLAN_DIR override', () => {
+      const r = runGet({ GSTACK_PLAN_DIR: '/tmp/explicit', HOME: '/h' }, ['--get', 'plan-root']);
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('/tmp/explicit');
+    });
+
+    test('--get tmp-root honors TMPDIR', () => {
+      const r = runGet({ TMPDIR: '/tmp/x', HOME: '/h' }, ['--get', 'tmp-root']);
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('/tmp/x');
+    });
+
+    test('--get with unknown key exits 1 and explains', () => {
+      const r = runGet({ HOME: '/h' }, ['--get', 'bogus']);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain("unknown key 'bogus'");
+    });
+
+    test('--get without a key exits 1', () => {
+      const r = runGet({ HOME: '/h' }, ['--get']);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain('--get requires a key');
+    });
+
+    test('unknown top-level flag exits 1', () => {
+      const r = runGet({ HOME: '/h' }, ['--bogus']);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain('unknown argument');
+    });
+
+    test('bare invocation stays backward-compatible (KEY=VALUE form)', () => {
+      const r = runGet({ HOME: '/tmp/h' }, []);
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain('GSTACK_STATE_ROOT=');
+      expect(r.stdout).toContain('PLAN_ROOT=');
+      expect(r.stdout).toContain('TMP_ROOT=');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Pattern 2 from #1329: `eval "$(~/.claude/skills/gstack/bin/gstack-paths)"` trips Claude Code's PreToolUse bash AST parser (`Unhandled node type: string`) because of tilde inside `$()` inside a double-quoted eval arg. `/codex` forces a manual approval on every run as a result.
- `gstack-paths --get state-root|plan-root|tmp-root` prints a single path with no `KEY=` prefix, so callers can use:

  ```bash
  PLAN_ROOT=$(~/.claude/skills/gstack/bin/gstack-paths --get plan-root)
  TMP_ROOT=$(~/.claude/skills/gstack/bin/gstack-paths --get tmp-root)
  ```

- Bare invocation stays backward-compatible (`KEY=VALUE` form). No compat break for skills that haven't been migrated yet.
- `codex/SKILL.md.tmpl` Step 0.6 switched to `--get`. `codex/SKILL.md` regenerated via `bun run gen:skill-docs`.

Refs #1329.

## Scope

Fix narrow on purpose — Pattern 2 in `/codex` only. Patterns 1 / 3 / 4 each need their own design (Pattern 1 = split `gstack-codex-probe` functions into binaries; Pattern 3 = subshell or `codex -C`; Pattern 4 = extract inline Python to `gstack-codex-jsonl-parser`). Bundling all four into one PR would balloon the diff across multiple binaries + skill surfaces.

Other skills that still use `eval "$(gstack-paths)"` (`learn`, `freeze`, `investigate`, `context-restore`, `office-hours`, `context-save`, `guard`, `unfreeze`, `plan-tune`) are unchanged here — migration can land one skill at a time on top of this PR with no compat risk because bare invocation still works.

## Tests

7 new cases in `test/gstack-paths.test.ts`:

- `--get state-root` / `plan-root` / `tmp-root` each return the single resolved path, no `KEY=` prefix.
- Each honors the same env override chain as the bare form (`GSTACK_PLAN_DIR`, `TMPDIR`, etc.).
- `--get bogus` exits 1 with `unknown key`.
- `--get` without a key exits 1 with `--get requires a key`.
- `--bogus` top-level flag exits 1 with `unknown argument`.
- Bare invocation still emits `GSTACK_STATE_ROOT=` / `PLAN_ROOT=` / `TMP_ROOT=` (backward-compat guard).

```bash
bun test test/gstack-paths.test.ts
# 15 pass, 0 fail (8 existing + 7 new)

bun test test/skill-validation.test.ts test/gen-skill-docs.test.ts test/gstack-paths.test.ts
# 727 pass, 0 fail
```

## Verification

Manual:

```bash
$ bin/gstack-paths --get plan-root
/Users/lavesh/.claude/plans

$ bin/gstack-paths --get bogus
gstack-paths: unknown key 'bogus' (expected state-root|plan-root|tmp-root)
# exit 1

$ bin/gstack-paths
GSTACK_STATE_ROOT=/Users/lavesh/.gstack
PLAN_ROOT=/Users/lavesh/.claude/plans
TMP_ROOT=/var/folders/.../T/
```