### PR TITLE
feat(ios): iOS skill suite — GStack × GBrain hackathon 1st place

### DIFF
--- a/ios-clean/SKILL.md.tmpl
+++ b/ios-clean/SKILL.md.tmpl
@@ -1,0 +1,115 @@
+---
+name: ios-clean
+version: 1.0.0
+description: |
+  Remove all DebugBridge files and references from an iOS app.
+  Cleans up everything injected by /ios-qa: StateServer, DebugOverlay,
+  accessors, manager, and all #if DEBUG wiring in ContentView/App files.
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+  - Glob
+  - Grep
+triggers:
+  - ios clean
+  - ios-clean
+  - remove debug bridge
+  - clean debug bridge
+  - uninstall ios qa
+---
+
+{{PREAMBLE}}
+
+# iOS Clean — Remove DebugBridge
+
+Remove all DebugBridge/iStack files and references injected by `/ios-qa`.
+This skill is non-destructive to app code — it only removes debug instrumentation.
+
+## Step 1: Find the app source directory
+
+```bash
+find . -maxdepth 3 -name "*.xcodeproj" -not -path "*/DebugBridge/*"
+```
+
+Identify the app source directory (the folder next to the .xcodeproj).
+
+## Step 2: Delete the DebugBridgeGenerated directory
+
+```bash
+rm -rf <AppSource>/DebugBridgeGenerated/
+```
+
+This removes:
+- `StateServer.swift`
+- `DebugOverlay.swift`
+- `DebugBridgeManager.swift`
+- All `*Accessor.swift` files
+- `DebugBridgeJSON.swift` (if present)
+
+## Step 3: Delete the DebugBridge package (if exists)
+
+```bash
+rm -rf DebugBridge/
+```
+
+## Step 4: Remove references from app code
+
+Search for and remove all DebugBridge wiring in the app's source files:
+
+```bash
+grep -rn "DebugBridgeManager\|debugBridgeOverlay\|DebugOverlayWindow\|DebugBridgeNotifier" --include="*.swift" .
+```
+
+For each file found:
+
+1. **ContentView.swift / App file** — Remove the `#if DEBUG` block that calls
+   `DebugBridgeManager.shared.start(...)` and `.debugBridgeOverlay()`.
+   Keep the rest of the file intact.
+
+2. **Any other file** — Remove `import DebugBridge` lines and any `#if DEBUG`
+   blocks that reference DebugBridge types.
+
+### What to remove (examples):
+
+```swift
+// REMOVE this entire block:
+#if DEBUG && canImport(UIKit)
+.debugBridgeOverlay()
+.onAppear {
+    DebugBridgeManager.shared.start(
+        workoutVM: workoutVM,
+        statsVM: statsVM,
+        profileVM: profileVM
+    )
+}
+#endif
+
+// REMOVE this line:
+import DebugBridge
+```
+
+### What NOT to remove:
+- Any app code that isn't DebugBridge-related
+- Other `#if DEBUG` blocks that belong to the app
+- Test files, previews, or other debug-only app code
+
+## Step 5: Verify clean build
+
+```bash
+xcodebuild -project <project>.xcodeproj -scheme <scheme> -destination "generic/platform=iOS" -configuration Debug build 2>&1 | grep -E "error:|BUILD"
+```
+
+If there are build errors referencing removed types, fix them (likely a missed
+reference in a file not caught in Step 4).
+
+## Step 6: Report
+
+```
+iOS Clean complete.
+Removed:
+- <AppSource>/DebugBridgeGenerated/ (N files)
+- DebugBridge/ package (if existed)
+- References in: ContentView.swift, ...
+Build: SUCCEEDED
+```

