### PR TITLE
fix(setup): surface codesign failures, verify signatures, exit non-zero on Apple Silicon (closes #1254)

### DIFF
--- a/setup
+++ b/setup
@@ -292,14 +292,49 @@ if [ "$NEEDS_BUILD" -eq 1 ]; then
   # signature block is corrupt. This is idempotent and costs <1s.
   # See: https://github.com/garrytan/gstack/issues/997
   if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+    _codesign_failures=0
+    _codesign_err="$(mktemp)"
+    _print_codesign_err() {
+      if [ -s "$_codesign_err" ]; then
+        while IFS= read -r _codesign_line; do
+          log "  $_codesign_line"
+        done < "$_codesign_err"
+      else
+        log "  (no stderr output)"
+      fi
+    }
+
     for _bin in browse/dist/browse browse/dist/find-browse design/dist/design make-pdf/dist/pdf bin/gstack-global-discover; do
       _bin_path="$SOURCE_GSTACK_DIR/$_bin"
       [ -f "$_bin_path" ] && [ -x "$_bin_path" ] || continue
-      codesign --remove-signature "$_bin_path" 2>/dev/null || true
-      if ! codesign -s - -f "$_bin_path" 2>/dev/null; then
-        log "warning: codesign failed for $_bin (binary may not run on Apple Silicon)"
+
+      : > "$_codesign_err"
+      if ! codesign --remove-signature "$_bin_path" 2>"$_codesign_err"; then
+        log "warning: codesign --remove-signature failed for $_bin:"
+        _print_codesign_err
+      fi
+
+      : > "$_codesign_err"
+      if ! codesign -s - -f "$_bin_path" 2>"$_codesign_err"; then
+        log "error: codesign failed for $_bin:"
+        _print_codesign_err
+        _codesign_failures=$((_codesign_failures + 1))
+        continue
+      fi
+
+      : > "$_codesign_err"
+      if ! codesign --verify --strict "$_bin_path" 2>"$_codesign_err"; then
+        log "error: codesign verification failed for $_bin:"
+        _print_codesign_err
+        _codesign_failures=$((_codesign_failures + 1))
       fi
     done
+
+    rm -f "$_codesign_err"
+    if [ "$_codesign_failures" -gt 0 ]; then
+      echo "gstack setup failed: $_codesign_failures binaries did not codesign. Apple Silicon will SIGKILL them on first run. See output above for codesign errors." >&2
+      exit 1
+    fi
   fi
 
   # macOS: install coreutils for `gtimeout` (Codex hang protection in /codex + /autoplan).

--- a/test/setup-codesign.test.ts
+++ b/test/setup-codesign.test.ts
@@ -24,10 +24,11 @@ describe('setup: Apple Silicon codesign', () => {
     const forMatch = content.match(/for _bin in ([^;]+);/);
     expect(forMatch).toBeTruthy();
     const binaries = forMatch![1].trim().split(/\s+/);
-    // All four compiled binaries from `bun run build` must be covered
+    // All compiled binaries from `bun run build` must be covered
     expect(binaries).toContain('browse/dist/browse');
     expect(binaries).toContain('browse/dist/find-browse');
     expect(binaries).toContain('design/dist/design');
+    expect(binaries).toContain('make-pdf/dist/pdf');
     expect(binaries).toContain('bin/gstack-global-discover');
   });
 
@@ -49,23 +50,27 @@ describe('setup: Apple Silicon codesign', () => {
     expect(content).toContain('[ -f "$_bin_path" ] && [ -x "$_bin_path" ] || continue');
   });
 
-  test('codesign failure is a warning, not a fatal error', () => {
+  test('codesign failures surface stderr, verify signatures, and fail setup', () => {
     const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
-    // On codesign failure, log a warning but don't exit
-    expect(content).toContain('warning: codesign failed for');
-    // Should NOT have `set -e` causing exit on codesign failure
-    // (the `|| true` after --remove-signature and the if-guard around -s - -f handle this)
-    expect(content).toContain('codesign --remove-signature "$_bin_path" 2>/dev/null || true');
+    expect(content).toContain('_codesign_err="$(mktemp)"');
+    expect(content).toContain('codesign --remove-signature "$_bin_path" 2>"$_codesign_err"');
+    expect(content).toContain('codesign -s - -f "$_bin_path" 2>"$_codesign_err"');
+    expect(content).toContain('codesign --verify --strict "$_bin_path" 2>"$_codesign_err"');
+    expect(content).toContain('_print_codesign_err');
+    expect(content).toContain('_codesign_failures=$((_codesign_failures + 1))');
+    expect(content).toContain('gstack setup failed: $_codesign_failures binaries did not codesign');
+    expect(content).toContain('exit 1');
+    expect(content).not.toContain('codesign --remove-signature "$_bin_path" 2>/dev/null || true');
   });
 
   test('codesign shell snippet is syntactically valid', () => {
     // Extract the codesign block and validate it parses as bash
     const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
-    const match = content.match(
-      /# macOS Apple Silicon: ad-hoc codesign[\s\S]*?done\n\s*fi/
-    );
-    expect(match).toBeTruthy();
-    const snippet = match![0];
+    const start = content.indexOf('# macOS Apple Silicon: ad-hoc codesign');
+    const end = content.indexOf('# macOS: install coreutils', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const snippet = content.slice(start, end);
     // Wrap in a function to make it a complete script, then syntax-check
     const testScript = `#!/usr/bin/env bash\nset -e\n_test_fn() {\n${snippet}\n}\n`;
     const result = spawnSync('bash', ['-n', '-c', testScript], {


### PR DESCRIPTION
## Summary

Setup's Apple Silicon codesign loop now surfaces codesign's stderr, verifies each signature actually applied, and exits non-zero when any binary fails to sign. The previous wrapper swallowed every error and exited 0 even when 5 of 5 binaries were left unsigned, so users hit SIGKILL minutes later with no breadcrumb.

## Why this matters

> After `gstack setup` (fresh install or upgrade), Bun-compiled binaries in `~/.claude/skills/gstack/{browse,design,make-pdf,bin}/` are killed by macOS Gatekeeper with SIGKILL (exit status 137) on first invocation. The setup itself reports success, so the failure surfaces later when a skill tries to call `$B`, `$D`, etc.

That's [@lucascaro on #1254](https://github.com/garrytan/gstack/issues/1254). The reporter pinpointed the codesign loop in `setup` lines 247-264 (now 288-303 after subsequent edits), reproduced 5/5 binaries unsigned despite a clean setup exit, and confirmed the manual recipe (`codesign --remove-signature && codesign -s - -f`) works on the same machine. The codesign machinery itself is fine; only the wrapper was lying.

The original codesign loop landed in #1056 / v0.18.4.0 to fix #997 (the SIGKILL class). It was correct on the happy path but its three failure modes were all silent: `2>/dev/null` swallowed diagnostics, `log "warning: ..."` returned 0, and there was no verification step to catch a signature that didn't take.

## Changes

- `setup` lines 288-303 (the Darwin+arm64 codesign block) now:
  - Captures both `codesign --remove-signature` and `codesign -s - -f` stderr to a tempfile and prints it via the existing `log` helper if non-empty. Users see exactly what codesign said.
  - Adds `codesign --verify --strict "$_bin_path"` after signing. Catches the silent-corruption case the reporter hit (signature applied but doesn't actually verify).
  - Maintains a `_codesign_failures` counter. Both signing failures and verification failures bump it.
  - Exits 1 with a clear message when the counter is non-zero. No more "setup succeeded, SIGKILL surfaces later" footgun.
- The Darwin+arm64 guard is unchanged. Other platforms see no behavior change.

## Testing

`bun test test/setup-codesign.test.ts`: 6 pass / 0 fail. Old assertions about "warning, not fatal" replaced with assertions for the new fail-loud structure. The `set -e` smoke test still passes (the codesign block is syntactically valid bash). Existing for-loop coverage expanded to assert all 5 binaries the setup loop iterates (the test was only checking 4; setup itself already had 5).

Fixes #1254.

AI was used for assistance.
