### PR TITLE
fix(gbrain-sync): add .gbrain-source to consumer repo .gitignore

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -459,6 +459,13 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
     };
   }
 
+  // v1.29.0.0 changelog promised the per-worktree pin would be ignored in the
+  // consuming repo, but the change actually only added .gbrain-source to
+  // gstack's own .gitignore. Without the consumer-side entry, the pin gets
+  // committed and breaks the per-worktree promise: Conductor sibling worktrees
+  // step on each other's pin every time anyone commits (#1384).
+  ensureGbrainSourceGitignored(root);
+
   return {
     name: "code",
     ran: true,
@@ -473,6 +480,39 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
       status: "ok",
     },
   };
+}
+
+/**
+ * Ensure `.gbrain-source` is listed in the consumer repo's `.gitignore`.
+ *
+ * Idempotent: only appends when the entry is not already present (matched on
+ * trimmed lines so a leading/trailing whitespace difference doesn't add a
+ * second copy). Wraps writes in try/catch so a read-only checkout or weird
+ * perms logs a warning and lets the rest of the sync continue.
+ */
+export function ensureGbrainSourceGitignored(root: string): void {
+  const gitignorePath = join(root, ".gitignore");
+  try {
+    let existing = "";
+    try {
+      existing = readFileSync(gitignorePath, "utf-8");
+    } catch {
+      // No .gitignore yet — we'll create it.
+    }
+    const alreadyIgnored = existing
+      .split("\n")
+      .some((line) => line.trim() === ".gbrain-source");
+    if (alreadyIgnored) {
+      return;
+    }
+    const sep = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+    writeFileSync(gitignorePath, existing + sep + ".gbrain-source\n");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[sync:code] could not add .gbrain-source to ${gitignorePath}: ${msg}`,
+    );
+  }
 }
 
 function runMemoryIngest(args: CliArgs): StageResult {
@@ -674,8 +714,10 @@ async function main(): Promise<void> {
   process.exit(exitCode);
 }
 
-main().catch((err) => {
-  console.error(`gstack-gbrain-sync fatal: ${err instanceof Error ? err.message : String(err)}`);
-  releaseLock();
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(`gstack-gbrain-sync fatal: ${err instanceof Error ? err.message : String(err)}`);
+    releaseLock();
+    process.exit(1);
+  });
+}

--- a/test/gbrain-source-gitignore.test.ts
+++ b/test/gbrain-source-gitignore.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the `.gbrain-source` gitignore append done by
+ * `runCodeImport` after a successful `gbrain sources attach`.
+ *
+ * Covers #1384: v1.29.0.0 changelog promised the per-worktree pin would be
+ * ignored in the consuming repo, but the change actually only added
+ * `.gbrain-source` to gstack's own `.gitignore`. Without the consumer-side
+ * entry, Conductor sibling worktrees commit the pin and clobber each other.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, statSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { ensureGbrainSourceGitignored } from "../bin/gstack-gbrain-sync";
+
+describe("ensureGbrainSourceGitignored", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "gstack-gbrain-gitignore-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("creates .gitignore with the pin entry when none exists", () => {
+    const gitignorePath = join(root, ".gitignore");
+    expect(existsSync(gitignorePath)).toBe(false);
+
+    ensureGbrainSourceGitignored(root);
+
+    expect(existsSync(gitignorePath)).toBe(true);
+    expect(readFileSync(gitignorePath, "utf-8")).toBe(".gbrain-source\n");
+  });
+
+  it("appends the pin entry to an existing .gitignore without trailing newline", () => {
+    const gitignorePath = join(root, ".gitignore");
+    writeFileSync(gitignorePath, "node_modules\n.env");
+
+    ensureGbrainSourceGitignored(root);
+
+    expect(readFileSync(gitignorePath, "utf-8")).toBe(
+      "node_modules\n.env\n.gbrain-source\n",
+    );
+  });
+
+  it("appends the pin entry to an existing .gitignore with trailing newline", () => {
+    const gitignorePath = join(root, ".gitignore");
+    writeFileSync(gitignorePath, "node_modules\n.env\n");
+
+    ensureGbrainSourceGitignored(root);
+
+    expect(readFileSync(gitignorePath, "utf-8")).toBe(
+      "node_modules\n.env\n.gbrain-source\n",
+    );
+  });
+
+  it("is idempotent: does not duplicate the pin entry on a second call", () => {
+    const gitignorePath = join(root, ".gitignore");
+    writeFileSync(gitignorePath, "node_modules\n.gbrain-source\n.env\n");
+
+    ensureGbrainSourceGitignored(root);
+    ensureGbrainSourceGitignored(root);
+
+    const lines = readFileSync(gitignorePath, "utf-8").split("\n");
+    const hits = lines.filter((line) => line.trim() === ".gbrain-source");
+    expect(hits.length).toBe(1);
+  });
+
+  it("recognizes the entry even when it has surrounding whitespace", () => {
+    const gitignorePath = join(root, ".gitignore");
+    writeFileSync(gitignorePath, "node_modules\n  .gbrain-source  \n");
+
+    ensureGbrainSourceGitignored(root);
+
+    const lines = readFileSync(gitignorePath, "utf-8").split("\n");
+    const hits = lines.filter((line) => line.trim() === ".gbrain-source");
+    expect(hits.length).toBe(1);
+  });
+
+  it("does not throw when the .gitignore is read-only", () => {
+    const gitignorePath = join(root, ".gitignore");
+    writeFileSync(gitignorePath, "node_modules\n");
+    const originalMode = statSync(gitignorePath).mode;
+    chmodSync(gitignorePath, 0o444);
+    try {
+      // Must not throw — sync stage continues on write failure.
+      expect(() => ensureGbrainSourceGitignored(root)).not.toThrow();
+    } finally {
+      chmodSync(gitignorePath, originalMode);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1384.

The v1.29.0.0 changelog claimed `.gbrain-source` was added to `.gitignore` so per-worktree pin doesn't leak across branches. The change actually shipped only added `.gbrain-source` to gstack's *own* `.gitignore`, not the consuming repo's. Conductor sibling worktrees of the same repo + branch end up clobbering each other's pin every time anyone commits the file.

Add the missing append in `bin/gstack-gbrain-sync.ts::runCodeImport`, right after `gbrain sources attach <id>` succeeds. The new `ensureGbrainSourceGitignored` helper is:

- **Idempotent** — line-trim match so leading/trailing whitespace, duplicate runs, or pre-existing entries don't add a second copy.
- **Tolerant** — missing `.gitignore` is created; unwritable file logs a warning and lets the rest of the sync continue. The pin failure mode is "noisy commits", not "broken sync", so we don't want to fail the whole stage.
- **Scoped** — only fires after a successful attach. Failed attach already short-circuits.

## Why this matters more for Conductor users

Single-worktree users mostly don't notice — the pin tracks the only checkout, so even if committed it points at the right source. Conductor users running `/sync-gbrain` in two sibling worktrees of the same repo + branch get *different* path-hash source IDs (correct, per v1.29.0.0). If either pin gets committed, `git pull` in the sibling overwrites the local pin and routes queries to the wrong worktree's source. The v1.29.0.0 changelog claimed to prevent exactly this.

## Verification

```
$ bun test test/gbrain-source-gitignore.test.ts
6 pass
0 fail
8 expect() calls
```

Six covered scenarios:

- creates `.gitignore` with the pin entry when none exists
- appends to existing `.gitignore` without trailing newline (preserves `\n` discipline)
- appends to existing `.gitignore` with trailing newline (no double newline)
- idempotent on repeat call
- recognizes the entry even when surrounded by whitespace (no duplicate add)
- does not throw when the `.gitignore` is read-only

Existing `test/gstack-gbrain-sync.test.ts` was already failing in 10/20 cases on machines without a local `gbrain` CLI on PATH (unrelated to this PR). Pre-change baseline = post-change baseline for those.

## Non-changes

- The `import.meta.main` gate on the top-level `main().catch(...)` call is a small piggyback so the test file can `import { ensureGbrainSourceGitignored }` without triggering a full sync run on module load. Behaviorally a no-op for the CLI path — `bun bin/gstack-gbrain-sync.ts` still runs `main()` because the module IS the entry there.
- `runMemoryIngest`, `runBrainSync`, and the dry-run path are untouched.
- No change to the `detach` path — issue notes the gitignore entry is harmless to leave behind.

No newsfragment added per `CLAUDE.md` ("Contributor PR authors should not edit CHANGELOG.md; maintainer/AI adds entries during landing/merge").