### PR TITLE
fix(gbrain-sync): append .gbrain-source to consumer repo's .gitignore after attach

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -408,6 +408,24 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
     };
   }
 
+  // After a successful attach, ensure .gbrain-source is in the consumer repo's
+  // .gitignore. The v1.29.0.0 changelog promised this; the original patch only
+  // added it to gstack's own .gitignore, not the consuming repo's. Without this,
+  // `git add -A` in any Conductor sibling worktree can commit the pin and silently
+  // override other worktrees' per-worktree source IDs on next pull.
+  try {
+    const gitignorePath = join(root, ".gitignore");
+    let existing = "";
+    try { existing = readFileSync(gitignorePath, "utf-8"); } catch { /* will create */ }
+    if (!existing.split("\n").some((line) => line.trim() === ".gbrain-source")) {
+      const sep = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+      writeFileSync(gitignorePath, existing + sep + ".gbrain-source\n");
+    }
+  } catch {
+    // Non-fatal — unwritable .gitignore (read-only checkout, weird perms) should
+    // not fail the stage. The user will need to add the entry manually.
+  }
+
   return {
     name: "code",
     ran: true,


### PR DESCRIPTION
## Summary

Fixes #1384.

The v1.29.0.0 changelog explicitly promised:
> `.gbrain-source` added to `.gitignore` so per-worktree pin doesn't leak across branches.

The original patch only added `.gbrain-source` to gstack's *own* `.gitignore`. Consumer repos were never updated, so the pin file shows up as an untracked file and can get committed accidentally, silently overwriting other Conductor sibling worktrees' per-worktree source IDs on next pull.

This patch adds the entry idempotently to the **consumer repo's** `.gitignore` immediately after a successful `gbrain sources attach`, inside `runCodeImport`. The write is wrapped in a non-fatal try/catch so read-only checkouts don't fail the whole stage.

## What changed

- `bin/gstack-gbrain-sync.ts`: after `gbrain sources attach` succeeds, append `.gbrain-source` to `<root>/.gitignore` if not already present.

## Test plan

- [ ] Run `/sync-gbrain` in a repo with no existing `.gbrain-source` line in `.gitignore` — line is appended after attach
- [ ] Run `/sync-gbrain` again in the same repo — line is NOT duplicated (idempotent)
- [ ] Run `/sync-gbrain` in a repo with no `.gitignore` — file is created with `.gbrain-source`
- [ ] Existing tests pass: `bun test` (doc-inventory and Supabase failures are pre-existing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)