### PR TITLE
fix(gbrain-sources): bump sources list --json timeout 10s → 30s

### DIFF
--- a/lib/gbrain-sources.ts
+++ b/lib/gbrain-sources.ts
@@ -53,7 +53,7 @@ export function probeSource(id: string, env?: NodeJS.ProcessEnv): SourceState {
   try {
     stdout = execFileSync("gbrain", ["sources", "list", "--json"], {
       encoding: "utf-8",
-      timeout: 10_000,
+      timeout: 30_000,
       stdio: ["ignore", "pipe", "pipe"],
       env,
     });
@@ -164,7 +164,7 @@ export function sourcePageCount(id: string, env?: NodeJS.ProcessEnv): number | n
   try {
     stdout = execFileSync("gbrain", ["sources", "list", "--json"], {
       encoding: "utf-8",
-      timeout: 10_000,
+      timeout: 30_000,
       stdio: ["ignore", "pipe", "pipe"],
       env,
     });


### PR DESCRIPTION
## Summary

- Bump the `gbrain sources list --json` timeout from 10s to 30s in both `probeSource()` and `sourcePageCount()` (`lib/gbrain-sources.ts`).
- Matches the 30s ceiling already used by `sources add` / `sources remove` in the same file.

## Why

On Supabase free-tier engines, `gbrain sources list --json` can take noticeably longer than 10s after a cold start. Observed today on a fresh `/sync-gbrain` invocation:

```
$ time gbrain sources list --json
... 14.5s total
```

That blew past `probeSource()`'s 10s timeout and surfaced as:

```
ERR   code   source registration failed: spawnSync gbrain ETIMEDOUT (23.8s)
```

The CLI itself was healthy — `gbrain sources add` (30s timeout) succeeded on the same machine when invoked manually, and a `/sync-gbrain --code-only` retry after that completed cleanly (98 pages, 310 chunks). The probe just needs more rope when the underlying engine is cold.

## Test plan

- [ ] `bun test lib/gbrain-sources.test.ts` (if covered) still passes
- [ ] Manual: `/sync-gbrain` on a Supabase-backed install after >7d inactivity (cold-start) succeeds on the first invocation instead of needing a `--code-only` retry
- [ ] No regression on PGLite-backed installs (timeout is an upper bound; fast engines still return quickly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)