--- a/ios-design-review/SKILL.md.tmpl
+++ b/ios-design-review/SKILL.md.tmpl
@@ -1,0 +1,238 @@
+---
+name: ios-design-review
+version: 1.0.0
+description: |
+  Visual design audit for iOS apps. Connects to a real iPhone via the same
+  StateServer as /ios-qa, screenshots every screen, and evaluates against
+  Apple HIG, DESIGN.md, and design best practices. Reports spacing issues,
+  typography problems, color contrast, layout breakage, and accessibility gaps.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Glob
+  - Grep
+triggers:
+  - ios design review
+  - ios-design-review
+  - review ios design
+  - check ios ui
+
+{{PREAMBLE}}
+---
+
+# iOS Design Review
+
+You are an expert iOS visual design reviewer. You connect to a real app running
+on a real iPhone via USB, screenshot every screen, and evaluate the UI against
+Apple's Human Interface Guidelines (HIG), the project's DESIGN.md (if one
+exists), and design best practices.
+
+You do NOT mutate app state to test functionality — you only navigate screens
+and capture screenshots for visual analysis.
+
+## Architecture
+
+```
+Claude Code (this skill — YOU)
+  └── curl -6 http://[TUNNEL_IPv6]:9999/*   (via CoreDevice USB tunnel)
+        ├── GET  /screenshot         → base64 PNG of current screen
+        ├── GET  /elements           → accessibility tree (labels, frames, traits)
+        ├── POST /tap                → inject tap at {x, y} pixel coords
+        ├── POST /swipe              → inject swipe {fromX, fromY, toX, toY}
+        ├── GET  /device             → device info (model, screen size)
+        ├── GET  /state              → list all registered state keys
+        ├── GET  /state/{key}        → read @Observable property
+        ├── POST /state/{key}        → write @Observable property (for navigation)
+        └── GET  /health             → health check
+```
+
+## Phase 1: Connect
+
+Same connection as /ios-qa — CoreDevice USB tunnel, IPv6.
+
+```bash
+# Kill any stale iproxy (they interfere)
+pkill -f iproxy 2>/dev/null
+
+# Find connected device
+xcrun devicectl list devices 2>&1 | grep "connected"
+
+# Get tunnel IP (replace DEVICE_ID with the Identifier from above)
+TUNNEL_IP=$(xcrun devicectl device info details --device DEVICE_ID 2>&1 | grep tunnelIPAddress | awk '{print $2}')
+echo "Tunnel IP: $TUNNEL_IP"
+
+# Set base URL
+DEVICE="http://[$TUNNEL_IP]:9999"
+
+# Verify connection
+curl -s -6 "$DEVICE/health"
+curl -s -6 "$DEVICE/device"
+```
+
+**CRITICAL**: Every `curl` command must use `-6` flag and `http://[IPv6]:9999` format.
+Do NOT use `localhost`, `127.0.0.1`, or iproxy.
+
+## Phase 2: Read DESIGN.md
+
+Look for a DESIGN.md in the project root or common locations:
+
+```bash
+find . -maxdepth 2 -name "DESIGN.md" -o -name "design.md"
+```
+
+If found, read it and use its constraints (colors, typography, spacing tokens)
+as the ground truth for the review. If not found, evaluate against Apple HIG
+defaults and general iOS design best practices.
+
+## Phase 3: Map All Screens
+
+Read the source code to understand the app's screen structure:
+
+```bash
+find . -maxdepth 3 \( -name "*.swift" \) -not -path "*/DebugBridge/*"
+```
+
+Read every View file to understand:
+- What screens exist and their hierarchy
+- Navigation structure (tabs, navigation stack, sheets)
+- What state keys control navigation (e.g., `NavigationRouter_selectedTab`)
+
+Plan a navigation sequence that visits every screen. Use `/state` to list
+available state keys for programmatic navigation.
+
+## Phase 4: Screenshot Every Screen
+
+For each screen, navigate to it and capture a screenshot:
+
+```bash
+mkdir -p /tmp/ios-design
+
+# Navigate via state writes (e.g., switch tabs)
+curl -s -6 -X POST "$DEVICE/state/NavigationRouter_selectedTab" -d '"home"'
+
+# Or tap navigation elements
+curl -s -6 -X POST "$DEVICE/tap" -d '{"x": 200, "y": 450}'
+
+# Capture screenshot
+curl -s -6 "$DEVICE/screenshot" | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" > /tmp/ios-design/home.png
+```
+
+Then **Read** `/tmp/ios-design/home.png` to analyze with vision.
+
+Also capture edge-case screens:
+- Empty states (write empty arrays to data state keys)
+- Loading states (if observable)
+- Error states (if triggerable via state)
+
+## Phase 5: Analyze Each Screenshot
+
+For every screenshot, evaluate against the analysis framework below.
+
+### Apple HIG Rules
+
+- **Navigation bar:** title centered or leading, 44pt height
+- **Tab bar:** max 5 items, SF Symbols, labels below icons
+- **Safe area:** content never behind notch/home indicator
+- **Touch targets:** minimum 44x44pt (check via /elements frame sizes)
+- **Text:** Dynamic Type support, minimum 11pt
+- **Modals:** sheet presentation for non-blocking, full-screen for immersive
+- **System colors:** use semantic colors (label, secondaryLabel, systemBackground)
+- **SF Symbols:** prefer over custom icons, consistent weight/size
+
+### Visual Design
+
+- **Spacing:** 4pt grid system (4, 8, 12, 16, 20, 24, 32, 40, 48)
+- **Typography:** max 3 font sizes per screen, clear size/weight hierarchy
+- **Color:** WCAG AA contrast (4.5:1 for text, 3:1 for large text/UI elements)
+- **Cards:** consistent corner radius throughout, appropriate shadow depth
+- **Icons:** consistent size and style within each context
+- **Margins:** consistent horizontal margins (typically 16pt or 20pt)
+- **Vertical rhythm:** consistent spacing between sections
+
+### Layout
+
+- **Full screen utilization:** App MUST fill the entire device screen. Compare
+  the element tree bounding boxes against /device screenWidth and screenHeight.
+  If all content is inset significantly (e.g., 20+ pt margins on all sides with
+  no elements near screen edges), the app is likely running in compatibility mode.
+  Common cause: missing `UILaunchScreen` key in Info.plist. Flag as CRITICAL if
+  the app appears letterboxed or doesn't use the full display real estate.
+- **Alignment:** left-aligned text groups share leading edge
+- **Overflow:** no text clipping, no unintended horizontal scroll
+- **Responsive:** works on smallest iPhone (SE, 375pt) and largest (Pro Max, 430pt)
+- **Safe area:** respect top/bottom safe area insets
+- **Keyboard:** text fields not obscured when keyboard appears
+
+### Accessibility
+
+- **Tap targets:** minimum 44x44pt (verify via /elements frame width/height)
+- **Text readability:** minimum 11pt, sufficient contrast
+- **Labels:** all interactive elements have accessibility labels (/elements)
+- **Color alone:** information not conveyed by color alone
+- **Motion:** respect reduce-motion preference
+
+### States
+
+- **Empty states:** meaningful message + action when no data
+- **Loading states:** skeleton or spinner where data loads asynchronously
+- **Error states:** clear error messaging with recovery action
+
+## Phase 6: Report
+
+Output a structured design review:
+
+```markdown
+## iOS Design Review - [App Name]
+**Device:** [from /device]
+**Screens reviewed:** N
+**Issues found:** N (Critical: X, Warning: X, Suggestion: X)
+**DESIGN.md:** [Found/Not found]
+
+---
+
+### Screen: [Name]
+**Screenshot:** /tmp/ios-design/[screen].png
+
+#### Issues:
+1. **[CRITICAL]** Tap target too small - "Add" button is 30x30pt, minimum is 44x44pt
+   **Fix:** Increase button frame or add contentEdgeInsets/padding
+
+2. **[WARNING]** Inconsistent spacing - card margins are 16pt on sides but 12pt between cards
+   **Fix:** Use consistent 16pt spacing throughout
+
+3. **[SUGGESTION]** Consider adding subtle shadow to floating action button for depth hierarchy
+```
+
+### Severity Levels
+
+- **CRITICAL** - accessibility failure, text unreadable, tap targets too small, content clipped/hidden, safe area violated
+- **WARNING** - spacing inconsistent, colors don't match DESIGN.md/system, alignment off, HIG violation, contrast borderline
+- **SUGGESTION** - could look better with minor tweaks, missing polish, optional enhancement
+
+### What to Report
+
+- Tap targets smaller than 44x44pt (use /elements frame data)
+- Text with insufficient contrast against background
+- Spacing that doesn't follow the 4pt grid or is inconsistent
+- More than 3 font sizes on a single screen
+- Content behind notch/home indicator
+- Misaligned elements (leading edges don't match)
+- Text clipping or truncation
+- Tab bars with more than 5 items or missing labels
+- Non-standard navigation patterns
+- Missing empty/loading/error states
+- Colors that don't match DESIGN.md (if present)
+
+### What NOT to Report
+
+- Subjective style preferences without a rule violation
+- Issues you can't see evidence of in the screenshot
+- Functional bugs (those belong in /ios-qa)
+
+## Error Handling
+
+- **curl connection refused / exit code 7:** Tunnel IP wrong or device disconnected. Re-run `xcrun devicectl device info details` to get fresh tunnel IP.
+- **curl exit code 56 (connection reset):** Stale iproxy processes. Run `pkill -f iproxy` and use IPv6 tunnel directly.
+- **Empty response:** App not running or Release build. Launch with `xcrun devicectl device process launch --device <ID> <bundle-id>`.
+- **Can't navigate to screen:** Try /state writes to programmatically switch. Check source for correct state key values.

--- a/ios-fix/README.md
+++ b/ios-fix/README.md
@@ -1,0 +1,38 @@
+# /ios-fix — Autonomous iOS Bug Fixer
+
+Closes the loop: **AI found the bug → AI fixed the bug → AI verified the fix.**
+
+## What it does
+
+Given a bug report (from `/ios-qa` or described by the user), this skill:
+
+1. Reads the Swift source to understand the root cause
+2. Writes a minimal, surgical fix
+3. Rebuilds and redeploys to the real device via USB
+4. Verifies the fix on-device via StateServer
+5. Outputs a structured report with before/after evidence
+
+## Usage
+
+```
+/ios-fix
+```
+
+Works best after `/ios-qa` has identified bugs. The full autonomous loop:
+
+```
+/ios-qa          → finds 4 bugs
+/ios-fix         → fixes all 4, one at a time, verified on device
+/ios-qa          → re-runs, confirms 0 bugs remain
+```
+
+## Requirements
+
+- Same as `/ios-qa`: real iPhone via USB, app with DebugBridge, Debug build
+- Xcode installed (for `xcodebuild`)
+- The app's source code in the current working directory
+
+## What makes this different
+
+Other tools find bugs. This one **fixes them too** — and proves the fix works
+on the real device. No simulator. No mocks. Real code, real device, real fix.

--- a/ios-fix/SKILL.md.tmpl
+++ b/ios-fix/SKILL.md.tmpl
@@ -63,6 +63,63 @@ Claude Code (this skill — YOU)
 
 5. **Report what you did.** Output a clear before/after with evidence.
 
+## Phase 0: Connect to Device (Do This First)
+
+Before reading any source, connect to the device and capture the bug state live.
+This gives you a "before" screenshot and confirms the bug is reproducible.
+
+### 0a. Get the tunnel IP (check session cache first)
+
+```bash
+# Try session cache first — instant
+CACHED=$(cat ~/.gstack/ios-qa-session.json 2>/dev/null)
+if [ -n "$CACHED" ]; then
+  TUNNEL_IP=$(echo "$CACHED" | python3 -c "import sys,json; print(json.load(sys.stdin)['tunnelIP'])")
+  DEVICE_ID=$(echo "$CACHED" | python3 -c "import sys,json; print(json.load(sys.stdin)['deviceId'])")
+  echo "Using cached device: $DEVICE_ID, IP: $TUNNEL_IP"
+fi
+
+# Verify health — if stale, rediscover
+DEVICE_URL="http://[$TUNNEL_IP]:9999"
+HEALTH=$(curl -s -6 --max-time 3 "$DEVICE_URL/health" 2>/dev/null)
+if echo "$HEALTH" | grep -q '"ok"'; then
+  echo "Device connected ✓"
+else
+  echo "Cache stale — rediscovering device..."
+  DEVICE_ID=$(xcrun devicectl list devices 2>&1 | grep "connected" | awk '{print $(NF-2)}')
+  TUNNEL_IP=$(xcrun devicectl device info details --device "$DEVICE_ID" 2>&1 | grep tunnelIPAddress | awk '{print $2}')
+  DEVICE_URL="http://[$TUNNEL_IP]:9999"
+  curl -s -6 "$DEVICE_URL/health"
+fi
+```
+
+### 0b. Take a "before" screenshot — capture the bug live
+
+```bash
+mkdir -p /tmp/ios-fix
+curl -s -6 "$DEVICE_URL/screenshot" \
+  | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" \
+  > /tmp/ios-fix/before.png
+```
+
+**Read `/tmp/ios-fix/before.png`** — describe what you see. Confirm the bug is
+visible in the current state. If the bug requires a specific UI interaction to
+trigger, navigate there now using `/tap`, `/type`, `/state` writes to reproduce it,
+then take another screenshot.
+
+### 0c. Capture the broken state value
+
+```bash
+# Read the state key(s) that show the wrong value
+curl -s -6 "$DEVICE_URL/state"
+# Then read the specific key from the bug report:
+curl -s -6 "$DEVICE_URL/state/<relevant_key>"
+```
+
+Record the **wrong value** — you'll compare against this after the fix.
+
+---
+
 ## Phase 1: Understand the Bug
 
 Read the bug report. Extract:
@@ -138,23 +195,66 @@ curl -s -6 "$DEVICE_URL/health"
 
 ## Phase 4: Verify the Fix
 
-Reproduce the exact steps from the bug report, then verify state:
+Reconnect (tunnel IP may have changed after relaunch), then reproduce and verify:
 
 ```bash
-# Example: reproduce the bug steps
-curl -s -6 "$DEVICE_URL/elements"
-curl -s -6 -X POST "$DEVICE_URL/tap" -d '{"x": 200, "y": 450}'
+# Refresh tunnel IP after relaunch
+TUNNEL_IP=$(xcrun devicectl device info details --device "$DEVICE_ID" 2>&1 | grep tunnelIPAddress | awk '{print $2}')
+DEVICE_URL="http://[$TUNNEL_IP]:9999"
 
-# Verify state is now correct
-curl -s -6 "$DEVICE_URL/state/CartViewModel_total"
-# Should now show the correct value
-
-# Screenshot for evidence
-mkdir -p /tmp/ios-fix
-curl -s -6 "$DEVICE_URL/screenshot" | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" > /tmp/ios-fix/after-fix.png
+# Wait for app to stabilize
+sleep 2
+curl -s -6 "$DEVICE_URL/health"
 ```
 
-Then **Read** `/tmp/ios-fix/after-fix.png` to visually confirm.
+### 4a. Navigate to the bug location and reproduce the trigger
+
+Use the same action keys / taps / state writes from Phase 0 to get back to the
+same state that showed the bug. Then trigger the failing action:
+
+```bash
+# Reset to same starting state
+curl -s -6 -X POST "$DEVICE_URL/state/<setup_key>" -d '<setup_value>'
+
+# Trigger the action that was broken
+curl -s -6 -X POST "$DEVICE_URL/state/<action_key>" -d '<trigger>'
+```
+
+### 4b. Read state — compare before vs after
+
+```bash
+# Read the key that was wrong before
+curl -s -6 "$DEVICE_URL/state/<relevant_key>"
+```
+
+Compare against the **wrong value** captured in Phase 0. It should now be correct.
+If it's still wrong, your fix didn't address the root cause — re-analyze.
+
+### 4c. Take the "after" screenshot
+
+```bash
+curl -s -6 "$DEVICE_URL/screenshot" \
+  | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" \
+  > /tmp/ios-fix/after.png
+```
+
+**Read `/tmp/ios-fix/after.png`** — visually confirm the UI now shows correct data.
+Describe specifically what changed vs the before screenshot.
+
+### 4d. Take screenshots of adjacent screens (regression check)
+
+For each screen that could be affected by the fix, navigate there and screenshot:
+
+```bash
+# Navigate to adjacent screen via tab tap or action key
+curl -s -6 -X POST "$DEVICE_URL/tap" -d '{"x": <tab_x>, "y": <tab_y>}'
+sleep 0.5
+curl -s -6 "$DEVICE_URL/screenshot" \
+  | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" \
+  > /tmp/ios-fix/regression-check.png
+```
+
+**Read** the regression screenshot. Confirm nothing else broke.
 
 ## Phase 5: Report
 
@@ -183,10 +283,14 @@ Output a structured fix report:
 2. [action taken]
 
 **State before fix:** [key] = [wrong value]
-**State after fix:** [key] = [correct value]
-**Screenshot:** /tmp/ios-fix/after-fix.png
+**State after fix:**  [key] = [correct value]
 
-### Status: VERIFIED FIXED
+**Before:** /tmp/ios-fix/before.png — [describe what was visually wrong]
+**After:**  /tmp/ios-fix/after.png  — [describe what is now correct]
+
+**Regression check:** /tmp/ios-fix/regression-check.png — [describe adjacent screens look fine]
+
+### Status: VERIFIED FIXED ✓
 ```
 
 ## Error Handling

--- a/ios-fix/SKILL.md.tmpl
+++ b/ios-fix/SKILL.md.tmpl
@@ -1,0 +1,217 @@
+---
+name: ios-fix
+version: 1.0.0
+description: |
+  Autonomous iOS bug fixer. Takes a bug found by /ios-qa, reads the source,
+  writes the fix, rebuilds, redeploys, and verifies the fix on the real device.
+  Closes the loop: find bug → fix bug → confirm fix — zero human intervention.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Agent
+triggers:
+  - ios fix
+  - ios-fix
+  - fix ios bug
+  - fix the bug
+---
+
+{{PREAMBLE}}
+
+# iStack: Autonomous iOS Bug Fixer (v1)
+
+You are an expert iOS developer AND QA tester. Given a bug report (from /ios-qa
+or described by the user), you:
+1. Read the source to understand the bug
+2. Write the fix
+3. Rebuild and redeploy to the real device
+4. Verify the fix via StateServer
+
+**The loop is closed. AI found it. AI fixed it. AI proved it's fixed.**
+
+## Architecture
+
+```
+Claude Code (this skill — YOU)
+  ├── Read/Edit Swift source files     (understand + fix)
+  ├── xcodebuild                       (rebuild)
+  ├── xcrun devicectl                  (redeploy)
+  └── curl -6 http://[TUNNEL_IPv6]:9999/*  (verify fix on device)
+        ├── GET  /state/{key}          → verify state is correct post-fix
+        ├── GET  /elements             → verify UI updated
+        ├── GET  /screenshot           → visual confirmation
+        └── POST /tap, /type, /swipe   → reproduce → verify fixed
+```
+
+## Non-Negotiable Rules
+
+1. **Understand before fixing.** Read the relevant ViewModel, View, and Model
+   files. Understand WHY the bug happens, not just WHERE.
+
+2. **Minimal fix.** Change the fewest lines possible. Don't refactor. Don't
+   "improve" surrounding code. Fix the bug, nothing more.
+
+3. **Verify on device.** After rebuilding and deploying, reproduce the original
+   bug steps. Confirm the state now matches expected. Screenshot for evidence.
+
+4. **Never break other things.** If your fix could affect other flows, verify
+   those too via /state reads.
+
+5. **Report what you did.** Output a clear before/after with evidence.
+
+## Phase 1: Understand the Bug
+
+Read the bug report. Extract:
+- **What's broken:** the symptom (wrong value, crash, visual issue)
+- **Where it happens:** which screen, which action triggers it
+- **Expected vs actual:** what should happen vs what does happen
+- **State key:** which /state/{key} shows the mismatch (if available)
+
+Then read the relevant source files:
+
+```bash
+# Find the relevant files
+find . -name "*.swift" -not -path "*/DebugBridge/*" -not -path "*/.build/*"
+```
+
+Read the ViewModel/Model that owns the broken state. Trace the logic path
+from user action → state mutation → where it goes wrong.
+
+## Phase 2: Write the Fix
+
+Edit the source file to fix the bug. Guidelines:
+
+- **Calculation bugs:** Fix the formula. (e.g., `total = price * quantity` not `total = price`)
+- **State mutation bugs:** Fix the mutation logic. (e.g., `count += 1` not `count = 1`)
+- **Missing updates:** Add the missing state update after an action.
+- **Logic errors:** Fix conditionals, nil checks, array indexing.
+- **UI bugs:** Fix SwiftUI layout (padding, frame, alignment).
+
+Use the Edit tool for surgical changes. Show the diff clearly.
+
+## Phase 3: Rebuild and Redeploy
+
+```bash
+# Find the Xcode project
+PROJECT=$(find . -maxdepth 2 -name "*.xcodeproj" -not -path "*/DebugBridge/*" | head -1)
+SCHEME=$(basename "$PROJECT" .xcodeproj)
+
+# Get the connected device
+DEVICE_ID=$(xcrun devicectl list devices 2>&1 | grep "connected" | awk '{print $(NF-2)}')
+
+# Build for device (Debug for StateServer)
+xcodebuild build \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -destination "generic/platform=iOS" \
+  -configuration Debug \
+  2>&1 | tail -5
+
+# If build fails, read the error, fix it, try again.
+# Common issues: typo in fix, missing import, type mismatch.
+
+# Install on device
+# Find the .app in DerivedData
+APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData -name "$SCHEME.app" -path "*/Debug-iphoneos/*" | head -1)
+
+# Install and launch
+xcrun devicectl device install app --device "$DEVICE_ID" "$APP_PATH" 2>&1
+BUNDLE_ID=$(defaults read "$APP_PATH/Info.plist" CFBundleIdentifier 2>/dev/null || plutil -extract CFBundleIdentifier raw "$APP_PATH/Info.plist")
+xcrun devicectl device process launch --device "$DEVICE_ID" "$BUNDLE_ID" 2>&1
+```
+
+Wait for the app to launch, then verify StateServer is reachable:
+
+```bash
+# Get tunnel IP
+TUNNEL_IP=$(xcrun devicectl device info details --device "$DEVICE_ID" 2>&1 | grep tunnelIPAddress | awk '{print $2}')
+DEVICE_URL="http://[$TUNNEL_IP]:9999"
+
+# Wait for app to start
+sleep 2
+curl -s -6 "$DEVICE_URL/health"
+```
+
+## Phase 4: Verify the Fix
+
+Reproduce the exact steps from the bug report, then verify state:
+
+```bash
+# Example: reproduce the bug steps
+curl -s -6 "$DEVICE_URL/elements"
+curl -s -6 -X POST "$DEVICE_URL/tap" -d '{"x": 200, "y": 450}'
+
+# Verify state is now correct
+curl -s -6 "$DEVICE_URL/state/CartViewModel_total"
+# Should now show the correct value
+
+# Screenshot for evidence
+mkdir -p /tmp/ios-fix
+curl -s -6 "$DEVICE_URL/screenshot" | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" > /tmp/ios-fix/after-fix.png
+```
+
+Then **Read** `/tmp/ios-fix/after-fix.png` to visually confirm.
+
+## Phase 5: Report
+
+Output a structured fix report:
+
+```markdown
+## iOS Fix Report
+
+### Bug Fixed: [Title from bug report]
+**Severity:** [from original report]
+**File:** [path/to/file.swift]
+**Line:** [line number]
+
+### Root Cause
+[1-2 sentences explaining WHY the bug happened]
+
+### Fix Applied
+```diff
+- [old code]
++ [new code]
+```
+
+### Verification
+**Steps reproduced:**
+1. [action taken]
+2. [action taken]
+
+**State before fix:** [key] = [wrong value]
+**State after fix:** [key] = [correct value]
+**Screenshot:** /tmp/ios-fix/after-fix.png
+
+### Status: VERIFIED FIXED
+```
+
+## Error Handling
+
+- **Build fails after fix:** Read the error. Common: typo, type mismatch, missing comma. Fix and retry.
+- **App crashes after fix:** Your fix introduced a regression. Revert, re-read the code, try a different approach.
+- **State still wrong after fix:** Your fix didn't address the root cause. Re-analyze.
+- **Can't reproduce original bug:** The bug might be state-dependent. Reset state via /state writes, then retry.
+- **Device disconnected:** Re-run `xcrun devicectl list devices` to reconnect.
+
+## Multiple Bugs
+
+If given multiple bugs (e.g., a full /ios-qa report), fix them one at a time:
+1. Fix bug #1 → verify → report
+2. Fix bug #2 → verify → report
+3. ...
+
+Do NOT batch fixes. Each fix gets its own build-verify cycle so you know
+exactly which fix resolved which bug.
+
+## Integration with /ios-qa
+
+Typical workflow:
+1. User runs `/ios-qa` → gets bug report with N bugs
+2. User runs `/ios-fix` → this skill fixes each bug
+3. User runs `/ios-qa` again → confirms zero bugs remain
+
+The dream: **AI found every bug. AI fixed every bug. Zero human code written.**

--- a/ios-fix/demo-app-prompt.md
+++ b/ios-fix/demo-app-prompt.md
@@ -1,0 +1,345 @@
+# Test App Prompt: "FitTrack" — Workout Tracker with 4 Bugs
+
+Create a SwiftUI iOS 17+ app called **FitTrack** — a simple workout tracker.
+It has 3 tabs: Workouts, Stats, Profile. Each tab has intentional bugs that
+/ios-qa can find and /ios-fix can repair.
+
+## App Structure
+
+### Models
+
+```swift
+// Workout.swift
+import Foundation
+
+struct Workout: Identifiable, Codable {
+    let id: UUID
+    var name: String
+    var sets: Int
+    var reps: Int
+    var weight: Double // in lbs
+    var date: Date
+    
+    var totalVolume: Double {
+        Double(sets * reps) * weight
+    }
+}
+```
+
+### ViewModels
+
+```swift
+// WorkoutViewModel.swift
+import SwiftUI
+
+@Observable
+class WorkoutViewModel {
+    var workouts: [Workout] = []
+    var weeklyVolume: Double = 0
+    var personalBest: Double = 0
+    
+    func addWorkout(_ workout: Workout) {
+        workouts.append(workout)
+        recalculateStats()
+    }
+    
+    func removeWorkout(at index: Int) {
+        workouts.remove(at: index)
+        recalculateStats()
+    }
+    
+    // BUG 1: weeklyVolume calculation is wrong
+    // It should sum totalVolume for workouts in the last 7 days
+    // Instead it only counts workouts from TODAY (not the full week)
+    private func recalculateStats() {
+        let start = Calendar.current.startOfDay(for: Date()) // BUG: should be 7 days ago
+        let thisWeek = workouts.filter { $0.date >= start }
+        weeklyVolume = thisWeek.reduce(0) { $0 + $1.totalVolume }
+        personalBest = workouts.map(\.totalVolume).max() ?? 0
+    }
+}
+```
+
+```swift
+// StatsViewModel.swift
+import SwiftUI
+
+@Observable
+class StatsViewModel {
+    var streakDays: Int = 0
+    var totalWorkouts: Int = 0
+    var averageVolume: Double = 0
+    
+    // BUG 2: streak calculation counts future dates
+    // Should only count consecutive days UP TO today, going backwards
+    func calculateStreak(from workouts: [Workout]) {
+        totalWorkouts = workouts.count
+        averageVolume = workouts.isEmpty ? 0 : workouts.reduce(0) { $0 + $1.totalVolume } / Double(workouts.count)
+        
+        // Bug: doesn't check that dates are <= today, and counts
+        // non-consecutive days. Should walk backwards from today.
+        let uniqueDays = Set(workouts.map { Calendar.current.startOfDay(for: $0.date) })
+        streakDays = uniqueDays.count  // BUG: should be consecutive days ending today
+    }
+}
+```
+
+```swift
+// ProfileViewModel.swift
+import SwiftUI
+
+@Observable
+class ProfileViewModel {
+    var name: String = "Athlete"
+    var goalVolume: Double = 10000 // weekly goal in lbs
+    var unit: String = "lbs"
+    
+    // BUG 3: unit conversion is backwards
+    // When switching to kg, it should DIVIDE by 2.205
+    // Instead it MULTIPLIES (making the number bigger, not smaller)
+    func toggleUnit() {
+        if unit == "lbs" {
+            unit = "kg"
+            goalVolume = goalVolume * 2.205  // BUG: should divide
+        } else {
+            unit = "lbs"
+            goalVolume = goalVolume / 2.205  // BUG: should multiply
+        }
+    }
+}
+```
+
+### Views
+
+```swift
+// WorkoutTab.swift
+import SwiftUI
+
+struct WorkoutTab: View {
+    @State var viewModel: WorkoutViewModel
+    @State private var showingAddSheet = false
+    
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("This Week") {
+                    HStack {
+                        Text("Volume")
+                        Spacer()
+                        Text("\(Int(viewModel.weeklyVolume)) lbs")
+                            .bold()
+                    }
+                    HStack {
+                        Text("Personal Best")
+                        Spacer()
+                        Text("\(Int(viewModel.personalBest)) lbs")
+                            .foregroundStyle(.orange)
+                    }
+                }
+                
+                Section("Recent Workouts") {
+                    ForEach(viewModel.workouts.sorted(by: { $0.date > $1.date })) { workout in
+                        WorkoutRow(workout: workout)
+                    }
+                    .onDelete { indexSet in
+                        for index in indexSet {
+                            viewModel.removeWorkout(at: index)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("FitTrack")
+            .toolbar {
+                Button("Add", systemImage: "plus") {
+                    showingAddSheet = true
+                }
+            }
+            .sheet(isPresented: $showingAddSheet) {
+                AddWorkoutSheet(viewModel: viewModel)
+            }
+        }
+    }
+}
+
+struct WorkoutRow: View {
+    let workout: Workout
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(workout.name)
+                .font(.headline)
+            // BUG 4: Display shows "sets x weight" but should show "sets x reps @ weight"
+            Text("\(workout.sets) x \(Int(workout.weight)) lbs")  // BUG: missing reps
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+```
+
+```swift
+// AddWorkoutSheet.swift
+import SwiftUI
+
+struct AddWorkoutSheet: View {
+    @State var viewModel: WorkoutViewModel
+    @Environment(\.dismiss) private var dismiss
+    
+    @State private var name = ""
+    @State private var sets = 3
+    @State private var reps = 10
+    @State private var weight = 135.0
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Exercise Name", text: $name)
+                Stepper("Sets: \(sets)", value: $sets, in: 1...10)
+                Stepper("Reps: \(reps)", value: $reps, in: 1...30)
+                HStack {
+                    Text("Weight")
+                    Spacer()
+                    TextField("lbs", value: $weight, format: .number)
+                        .keyboardType(.decimalPad)
+                        .frame(width: 80)
+                        .multilineTextAlignment(.trailing)
+                }
+            }
+            .navigationTitle("Add Workout")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let workout = Workout(
+                            id: UUID(),
+                            name: name,
+                            sets: sets,
+                            reps: reps,
+                            weight: weight,
+                            date: Date()
+                        )
+                        viewModel.addWorkout(workout)
+                        dismiss()
+                    }
+                    .disabled(name.isEmpty)
+                }
+            }
+        }
+    }
+}
+```
+
+```swift
+// StatsTab.swift
+import SwiftUI
+
+struct StatsTab: View {
+    @State var statsViewModel: StatsViewModel
+    let workoutViewModel: WorkoutViewModel
+    
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Streak") {
+                    HStack {
+                        Image(systemName: "flame.fill")
+                            .foregroundStyle(.orange)
+                        Text("\(statsViewModel.streakDays) day streak")
+                            .font(.title2)
+                    }
+                }
+                
+                Section("All Time") {
+                    LabeledContent("Total Workouts", value: "\(statsViewModel.totalWorkouts)")
+                    LabeledContent("Avg Volume", value: "\(Int(statsViewModel.averageVolume)) lbs")
+                }
+            }
+            .navigationTitle("Stats")
+            .onAppear {
+                statsViewModel.calculateStreak(from: workoutViewModel.workouts)
+            }
+        }
+    }
+}
+```
+
+```swift
+// ProfileTab.swift
+import SwiftUI
+
+struct ProfileTab: View {
+    @State var viewModel: ProfileViewModel
+    
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Profile") {
+                    LabeledContent("Name", value: viewModel.name)
+                }
+                
+                Section("Goals") {
+                    LabeledContent("Weekly Volume Goal", value: "\(Int(viewModel.goalVolume)) \(viewModel.unit)")
+                    Button("Switch to \(viewModel.unit == "lbs" ? "kg" : "lbs")") {
+                        viewModel.toggleUnit()
+                    }
+                }
+                
+                Section("Unit") {
+                    Text("Current: \(viewModel.unit)")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("Profile")
+        }
+    }
+}
+```
+
+```swift
+// ContentView.swift
+import SwiftUI
+
+struct ContentView: View {
+    @State private var workoutVM = WorkoutViewModel()
+    @State private var statsVM = StatsViewModel()
+    @State private var profileVM = ProfileViewModel()
+    
+    var body: some View {
+        TabView {
+            WorkoutTab(viewModel: workoutVM)
+                .tabItem {
+                    Label("Workouts", systemImage: "dumbbell.fill")
+                }
+            
+            StatsTab(statsViewModel: statsVM, workoutViewModel: workoutVM)
+                .tabItem {
+                    Label("Stats", systemImage: "chart.bar.fill")
+                }
+            
+            ProfileTab(viewModel: profileVM)
+                .tabItem {
+                    Label("Profile", systemImage: "person.fill")
+                }
+        }
+    }
+}
+```
+
+## The 4 Bugs (for /ios-qa to find, /ios-fix to repair)
+
+| # | Bug | Location | Symptom | Fix |
+|---|-----|----------|---------|-----|
+| 1 | Weekly volume only counts today | `WorkoutViewModel.recalculateStats()` | Volume shows 0 when workouts were yesterday | Change `startOfDay(for: Date())` to `Date().addingTimeInterval(-7*24*3600)` |
+| 2 | Streak counts non-consecutive days | `StatsViewModel.calculateStreak()` | Shows "5 day streak" when workouts were Mon, Wed, Fri (should be 1) | Walk backwards from today counting consecutive days |
+| 3 | Unit conversion is inverted | `ProfileViewModel.toggleUnit()` | Switching to kg makes number BIGGER (22,050 kg) | Swap multiply/divide |
+| 4 | Workout row missing reps | `WorkoutRow` | Shows "3 x 135 lbs" not "3 x 10 @ 135 lbs" | Add `reps` to the text |
+
+## Important Notes
+
+- Use iOS 17+ with @Observable (NOT ObservableObject)
+- Add `UILaunchScreen` key to Info.plist (empty dict) so it uses full screen
+- The DebugBridge will be generated by /ios-qa — don't include it
+- Keep it simple: no persistence, no networking, just in-memory state
+- Make sure the tab bar uses SF Symbols as shown above

--- a/ios-qa/README.md
+++ b/ios-qa/README.md
@@ -1,0 +1,126 @@
+# iStack: /ios-qa
+
+AI-powered iOS QA testing that drives your REAL iPhone. Claude connects via USB CoreDevice tunnel, reads your Swift source, then systematically navigates every screen, mutates @Observable state, and finds bugs while you watch.
+
+## The Demo Moment
+
+You type `/ios-qa`. Claude reads your Swift source, understands your @Observable classes, connects to your phone over USB. A blue animated border appears on your phone. "Claude is debugging this app" shows at the top. Claude starts navigating, mutating state, taking screenshots, and filing bug reports with evidence.
+
+## How It Works
+
+```
+┌─────────────────────────┐          ┌──────────────────────────────┐
+│ Claude Code (Mac)       │          │ iPhone (debug build)         │
+│                         │   USB    │                              │
+│  /ios-qa skill          │◄────────►│  StateServer (HTTP :9999)    │
+│  curl -6 http://[ipv6]  │ CoreDev  │    ├─ Screenshot capture     │
+│       :9999/*           │  tunnel  │    ├─ Tap/Swipe/Type inject  │
+│                         │          │    ├─ Accessibility tree     │
+│  Agent loop:            │          │    ├─ @Observable state R/W  │
+│   screenshot → analyze  │          │    └─ Device info            │
+│   → decide → act →     │          │                              │
+│   verify → repeat       │          │  DebugOverlay (visual):      │
+│                         │          │    ├─ Blue animated border   │
+│  Reports bugs with:     │          │    ├─ "Claude is debugging"  │
+│   - screenshots         │          │    ├─ Action text display    │
+│   - state evidence      │          │    └─ State mutation pulse   │
+│   - file + line refs    │          │                              │
+└─────────────────────────┘          └──────────────────────────────┘
+```
+
+**Connection:** Apple's CoreDevice USB tunnel provides direct IPv6 access. No WiFi, no Bonjour, no iproxy. Just `curl -6 http://[tunnel-ipv6]:9999`.
+
+## Requirements
+
+- macOS with Xcode 15+
+- iPhone/iPad running iOS 17+ connected via USB
+- App using `@Observable` classes (iOS 17 Observation framework)
+- CoreDevice tunnel active (automatic when device is connected and trusted)
+
+## Quick Start
+
+```bash
+# 1. Find your device tunnel IP
+xcrun devicectl list devices 2>&1 | grep connected
+xcrun devicectl device info details --device <ID> 2>&1 | grep tunnelIPAddress
+
+# 2. Verify connection (substitute your IPv6)
+curl -s -6 http://[fdac:e671:bcd7::1]:9999/health
+# → {"status":"ok"}
+
+# 3. Run the skill
+/ios-qa
+```
+
+## What the Skill Does
+
+1. **Reads source** - scans every ViewModel, View, Model file to understand the app
+2. **Generates DebugBridge** (first run) - creates StateServer + typed accessors for your @Observable classes
+3. **Connects** - discovers device via `xcrun devicectl`, hits the HTTP StateServer
+4. **Runs agent loop** - screenshot, analyze with vision, tap/swipe/type, verify state, repeat
+5. **Reports bugs** - structured report with severity, file references, screenshots, state evidence
+
+## API (StateServer Endpoints)
+
+| Endpoint | Method | Returns |
+|----------|--------|---------|
+| `/health` | GET | `{"status":"ok"}` |
+| `/screenshot` | GET | `{"image":"<base64 PNG>"}` |
+| `/elements` | GET | JSON array: label, center, frame, traits, interactive |
+| `/tap` | POST | Inject tap at `{"x":N,"y":N}` |
+| `/swipe` | POST | Swipe `{"fromX","fromY","toX","toY"}` |
+| `/type` | POST | Type `{"text":"..."}` into focused field |
+| `/device` | GET | Model, OS, screen size, safe area |
+| `/state` | GET | All registered state keys |
+| `/state/{key}` | GET | Read @Observable property value |
+| `/state/{key}` | POST | Write @Observable property (body = new value) |
+
+## Templates
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `Package.swift.template` | 22 | SPM manifest (iOS 17+, debug-only) |
+| `StateServer.swift.template` | 497 | HTTP server (NWListener): screenshot, tap, swipe, type, elements, state |
+| `DebugOverlay.swift.template` | 204 | Blue animated border + "Claude is debugging" header |
+| `DebugBridgeManager.swift.template` | 40 | Singleton that starts StateServer + registers accessors |
+| `DebugBridgeJSON.swift.template` | 21 | JSON serialization helper |
+| `StateAccessor.swift.template` | 39 | Per-class typed read/write accessor pattern |
+
+`DebugBridge/` is a standalone SPM package. Typed state accessors are generated into `<App>/DebugBridgeGenerated/` and added to the app target.
+
+## Integration (2 lines)
+
+```swift
+#if DEBUG
+import DebugBridge
+
+// In your App struct:
+var body: some Scene {
+    WindowGroup {
+        ContentView()
+            .debugBridgeOverlay()
+            .task { DebugBridgeManager.shared.start(viewModel1: vm1, viewModel2: vm2) }
+    }
+}
+#endif
+```
+
+## Example Results
+
+Tested against QuickShop (demo e-commerce app). Found 5/5 planted bugs:
+
+| Bug | Severity | What |
+|-----|----------|------|
+| BUG-001 | High | Cart total not recalculated after quantity change |
+| BUG-002 | Critical | Force-unwrap crash on empty cart checkout |
+| BUG-003 | Medium | AsyncImage URLs fail (missing percent-encoding) |
+| BUG-004 | High | Stale cached user after logout/re-login |
+| BUG-005 | High | .fixedSize() breaks layout on long product names |
+
+## What's NOT Here
+
+- No simulator (real device only, you watch it happen)
+- No XCTest (HTTP + accessibility, not test frameworks)
+- No iproxy (CoreDevice tunnel directly, not usbmuxd)
+- No auth (debug builds only, USB connection required)
+- No external dependencies (just `curl` and `xcrun devicectl`)

--- a/ios-qa/SKILL.md.tmpl
+++ b/ios-qa/SKILL.md.tmpl
@@ -1,0 +1,366 @@
+---
+name: ios-qa
+version: 4.0.0
+description: |
+  Live-device iOS QA for SwiftUI apps. Connects to a real iPhone via USB
+  port-forward, reads Swift source to understand every screen, then runs a
+  vision-driven agent loop: screenshot → analyze → decide → act → verify → repeat.
+  All interaction happens via HTTP to an embedded StateServer in the app.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Agent
+triggers:
+  - ios qa
+  - ios-qa
+  - test ios app
+  - qa my phone
+---
+
+{{PREAMBLE}}
+
+# iStack: Live-Device iOS QA (v4)
+
+You are an expert iOS QA tester. You connect to a real app running on a real
+iPhone via USB, read its source code, then run a browser-agent-loop to
+systematically find bugs: screenshot → identify elements → choose action →
+execute → verify state → repeat.
+
+## Architecture
+
+```
+Claude Code (this skill — YOU)
+  └── curl -6 http://[TUNNEL_IPv6]:9999/*   (via CoreDevice USB tunnel)
+        ├── GET  /screenshot         → base64 PNG of current screen
+        ├── GET  /elements           → accessibility tree (labels, frames, traits)
+        ├── POST /tap                → inject tap at {x, y} pixel coords
+        ├── POST /swipe              → inject swipe {fromX, fromY, toX, toY}
+        ├── POST /type               → type text into focused field
+        ├── GET  /device             → device info (model, screen size)
+        ├── GET  /state              → list all registered state keys
+        ├── GET  /state/{key}        → read @Observable property
+        ├── POST /state/{key}        → write @Observable property
+        └── GET  /health             → health check
+```
+
+**No external tools needed** besides `curl` and `xcrun devicectl`.
+Everything runs inside the app via an embedded HTTP StateServer.
+Connection uses the CoreDevice USB tunnel (IPv6) — **NOT iproxy**.
+
+## Performance Model
+
+Use **Sonnet** (fast model) for the QA execution loop. The agent loop needs speed
+over deep reasoning. Sonnet is fast enough to read accessibility trees, decide
+what to tap, and verify state. When spawning subagents for the QA loop, use
+`model: "sonnet"`.
+
+Use the **default model** (Opus) only for:
+- Initial source code analysis (Phase 1)
+- Test plan generation (Phase 4)
+- Final bug report synthesis (Phase 6)
+
+## Non-Negotiable Rules
+
+1. **Read the source code FIRST.** Before testing anything, read every ViewModel,
+   View, and Model file. Know what each screen does, what buttons exist, what
+   state they affect, and what could go wrong.
+
+2. **Use /elements as your primary navigation tool.** The accessibility tree gives
+   you element labels and pixel coordinates instantly. Use it to find tap targets,
+   understand what's on screen, and decide what to do next. This is FAST.
+
+3. **Screenshots only when needed for visual verification.** Take a screenshot when:
+   - Checking for layout bugs (text overflow, clipping, broken images)
+   - Verifying visual state that /elements can't convey (colors, alignment, spacing)
+   - Capturing evidence for a visual bug report
+   Do NOT screenshot before every action. /elements + /state is sufficient for navigation.
+
+4. **Verify with state reads.** After every action, read relevant state via
+   `/state/{key}`. Compare actual vs expected. Mismatch = bug.
+
+5. **Only report bugs you can prove.** Each bug needs evidence: a state read
+   showing wrong value, or a screenshot showing visual breakage.
+
+## The Agent Loop
+
+This is a **fast agent loop** optimized for speed. Use /elements and /state for
+most iterations. Only pull screenshots for visual verification.
+
+```
+1. IDENTIFY    → curl GET /elements → parse JSON → understand what's on screen
+2. DECIDE      → Based on test plan + element labels, choose next action
+3. EXECUTE     → curl POST /tap or /type or /swipe
+4. VERIFY      → curl GET /state/{key} → compare actual vs expected
+5. VISUAL CHECK (only when needed) → screenshot → check for layout/visual bugs
+6. REPEAT      → Go to step 1
+```
+
+**When to screenshot:**
+- After navigating to a NEW screen for the first time (baseline visual check)
+- When testing for visual bugs (overflow, clipping, broken images, wrong colors)
+- When /elements returns unexpected results and you need to see what's actually rendered
+- When capturing evidence for a bug report
+
+**When NOT to screenshot:**
+- Before every tap (use /elements instead)
+- After state mutations that have no visual component
+- When verifying numeric state values (/state/{key} is instant)
+
+Run this loop until you've covered every screen, every flow, every edge case.
+
+## Setup — Discover Device Tunnel IP
+
+Modern iOS devices connect via Apple's CoreDevice tunnel (IPv6), NOT the old
+usbmuxd protocol. **Do NOT use iproxy** — it doesn't work with CoreDevice.
+
+```bash
+# Step 1: Find the connected device
+xcrun devicectl list devices 2>&1 | grep "connected"
+# Look for a line like:
+# who paid ?   who-paid-.coredevice.local   E111536C-...   connected   iPhone 16 Pro
+
+# Step 2: Get the tunnel IP address
+# Use the device identifier from step 1
+xcrun devicectl device info details --device <IDENTIFIER> 2>&1 | grep tunnelIPAddress
+# Output: tunnelIPAddress: fdac:e671:bcd7::1
+# THIS is your device IP. It's an IPv6 address on the CoreDevice tunnel.
+
+# Step 3: Set your base URL (use this for ALL curl commands)
+DEVICE="http://[fdac:e671:bcd7::1]:9999"
+# IMPORTANT: The brackets around the IPv6 address are required.
+# IMPORTANT: Always pass -6 flag to curl for IPv6.
+
+# Step 4: Verify the StateServer is reachable
+curl -s -6 "$DEVICE/health"
+# Expected: {"status":"ok"}
+
+# Step 5: Get device info
+curl -s -6 "$DEVICE/device"
+```
+
+**CRITICAL**: Every `curl` command must use `-6` flag and the `http://[IPv6]:9999` format.
+Do NOT use `localhost`, `127.0.0.1`, or iproxy. The CoreDevice tunnel provides direct
+IPv6 access to the device over USB.
+
+If `/health` fails:
+- The app isn't running on the device → launch it: `xcrun devicectl device process launch --device <ID> <bundle-id>`
+- The app is a Release build → StateServer is `#if DEBUG` only, must be Debug build
+- The tunnel IP changed → re-run step 2 to get the current tunnel IP
+- Kill any stale iproxy processes: `pkill -f iproxy` (they interfere)
+
+## API Reference
+
+**All curl commands must use `-6` and the `http://[TUNNEL_IP]:9999` format.**
+Set `DEVICE` variable first (from Setup step 3), then use `$DEVICE` everywhere.
+
+### Screenshot
+```bash
+# Returns {"image": "<base64 PNG>"}
+curl -s -6 "$DEVICE/screenshot" | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" > /tmp/ios-qa/screen.png
+```
+Then `Read /tmp/ios-qa/screen.png` to analyze with vision.
+
+### Accessibility Elements
+```bash
+# Returns JSON array of elements with labels, frames, centers, traits
+curl -s -6 "$DEVICE/elements"
+```
+Each element has:
+- `label` — accessibility label (what you see on screen)
+- `center` — `{"x": 200, "y": 450}` (where to tap)
+- `frame` — `{"x", "y", "width", "height"}` (bounding box)
+- `traits` — `["button"]`, `["text"]`, etc.
+- `interactive` — true if tappable
+
+### Tap
+```bash
+# Tap at pixel coordinates
+curl -s -6 -X POST "$DEVICE/tap" -d '{"x": 200, "y": 450}'
+# Returns: {"ok": true, "target": "UIButton", "label": "Add to Cart"}
+```
+
+### Swipe
+```bash
+# Swipe from point A to point B
+curl -s -6 -X POST "$DEVICE/swipe" -d '{"fromX": 200, "fromY": 600, "toX": 200, "toY": 200}'
+```
+
+### Type Text
+```bash
+# Type into the currently focused text field
+curl -s -6 -X POST "$DEVICE/type" -d '{"text": "hello@test.com"}'
+```
+
+### State Read/Write
+```bash
+# List all state keys
+curl -s -6 "$DEVICE/state"
+
+# Read a value
+curl -s -6 "$DEVICE/state/CartViewModel_total"
+
+# Write a value (body is the new value)
+curl -s -6 -X POST "$DEVICE/state/CartViewModel_items" -d '[]'
+```
+
+## Phase 1: Analyze Source
+
+```bash
+find . -maxdepth 3 \( -name "*.xcodeproj" -o -name "Package.swift" \) -not -path "*/DebugBridge/*"
+```
+
+Read every file to understand:
+- What screens exist (Views)
+- What state exists (ViewModels with @Observable)
+- What flows are possible (navigation, buttons, forms)
+- What could go wrong (force unwraps, missing recalculations, bad URLs, layout issues)
+
+## Phase 2: Generate DebugBridge (if needed)
+
+If not already generated, create the DebugBridge package and accessors.
+See templates at `~/.claude/skills/ios-qa/templates/`.
+
+The DebugBridge package (`DebugBridge/`) contains:
+- `StateServer.swift` — HTTP server with screenshot/tap/elements/state endpoints
+- `DebugOverlay.swift` — visual "Claude is debugging" indicator
+
+App-specific accessors go in `<AppSource>/DebugBridgeGenerated/`:
+- `DebugBridgeManager.swift` — starts StateServer, registers all accessors
+- `<ClassName>Accessor.swift` — per-class state read/write registrations
+- `DebugBridgeJSON.swift` — serialization helpers
+
+## Phase 3: Connect
+
+```bash
+# Kill any stale iproxy (they don't work with CoreDevice and interfere)
+pkill -f iproxy 2>/dev/null
+
+# Find connected device
+xcrun devicectl list devices 2>&1 | grep "connected"
+
+# Get tunnel IP (replace DEVICE_ID with the Identifier from above)
+TUNNEL_IP=$(xcrun devicectl device info details --device DEVICE_ID 2>&1 | grep tunnelIPAddress | awk '{print $2}')
+echo "Tunnel IP: $TUNNEL_IP"
+
+# Set the base URL for all requests
+DEVICE="http://[$TUNNEL_IP]:9999"
+
+# Verify connection
+curl -s -6 "$DEVICE/health"
+curl -s -6 "$DEVICE/device"
+curl -s -6 "$DEVICE/state"
+```
+
+## Phase 4: Build Test Plan
+
+Based on source analysis, plan tests:
+
+```
+TEST 1: Home screen renders correctly
+  - screenshot → verify hero, categories, products visible
+  
+TEST 2: Add to cart flow
+  - read CartViewModel_items → should be []
+  - find "Add to Cart" button via /elements
+  - tap it
+  - read CartViewModel_items → should have 1 item
+  - read CartViewModel_total → should match price
+
+TEST 3: Quantity change updates total
+  - add item, read total → T1
+  - increment quantity via UI
+  - read total → T2
+  - assert T2 == T1 * new_quantity (if not → BUG)
+```
+
+## Phase 5: Execute — The Agent Loop
+
+For each test, run the loop:
+
+### 5a. Screenshot + Vision
+```bash
+mkdir -p /tmp/ios-qa
+curl -s -6 "$DEVICE/screenshot" | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" > /tmp/ios-qa/screen.png
+```
+Then **Read** `/tmp/ios-qa/screen.png` and analyze what you see.
+
+### 5b. Get elements
+```bash
+curl -s -6 "$DEVICE/elements"
+```
+Find the element you want to interact with. Note its `center.x` and `center.y`.
+
+### 5c. Perform action
+```bash
+# Tap a button
+curl -s -6 -X POST "$DEVICE/tap" -d '{"x": 207, "y": 543}'
+
+# Or type into a field
+curl -s -6 -X POST "$DEVICE/type" -d '{"text": "test@example.com"}'
+
+# Or swipe to scroll
+curl -s -6 -X POST "$DEVICE/swipe" -d '{"fromX":200,"fromY":600,"toX":200,"toY":200}'
+```
+
+### 5d. Verify state
+```bash
+curl -s -6 "$DEVICE/state/CartViewModel_total"
+# Compare to expected value
+```
+
+### 5e. Screenshot again to confirm visual state
+```bash
+curl -s -6 "$DEVICE/screenshot" | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" > /tmp/ios-qa/after.png
+```
+
+### 5f. Loop back to 5a for next action
+
+## Phase 6: Report
+
+```markdown
+## iOS QA Report — [App Name]
+**Device:** [from /device]
+**Tests run:** N
+**Bugs found:** N (Critical: X, High: X, Medium: X, Low: X)
+
+### BUG-001: [Title]
+**Severity:** Critical/High/Medium/Low
+**Screen:** [Which screen]
+**Steps to reproduce:**
+1. [Exact curl commands used]
+2. [What you observed]
+**Expected:** [What should happen]
+**Actual:** [What actually happened]
+**Evidence:** [State read or screenshot path]
+```
+
+### Severity Guide
+- **Critical:** App crash, data loss
+- **High:** Feature completely broken, major visual breakage
+- **Medium:** Feature partially broken, incorrect data
+- **Low:** Cosmetic, minor overflow
+
+### What IS a bug
+- State doesn't match expected after action (total didn't update)
+- StateServer becomes unreachable (app crashed)
+- Screenshot shows wrong data, broken layout, missing images
+- Text overflows container
+- Navigation goes to wrong screen
+
+### What is NOT a bug
+- "I couldn't tap this element" (try different coordinates or /elements)
+- Anything without evidence
+
+## Error Handling
+
+- **curl connection refused / exit code 7:** Tunnel IP wrong or device disconnected. Re-run `xcrun devicectl device info details` to get fresh tunnel IP.
+- **curl exit code 56 (connection reset):** Stale iproxy processes are interfering. Run `pkill -f iproxy` and use the IPv6 tunnel IP directly.
+- **Empty response:** App not running or was built in Release mode. Launch with `xcrun devicectl device process launch --device <ID> <bundle-id>`.
+- **App crash:** StateServer goes silent. Note what caused it (Critical bug). Relaunch app.
+- **Tap has no effect:** Check coordinates against /elements. Try tapping the center point.
+- **No elements returned:** The view might use custom drawing. Use screenshot + vision instead.
+- **"localhost" doesn't work:** Correct. Use `http://[TUNNEL_IPv6]:9999` with `-6` flag. Never use localhost.

--- a/ios-qa/SKILL.md.tmpl
+++ b/ios-qa/SKILL.md.tmpl
@@ -88,11 +88,17 @@ Use the **default model** (Opus) only for:
 6. **NEVER rebuild during QA.** All code-gen (action keys, injection helpers,
    state accessors) must be complete BEFORE the first test runs. If you discover
    you need a new state key mid-QA, that means code-gen was incomplete — note it
-   as a limitation, don't rebuild. The QA phase is read-only on the source.
+   as "SKIPPED: missing action key for X" and MOVE ON. Do NOT stop to add it.
+   Each rebuild costs 2+ minutes and requires re-launching the app. A single
+   session with 7 mid-QA rebuilds wasted 14 minutes (turned a 4-min run into 20).
 
-7. **Use action keys over UI taps for state mutations.** Tapping SwiftUI buttons
-   inside List/Form cells is unreliable. Action keys are instant and never fail.
-   Only tap when testing navigation or verifying button existence.
+7. **Use action keys over UI taps for ALL state mutations.** SwiftUI toolbar
+   buttons, sheet buttons, and List/Form cell buttons CANNOT be tapped
+   programmatically — they use SwiftUI gesture handlers that are inaccessible
+   from UIKit. This is not a "sometimes fails" situation — it NEVER works.
+   Action keys are the ONLY reliable way to invoke ViewModel functions.
+   Only tap when testing: navigation (tabs), text field focus, or verifying
+   that a button element EXISTS in the accessibility tree.
 
 8. **Batch state reads.** Combine multiple `curl` calls into a single Bash
    invocation. Don't make 5 separate tool calls when one bash script handles all 5.
@@ -234,18 +240,43 @@ Read every file to understand:
 ## Phase 2: Generate DebugBridge (if needed)
 
 If not already generated, create the DebugBridge package and accessors.
-See templates at `~/.claude/skills/ios-qa/templates/`.
 
-The DebugBridge package (`DebugBridge/`) contains:
-- `StateServer.swift` — HTTP server with screenshot/tap/elements/state endpoints
-- `DebugOverlay.swift` — visual "Claude is debugging" indicator
+### Step 2a: Copy templates VERBATIM
+
+Read the templates from `~/.claude/skills/ios-qa/templates/` and copy them
+directly. **Do NOT rewrite from memory or simplify.**
+
+- `StateServer.swift.template` → copy to `<AppSource>/DebugBridgeGenerated/StateServer.swift`
+  (Replace `{{PLACEHOLDER}}` tokens only. Keep the tap priority chain intact.)
+- `DebugOverlay.swift.template` → copy to `<AppSource>/DebugBridgeGenerated/DebugOverlay.swift`
+  (Keep all 4 glow layers, GeometryReader, double .ignoresSafeArea)
+
+### Step 2b: Generate app-specific accessors
 
 App-specific accessors go in `<AppSource>/DebugBridgeGenerated/`:
 - `DebugBridgeManager.swift` — starts StateServer, registers all accessors
 - `<ClassName>Accessor.swift` — per-class state read/write registrations
-- `DebugBridgeJSON.swift` — serialization helpers
 
-### CRITICAL: Complete Code-Gen FIRST
+### Step 2c: Enumerate ALL functions (MANDATORY before build)
+
+For EVERY @Observable class, grep for `func ` and generate an action key for
+each one. Print the inventory:
+
+```
+FUNCTION INVENTORY:
+  WorkoutViewModel.addWorkout(_:)     → WorkoutViewModel_addWorkout (JSON body)
+  WorkoutViewModel.removeWorkout(at:) → WorkoutViewModel_removeWorkout (index)
+  ProfileViewModel.toggleUnit()       → ProfileViewModel_toggleUnit (no params)
+  StatsViewModel.calculateStreak(from:) → StatsViewModel_calculateStreak (trigger)
+
+  Total functions: 4
+  Action keys generated: 4
+  Missing: 0 ← MUST BE ZERO
+```
+
+Only proceed to build after missing = 0.
+
+### CRITICAL: Complete Code-Gen FIRST — PRE-FLIGHT GATE
 
 **Generate ALL accessors before building.** This includes:
 
@@ -253,26 +284,86 @@ App-specific accessors go in `<AppSource>/DebugBridgeGenerated/`:
 2. **Property writes** — every mutable `var` gets a write key
 3. **Action keys** — every mutating `func` gets a write key that invokes it directly
 4. **Data injection** — for any `func addX(item)`, also generate an injection key
-   that accepts CSV params (e.g., `"name,sets,reps,weight,daysAgo"`) so the agent
-   can create test data with specific dates/values without using the UI
+   that accepts JSON body so the agent can create test data with specific dates/values
+   without using the UI
 
-**Why this matters:** If you skip action keys, the QA agent will fail to tap
-SwiftUI buttons inside List cells (a known limitation), then need to add keys
-mid-QA, triggering a rebuild cycle. Each rebuild costs ~2 minutes. By front-loading
-ALL keys, the agent does ONE build and never rebuilds during testing.
+**Why this matters:** If you skip action keys, you will waste 10+ minutes trying
+to tap SwiftUI toolbar/sheet buttons that CANNOT be activated programmatically.
+Each failed attempt leads to a rebuild cycle (~2 min). A 5-test session with
+missing action keys took 20 minutes. With complete action keys: 4 minutes.
 
-**Example action keys to always generate:**
+### PRE-FLIGHT CHECKLIST (MUST complete before `xcodebuild`)
+
+Before running any build, print this checklist and verify every box:
+
+```
+PRE-FLIGHT: Action Key Completeness Check
+──────────────────────────────────────────
+For each @Observable class, list ALL func declarations found in source:
+
+[ ] ClassName.functionName() → action key: "ClassName_functionName" ✓
+[ ] ClassName.otherFunc(arg) → action key: "ClassName_otherFunc" ✓
+...
+
+Missing action keys: 0  ← MUST be 0 before building
+```
+
+**If ANY mutating function is missing an action key, DO NOT BUILD.** Add the key
+first. This is the #1 cause of mid-QA rebuild spirals.
+
+### HARD RULES (violations caused 14 min waste in real session)
+
+1. **NEVER try to tap SwiftUI toolbar buttons (.toolbar, .navigationBarItems).**
+   They wrap in UIKitBarItemHost → accessibilityActivate() returns true but
+   doesn't fire the action. sendActions(.touchUpInside) does nothing. Private
+   `_targets` API crashes the app. There is NO working programmatic tap for
+   SwiftUI toolbar buttons. Use action keys ALWAYS.
+
+2. **NEVER try to tap SwiftUI sheet/form confirmation buttons.**
+   Same issue — they're SwiftUI-managed, not UIKit controls.
+
+3. **Copy the StateServer template verbatim.** Do NOT write a simplified version.
+   The template at `~/.claude/skills/ios-qa/templates/StateServer.swift.template`
+   already has the correct tap priority chain:
+   - Priority 1: UITextField → becomeFirstResponder (for keyboard focus)
+   - Priority 2: UITextView → becomeFirstResponder
+   - Priority 3: UIControl → sendActions(.touchUpInside)
+   - Priority 4: accessibilityActivate()
+   - Priority 5: Ancestor walk
+   - Priority 6: Gesture recognizers
+
+   Writing your own tap handler from scratch WILL miss cases and force rebuilds.
+
+4. **Copy the DebugOverlay template verbatim.** The template has the full-screen
+   GeometryReader + 4-layer glow. Don't simplify it.
+
+5. **ONE build. ZERO rebuilds during QA.** If a test can't run because of a
+   missing key, document it as "SKIPPED: missing action key" and move on.
+   Do NOT stop to add the key and rebuild.
+
+### Example action keys to always generate:
 ```swift
 // For: func toggleUnit()
 server.registerWrite("ProfileVM_toggleUnit") { _ in instance.toggleUnit(); return true }
 
-// For: func addItem(_ item: Item)  — also generate injection helper
+// For: func addItem(_ item: Item)  — JSON injection helper
 server.registerWrite("CartVM_addItem") { value in
-    // CSV: "name,price,quantity,daysAgo"
-    let parts = value.split(separator: ",").map(String.init)
-    guard parts.count >= 3 else { return false }
-    // ... parse and create item with optional date offset
+    guard let data = value.data(using: .utf8),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let name = json["name"] as? String else { return false }
+    let price = json["price"] as? Double ?? 0
+    let qty = json["quantity"] as? Int ?? 1
+    let daysAgo = json["daysAgo"] as? Double ?? 0
+    let date = Date().addingTimeInterval(-daysAgo * 86400)
+    let item = Item(name: name, price: price, quantity: qty, date: date)
     instance.addItem(item)
+    return true
+}
+
+// For: func removeItem(at index: Int)
+server.registerWrite("CartVM_removeItem") { value in
+    guard let idx = Int(value), idx < instance.items.count else { return false }
+    instance.removeItem(at: idx)
     return true
 }
 
@@ -282,6 +373,18 @@ server.registerWrite("StatsVM_calculateStats") { _ in
     return true
 }
 ```
+
+### What taps ARE safe (use these only):
+- Tab bar buttons (`_UITabButton`) — always work via accessibilityActivate
+- Navigation back buttons — always work
+- UITextField focus — works with becomeFirstResponder in template
+- Standard UIButton (not SwiftUI) — works via sendActions
+
+### What taps are NEVER safe (use action keys instead):
+- SwiftUI `.toolbar` items (Save, Done, Cancel, Add in nav bar)
+- SwiftUI `Button` inside `List` or `Form` cells
+- SwiftUI `Sheet` dismiss/confirm buttons
+- Any SwiftUI button wrapped in host views (UIKitBarItemHost, CellHostingView)
 
 **Rule: ONE build, then pure QA. Never rebuild mid-test.**
 
@@ -442,6 +545,27 @@ Do NOT screenshot between every action. Only screenshot when:
 - **curl exit code 56 (connection reset):** Stale iproxy processes are interfering. Run `pkill -f iproxy` and use the IPv6 tunnel IP directly.
 - **Empty response:** App not running or was built in Release mode. Launch with `xcrun devicectl device process launch --device <ID> <bundle-id>`.
 - **App crash:** StateServer goes silent. Note what caused it (Critical bug). Relaunch app.
-- **Tap has no effect:** Check coordinates against /elements. Try tapping the center point.
+- **Tap has no effect on toolbar/sheet button:** This is EXPECTED. SwiftUI toolbar buttons cannot be tapped programmatically. Use the action key instead. Do NOT try to fix the tap handler — it's a SwiftUI architectural limitation, not a bug in StateServer.
+- **"no focused text field" after tapping:** The StateServer tap handler uses becomeFirstResponder. If it fails, the view might be a SwiftUI TextField that hasn't propagated focus yet. Wait 500ms and try `/type` again. If still failing, verify the template's Priority 1 (UITextField) check is present.
 - **No elements returned:** The view might use custom drawing. Use screenshot + vision instead.
 - **"localhost" doesn't work:** Correct. Use `http://[TUNNEL_IPv6]:9999` with `-6` flag. Never use localhost.
+
+## Known Tap Limitations (DO NOT TRY TO FIX — use action keys)
+
+These are architectural limitations of SwiftUI's UIKit bridge. They CANNOT be
+solved by modifying the StateServer tap handler. Don't waste time trying.
+
+| UI Element | Why it fails | Solution |
+|-----------|-------------|----------|
+| `.toolbar` items (Save/Done/Cancel/Add) | Wrapped in UIKitBarItemHost, accessibilityActivate returns true but doesn't fire action | Action key |
+| `Button` inside `List`/`Form` cell | CellHostingView intercepts, accessibilityActivate activates the cell not the button | Action key |
+| `Sheet` confirm/dismiss buttons | SwiftUI manages presentation state directly | Action key |
+| `NavigationLink` with custom label | accessibilityActivate triggers but navigation state doesn't update | Tap works ~50%, use action key for reliability |
+| `Picker`/`Toggle`/`Stepper` | Composite controls with internal state | Write directly to the bound property |
+
+**The tap handler works reliably for:**
+- Tab bar buttons (UITabBarButton) — always works
+- Text fields (UITextField) — becomeFirstResponder works
+- Navigation back button — always works
+- Standard UIButtons (not SwiftUI-wrapped) — sendActions works
+- UIControl subclasses — sendActions works

--- a/ios-qa/SKILL.md.tmpl
+++ b/ios-qa/SKILL.md.tmpl
@@ -25,6 +25,92 @@ triggers:
 
 # iStack: Live-Device iOS QA (v4)
 
+## Warm Start (Check This FIRST — Before Any Other Phase)
+
+Before doing anything else, check if a session cache exists:
+
+```bash
+cat ~/.gstack/ios-qa-session.json 2>/dev/null
+```
+
+If the file exists and the session is less than 24 hours old:
+
+1. **Skip Phases 1 and 2 entirely** (no source reading, no code-gen, no build)
+2. Verify the device is still connected and the app is still running:
+   ```bash
+   CACHED_IP=$(cat ~/.gstack/ios-qa-session.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['tunnelIP'])")
+   curl -s -6 --max-time 3 "http://[$CACHED_IP]:9999/health"
+   ```
+3. If `/health` returns `{"status":"ok"}`:
+   - Print: `WARM START ✓ — Skipping code-gen and build. Using cached session.`
+   - Print the cached function inventory from `vmFunctions`
+   - Set `DEVICE="http://[$CACHED_IP]:9999"` and jump straight to **Phase 4**
+4. If health check fails (app not running or tunnel IP changed):
+   - Print: `WARM START: Cache stale — re-discovering device...`
+   - Re-run device discovery (Phase 3 only), then jump to Phase 4 (code-gen already done)
+   - Update `tunnelIP` in the cache file
+
+**Session cache format** (`~/.gstack/ios-qa-session.json`):
+```json
+{
+  "bundleId": "com.example.MyApp",
+  "tunnelIP": "fdac:e671:bcd7::1",
+  "deviceId": "E111536C-...",
+  "appSourceDir": "/path/to/App/",
+  "vmFunctions": {
+    "WorkoutViewModel": ["addWorkout(_:)", "removeWorkout(at:)", "toggleUnit()"],
+    "StatsViewModel": ["calculateStreak(from:)"]
+  },
+  "actionKeys": ["WorkoutVM_addWorkout", "WorkoutVM_removeWorkout", "ProfileVM_toggleUnit"],
+  "generatedAt": "2026-05-17T00:00:00Z"
+}
+```
+
+**Write the session cache** after a successful Phase 2 build (or after first successful
+`/health` response). Always overwrite — the newest successful session wins.
+
+```bash
+python3 -c "
+import json, datetime
+cache = {
+  'bundleId': 'BUNDLE_ID',
+  'tunnelIP': 'TUNNEL_IP',
+  'deviceId': 'DEVICE_ID',
+  'appSourceDir': 'APP_SOURCE_DIR',
+  'vmFunctions': VM_FUNCTIONS_DICT,
+  'actionKeys': ACTION_KEYS_LIST,
+  'generatedAt': datetime.datetime.utcnow().isoformat() + 'Z'
+}
+json.dump(cache, open('/Users/sinmat/.gstack/ios-qa-session.json', 'w'), indent=2)
+print('Session cached.')
+"
+```
+
+---
+
+## Rapid Mode
+
+If the user says "rapid", "fast", "quick test", "quick qa", or "speed run":
+
+**RAPID MODE** is active. This mode is optimized purely for speed.
+
+1. **Use Sonnet for ALL phases** — no Opus anywhere, even for test plan and report.
+2. **Batch everything.** Combine all state reads into single bash calls. Never make
+   a separate curl call for something you can read in the same script.
+3. **No narration.** Skip the "Tapping the + button..." text. Just act.
+4. **Minimal screenshots.** Take one screenshot per new screen only. Skip screenshots
+   for state-only tests (use `/state` reads exclusively). Still capture bug evidence.
+5. **No pauses.** Remove all `sleep` calls.
+6. **Blitz the test plan.** Run tests in parallel where possible — inject state for
+   multiple tests, then read all results in one batch.
+7. **Terse report.** Bug list only, no prose. One line per bug: `BUG: [what] [screen] [evidence]`
+
+**Rapid mode target:** Complete a full QA pass in under 90 seconds after warm start.
+
+Rapid mode is compatible with warm start — both can be active simultaneously.
+
+---
+
 You are an expert iOS QA tester. You connect to a real app running on a real
 iPhone via USB, read its source code, then run a browser-agent-loop to
 systematically find bugs: screenshot → identify elements → choose action →
@@ -40,6 +126,7 @@ Claude Code (this skill — YOU)
         ├── POST /tap                → inject tap at {x, y} pixel coords
         ├── POST /swipe              → inject swipe {fromX, fromY, toX, toY}
         ├── POST /type               → type text into focused field
+        ├── POST /dismiss            → close the topmost sheet/alert/modal
         ├── GET  /device             → device info (model, screen size)
         ├── GET  /state              → list all registered state keys
         ├── GET  /state/{key}        → read @Observable property
@@ -53,15 +140,59 @@ Connection uses the CoreDevice USB tunnel (IPv6) — **NOT iproxy**.
 
 ## Performance Model
 
-Use **Sonnet** (fast model) for the QA execution loop. The agent loop needs speed
-over deep reasoning. Sonnet is fast enough to read accessibility trees, decide
-what to tap, and verify state. When spawning subagents for the QA loop, use
-`model: "sonnet"`.
+Use **Sonnet** (fast model) for:
+- Code-gen subagent (Phase 1+2) — mechanical file generation, no deep reasoning needed
+- QA execution loop (Phase 5) — reading accessibility trees, deciding taps, verifying state
+
+When spawning subagents, use `model: "sonnet"`.
 
 Use the **default model** (Opus) only for:
-- Initial source code analysis (Phase 1)
 - Test plan generation (Phase 4)
 - Final bug report synthesis (Phase 6)
+
+## Demo Mode
+
+If the user says "demo", "demo mode", "show me", or "I want to see it working",
+run in **DEMO MODE**. This changes how you interact with the app:
+
+**DEMO MODE OVERRIDES ALL OTHER RULES IN THIS FILE.** When demo mode is active,
+Rules 3, 7, and 8 in "Non-Negotiable Rules" below DO NOT APPLY. Demo mode rules
+take absolute precedence.
+
+**DEMO MODE rules:**
+
+1. **NEVER use action keys. NEVER use /state/ write endpoints. NEVER inject data
+   programmatically.** Every single interaction MUST go through the UI — tap
+   buttons, type into text fields, use pickers. The person watching the phone
+   must see EVERY action happen visually. If you call a /state/ write endpoint
+   or action key in demo mode, you have failed the demo. The entire point is
+   showing Claude controlling the phone like a human.
+
+2. **Tap. Every. Button.** To add an item: tap the + button, tap the text field,
+   type the name, tap Save. To toggle a setting: tap the Settings tab, tap the
+   toggle button. To delete: swipe the row, tap Delete. NO SHORTCUTS.
+
+3. **Take a screenshot after every action.** The viewer needs to see each step.
+
+4. **Navigate between tabs by tapping the tab bar.** Go to each screen visually.
+
+5. **If a button genuinely can't be tapped** (SwiftUI toolbar Save/Done), try
+   tapping it first anyway. If it fails, use /dismiss or the action key, and
+   say "This toolbar button can't be tapped programmatically — using the
+   direct API to complete this action." This should be RARE, not the default.
+
+6. **Pause between actions** (sleep 0.5-1s) so the viewer can follow on screen.
+
+7. **Narrate every action** with short text output:
+   "Tapping the + button to add a new pet..."
+   "Typing 'Buddy' into the name field..."
+   "Switching to Settings to check the weight unit..."
+
+8. **When you find a bug, call it out:**
+   "BUG FOUND: The weights didn't convert when I switched to kg!"
+
+**Speed does NOT matter in demo mode. Visual impact does.
+DO NOT USE ACTION KEYS. TAP THE ACTUAL BUTTONS.**
 
 ## Non-Negotiable Rules
 
@@ -213,6 +344,15 @@ curl -s -6 -X POST "$DEVICE/swipe" -d '{"fromX": 200, "fromY": 600, "toX": 200, 
 curl -s -6 -X POST "$DEVICE/type" -d '{"text": "hello@test.com"}'
 ```
 
+### Dismiss (close sheets/alerts/modals)
+```bash
+# Programmatically dismiss the topmost presented view controller
+curl -s -6 -X POST "$DEVICE/dismiss"
+# Returns: {"ok": true, "dismissed": "UISheetPresentationController"}
+```
+**Always use `/dismiss` instead of swiping down to close sheets.** Swiping down
+scrolls the sheet's content instead of dismissing it.
+
 ### State Read/Write
 ```bash
 # List all state keys
@@ -225,56 +365,76 @@ curl -s -6 "$DEVICE/state/CartViewModel_total"
 curl -s -6 -X POST "$DEVICE/state/CartViewModel_items" -d '[]'
 ```
 
-## Phase 1: Analyze Source
+## Phase 1+2: Analyze Source & Generate DebugBridge (PARALLEL)
 
-```bash
-find . -maxdepth 3 \( -name "*.xcodeproj" -o -name "Package.swift" \) -not -path "*/DebugBridge/*"
-```
+**These phases run simultaneously to save time.** Use a Sonnet subagent for
+code-gen while the main agent discovers the device.
 
-Read every file to understand:
-- What screens exist (Views)
-- What state exists (ViewModels with @Observable)
-- What flows are possible (navigation, buttons, forms)
-- What could go wrong (force unwraps, missing recalculations, bad URLs, layout issues)
+### FAST START: Launch these in parallel (single message, multiple tool calls):
 
-## Phase 2: Generate DebugBridge (if needed)
+1. **Agent (Sonnet): Code-Gen** — handles source analysis + file generation
+2. **Main agent: Device discovery** — finds tunnel IP, verifies connection
 
-If not already generated, create the DebugBridge package and accessors.
+### Code-Gen Subagent Instructions (Sonnet)
 
-### Step 2a: Copy templates VERBATIM
-
-Read the templates from `~/.claude/skills/ios-qa/templates/` and copy them
-directly. **Do NOT rewrite from memory or simplify.**
-
-- `StateServer.swift.template` → copy to `<AppSource>/DebugBridgeGenerated/StateServer.swift`
-  (Replace `{{PLACEHOLDER}}` tokens only. Keep the tap priority chain intact.)
-- `DebugOverlay.swift.template` → copy to `<AppSource>/DebugBridgeGenerated/DebugOverlay.swift`
-  (Keep all 4 glow layers, GeometryReader, double .ignoresSafeArea)
-
-### Step 2b: Generate app-specific accessors
-
-App-specific accessors go in `<AppSource>/DebugBridgeGenerated/`:
-- `DebugBridgeManager.swift` — starts StateServer, registers all accessors
-- `<ClassName>Accessor.swift` — per-class state read/write registrations
-
-### Step 2c: Enumerate ALL functions (MANDATORY before build)
-
-For EVERY @Observable class, grep for `func ` and generate an action key for
-each one. Print the inventory:
+The code-gen subagent receives this brief:
 
 ```
-FUNCTION INVENTORY:
-  WorkoutViewModel.addWorkout(_:)     → WorkoutViewModel_addWorkout (JSON body)
-  WorkoutViewModel.removeWorkout(at:) → WorkoutViewModel_removeWorkout (index)
-  ProfileViewModel.toggleUnit()       → ProfileViewModel_toggleUnit (no params)
+You are generating DebugBridge files for an iOS app. Do this FAST:
+
+1. Find the Xcode project: find . -maxdepth 3 \( -name "*.xcodeproj" -o -name "Package.swift" \)
+2. Read ALL @Observable ViewModel files (grep -r "@Observable" --include="*.swift")
+3. Read the templates from ~/.claude/skills/ios-qa/templates/
+4. Create <AppSource>/DebugBridgeGenerated/ with:
+   - StateServer.swift (COPY template verbatim, only change #if guard to "#if DEBUG && canImport(UIKit)")
+   - DebugOverlay.swift (COPY template verbatim, add "#if DEBUG && canImport(UIKit)" + "import UIKit")
+   - DebugBridgeManager.swift (wire up all ViewModels)
+   - One <ClassName>Accessor.swift per @Observable class
+
+CRITICAL: For EVERY `func` in every @Observable class, generate an action key.
+No exceptions. Print the function inventory when done.
+```
+
+### What the code-gen subagent MUST do:
+
+1. **Copy `StateServer.swift.template` verbatim** — do NOT rewrite or simplify.
+   Only change: add `#if DEBUG && canImport(UIKit)` guard + `import UIKit`.
+
+2. **Copy `DebugOverlay.swift.template` verbatim** — keep all 4 glow layers,
+   GeometryReader, double `.ignoresSafeArea()`.
+
+3. **Generate complete accessors** with action keys for EVERY function:
+
+```
+FUNCTION INVENTORY (print this when done):
+  WorkoutViewModel.addWorkout(_:)       → WorkoutViewModel_addWorkout (JSON body)
+  WorkoutViewModel.removeWorkout(at:)   → WorkoutViewModel_removeWorkout (index)
+  ProfileViewModel.toggleUnit()         → ProfileViewModel_toggleUnit (no params)
   StatsViewModel.calculateStreak(from:) → StatsViewModel_calculateStreak (trigger)
 
-  Total functions: 4
-  Action keys generated: 4
-  Missing: 0 ← MUST BE ZERO
+  Total functions: 4 | Action keys generated: 4 | Missing: 0
 ```
 
-Only proceed to build after missing = 0.
+4. **Wire up ContentView** — add `.debugBridgeOverlay()` and `.onAppear { DebugBridgeManager.shared.start(...) }`
+
+5. **Build** — run `xcodebuild` and fix any errors.
+
+### Skip if already generated
+
+If `<AppSource>/DebugBridgeGenerated/StateServer.swift` exists AND responds to
+`/health`, skip code-gen entirely. Just verify action keys are complete by
+reading the accessor files and checking against the ViewModel functions.
+
+### Main agent: Device Discovery (runs in parallel with code-gen)
+
+While code-gen runs, discover the device:
+
+```bash
+xcrun devicectl list devices 2>&1 | grep "connected"
+xcrun devicectl device info details --device <ID> 2>&1 | grep tunnelIPAddress
+```
+
+By the time code-gen + build finishes, you already have the tunnel IP ready.
 
 ### CRITICAL: Complete Code-Gen FIRST — PRE-FLIGHT GATE
 
@@ -385,6 +545,8 @@ server.registerWrite("StatsVM_calculateStats") { _ in
 - SwiftUI `Button` inside `List` or `Form` cells
 - SwiftUI `Sheet` dismiss/confirm buttons
 - Any SwiftUI button wrapped in host views (UIKitBarItemHost, CellHostingView)
+- **Swiping down to dismiss a sheet** — use `POST /dismiss` instead (swipe scrolls
+  the sheet content instead of dismissing it)
 
 **Rule: ONE build, then pure QA. Never rebuild mid-test.**
 

--- a/ios-qa/SKILL.md.tmpl
+++ b/ios-qa/SKILL.md.tmpl
@@ -85,6 +85,18 @@ Use the **default model** (Opus) only for:
 5. **Only report bugs you can prove.** Each bug needs evidence: a state read
    showing wrong value, or a screenshot showing visual breakage.
 
+6. **NEVER rebuild during QA.** All code-gen (action keys, injection helpers,
+   state accessors) must be complete BEFORE the first test runs. If you discover
+   you need a new state key mid-QA, that means code-gen was incomplete — note it
+   as a limitation, don't rebuild. The QA phase is read-only on the source.
+
+7. **Use action keys over UI taps for state mutations.** Tapping SwiftUI buttons
+   inside List/Form cells is unreliable. Action keys are instant and never fail.
+   Only tap when testing navigation or verifying button existence.
+
+8. **Batch state reads.** Combine multiple `curl` calls into a single Bash
+   invocation. Don't make 5 separate tool calls when one bash script handles all 5.
+
 ## The Agent Loop
 
 This is a **fast agent loop** optimized for speed. Use /elements and /state for
@@ -233,6 +245,46 @@ App-specific accessors go in `<AppSource>/DebugBridgeGenerated/`:
 - `<ClassName>Accessor.swift` — per-class state read/write registrations
 - `DebugBridgeJSON.swift` — serialization helpers
 
+### CRITICAL: Complete Code-Gen FIRST
+
+**Generate ALL accessors before building.** This includes:
+
+1. **Property reads** — every `var` in @Observable classes gets a read key
+2. **Property writes** — every mutable `var` gets a write key
+3. **Action keys** — every mutating `func` gets a write key that invokes it directly
+4. **Data injection** — for any `func addX(item)`, also generate an injection key
+   that accepts CSV params (e.g., `"name,sets,reps,weight,daysAgo"`) so the agent
+   can create test data with specific dates/values without using the UI
+
+**Why this matters:** If you skip action keys, the QA agent will fail to tap
+SwiftUI buttons inside List cells (a known limitation), then need to add keys
+mid-QA, triggering a rebuild cycle. Each rebuild costs ~2 minutes. By front-loading
+ALL keys, the agent does ONE build and never rebuilds during testing.
+
+**Example action keys to always generate:**
+```swift
+// For: func toggleUnit()
+server.registerWrite("ProfileVM_toggleUnit") { _ in instance.toggleUnit(); return true }
+
+// For: func addItem(_ item: Item)  — also generate injection helper
+server.registerWrite("CartVM_addItem") { value in
+    // CSV: "name,price,quantity,daysAgo"
+    let parts = value.split(separator: ",").map(String.init)
+    guard parts.count >= 3 else { return false }
+    // ... parse and create item with optional date offset
+    instance.addItem(item)
+    return true
+}
+
+// For: func calculateStats(from items: [Item])
+server.registerWrite("StatsVM_calculateStats") { _ in
+    instance.calculateStats(from: otherVM.items)
+    return true
+}
+```
+
+**Rule: ONE build, then pure QA. Never rebuild mid-test.**
+
 ## Phase 3: Connect
 
 ```bash
@@ -257,67 +309,96 @@ curl -s -6 "$DEVICE/state"
 
 ## Phase 4: Build Test Plan
 
-Based on source analysis, plan tests:
+Based on source analysis, plan tests. **Prefer action keys over UI taps** for
+state mutations — they're instant, never fail, and skip SwiftUI tap issues.
+Only tap the UI when testing the tap itself (e.g., navigation, button visibility).
 
 ```
 TEST 1: Home screen renders correctly
-  - screenshot → verify hero, categories, products visible
-  
+  - screenshot → verify layout, elements visible
+
 TEST 2: Add to cart flow
   - read CartViewModel_items → should be []
-  - find "Add to Cart" button via /elements
-  - tap it
-  - read CartViewModel_items → should have 1 item
-  - read CartViewModel_total → should match price
+  - POST /state/CartViewModel_addItem with "Widget,9.99,1,0"
+  - read CartViewModel_items ��� should have 1 item
+  - read CartViewModel_total → should be 9.99
 
 TEST 3: Quantity change updates total
-  - add item, read total → T1
-  - increment quantity via UI
+  - inject item via action key, read total → T1
+  - POST /state/CartViewModel_updateQuantity with "itemId,2"
   - read total → T2
-  - assert T2 == T1 * new_quantity (if not → BUG)
+  - assert T2 == T1 * 2 (if not → BUG)
+
+TEST 4: Unit conversion
+  - read ProfileVM_unit → "lbs", read ProfileVM_goal → 10000
+  - POST /state/ProfileVM_toggleUnit (action key)
+  - read ProfileVM_unit → "kg", read ProfileVM_goal → should be ~4535
+  - if goal > 10000 → BUG (multiplied instead of divided)
 ```
+
+**Key principle:** Use action keys to SET UP state for testing. Use UI taps only
+to test the UI itself. This makes tests 10x faster and eliminates false failures
+from tap-targeting issues.
 
 ## Phase 5: Execute — The Agent Loop
 
+**Speed targets:** Most tests should complete in under 30 seconds each.
+A 5-bug app should finish in under 4 minutes total (not 11).
+
 For each test, run the loop:
 
-### 5a. Screenshot + Vision
+### 5a. State-first approach (FAST — no UI interaction needed)
 ```bash
-mkdir -p /tmp/ios-qa
-curl -s -6 "$DEVICE/screenshot" | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" > /tmp/ios-qa/screen.png
-```
-Then **Read** `/tmp/ios-qa/screen.png` and analyze what you see.
+DEVICE="http://[TUNNEL_IP]:9999"
 
-### 5b. Get elements
+# Inject test data via action keys (instant, never fails)
+curl -s -6 -X POST "$DEVICE/state/WorkoutVM_addItem" -d 'Squat,3,10,135,0'
+curl -s -6 -X POST "$DEVICE/state/WorkoutVM_addItem" -d 'Bench,3,10,185,3'
+
+# Invoke function under test
+curl -s -6 -X POST "$DEVICE/state/ProfileVM_toggleUnit" -d ''
+
+# Read state — compare actual vs expected
+curl -s -6 "$DEVICE/state/ProfileVM_goalVolume"
+curl -s -6 "$DEVICE/state/WorkoutVM_weeklyVolume"
+```
+
+### 5b. Get elements (when testing UI presence/navigation)
 ```bash
 curl -s -6 "$DEVICE/elements"
 ```
 Find the element you want to interact with. Note its `center.x` and `center.y`.
 
-### 5c. Perform action
+### 5c. Tap only when testing the TAP ITSELF
 ```bash
-# Tap a button
-curl -s -6 -X POST "$DEVICE/tap" -d '{"x": 207, "y": 543}'
+# Navigate between tabs
+curl -s -6 -X POST "$DEVICE/tap" -d '{"x": 115, "y": 822}'
 
-# Or type into a field
+# Type into a focused field
 curl -s -6 -X POST "$DEVICE/type" -d '{"text": "test@example.com"}'
-
-# Or swipe to scroll
-curl -s -6 -X POST "$DEVICE/swipe" -d '{"fromX":200,"fromY":600,"toX":200,"toY":200}'
 ```
 
-### 5d. Verify state
+### 5d. Screenshot only for visual bugs
 ```bash
-curl -s -6 "$DEVICE/state/CartViewModel_total"
-# Compare to expected value
+mkdir -p /tmp/ios-qa
+# Only when checking: layout, overflow, visual state, evidence for report
+curl -s -6 "$DEVICE/screenshot" | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" > /tmp/ios-qa/screen.png
 ```
 
-### 5e. Screenshot again to confirm visual state
+### 5e. Batch multiple state checks in one command
 ```bash
-curl -s -6 "$DEVICE/screenshot" | python3 -c "import sys,json,base64; sys.stdout.buffer.write(base64.b64decode(json.load(sys.stdin)['image']))" > /tmp/ios-qa/after.png
+# Check multiple values in a single bash call — faster than separate curls
+DEVICE="http://[TUNNEL_IP]:9999"
+echo "volume: $(curl -s -6 $DEVICE/state/WorkoutVM_weeklyVolume)"
+echo "best: $(curl -s -6 $DEVICE/state/WorkoutVM_personalBest)"
+echo "count: $(curl -s -6 $DEVICE/state/WorkoutVM_workouts_count)"
 ```
 
-### 5f. Loop back to 5a for next action
+### 5f. Move to next test immediately
+Do NOT screenshot between every action. Only screenshot when:
+- First visit to a new screen (baseline)
+- Suspected visual bug
+- Evidence capture for the final report
 
 ## Phase 6: Report
 

--- a/ios-qa/templates/DebugBridgeJSON.swift.template
+++ b/ios-qa/templates/DebugBridgeJSON.swift.template
@@ -1,0 +1,21 @@
+import Foundation
+
+#if DEBUG
+import DebugBridge
+
+enum DebugBridgeJSON {
+    static func stringify(_ object: Any) -> String {
+        if JSONSerialization.isValidJSONObject(object),
+           let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+           let json = String(data: data, encoding: .utf8) {
+            return json
+        }
+        return String(describing: object)
+    }
+
+    static func mutation(_ description: String) {
+        DebugBridgeNotifier.stateMutation()
+        DebugBridgeNotifier.action(description)
+    }
+}
+#endif

--- a/ios-qa/templates/DebugBridgeManager.swift.template
+++ b/ios-qa/templates/DebugBridgeManager.swift.template
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftUI
+
+#if DEBUG
+import DebugBridge
+
+@MainActor
+final class DebugBridgeManager {
+    static let shared = DebugBridgeManager()
+
+    private var server: StateServer?
+
+    private init() {}
+
+    func start(
+        {{INIT_PARAMS}}
+    ) {
+        if server != nil {
+            return
+        }
+
+        let server = StateServer()
+
+        {{ACCESSOR_REGISTRATIONS}}
+
+        server.start()
+        self.server = server
+
+        DebugBridgeNotifier.action("state server started")
+        print("[iStack] StateServer started on port 9999")
+    }
+
+    func stop() {
+        server?.stop()
+        server = nil
+        DebugBridgeNotifier.disconnected()
+        print("[iStack] StateServer stopped")
+    }
+}
+#endif

--- a/ios-qa/templates/DebugBridgeManager.swift.template
+++ b/ios-qa/templates/DebugBridgeManager.swift.template
@@ -26,6 +26,9 @@ final class DebugBridgeManager {
         server.start()
         self.server = server
 
+        // Install the overlay window ABOVE all other content (sheets, alerts, modals)
+        DebugOverlayWindow.shared.install()
+
         DebugBridgeNotifier.action("state server started")
         print("[iStack] StateServer started on port 9999")
     }

--- a/ios-qa/templates/DebugOverlay.swift.template
+++ b/ios-qa/templates/DebugOverlay.swift.template
@@ -9,118 +9,162 @@ public struct DebugOverlayView: View {
     @State private var lastAction = ""
     @State private var showingAction = false
     @State private var gradientRotation: Double = 0
-    @State private var borderWidth: CGFloat = 3
-    @State private var pulseOpacity: Double = 0
+    @State private var borderWidth: CGFloat = 5
+    @State private var pulseScale: CGFloat = 1.0
 
     public init() {}
 
     public var body: some View {
-        ZStack {
-            // Animated gradient border — flows around the screen edge
-            if isConnected {
-                RoundedRectangle(cornerRadius: 16)
-                    .strokeBorder(
-                        AngularGradient(
-                            gradient: Gradient(colors: [
-                                Color(red: 0.0, green: 0.5, blue: 1.0),   // blue
-                                Color(red: 0.0, green: 0.8, blue: 1.0),   // cyan
-                                Color(red: 0.4, green: 0.3, blue: 1.0),   // purple
-                                Color(red: 0.0, green: 0.6, blue: 1.0),   // blue-cyan
-                                Color(red: 0.2, green: 0.9, blue: 0.9),   // teal
-                                Color(red: 0.5, green: 0.2, blue: 1.0),   // violet
-                                Color(red: 0.0, green: 0.5, blue: 1.0),   // back to blue
-                            ]),
-                            center: .center,
-                            startAngle: .degrees(gradientRotation),
-                            endAngle: .degrees(gradientRotation + 360)
-                        ),
-                        lineWidth: borderWidth
-                    )
-                    .ignoresSafeArea()
-                    .onAppear {
-                        withAnimation(.linear(duration: 2.5).repeatForever(autoreverses: false)) {
-                            gradientRotation = 360
-                        }
-                    }
-
-                // Outer glow
-                RoundedRectangle(cornerRadius: 16)
-                    .strokeBorder(
-                        AngularGradient(
-                            gradient: Gradient(colors: [
-                                .cyan.opacity(0.3), .blue.opacity(0.1),
-                                .purple.opacity(0.3), .cyan.opacity(0.1),
-                                .blue.opacity(0.3), .purple.opacity(0.1),
-                                .cyan.opacity(0.3)
-                            ]),
-                            center: .center,
-                            startAngle: .degrees(gradientRotation + 180),
-                            endAngle: .degrees(gradientRotation + 540)
-                        ),
-                        lineWidth: 8
-                    )
-                    .blur(radius: 6)
-                    .ignoresSafeArea()
-            }
-
-            // Top debug bar with glassmorphism
-            VStack(spacing: 0) {
+        GeometryReader { geo in
+            ZStack {
                 if isConnected {
-                    HStack(spacing: 8) {
-                        // Glowing connection dot
-                        Circle()
-                            .fill(Color.cyan)
-                            .frame(width: 6, height: 6)
-                            .shadow(color: .cyan, radius: 4)
-                            .shadow(color: .cyan, radius: 8)
+                    // Layer 1: Outermost aura — wide, soft, fades inward from edges
+                    RoundedRectangle(cornerRadius: 44)
+                        .strokeBorder(
+                            AngularGradient(
+                                gradient: Gradient(colors: [
+                                    .cyan.opacity(0.15), .blue.opacity(0.05),
+                                    .purple.opacity(0.15), .cyan.opacity(0.05),
+                                    .blue.opacity(0.15), .purple.opacity(0.05),
+                                    .cyan.opacity(0.15)
+                                ]),
+                                center: .center,
+                                startAngle: .degrees(gradientRotation + 90),
+                                endAngle: .degrees(gradientRotation + 450)
+                            ),
+                            lineWidth: 40
+                        )
+                        .blur(radius: 20)
+                        .scaleEffect(pulseScale)
 
-                        Text("Claude is debugging")
-                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                            .foregroundStyle(
-                                LinearGradient(
-                                    colors: [.white, .cyan.opacity(0.9)],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
+                    // Layer 2: Mid glow — tighter, more color
+                    RoundedRectangle(cornerRadius: 30)
+                        .strokeBorder(
+                            AngularGradient(
+                                gradient: Gradient(colors: [
+                                    .cyan.opacity(0.4), .blue.opacity(0.2),
+                                    .purple.opacity(0.4), .cyan.opacity(0.2),
+                                    .blue.opacity(0.4), .purple.opacity(0.2),
+                                    .cyan.opacity(0.4)
+                                ]),
+                                center: .center,
+                                startAngle: .degrees(gradientRotation + 180),
+                                endAngle: .degrees(gradientRotation + 540)
+                            ),
+                            lineWidth: 16
+                        )
+                        .blur(radius: 8)
+
+                    // Layer 3: Core border — sharp, vibrant, animated rotation
+                    RoundedRectangle(cornerRadius: 20)
+                        .strokeBorder(
+                            AngularGradient(
+                                gradient: Gradient(colors: [
+                                    Color(red: 0.0, green: 0.5, blue: 1.0),
+                                    Color(red: 0.0, green: 0.85, blue: 1.0),
+                                    Color(red: 0.4, green: 0.3, blue: 1.0),
+                                    Color(red: 0.0, green: 0.7, blue: 1.0),
+                                    Color(red: 0.2, green: 0.9, blue: 0.9),
+                                    Color(red: 0.5, green: 0.2, blue: 1.0),
+                                    Color(red: 0.0, green: 0.5, blue: 1.0),
+                                ]),
+                                center: .center,
+                                startAngle: .degrees(gradientRotation),
+                                endAngle: .degrees(gradientRotation + 360)
+                            ),
+                            lineWidth: borderWidth
+                        )
+
+                    // Layer 4: Inner tint — subtle color wash bleeding inward
+                    RoundedRectangle(cornerRadius: 20)
+                        .fill(
+                            RadialGradient(
+                                gradient: Gradient(colors: [
+                                    .clear,
+                                    .clear,
+                                    .clear,
+                                    .cyan.opacity(0.03),
+                                    .blue.opacity(0.06)
+                                ]),
+                                center: .center,
+                                startRadius: min(geo.size.width, geo.size.height) * 0.3,
+                                endRadius: max(geo.size.width, geo.size.height) * 0.55
                             )
+                        )
+                }
+
+                // Top debug bar with glassmorphism
+                VStack(spacing: 0) {
+                    if isConnected {
+                        HStack(spacing: 8) {
+                            // Glowing connection dot
+                            Circle()
+                                .fill(Color.cyan)
+                                .frame(width: 7, height: 7)
+                                .shadow(color: .cyan, radius: 4)
+                                .shadow(color: .cyan.opacity(0.6), radius: 8)
+                                .shadow(color: .cyan.opacity(0.3), radius: 12)
+
+                            Text("Claude is controlling")
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(
+                                    LinearGradient(
+                                        colors: [.white, .cyan.opacity(0.9)],
+                                        startPoint: .leading,
+                                        endPoint: .trailing
+                                    )
+                                )
+
+                            Spacer()
+
+                            if showingAction {
+                                Text(lastAction)
+                                    .font(.system(size: 10, weight: .regular, design: .monospaced))
+                                    .foregroundColor(.white.opacity(0.6))
+                                    .lineLimit(1)
+                                    .transition(.opacity.combined(with: .move(edge: .trailing)))
+                            }
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 7)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(.ultraThinMaterial)
+                                .environment(\.colorScheme, .dark)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .strokeBorder(
+                                            LinearGradient(
+                                                colors: [.white.opacity(0.25), .clear, .cyan.opacity(0.15)],
+                                                startPoint: .topLeading,
+                                                endPoint: .bottomTrailing
+                                            ),
+                                            lineWidth: 0.5
+                                        )
+                                )
+                                .shadow(color: .cyan.opacity(0.2), radius: 8, y: 2)
+                        )
+                        .padding(.horizontal, 12)
+                        .padding(.top, getSafeAreaTop() + 4)
 
                         Spacer()
-
-                        if showingAction {
-                            Text(lastAction)
-                                .font(.system(size: 10, weight: .regular, design: .monospaced))
-                                .foregroundColor(.white.opacity(0.6))
-                                .transition(.opacity.combined(with: .move(edge: .trailing)))
-                        }
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 6)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(.ultraThinMaterial)
-                            .environment(\.colorScheme, .dark)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .strokeBorder(
-                                        LinearGradient(
-                                            colors: [.white.opacity(0.2), .clear, .white.opacity(0.1)],
-                                            startPoint: .topLeading,
-                                            endPoint: .bottomTrailing
-                                        ),
-                                        lineWidth: 0.5
-                                    )
-                            )
-                    )
-                    .padding(.horizontal, 8)
-                    .padding(.top, getSafeAreaTop() + 4)
-
-                    Spacer()
                 }
             }
+            .ignoresSafeArea()
         }
+        .ignoresSafeArea()
         .allowsHitTesting(false)
+        .onAppear {
+            withAnimation(.linear(duration: 3.0).repeatForever(autoreverses: false)) {
+                gradientRotation = 360
+            }
+            withAnimation(.easeInOut(duration: 2.0).repeatForever(autoreverses: true)) {
+                pulseScale = 1.02
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .debugBridgeConnected)) { _ in
-            withAnimation(.easeInOut(duration: 0.5)) {
+            withAnimation(.easeInOut(duration: 0.6)) {
                 isConnected = true
             }
         }
@@ -131,7 +175,7 @@ public struct DebugOverlayView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .debugBridgeAction)) { notification in
             if let action = notification.userInfo?["action"] as? String {
-                lastAction = action
+                lastAction = String(action.prefix(30))
                 withAnimation(.easeInOut(duration: 0.2)) { showingAction = true }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                     withAnimation(.easeOut(duration: 0.3)) { showingAction = false }
@@ -139,13 +183,13 @@ public struct DebugOverlayView: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .debugBridgeStateMutation)) { _ in
-            // Pulse the border on state mutations
-            withAnimation(.easeIn(duration: 0.1)) {
-                borderWidth = 6
+            // Pulse border thicker on state mutations
+            withAnimation(.easeIn(duration: 0.08)) {
+                borderWidth = 9
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                withAnimation(.easeOut(duration: 0.4)) {
-                    borderWidth = 3
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    borderWidth = 5
                 }
             }
         }

--- a/ios-qa/templates/DebugOverlay.swift.template
+++ b/ios-qa/templates/DebugOverlay.swift.template
@@ -1,0 +1,204 @@
+import SwiftUI
+
+#if DEBUG
+
+// MARK: - Debug Overlay View
+
+public struct DebugOverlayView: View {
+    @State private var isConnected = false
+    @State private var lastAction = ""
+    @State private var showingAction = false
+    @State private var gradientRotation: Double = 0
+    @State private var borderWidth: CGFloat = 3
+    @State private var pulseOpacity: Double = 0
+
+    public init() {}
+
+    public var body: some View {
+        ZStack {
+            // Animated gradient border — flows around the screen edge
+            if isConnected {
+                RoundedRectangle(cornerRadius: 16)
+                    .strokeBorder(
+                        AngularGradient(
+                            gradient: Gradient(colors: [
+                                Color(red: 0.0, green: 0.5, blue: 1.0),   // blue
+                                Color(red: 0.0, green: 0.8, blue: 1.0),   // cyan
+                                Color(red: 0.4, green: 0.3, blue: 1.0),   // purple
+                                Color(red: 0.0, green: 0.6, blue: 1.0),   // blue-cyan
+                                Color(red: 0.2, green: 0.9, blue: 0.9),   // teal
+                                Color(red: 0.5, green: 0.2, blue: 1.0),   // violet
+                                Color(red: 0.0, green: 0.5, blue: 1.0),   // back to blue
+                            ]),
+                            center: .center,
+                            startAngle: .degrees(gradientRotation),
+                            endAngle: .degrees(gradientRotation + 360)
+                        ),
+                        lineWidth: borderWidth
+                    )
+                    .ignoresSafeArea()
+                    .onAppear {
+                        withAnimation(.linear(duration: 2.5).repeatForever(autoreverses: false)) {
+                            gradientRotation = 360
+                        }
+                    }
+
+                // Outer glow
+                RoundedRectangle(cornerRadius: 16)
+                    .strokeBorder(
+                        AngularGradient(
+                            gradient: Gradient(colors: [
+                                .cyan.opacity(0.3), .blue.opacity(0.1),
+                                .purple.opacity(0.3), .cyan.opacity(0.1),
+                                .blue.opacity(0.3), .purple.opacity(0.1),
+                                .cyan.opacity(0.3)
+                            ]),
+                            center: .center,
+                            startAngle: .degrees(gradientRotation + 180),
+                            endAngle: .degrees(gradientRotation + 540)
+                        ),
+                        lineWidth: 8
+                    )
+                    .blur(radius: 6)
+                    .ignoresSafeArea()
+            }
+
+            // Top debug bar with glassmorphism
+            VStack(spacing: 0) {
+                if isConnected {
+                    HStack(spacing: 8) {
+                        // Glowing connection dot
+                        Circle()
+                            .fill(Color.cyan)
+                            .frame(width: 6, height: 6)
+                            .shadow(color: .cyan, radius: 4)
+                            .shadow(color: .cyan, radius: 8)
+
+                        Text("Claude is debugging")
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(
+                                LinearGradient(
+                                    colors: [.white, .cyan.opacity(0.9)],
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                )
+                            )
+
+                        Spacer()
+
+                        if showingAction {
+                            Text(lastAction)
+                                .font(.system(size: 10, weight: .regular, design: .monospaced))
+                                .foregroundColor(.white.opacity(0.6))
+                                .transition(.opacity.combined(with: .move(edge: .trailing)))
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(.ultraThinMaterial)
+                            .environment(\.colorScheme, .dark)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .strokeBorder(
+                                        LinearGradient(
+                                            colors: [.white.opacity(0.2), .clear, .white.opacity(0.1)],
+                                            startPoint: .topLeading,
+                                            endPoint: .bottomTrailing
+                                        ),
+                                        lineWidth: 0.5
+                                    )
+                            )
+                    )
+                    .padding(.horizontal, 8)
+                    .padding(.top, getSafeAreaTop() + 4)
+
+                    Spacer()
+                }
+            }
+        }
+        .allowsHitTesting(false)
+        .onReceive(NotificationCenter.default.publisher(for: .debugBridgeConnected)) { _ in
+            withAnimation(.easeInOut(duration: 0.5)) {
+                isConnected = true
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .debugBridgeDisconnected)) { _ in
+            withAnimation(.easeInOut(duration: 0.3)) {
+                isConnected = false
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .debugBridgeAction)) { notification in
+            if let action = notification.userInfo?["action"] as? String {
+                lastAction = action
+                withAnimation(.easeInOut(duration: 0.2)) { showingAction = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    withAnimation(.easeOut(duration: 0.3)) { showingAction = false }
+                }
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .debugBridgeStateMutation)) { _ in
+            // Pulse the border on state mutations
+            withAnimation(.easeIn(duration: 0.1)) {
+                borderWidth = 6
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                withAnimation(.easeOut(duration: 0.4)) {
+                    borderWidth = 3
+                }
+            }
+        }
+    }
+
+    private func getSafeAreaTop() -> CGFloat {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first { $0.isKeyWindow }?
+            .safeAreaInsets.top ?? 0
+    }
+}
+
+// MARK: - Notification Names
+
+extension Notification.Name {
+    public static let debugBridgeConnected = Notification.Name("debugBridgeConnected")
+    public static let debugBridgeDisconnected = Notification.Name("debugBridgeDisconnected")
+    public static let debugBridgeAction = Notification.Name("debugBridgeAction")
+    public static let debugBridgeStateMutation = Notification.Name("debugBridgeStateMutation")
+}
+
+// MARK: - Notifier
+
+public enum DebugBridgeNotifier {
+    public static func connected() {
+        NotificationCenter.default.post(name: .debugBridgeConnected, object: nil)
+    }
+
+    public static func disconnected() {
+        NotificationCenter.default.post(name: .debugBridgeDisconnected, object: nil)
+    }
+
+    public static func action(_ description: String) {
+        NotificationCenter.default.post(
+            name: .debugBridgeAction,
+            object: nil,
+            userInfo: ["action": description]
+        )
+    }
+
+    public static func stateMutation() {
+        NotificationCenter.default.post(name: .debugBridgeStateMutation, object: nil)
+    }
+}
+
+// MARK: - View Extension
+
+public extension View {
+    func debugBridgeOverlay() -> some View {
+        self.overlay(DebugOverlayView())
+    }
+}
+
+#endif

--- a/ios-qa/templates/DebugOverlay.swift.template
+++ b/ios-qa/templates/DebugOverlay.swift.template
@@ -1,8 +1,89 @@
 import SwiftUI
 
-#if DEBUG
+#if DEBUG && canImport(UIKit)
+import UIKit
+
+// MARK: - Overlay Window (stays above sheets, alerts, and modals)
+
+@MainActor
+public final class DebugOverlayWindow {
+    public static let shared = DebugOverlayWindow()
+    private var window: UIWindow?
+
+    private init() {}
+
+    public func install() {
+        guard window == nil else { return }
+        guard let scene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first else { return }
+
+        let overlayWindow = PassthroughWindow(windowScene: scene)
+        overlayWindow.windowLevel = .alert + 1
+        overlayWindow.backgroundColor = .clear
+        overlayWindow.isHidden = false
+
+        let hostingController = UIHostingController(rootView: DebugOverlayView())
+        hostingController.view.backgroundColor = .clear
+        hostingController.view.isAccessibilityElement = false
+        hostingController.view.accessibilityElementsHidden = true
+        overlayWindow.rootViewController = hostingController
+        overlayWindow.accessibilityElementsHidden = true
+
+        self.window = overlayWindow
+    }
+}
+
+class PassthroughWindow: UIWindow {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        return nil
+    }
+}
 
 // MARK: - Debug Overlay View
+
+struct TapRipple: Identifiable {
+    let id = UUID()
+    let x: CGFloat
+    let y: CGFloat
+}
+
+struct TapRippleView: View {
+    let ripple: TapRipple
+    let onComplete: () -> Void
+    @State private var ringScale: CGFloat = 0.1
+    @State private var ringOpacity: Double = 0.9
+    @State private var dotOpacity: Double = 1.0
+
+    var body: some View {
+        ZStack {
+            // Expanding ring
+            Circle()
+                .strokeBorder(Color.cyan.opacity(ringOpacity), lineWidth: 2)
+                .frame(width: 56, height: 56)
+                .scaleEffect(ringScale)
+
+            // Center dot
+            Circle()
+                .fill(Color.cyan.opacity(dotOpacity))
+                .frame(width: 10, height: 10)
+        }
+        .position(x: ripple.x, y: ripple.y)
+        .allowsHitTesting(false)
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.45)) {
+                ringScale = 1.0
+                ringOpacity = 0
+            }
+            withAnimation(.easeIn(duration: 0.15)) {
+                dotOpacity = 0
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                onComplete()
+            }
+        }
+    }
+}
 
 public struct DebugOverlayView: View {
     @State private var isConnected = false
@@ -11,6 +92,7 @@ public struct DebugOverlayView: View {
     @State private var gradientRotation: Double = 0
     @State private var borderWidth: CGFloat = 5
     @State private var pulseScale: CGFloat = 1.0
+    @State private var tapRipples: [TapRipple] = []
 
     public init() {}
 
@@ -93,63 +175,44 @@ public struct DebugOverlayView: View {
                         )
                 }
 
-                // Top debug bar with glassmorphism
-                VStack(spacing: 0) {
+                // Tap ripple animations
+                ForEach(tapRipples) { ripple in
+                    TapRippleView(ripple: ripple) {
+                        tapRipples.removeAll { $0.id == ripple.id }
+                    }
+                }
+
+                // Bottom-left compact pill (doesn't block toolbar buttons)
+                VStack {
+                    Spacer()
                     if isConnected {
-                        HStack(spacing: 8) {
-                            // Glowing connection dot
+                        HStack(spacing: 6) {
                             Circle()
                                 .fill(Color.cyan)
-                                .frame(width: 7, height: 7)
-                                .shadow(color: .cyan, radius: 4)
-                                .shadow(color: .cyan.opacity(0.6), radius: 8)
-                                .shadow(color: .cyan.opacity(0.3), radius: 12)
+                                .frame(width: 6, height: 6)
+                                .shadow(color: .cyan, radius: 3)
 
-                            Text("Claude is controlling")
-                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                                .foregroundStyle(
-                                    LinearGradient(
-                                        colors: [.white, .cyan.opacity(0.9)],
-                                        startPoint: .leading,
-                                        endPoint: .trailing
-                                    )
-                                )
-
-                            Spacer()
-
-                            if showingAction {
-                                Text(lastAction)
-                                    .font(.system(size: 10, weight: .regular, design: .monospaced))
-                                    .foregroundColor(.white.opacity(0.6))
-                                    .lineLimit(1)
-                                    .transition(.opacity.combined(with: .move(edge: .trailing)))
-                            }
+                            Text(showingAction ? lastAction : "Claude")
+                                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                                .foregroundColor(.white.opacity(0.8))
+                                .lineLimit(1)
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 7)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
                         .background(
-                            RoundedRectangle(cornerRadius: 12)
+                            Capsule()
                                 .fill(.ultraThinMaterial)
                                 .environment(\.colorScheme, .dark)
                                 .overlay(
-                                    RoundedRectangle(cornerRadius: 12)
-                                        .strokeBorder(
-                                            LinearGradient(
-                                                colors: [.white.opacity(0.25), .clear, .cyan.opacity(0.15)],
-                                                startPoint: .topLeading,
-                                                endPoint: .bottomTrailing
-                                            ),
-                                            lineWidth: 0.5
-                                        )
+                                    Capsule()
+                                        .strokeBorder(.white.opacity(0.15), lineWidth: 0.5)
                                 )
-                                .shadow(color: .cyan.opacity(0.2), radius: 8, y: 2)
                         )
-                        .padding(.horizontal, 12)
-                        .padding(.top, getSafeAreaTop() + 4)
-
-                        Spacer()
+                        .padding(.leading, 16)
+                        .padding(.bottom, getSafeAreaBottom() + 60)
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
             .ignoresSafeArea()
         }
@@ -183,7 +246,6 @@ public struct DebugOverlayView: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .debugBridgeStateMutation)) { _ in
-            // Pulse border thicker on state mutations
             withAnimation(.easeIn(duration: 0.08)) {
                 borderWidth = 9
             }
@@ -191,6 +253,12 @@ public struct DebugOverlayView: View {
                 withAnimation(.easeOut(duration: 0.5)) {
                     borderWidth = 5
                 }
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .debugBridgeTap)) { notification in
+            if let x = notification.userInfo?["x"] as? CGFloat,
+               let y = notification.userInfo?["y"] as? CGFloat {
+                tapRipples.append(TapRipple(x: x, y: y))
             }
         }
     }
@@ -202,6 +270,14 @@ public struct DebugOverlayView: View {
             .first { $0.isKeyWindow }?
             .safeAreaInsets.top ?? 0
     }
+
+    private func getSafeAreaBottom() -> CGFloat {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first { $0.isKeyWindow }?
+            .safeAreaInsets.bottom ?? 0
+    }
 }
 
 // MARK: - Notification Names
@@ -211,6 +287,7 @@ extension Notification.Name {
     public static let debugBridgeDisconnected = Notification.Name("debugBridgeDisconnected")
     public static let debugBridgeAction = Notification.Name("debugBridgeAction")
     public static let debugBridgeStateMutation = Notification.Name("debugBridgeStateMutation")
+    public static let debugBridgeTap = Notification.Name("debugBridgeTap")
 }
 
 // MARK: - Notifier
@@ -219,29 +296,17 @@ public enum DebugBridgeNotifier {
     public static func connected() {
         NotificationCenter.default.post(name: .debugBridgeConnected, object: nil)
     }
-
     public static func disconnected() {
         NotificationCenter.default.post(name: .debugBridgeDisconnected, object: nil)
     }
-
     public static func action(_ description: String) {
-        NotificationCenter.default.post(
-            name: .debugBridgeAction,
-            object: nil,
-            userInfo: ["action": description]
-        )
+        NotificationCenter.default.post(name: .debugBridgeAction, object: nil, userInfo: ["action": description])
     }
-
     public static func stateMutation() {
         NotificationCenter.default.post(name: .debugBridgeStateMutation, object: nil)
     }
-}
-
-// MARK: - View Extension
-
-public extension View {
-    func debugBridgeOverlay() -> some View {
-        self.overlay(DebugOverlayView())
+    public static func tap(at point: CGPoint) {
+        NotificationCenter.default.post(name: .debugBridgeTap, object: nil, userInfo: ["x": point.x, "y": point.y])
     }
 }
 

--- a/ios-qa/templates/Package.swift.template
+++ b/ios-qa/templates/Package.swift.template
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "DebugBridge",
+    platforms: [.iOS(.v17)],
+    products: [
+        .library(
+            name: "DebugBridge",
+            targets: ["DebugBridge"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "DebugBridge",
+            dependencies: [],
+            swiftSettings: [
+                .define("DEBUG", .when(configuration: .debug))
+            ]
+        ),
+    ]
+)

--- a/ios-qa/templates/StateAccessor.swift.template
+++ b/ios-qa/templates/StateAccessor.swift.template
@@ -11,6 +11,7 @@ enum {{CLASS_NAME}}Accessor {
     static func register(on server: StateServer, instance: {{CLASS_NAME}}) {
         {{READ_REGISTRATIONS}}
         {{WRITE_REGISTRATIONS}}
+        {{ACTION_REGISTRATIONS}}
     }
 }
 
@@ -35,5 +36,39 @@ enum {{CLASS_NAME}}Accessor {
 //   Bool:     value == "true" → instance.prop
 //   [T]:      if value == "[]" → instance.prop = []
 //   T?:       if value == "null" → instance.prop = nil
+//
+// --- Action registration pattern (generated per-function) ---
+//
+// For every `func` in the ViewModel that mutates state, generate an
+// action key so the QA agent can invoke it directly without tapping UI:
+//
+// ACTION (no params):
+//   server.registerWrite("{{CLASS_NAME}}_functionName") { _ in
+//       instance.functionName()
+//       return true
+//   }
+//
+// ACTION (with params, comma-separated body):
+//   server.registerWrite("{{CLASS_NAME}}_functionName") { value in
+//       let parts = value.split(separator: ",").map(String.init)
+//       guard let arg1 = Type(parts[0]) else { return false }
+//       instance.functionName(arg1: arg1)
+//       return true
+//   }
+//
+// ACTION (data injection — add items with specific dates for testing):
+//   server.registerWrite("{{CLASS_NAME}}_addItem") { value in
+//       // Parse CSV: "field1,field2,field3,daysAgo"
+//       let parts = value.split(separator: ",").map(String.init)
+//       guard parts.count >= N else { return false }
+//       let date = Date().addingTimeInterval(-(Double(parts.last!) ?? 0) * 86400)
+//       let item = ItemType(...)
+//       instance.addItem(item)
+//       return true
+//   }
+//
+// IMPORTANT: Generate action keys for ALL mutating functions during code-gen.
+// This eliminates the need to tap buttons for state mutations and prevents
+// mid-QA rebuild cycles. The agent can test any ViewModel function directly.
 
 #endif

--- a/ios-qa/templates/StateAccessor.swift.template
+++ b/ios-qa/templates/StateAccessor.swift.template
@@ -1,0 +1,39 @@
+import Foundation
+#if DEBUG
+import DebugBridge
+
+// Auto-generated state accessor for {{CLASS_NAME}}
+// DO NOT EDIT - regenerate with /ios-qa
+
+@MainActor
+enum {{CLASS_NAME}}Accessor {
+
+    static func register(on server: StateServer, instance: {{CLASS_NAME}}) {
+        {{READ_REGISTRATIONS}}
+        {{WRITE_REGISTRATIONS}}
+    }
+}
+
+// --- Registration pattern (generated per-property) ---
+//
+// READ:
+//   server.registerRead("{{CLASS_NAME}}_propertyName") {
+//       return "\(instance.propertyName)"
+//   }
+//
+// WRITE:
+//   server.registerWrite("{{CLASS_NAME}}_propertyName") { value in
+//       // parse value from JSON string body
+//       instance.propertyName = parsed
+//       return true
+//   }
+//
+// Type-specific patterns:
+//   String:   instance.prop = value (body is the raw string)
+//   Int:      Int(value) → instance.prop
+//   Double:   Double(value) → instance.prop
+//   Bool:     value == "true" → instance.prop
+//   [T]:      if value == "[]" → instance.prop = []
+//   T?:       if value == "null" → instance.prop = nil
+
+#endif

--- a/ios-qa/templates/StateServer.swift.template
+++ b/ios-qa/templates/StateServer.swift.template
@@ -65,15 +65,55 @@ public final class StateServer {
 
     private func handleConnection(_ connection: NWConnection) {
         connection.start(queue: .main)
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, error in
+        receiveFullRequest(on: connection, buffer: Data())
+    }
+
+    /// Accumulates data until the full HTTP request (headers + Content-Length body) is received.
+    /// This prevents partial-read bugs where POST bodies are truncated over USB tunnels.
+    private func receiveFullRequest(on connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
             Task { @MainActor in
-                guard let self = self, let data = data else {
-                    connection.cancel()
+                guard let self = self else { connection.cancel(); return }
+                guard let data = data, !data.isEmpty else {
+                    if buffer.isEmpty { connection.cancel(); return }
+                    self.handleRequest(buffer, on: connection)
                     return
                 }
-                self.handleRequest(data, on: connection)
+                var accumulated = buffer
+                accumulated.append(data)
+
+                // Check if we have the full request (headers + body based on Content-Length)
+                if let raw = String(data: accumulated, encoding: .utf8),
+                   let headerEnd = raw.range(of: "\r\n\r\n") {
+                    let headers = String(raw[..<headerEnd.lowerBound])
+                    let bodyStartIndex = raw.index(headerEnd.upperBound, offsetBy: 0)
+                    let bodyReceived = raw[bodyStartIndex...].utf8.count
+                    let contentLength = self.parseContentLength(from: headers)
+
+                    if bodyReceived >= contentLength {
+                        // Full request received
+                        self.handleRequest(accumulated, on: connection)
+                        return
+                    }
+                }
+
+                if isComplete {
+                    self.handleRequest(accumulated, on: connection)
+                } else {
+                    self.receiveFullRequest(on: connection, buffer: accumulated)
+                }
             }
         }
+    }
+
+    private func parseContentLength(from headers: String) -> Int {
+        for line in headers.components(separatedBy: "\r\n") {
+            if line.lowercased().hasPrefix("content-length:") {
+                let value = line.dropFirst("content-length:".count).trimmingCharacters(in: .whitespaces)
+                return Int(value) ?? 0
+            }
+        }
+        return 0
     }
 
     private func handleRequest(_ data: Data, on connection: NWConnection) {
@@ -224,20 +264,45 @@ public final class StateServer {
 
         // Find the hit target
         if let target = window.hitTest(point, with: nil) {
-            // Try accessibility activate
-            if target.accessibilityActivate() {
-                DebugBridgeNotifier.action("tap \(Int(x)),\(Int(y)) → \(type(of: target))")
-                return "{\"ok\":true,\"target\":\"\(type(of: target))\",\"label\":\"\(target.accessibilityLabel ?? "")\"}"
+            // Priority 1: UITextField — becomeFirstResponder for keyboard focus
+            if let textField = findTextField(from: target) {
+                textField.becomeFirstResponder()
+                DebugBridgeNotifier.action("tap \(Int(x)),\(Int(y)) → UITextField (focused)")
+                return "{\"ok\":true,\"target\":\"UITextField\",\"focused\":true}"
             }
 
-            // Try as UIControl
+            // Priority 2: UITextView — becomeFirstResponder
+            if let textView = findTextView(from: target) {
+                textView.becomeFirstResponder()
+                DebugBridgeNotifier.action("tap \(Int(x)),\(Int(y)) → UITextView (focused)")
+                return "{\"ok\":true,\"target\":\"UITextView\",\"focused\":true}"
+            }
+
+            // Priority 3: UIControl (buttons, switches, etc)
             if let control = findControl(from: target) {
                 control.sendActions(for: .touchUpInside)
                 DebugBridgeNotifier.action("tap \(Int(x)),\(Int(y)) → \(type(of: control))")
                 return "{\"ok\":true,\"target\":\"\(type(of: control))\",\"label\":\"\(control.accessibilityLabel ?? "")\"}"
             }
 
-            // Try gesture recognizers on the view hierarchy
+            // Priority 4: accessibilityActivate (catches SwiftUI buttons in some cases)
+            if target.accessibilityActivate() {
+                DebugBridgeNotifier.action("tap \(Int(x)),\(Int(y)) → \(type(of: target))")
+                return "{\"ok\":true,\"target\":\"\(type(of: target))\",\"label\":\"\(target.accessibilityLabel ?? "")\"}"
+            }
+
+            // Priority 5: Walk UP the hierarchy looking for any UIControl or activatable view
+            if let activatable = findActivatable(from: target) {
+                if let control = activatable as? UIControl {
+                    control.sendActions(for: .touchUpInside)
+                } else {
+                    activatable.accessibilityActivate()
+                }
+                DebugBridgeNotifier.action("tap \(Int(x)),\(Int(y)) → \(type(of: activatable)) (ancestor)")
+                return "{\"ok\":true,\"target\":\"\(type(of: activatable))\",\"method\":\"ancestor\",\"label\":\"\(activatable.accessibilityLabel ?? "")\"}"
+            }
+
+            // Priority 6: Gesture recognizers
             if activateGestureRecognizer(on: target) {
                 DebugBridgeNotifier.action("tap \(Int(x)),\(Int(y)) → gesture")
                 return "{\"ok\":true,\"target\":\"\(type(of: target))\",\"method\":\"gesture\"}"
@@ -250,10 +315,39 @@ public final class StateServer {
         return "{\"ok\":false,\"error\":\"no hit target at (\(x),\(y))\"}"
     }
 
+    private func findTextField(from view: UIView) -> UITextField? {
+        var current: UIView? = view
+        while let v = current {
+            if let tf = v as? UITextField { return tf }
+            current = v.superview
+        }
+        return nil
+    }
+
+    private func findTextView(from view: UIView) -> UITextView? {
+        var current: UIView? = view
+        while let v = current {
+            if let tv = v as? UITextView { return tv }
+            current = v.superview
+        }
+        return nil
+    }
+
     private func findControl(from view: UIView) -> UIControl? {
         var current: UIView? = view
         while let v = current {
             if let control = v as? UIControl { return control }
+            current = v.superview
+        }
+        return nil
+    }
+
+    private func findActivatable(from view: UIView) -> UIView? {
+        var current: UIView? = view.superview
+        while let v = current {
+            if v is UIControl { return v }
+            if v.accessibilityTraits.contains(.button) { return v }
+            if v.accessibilityTraits.contains(.link) { return v }
             current = v.superview
         }
         return nil

--- a/ios-qa/templates/StateServer.swift.template
+++ b/ios-qa/templates/StateServer.swift.template
@@ -1,0 +1,497 @@
+import Foundation
+import Network
+import UIKit
+
+#if DEBUG
+
+@MainActor
+public final class StateServer {
+    private var listener: NWListener?
+    private var readHandlers: [String: () -> String] = [:]
+    private var writeHandlers: [String: (String) -> Bool] = [:]
+    public private(set) var port: UInt16 = 0
+    private var hasConnected = false
+
+    public init() {}
+
+    public func registerRead(_ key: String, handler: @escaping @MainActor () -> String) {
+        readHandlers[key] = handler
+    }
+
+    public func registerWrite(_ key: String, handler: @escaping @MainActor (String) -> Bool) {
+        writeHandlers[key] = handler
+    }
+
+    public func start(port: UInt16 = 9999) {
+        do {
+            let params = NWParameters.tcp
+            listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
+
+            listener?.stateUpdateHandler = { [weak self] state in
+                Task { @MainActor in
+                    switch state {
+                    case .ready:
+                        if let p = self?.listener?.port?.rawValue {
+                            self?.port = p
+                            print("[DebugBridge] StateServer listening on http://localhost:\(p)")
+                        }
+                    case .failed(let error):
+                        print("[DebugBridge] StateServer failed: \(error)")
+                        self?.listener?.cancel()
+                    default:
+                        break
+                    }
+                }
+            }
+
+            listener?.newConnectionHandler = { [weak self] connection in
+                Task { @MainActor in
+                    self?.handleConnection(connection)
+                }
+            }
+
+            listener?.start(queue: .main)
+        } catch {
+            print("[DebugBridge] Failed to start StateServer: \(error)")
+        }
+    }
+
+    public func stop() {
+        listener?.cancel()
+        listener = nil
+    }
+
+    // MARK: - Connection Handling
+
+    private func handleConnection(_ connection: NWConnection) {
+        connection.start(queue: .main)
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, error in
+            Task { @MainActor in
+                guard let self = self, let data = data else {
+                    connection.cancel()
+                    return
+                }
+                self.handleRequest(data, on: connection)
+            }
+        }
+    }
+
+    private func handleRequest(_ data: Data, on connection: NWConnection) {
+        guard let raw = String(data: data, encoding: .utf8) else {
+            sendResponse(connection, status: 400, body: "{\"error\":\"bad request\"}")
+            return
+        }
+
+        if !hasConnected {
+            hasConnected = true
+            DebugBridgeNotifier.connected()
+        }
+
+        let lines = raw.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else {
+            sendResponse(connection, status: 400, body: "{\"error\":\"bad request\"}")
+            return
+        }
+
+        let parts = requestLine.split(separator: " ", maxSplits: 2)
+        guard parts.count >= 2 else {
+            sendResponse(connection, status: 400, body: "{\"error\":\"bad request\"}")
+            return
+        }
+
+        let method = String(parts[0])
+        let path = String(parts[1])
+        let body = extractBody(from: raw)
+
+        // Route dispatch
+        switch (method, path) {
+        case ("GET", "/health"):
+            sendResponse(connection, status: 200, body: "{\"status\":\"ok\"}")
+
+        case ("GET", "/state"):
+            let keys = Array(readHandlers.keys).sorted()
+            let json = "[\(keys.map { "\"\($0)\"" }.joined(separator: ","))]"
+            sendResponse(connection, status: 200, body: json)
+
+        case ("GET", _) where path.hasPrefix("/state/"):
+            let key = String(path.dropFirst("/state/".count))
+            if let handler = readHandlers[key] {
+                let value = handler()
+                sendResponse(connection, status: 200, body: value)
+                DebugBridgeNotifier.action("read \(key)")
+            } else {
+                sendResponse(connection, status: 404, body: "{\"error\":\"key not found\"}")
+            }
+
+        case ("POST", _) where path.hasPrefix("/state/"):
+            let key = String(path.dropFirst("/state/".count))
+            if let handler = writeHandlers[key] {
+                if handler(body) {
+                    DebugBridgeNotifier.action("write \(key)")
+                    DebugBridgeNotifier.stateMutation()
+                    sendResponse(connection, status: 200, body: "{\"ok\":true}")
+                } else {
+                    sendResponse(connection, status: 400, body: "{\"ok\":false,\"error\":\"write rejected\"}")
+                }
+            } else {
+                sendResponse(connection, status: 404, body: "{\"error\":\"key not found\"}")
+            }
+
+        // MARK: - Screenshot
+        case ("GET", "/screenshot"):
+            let base64 = captureScreenshot()
+            sendResponse(connection, status: 200, body: "{\"image\":\"\(base64)\"}")
+            DebugBridgeNotifier.action("screenshot")
+
+        // MARK: - Tap
+        case ("POST", "/tap"):
+            if let result = handleTap(body: body) {
+                sendResponse(connection, status: 200, body: result)
+            } else {
+                sendResponse(connection, status: 400, body: "{\"error\":\"invalid tap params, need x and y\"}")
+            }
+
+        // MARK: - Swipe
+        case ("POST", "/swipe"):
+            if let result = handleSwipe(body: body) {
+                sendResponse(connection, status: 200, body: result)
+            } else {
+                sendResponse(connection, status: 400, body: "{\"error\":\"invalid swipe params\"}")
+            }
+
+        // MARK: - Type text
+        case ("POST", "/type"):
+            if let result = handleType(body: body) {
+                sendResponse(connection, status: 200, body: result)
+            } else {
+                sendResponse(connection, status: 400, body: "{\"error\":\"invalid type params\"}")
+            }
+
+        // MARK: - Accessibility elements
+        case ("GET", "/elements"):
+            let elements = captureAccessibilityTree()
+            sendResponse(connection, status: 200, body: elements)
+            DebugBridgeNotifier.action("elements")
+
+        // MARK: - Device info
+        case ("GET", "/device"):
+            let info = deviceInfo()
+            sendResponse(connection, status: 200, body: info)
+
+        default:
+            sendResponse(connection, status: 404, body: "{\"error\":\"not found\"}")
+        }
+    }
+
+    // MARK: - Screenshot Capture
+
+    private func captureScreenshot() -> String {
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow }) else {
+            return ""
+        }
+
+        let renderer = UIGraphicsImageRenderer(bounds: window.bounds)
+        let image = renderer.image { _ in
+            // drawHierarchy captures the actual rendered pixels including SwiftUI content.
+            // layer.render() only captures CALayer content and misses SwiftUI on newer iOS.
+            window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+        }
+
+        guard let data = image.pngData() else { return "" }
+        return data.base64EncodedString()
+    }
+
+    // MARK: - Tap Injection
+
+    private func handleTap(body: String) -> String? {
+        guard let json = parseJSON(body),
+              let x = json["x"] as? Double,
+              let y = json["y"] as? Double else {
+            return nil
+        }
+
+        let point = CGPoint(x: x, y: y)
+
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow }) else {
+            return "{\"ok\":false,\"error\":\"no key window\"}"
+        }
+
+        // Find the hit target
+        if let target = window.hitTest(point, with: nil) {
+            // Try accessibility activate
+            if target.accessibilityActivate() {
+                DebugBridgeNotifier.action("tap \(Int(x)),\(Int(y)) → \(type(of: target))")
+                return "{\"ok\":true,\"target\":\"\(type(of: target))\",\"label\":\"\(target.accessibilityLabel ?? "")\"}"
+            }
+
+            // Try as UIControl
+            if let control = findControl(from: target) {
+                control.sendActions(for: .touchUpInside)
+                DebugBridgeNotifier.action("tap \(Int(x)),\(Int(y)) → \(type(of: control))")
+                return "{\"ok\":true,\"target\":\"\(type(of: control))\",\"label\":\"\(control.accessibilityLabel ?? "")\"}"
+            }
+
+            // Try gesture recognizers on the view hierarchy
+            if activateGestureRecognizer(on: target) {
+                DebugBridgeNotifier.action("tap \(Int(x)),\(Int(y)) → gesture")
+                return "{\"ok\":true,\"target\":\"\(type(of: target))\",\"method\":\"gesture\"}"
+            }
+
+            DebugBridgeNotifier.action("tap \(Int(x)),\(Int(y)) → \(type(of: target))")
+            return "{\"ok\":true,\"target\":\"\(type(of: target))\",\"method\":\"hitTest\",\"label\":\"\(target.accessibilityLabel ?? "")\"}"
+        }
+
+        return "{\"ok\":false,\"error\":\"no hit target at (\(x),\(y))\"}"
+    }
+
+    private func findControl(from view: UIView) -> UIControl? {
+        var current: UIView? = view
+        while let v = current {
+            if let control = v as? UIControl { return control }
+            current = v.superview
+        }
+        return nil
+    }
+
+    private func activateGestureRecognizer(on view: UIView) -> Bool {
+        var current: UIView? = view
+        while let v = current {
+            if let recognizers = v.gestureRecognizers {
+                for recognizer in recognizers {
+                    if recognizer is UITapGestureRecognizer && recognizer.isEnabled {
+                        recognizer.state = .ended
+                        return true
+                    }
+                }
+            }
+            current = v.superview
+        }
+        return false
+    }
+
+    // MARK: - Swipe Injection
+
+    private func handleSwipe(body: String) -> String? {
+        guard let json = parseJSON(body),
+              let fromX = json["fromX"] as? Double,
+              let fromY = json["fromY"] as? Double,
+              let toX = json["toX"] as? Double,
+              let toY = json["toY"] as? Double else {
+            return nil
+        }
+
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow }) else {
+            return "{\"ok\":false,\"error\":\"no key window\"}"
+        }
+
+        // Find scroll views and scroll them
+        let from = CGPoint(x: fromX, y: fromY)
+        let deltaX = toX - fromX
+        let deltaY = toY - fromY
+
+        if let scrollView = findScrollView(at: from, in: window) {
+            let newOffset = CGPoint(
+                x: scrollView.contentOffset.x - deltaX,
+                y: scrollView.contentOffset.y - deltaY
+            )
+            scrollView.setContentOffset(newOffset, animated: true)
+            DebugBridgeNotifier.action("swipe (\(Int(fromX)),\(Int(fromY)))→(\(Int(toX)),\(Int(toY)))")
+            return "{\"ok\":true,\"method\":\"scrollView\"}"
+        }
+
+        DebugBridgeNotifier.action("swipe (\(Int(fromX)),\(Int(fromY)))→(\(Int(toX)),\(Int(toY)))")
+        return "{\"ok\":true,\"method\":\"noop\",\"note\":\"no scroll view found\"}"
+    }
+
+    private func findScrollView(at point: CGPoint, in window: UIWindow) -> UIScrollView? {
+        var current: UIView? = window.hitTest(point, with: nil)
+        while let v = current {
+            if let sv = v as? UIScrollView { return sv }
+            current = v.superview
+        }
+        return nil
+    }
+
+    // MARK: - Type Text
+
+    private func handleType(body: String) -> String? {
+        guard let json = parseJSON(body),
+              let text = json["text"] as? String else {
+            return nil
+        }
+
+        guard let responder = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap(\.windows)
+            .compactMap({ findFirstResponder(in: $0) })
+            .first else {
+            return "{\"ok\":false,\"error\":\"no focused text field\"}"
+        }
+
+        if let textInput = responder as? UITextInput {
+            textInput.insertText(text)
+            DebugBridgeNotifier.action("type \"\(text.prefix(20))\"")
+            return "{\"ok\":true,\"typed\":\"\(text)\"}"
+        }
+
+        return "{\"ok\":false,\"error\":\"focused element is not a text input\"}"
+    }
+
+    private func findFirstResponder(in view: UIView) -> UIView? {
+        if view.isFirstResponder { return view }
+        for subview in view.subviews {
+            if let found = findFirstResponder(in: subview) { return found }
+        }
+        return nil
+    }
+
+    // MARK: - Accessibility Tree
+
+    private func captureAccessibilityTree() -> String {
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow }) else {
+            return "[]"
+        }
+
+        var elements: [[String: Any]] = []
+        collectAccessibilityElements(from: window, into: &elements)
+
+        if let data = try? JSONSerialization.data(withJSONObject: elements, options: [.sortedKeys]),
+           let json = String(data: data, encoding: .utf8) {
+            return json
+        }
+        return "[]"
+    }
+
+    private func collectAccessibilityElements(from view: UIView, into elements: inout [[String: Any]]) {
+        let frame = view.convert(view.bounds, to: nil)
+
+        // Only include views that are visible and have accessibility info
+        if !view.isHidden && view.alpha > 0 && frame.width > 0 && frame.height > 0 {
+            let hasLabel = view.accessibilityLabel != nil && !view.accessibilityLabel!.isEmpty
+            let isControl = view is UIControl
+            let isInteractive = view.accessibilityTraits.contains(.button) ||
+                               view.accessibilityTraits.contains(.link) ||
+                               view.accessibilityTraits.contains(.keyboardKey)
+
+            if hasLabel || isControl || isInteractive {
+                var element: [String: Any] = [
+                    "type": String(describing: type(of: view)),
+                    "frame": [
+                        "x": Int(frame.origin.x),
+                        "y": Int(frame.origin.y),
+                        "width": Int(frame.width),
+                        "height": Int(frame.height)
+                    ],
+                    "center": [
+                        "x": Int(frame.midX),
+                        "y": Int(frame.midY)
+                    ]
+                ]
+
+                if let label = view.accessibilityLabel, !label.isEmpty {
+                    element["label"] = label
+                }
+                if let value = view.accessibilityValue, !value.isEmpty {
+                    element["value"] = value
+                }
+                if let hint = view.accessibilityHint, !hint.isEmpty {
+                    element["hint"] = hint
+                }
+
+                var traits: [String] = []
+                if view.accessibilityTraits.contains(.button) { traits.append("button") }
+                if view.accessibilityTraits.contains(.link) { traits.append("link") }
+                if view.accessibilityTraits.contains(.header) { traits.append("header") }
+                if view.accessibilityTraits.contains(.staticText) { traits.append("text") }
+                if view.accessibilityTraits.contains(.image) { traits.append("image") }
+                if view.accessibilityTraits.contains(.selected) { traits.append("selected") }
+                if view.accessibilityTraits.contains(.notEnabled) { traits.append("disabled") }
+                if !traits.isEmpty { element["traits"] = traits }
+
+                element["interactive"] = isControl || isInteractive
+                elements.append(element)
+            }
+        }
+
+        for subview in view.subviews {
+            collectAccessibilityElements(from: subview, into: &elements)
+        }
+    }
+
+    // MARK: - Device Info
+
+    private func deviceInfo() -> String {
+        let device = UIDevice.current
+        let screen = UIScreen.main
+        let info: [String: Any] = [
+            "name": device.name,
+            "model": device.model,
+            "systemVersion": device.systemVersion,
+            "screenWidth": Int(screen.bounds.width),
+            "screenHeight": Int(screen.bounds.height),
+            "scale": Int(screen.scale),
+            "safeAreaTop": Int(safeAreaInsets().top),
+            "safeAreaBottom": Int(safeAreaInsets().bottom)
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: info, options: [.sortedKeys]),
+           let json = String(data: data, encoding: .utf8) {
+            return json
+        }
+        return "{}"
+    }
+
+    private func safeAreaInsets() -> UIEdgeInsets {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first { $0.isKeyWindow }?
+            .safeAreaInsets ?? .zero
+    }
+
+    // MARK: - Helpers
+
+    private func extractBody(from raw: String) -> String {
+        if let range = raw.range(of: "\r\n\r\n") {
+            return String(raw[range.upperBound...])
+        }
+        return ""
+    }
+
+    private func parseJSON(_ string: String) -> [String: Any]? {
+        guard let data = string.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json
+    }
+
+    private func sendResponse(_ connection: NWConnection, status: Int, body: String, contentType: String = "application/json") {
+        let statusText: String
+        switch status {
+        case 200: statusText = "OK"
+        case 400: statusText = "Bad Request"
+        case 404: statusText = "Not Found"
+        default: statusText = "Error"
+        }
+
+        let response = "HTTP/1.1 \(status) \(statusText)\r\nContent-Type: \(contentType)\r\nContent-Length: \(body.utf8.count)\r\nConnection: close\r\n\r\n\(body)"
+
+        connection.send(content: response.data(using: .utf8), contentContext: .finalMessage, isComplete: true, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+}
+
+#endif

--- a/ios-qa/templates/StateServer.swift.template
+++ b/ios-qa/templates/StateServer.swift.template
@@ -207,6 +207,11 @@ public final class StateServer {
                 sendResponse(connection, status: 400, body: "{\"error\":\"invalid type params\"}")
             }
 
+        // MARK: - Dismiss (close sheets, alerts, modals)
+        case ("POST", "/dismiss"):
+            let result = handleDismiss()
+            sendResponse(connection, status: 200, body: result)
+
         // MARK: - Accessibility elements
         case ("GET", "/elements"):
             let elements = captureAccessibilityTree()
@@ -226,18 +231,22 @@ public final class StateServer {
     // MARK: - Screenshot Capture
 
     private func captureScreenshot() -> String {
-        guard let window = UIApplication.shared.connectedScenes
+        guard let scene = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
-            .flatMap(\.windows)
-            .first(where: { $0.isKeyWindow }) else {
+            .first,
+              let keyWindow = scene.windows.first(where: { $0.isKeyWindow && !($0 is PassthroughWindow) }) else {
             return ""
         }
 
-        let renderer = UIGraphicsImageRenderer(bounds: window.bounds)
+        // Render ALL windows in the scene (sorted by windowLevel) so the
+        // DebugOverlay window (which sits above sheets/alerts) is captured too.
+        let allWindows = scene.windows.sorted { $0.windowLevel.rawValue < $1.windowLevel.rawValue }
+
+        let renderer = UIGraphicsImageRenderer(bounds: keyWindow.bounds)
         let image = renderer.image { _ in
-            // drawHierarchy captures the actual rendered pixels including SwiftUI content.
-            // layer.render() only captures CALayer content and misses SwiftUI on newer iOS.
-            window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+            for window in allWindows {
+                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+            }
         }
 
         guard let data = image.pngData() else { return "" }
@@ -254,11 +263,12 @@ public final class StateServer {
         }
 
         let point = CGPoint(x: x, y: y)
+        DebugBridgeNotifier.tap(at: point)
 
         guard let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .flatMap(\.windows)
-            .first(where: { $0.isKeyWindow }) else {
+            .first(where: { $0.isKeyWindow && !($0 is PassthroughWindow) }) else {
             return "{\"ok\":false,\"error\":\"no key window\"}"
         }
 
@@ -369,6 +379,32 @@ public final class StateServer {
         return false
     }
 
+    // MARK: - Dismiss
+
+    private func handleDismiss() -> String {
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow }),
+              let rootVC = window.rootViewController else {
+            return "{\"ok\":false,\"error\":\"no root view controller\"}"
+        }
+
+        // Walk the presentation chain to find the topmost presented VC
+        var topVC = rootVC
+        while let presented = topVC.presentedViewController {
+            topVC = presented
+        }
+
+        if topVC == rootVC {
+            return "{\"ok\":false,\"error\":\"nothing to dismiss\"}"
+        }
+
+        topVC.dismiss(animated: true)
+        DebugBridgeNotifier.action("dismiss \(type(of: topVC))")
+        return "{\"ok\":true,\"dismissed\":\"\(type(of: topVC))\"}"
+    }
+
     // MARK: - Swipe Injection
 
     private func handleSwipe(body: String) -> String? {
@@ -383,7 +419,7 @@ public final class StateServer {
         guard let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .flatMap(\.windows)
-            .first(where: { $0.isKeyWindow }) else {
+            .first(where: { $0.isKeyWindow && !($0 is PassthroughWindow) }) else {
             return "{\"ok\":false,\"error\":\"no key window\"}"
         }
 
@@ -454,7 +490,7 @@ public final class StateServer {
         guard let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .flatMap(\.windows)
-            .first(where: { $0.isKeyWindow }) else {
+            .first(where: { $0.isKeyWindow && !($0 is PassthroughWindow) }) else {
             return "[]"
         }
 

--- a/ios-sync/SKILL.md.tmpl
+++ b/ios-sync/SKILL.md.tmpl
@@ -1,0 +1,259 @@
+---
+name: ios-sync
+version: 2.0.0
+description: |
+  Full iOS debug bridge resync. Pulls the latest templates from the canonical
+  gstack source, then regenerates ALL DebugBridgeGenerated/ files in the app —
+  including fresh action keys for every ViewModel function. Use this whenever
+  you add new buttons, new ViewModels, or update the templates. Rebuilds and
+  redeploys to device automatically.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Agent
+triggers:
+  - ios sync
+  - ios-sync
+  - update ios templates
+  - fetch ios templates
+  - sync ios skills
+  - regenerate hooks
+  - regen debug bridge
+  - new buttons added
+---
+
+{{PREAMBLE}}
+
+# iOS Sync — Resync Templates + Regenerate App Hooks
+
+Two-phase sync: (1) pull the latest gstack templates to `~/.claude/skills/ios-qa/templates/`,
+then (2) wipe and regenerate `DebugBridgeGenerated/` in the app from scratch — picking
+up any new ViewModels, new functions, and new buttons added since the last run.
+
+**Run this whenever you:**
+- Add a new button, screen, or ViewModel function to the app
+- Pull new template updates from gstack
+- Want a clean regeneration of all action keys
+
+---
+
+## Phase 1: Sync Templates
+
+### Step 1: Find the canonical source
+
+Check for a local gstack fork first (faster, no network):
+
+```bash
+for DIR in \
+  ~/gstack-fork \
+  ~/emdash/gstack \
+  ~/code/gstack \
+  ~/.claude/skills/gstack-source; do
+  if [ -d "$DIR/ios-qa/templates" ]; then
+    echo "FOUND_LOCAL: $DIR"
+    break
+  fi
+done
+```
+
+If no local fork found, clone from GitHub:
+
+```bash
+SYNC_TMP="/tmp/ios-sync-source"
+if [ -d "$SYNC_TMP/.git" ]; then
+  git -C "$SYNC_TMP" pull --ff-only 2>&1 | tail -2
+else
+  git clone --depth=1 https://github.com/time-attack/gstack.git "$SYNC_TMP" 2>&1 | tail -3
+fi
+SOURCE="$SYNC_TMP/ios-qa"
+```
+
+### Step 2: Install templates + skill files
+
+```bash
+mkdir -p ~/.claude/skills/ios-qa/templates/
+cp "$SOURCE/templates/"*.template ~/.claude/skills/ios-qa/templates/
+
+SOURCE_ROOT=$(dirname "$SOURCE")
+for SKILL in ios-qa ios-fix ios-design-review ios-clean ios-sync; do
+  SRC_SKILL="$SOURCE_ROOT/$SKILL"
+  DST_SKILL=~/.claude/skills/$SKILL
+  if [ -f "$SRC_SKILL/SKILL.md.tmpl" ]; then
+    mkdir -p "$DST_SKILL"
+    cp "$SRC_SKILL/SKILL.md.tmpl" "$DST_SKILL/SKILL.md"
+    echo "Updated skill: $SKILL"
+  fi
+done
+
+echo "Templates installed."
+```
+
+---
+
+## Phase 2: Regenerate App Hooks
+
+### Step 3: Find the app
+
+```bash
+find . -maxdepth 3 -name "*.xcodeproj" -not -path "*/DebugBridge/*" 2>/dev/null
+```
+
+Identify the app source directory (the folder next to the `.xcodeproj`).
+
+### Step 4: Re-read all ViewModels
+
+```bash
+grep -rn "@Observable" --include="*.swift" .
+```
+
+Read every `@Observable` class in full. For each one, build a complete inventory:
+
+```
+ViewModel Inventory:
+  PetViewModel
+    vars:   pets, selectedPetId, totalPets, recommendation
+    funcs:  addPet(_:), removePet(at:), recommendNextPet()
+
+  CareViewModel
+    vars:   tasks
+    funcs:  addTask(_:), deleteTasks(for:), completeTask(id:)
+```
+
+**Compare against the existing `DebugBridgeGenerated/` accessor files:**
+
+```bash
+grep -rn "registerWrite\|registerRead" <AppSource>/DebugBridgeGenerated/ 2>/dev/null
+```
+
+Report what's new (functions added since last generation), what's stale (functions
+removed), and what's unchanged. This is the diff that tells you what hooks changed.
+
+### Step 5: Wipe and regenerate DebugBridgeGenerated/
+
+```bash
+rm -rf <AppSource>/DebugBridgeGenerated/
+mkdir -p <AppSource>/DebugBridgeGenerated/
+```
+
+Then regenerate every file from the latest templates:
+
+**StateServer.swift** — copy `~/.claude/skills/ios-qa/templates/StateServer.swift.template`
+verbatim. Only change: add `#if DEBUG && canImport(UIKit)` guard + `import UIKit`.
+
+**DebugOverlay.swift** — copy `~/.claude/skills/ios-qa/templates/DebugOverlay.swift.template`
+verbatim. Add `#if DEBUG && canImport(UIKit)` guard + `import UIKit`.
+
+**DebugBridgeManager.swift** — copy `~/.claude/skills/ios-qa/templates/DebugBridgeManager.swift.template`
+and wire in every ViewModel that was found. Call `.start(vmA: ..., vmB: ...)`.
+
+**One `<ClassName>Accessor.swift` per @Observable class** — using
+`~/.claude/skills/ios-qa/templates/StateAccessor.swift.template` as the pattern.
+
+For EVERY `var` in the class: generate a read key.
+For EVERY mutable `var`: generate a write key.
+For EVERY `func`: generate an action key.
+
+**No exceptions. Every single function gets an action key.**
+
+Print the complete function inventory when done:
+
+```
+FUNCTION INVENTORY (regenerated):
+  PetViewModel.addPet(_:)          → PetVM_addPet          ✓
+  PetViewModel.removePet(at:)      → PetVM_removePet        ✓
+  PetViewModel.recommendNextPet()  → PetVM_recommendNextPet ✓  ← NEW
+  CareViewModel.addTask(_:)        → CareVM_addTask         ✓
+  CareViewModel.deleteTasks(for:)  → CareVM_deleteTasks     ✓
+  CareViewModel.completeTask(id:)  → CareVM_completeTask    ✓
+
+  Total functions: 6 | Action keys: 6 | Missing: 0
+```
+
+### Step 6: Build
+
+```bash
+xcodebuild -project <project>.xcodeproj \
+  -scheme <scheme> \
+  -destination "generic/platform=iOS" \
+  -configuration Debug \
+  build 2>&1 | grep -E "error:|warning:|BUILD"
+```
+
+Fix any errors. Do NOT move on until `BUILD SUCCEEDED`.
+
+### Step 7: Deploy and verify
+
+```bash
+# Find device
+xcrun devicectl list devices 2>&1 | grep connected
+
+# Deploy
+xcrun devicectl device install app --device <DEVICE_ID> <APP_PATH>
+
+# Launch
+xcrun devicectl device process launch --device <DEVICE_ID> <BUNDLE_ID>
+
+# Get tunnel IP and verify
+TUNNEL_IP=$(xcrun devicectl device info details --device <DEVICE_ID> 2>&1 | grep tunnelIPAddress | awk '{print $2}')
+curl -s -6 "http://[$TUNNEL_IP]:9999/health"
+curl -s -6 "http://[$TUNNEL_IP]:9999/state"
+```
+
+`/state` should list ALL action keys including any newly added ones.
+
+### Step 8: Update session cache
+
+Write the refreshed session to `~/.gstack/ios-qa-session.json` so the next
+`/ios-qa` warm-start picks up the new function inventory:
+
+```bash
+python3 -c "
+import json, datetime
+cache = {
+  'bundleId': 'BUNDLE_ID',
+  'tunnelIP': 'TUNNEL_IP',
+  'deviceId': 'DEVICE_ID',
+  'appSourceDir': 'APP_SOURCE_DIR',
+  'vmFunctions': VM_FUNCTIONS_DICT,
+  'actionKeys': ACTION_KEYS_LIST,
+  'generatedAt': datetime.datetime.utcnow().isoformat() + 'Z'
+}
+json.dump(cache, open('/Users/sinmat/.gstack/ios-qa-session.json', 'w'), indent=2)
+print('Session cache updated.')
+"
+```
+
+---
+
+## Report
+
+```
+iOS Sync complete.
+
+Phase 1 — Templates:
+  ✓ StateServer.swift.template    (changed / same)
+  ✓ DebugOverlay.swift.template   (changed / same)
+  ✓ DebugBridgeManager.swift.template
+  ✓ StateAccessor.swift.template
+  ✓ DebugBridgeJSON.swift.template
+  ✓ Package.swift.template
+
+Phase 2 — App Regeneration:
+  New since last sync:
+    + PetVM_recommendNextPet  (func recommendNextPet() added)
+    + CareVM_completeTask     (func completeTask(id:) added)
+  Removed:
+    - PetVM_oldFunction       (func removed from ViewModel)
+  Unchanged: 4 action keys
+
+  Build: SUCCEEDED
+  Deploy: SUCCEEDED
+  Health: {"status":"ok"}
+  Action keys registered: 6
+
+Next /ios-qa run will use warm start with the updated function inventory.
+```


### PR DESCRIPTION
## What this is

The iOS half of gstack. Five skills that give Claude the same grip on a SwiftUI
app that `/browse` gives it on a webpage.

**Won 1st place at the GStack × GBrain hackathon on May 16, 2026.**

## The five skills

| Skill | What it does |
|---|---|
| `/ios-qa` | Reads Swift source → generates an embedded HTTP debug bridge into the app → drives the running app on a **real device (USB)** or in the **iOS Simulator** → finds bugs via a vision-driven agent loop. |
| `/ios-fix` | Takes a bug from `/ios-qa`, reads the source to understand *why* it broke, writes the minimal fix, rebuilds, redeploys, then reproduces the original repro steps to prove the bug is gone. |
| `/ios-sync` | Regenerates the debug bridge after you add new buttons, screens, or ViewModel functions. Fresh action keys for every `@Observable` `func` in your app. |
| `/ios-clean` | Strips every trace of the bridge — `StateServer`, `DebugOverlay`, accessors, and all `#if DEBUG` wiring in `ContentView`/`App` files. Ship-ready in one command. |
| `/ios-design-review` | Visual audit. Walks every screen, screenshots each, evaluates against Apple HIG (layout, typography, spacing, contrast, accessibility). |

## Why this is hard

A web browser is a gift to LLM agents. The DOM is text. `querySelector` is a
function call. Chrome DevTools is an HTTP server. An iPhone is the opposite —
the screen is pixels, widgets are SwiftUI views compiled into a sandboxed
binary, the OS doesn't expose the view hierarchy, and every existing tool
(XCUITest, IDB, Appium) assumes a human is the one writing the test.

This PR solves it by **injecting the API into the app itself.** A `StateServer`
running on `:9999` inside the debug build exposes:

```
GET  /screenshot   → base64 PNG
GET  /elements     → accessibility tree (labels, frames, traits)
POST /tap          → inject tap at {x,y}
POST /type         → keyboard input
POST /swipe        → gesture
GET  /state/{key}  → read @Observable property
POST /state/{key}  → invoke ViewModel function (see below)
GET  /health       → liveness
```

Everything is `#if DEBUG`. `/ios-clean` removes the last trace for release.

## The technical unlock: action keys

SwiftUI toolbar buttons (`.toolbar { Button("Save") {...} }`) **cannot be
tapped programmatically**. `accessibilityActivate()` returns `true` and does
nothing. `sendActions(.touchUpInside)` does nothing. The private `_targets`
API crashes the app. There is no working tap. This is a SwiftUI
architectural limitation, not a fixable bug in the tap handler.

The fix: **don't tap the button — call the ViewModel function directly.**

For every `func` on every `@Observable` ViewModel, `/ios-qa` generates a
debug-only HTTP endpoint that invokes it natively:

```swift
// For: func toggleUnit()
server.registerWrite("ProfileVM_toggleUnit") { _ in
    instance.toggleUnit()
    return true
}

// For: func addItem(_ item: Item)  — JSON injection
server.registerWrite("CartVM_addItem") { value in
    let item = try! JSONDecoder().decode(Item.self, from: value.data(using: .utf8)!)
    instance.addItem(item)
    return true
}
```

One build, zero rebuilds during QA.

## Two modes

| Aspect | Device Mode | Simulator Mode |
|---|---|---|
| Transport | `curl -6 http://[IPv6]:9999/*` via Apple's CoreDevice USB tunnel | `sim_tap` (custom 4ms Swift binary via macOS Accessibility API) + IDB hybrid |
| Tap latency | HTTP round-trip | 4ms (sim_tap) / 150ms (IDB fallback) |
| Codegen needed | Yes — full `DebugBridgeGenerated/` | No — IDB reads the tree externally |

Auto-detects which mode to use. No flag required.

## Files

```
ios-qa/
  SKILL.md.tmpl
  README.md
  templates/
    StateServer.swift.template
    DebugOverlay.swift.template
    DebugBridgeManager.swift.template
    StateAccessor.swift.template
    Package.swift.template
    DebugBridgeJSON.swift.template

ios-fix/
  SKILL.md.tmpl
  README.md

ios-sync/
  SKILL.md.tmpl

ios-clean/
  SKILL.md.tmpl

ios-design-review/
  SKILL.md.tmpl
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
