### PR TITLE
fix(sync-gbrain): seed DATABASE_URL from ~/.gbrain/config.json into gbrain spawns

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -241,6 +241,52 @@ function gbrainAvailable(): boolean {
   }
 }
 
+/**
+ * gbrain auto-loads `.env.local` from cwd via dotenv. When this orchestrator
+ * runs inside a Next.js / Prisma / Rails project whose .env.local defines its
+ * own DATABASE_URL (pointing at the app's DB), gbrain picks that up instead of
+ * its own `~/.gbrain/config.json` connection URL. Auth fails, code + memory
+ * stages crash. brain-sync survives because it only does git push.
+ *
+ * Fix: read ~/.gbrain/config.json once and build a child-env dict with the
+ * correct DATABASE_URL. Pass `env: gbrainEnv` to every gbrain spawn. gbrain's
+ * own dotenv-load respects pre-set env (override=false), so the explicit value
+ * beats .env.local.
+ *
+ * Important Bun caveat: mutating `process.env.DATABASE_URL` at runtime does
+ * NOT propagate to children of `child_process.spawnSync` — Bun's child gets
+ * the original startup env. So we cannot just set process.env; we must thread
+ * an explicit env dict to every spawn. lib/gbrain-sources.ts already accepts
+ * an `env` option for exactly this reason.
+ *
+ * Escape hatch: GSTACK_RESPECT_ENV_DATABASE_URL=1 returns process.env
+ * unchanged (e.g., when intentionally syncing a brain that lives in the
+ * project's local DB).
+ */
+function buildGbrainEnv(quiet: boolean): NodeJS.ProcessEnv {
+  const base: NodeJS.ProcessEnv = { ...process.env };
+  if (process.env.GSTACK_RESPECT_ENV_DATABASE_URL === "1") return base;
+  const configPath = join(HOME, ".gbrain", "config.json");
+  if (!existsSync(configPath)) return base;
+  let cfg: { database_url?: string } = {};
+  try {
+    cfg = JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch {
+    return base;
+  }
+  if (!cfg.database_url) return base;
+  if (base.DATABASE_URL === cfg.database_url) return base;
+  const had = base.DATABASE_URL !== undefined;
+  base.DATABASE_URL = cfg.database_url;
+  if (!quiet) {
+    console.error(
+      `[gbrain-sync] seeded DATABASE_URL from ~/.gbrain/config.json` +
+      (had ? " (overrode value from caller env / .env.local)" : "")
+    );
+  }
+  return base;
+}
+
 // ── Lock file (D1) ─────────────────────────────────────────────────────────
 
 interface LockInfo {
@@ -290,7 +336,7 @@ function releaseLock(): void {
 
 // ── Stage runners ──────────────────────────────────────────────────────────
 
-async function runCodeImport(args: CliArgs): Promise<StageResult> {
+async function runCodeImport(args: CliArgs, env: NodeJS.ProcessEnv): Promise<StageResult> {
   const t0 = Date.now();
   const root = repoRoot();
   if (!root) {
@@ -327,6 +373,7 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
       encoding: "utf-8",
       timeout: 30_000,
       stdio: ["ignore", "pipe", "pipe"],
+      env,
     });
     // Treat absent-source as success (clean state). gbrain emits "not found" on
     // missing id; treat any non-zero exit without "not found" as a soft fail.
@@ -337,7 +384,7 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
   // no synchronous duplicate here (per /codex review #12).
   let registered = false;
   try {
-    const result = await ensureSourceRegistered(sourceId, root, { federated: true });
+    const result = await ensureSourceRegistered(sourceId, root, { federated: true, env });
     registered = result.changed;
   } catch (err) {
     return {
@@ -358,6 +405,7 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
   const syncResult = spawnSync("gbrain", syncArgs, {
     stdio: args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"],
     timeout: 35 * 60 * 1000,
+    env,
   });
 
   if (syncResult.status !== 0) {
@@ -385,8 +433,9 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
     timeout: 10_000,
     cwd: root,
     stdio: ["ignore", "pipe", "pipe"],
+    env,
   });
-  const pageCount = sourcePageCount(sourceId);
+  const pageCount = sourcePageCount(sourceId, env);
   const legacyNote = legacyRemoved ? `, removed legacy ${legacyId}` : "";
   const baseSummary = `${registered ? "registered + " : ""}synced ${sourceId} (page_count=${pageCount ?? "unknown"}${legacyNote})`;
 
@@ -424,7 +473,7 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
   };
 }
 
-function runMemoryIngest(args: CliArgs): StageResult {
+function runMemoryIngest(args: CliArgs, env: NodeJS.ProcessEnv): StageResult {
   const t0 = Date.now();
 
   if (args.mode === "dry-run") {
@@ -440,6 +489,7 @@ function runMemoryIngest(args: CliArgs): StageResult {
   const result = spawnSync("bun", ingestArgs, {
     encoding: "utf-8",
     timeout: 35 * 60 * 1000,
+    env,
   });
 
   // D6: parse [memory-ingest] lines from the child's stderr. ERR-prefixed
@@ -469,7 +519,7 @@ function runMemoryIngest(args: CliArgs): StageResult {
   };
 }
 
-function runBrainSyncPush(args: CliArgs): StageResult {
+function runBrainSyncPush(args: CliArgs, env: NodeJS.ProcessEnv): StageResult {
   const t0 = Date.now();
 
   if (args.mode === "dry-run") {
@@ -484,10 +534,12 @@ function runBrainSyncPush(args: CliArgs): StageResult {
   spawnSync(brainSyncPath, ["--discover-new"], {
     stdio: args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"],
     timeout: 60 * 1000,
+    env,
   });
   const result = spawnSync(brainSyncPath, ["--once"], {
     stdio: args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"],
     timeout: 60 * 1000,
+    env,
   });
 
   return {
@@ -550,6 +602,8 @@ function formatStage(s: StageResult): string {
 async function main(): Promise<void> {
   const args = parseArgs();
 
+  const gbrainEnv = buildGbrainEnv(args.quiet);
+
   if (!args.quiet) {
     const engine = detectEngineTier();
     console.error(`[gbrain-sync] mode=${args.mode} engine=${engine.engine}`);
@@ -581,13 +635,13 @@ async function main(): Promise<void> {
     const stages: StageResult[] = [];
 
     if (!args.noCode) {
-      stages.push(await withErrorContext("sync:code", () => runCodeImport(args), "gstack-gbrain-sync"));
+      stages.push(await withErrorContext("sync:code", () => runCodeImport(args, gbrainEnv), "gstack-gbrain-sync"));
     }
     if (!args.noMemory) {
-      stages.push(await withErrorContext("sync:memory", () => runMemoryIngest(args), "gstack-gbrain-sync"));
+      stages.push(await withErrorContext("sync:memory", () => runMemoryIngest(args, gbrainEnv), "gstack-gbrain-sync"));
     }
     if (!args.noBrainSync) {
-      stages.push(await withErrorContext("sync:brain-sync", () => runBrainSyncPush(args), "gstack-gbrain-sync"));
+      stages.push(await withErrorContext("sync:brain-sync", () => runBrainSyncPush(args, gbrainEnv), "gstack-gbrain-sync"));
     }
 
     if (args.mode !== "dry-run") {


### PR DESCRIPTION
## Summary

`/sync-gbrain` fails inside any project whose `.env.local` defines its own `DATABASE_URL` (Next.js, Prisma, Rails, etc.). gbrain auto-loads the project's `.env.local` from cwd via dotenv, picks up the app's local-Postgres URL, and tries to authenticate there with the password from `~/.gbrain/config.json`. Auth fails. Code and memory stages crash; only the git-push brain-sync stage survives.

## Repro

```bash
cd <Next.js project with DATABASE_URL=postgresql://postgres:***@localhost:5433/app in .env.local>
/sync-gbrain
# → ERR  code         source registration failed: gbrain not configured (run /setup-gbrain)
# → ERR  memory       gbrain import exited 1: password authentication failed for user "postgres"
# → OK   brain-sync   curated artifacts pushed
```

`gbrain doctor` run from the same cwd reports `URL from env:DATABASE_URL` — confirming gbrain is picking up the project's value, not the configured one. `gbrain doctor` from `/tmp` connects cleanly.

## Fix

New helper `buildGbrainEnv()` in `bin/gstack-gbrain-sync.ts`:
- Reads `~/.gbrain/config.json`.
- Returns `{ ...process.env, DATABASE_URL: cfg.database_url }`.
- Skipped when `GSTACK_RESPECT_ENV_DATABASE_URL=1` is set (escape hatch for users whose brain genuinely lives in the project DB).
- One-line log when it overrides a caller value.

Threaded through every gbrain spawn in `runCodeImport`, `runMemoryIngest`, and `runBrainSyncPush`. `lib/gbrain-sources.ts` already exposed an `env` option for exactly this case — wired up `ensureSourceRegistered(... { env })` and `sourcePageCount(id, env)`.

## Why not just mutate `process.env`?

Tried that first. Doesn't work in Bun: `child_process.spawnSync` children receive Bun's startup env, not runtime mutations. Verified with a minimal repro — `printenv` in a Bun-spawned child returns the original `.env.local` value even after `process.env.DATABASE_URL = ...`. Must pass `env:` explicitly. There's already a comment in `lib/gbrain-sources.ts` noting this exact caveat.

## Verification

End-to-end run from the repro project after the patch:

```
[gbrain-sync] seeded DATABASE_URL from ~/.gbrain/config.json (overrode value from caller env / .env.local)
[gbrain-sync] mode=incremental engine=supabase

gstack-gbrain-sync (incremental):
  OK    code         registered + synced gstack-code-org-fd8a2521-d5b972 (page_count=575) (289.7s)
  OK    memory       gbrain import: 9 imported, 0 unchanged, 0 failed (36.2s)
  OK    brain-sync   curated artifacts pushed (0.4s)

  3 ok, 0 error, 0 skipped
```

## Upstream gbrain consideration

The underlying root cause is on gbrain's side: the CLI shouldn't let CWD `.env.local` override its own `~/.gbrain/config.json`. Either config wins over CWD dotenv, or gbrain namespaces its connection var (`GBRAIN_DATABASE_URL`) so collisions are impossible. This patch is a gstack-side workaround; happy to also file a gbrain bug.

## Test plan

- [x] `bun run bin/gstack-gbrain-sync.ts --help` parses
- [x] `bun run bin/gstack-gbrain-sync.ts --dry-run` emits the seed-env log line
- [x] Real incremental sync from inside a Next.js project: all 3 stages OK (575 pages indexed)
- [x] Escape hatch: `GSTACK_RESPECT_ENV_DATABASE_URL=1 bun run ...` returns process.env unchanged (verified by reading the buildGbrainEnv code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)