### PR TITLE
fix: reflect CORS for chrome-extension origins so Side Panel fetches succeed

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -1323,8 +1323,41 @@ export function buildFetchHandler(cfg: ServerConfig): ServerHandle {
   // `authToken` (the cfg-derived value) explicitly.
   const browserManager = cfgBrowserManager;
 
+  // CORS wrapper for the Side Panel. The extension's sidepanel.html runs in a
+  // chrome-extension:// origin and fetches /health, /command, /sse-session,
+  // /refs, /activity/stream, /pty-session, etc. /health is localhost-only, so
+  // reflecting Origin back is safe — we only do it for chrome-extension://
+  // requests, not arbitrary websites.
+  const withCors = (
+    handler: (req: Request) => Promise<Response>,
+  ) => async (req: Request): Promise<Response> => {
+    const origin = req.headers.get('origin');
+    const isExt = origin?.startsWith('chrome-extension://');
+    if (isExt && req.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 204,
+        headers: {
+          'Access-Control-Allow-Origin': origin!,
+          'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+          'Access-Control-Allow-Credentials': 'true',
+          'Access-Control-Max-Age': '86400',
+        },
+      });
+    }
+    const resp = await handler(req);
+    if (!isExt) return resp;
+    const headers = new Headers(resp.headers);
+    headers.set('Access-Control-Allow-Origin', origin!);
+    headers.set('Access-Control-Allow-Credentials', 'true');
+    return new Response(resp.body, {
+      status: resp.status,
+      statusText: resp.statusText,
+      headers,
+    });
+  };
 
-  const makeFetchHandler = (surface: Surface) => async (req: Request): Promise<Response> => {
+  const makeFetchHandler = (surface: Surface) => withCors(async (req: Request): Promise<Response> => {
     const url = new URL(req.url);
 
     // ─── Tunnel surface filter (runs before any route dispatch) ──
@@ -2287,7 +2320,7 @@ export function buildFetchHandler(cfg: ServerConfig): ServerHandle {
       }
 
       return new Response('Not found', { status: 404 });
-  };
+  });
 
   return {
     fetchLocal: makeFetchHandler('local'),

--- a/browse/src/terminal-agent.ts
+++ b/browse/src/terminal-agent.ts
@@ -240,9 +240,18 @@ function buildServer() {
       if (url.pathname === '/claude-available' && req.method === 'GET') {
         writeClaudeAvailable();
         const found = findClaude();
+        const origin = req.headers.get('origin');
         return new Response(JSON.stringify({ available: !!found, path: found }), {
           status: 200,
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            ...(origin?.startsWith('chrome-extension://')
+              ? {
+                  'Access-Control-Allow-Origin': origin,
+                  'Access-Control-Allow-Credentials': 'true',
+                }
+              : {}),
+          },
         });
       }
 

--- a/browse/test/server-auth.test.ts
+++ b/browse/test/server-auth.test.ts
@@ -61,6 +61,28 @@ describe('Server auth security', () => {
     expect(refsBlock).not.toContain("'*'");
   });
 
+  // Test 3a: withCors middleware exists and reflects only chrome-extension origins.
+  // Background: the Side Panel runs in a chrome-extension:// origin and fetches
+  // /health, /command, /refs, /activity/stream, etc. with credentials:'include'.
+  // Without CORS reflection, every fetch fails and the panel never reaches the
+  // "connected" state. Reflecting * would be unsafe; reflecting only
+  // chrome-extension:// keeps arbitrary websites blocked.
+  test('withCors middleware reflects only chrome-extension origins', () => {
+    expect(SERVER_SRC).toContain('const withCors = ');
+    expect(SERVER_SRC).toContain("origin?.startsWith('chrome-extension://')");
+    // Must include Allow-Credentials because the panel uses credentials:'include'.
+    expect(SERVER_SRC).toContain("'Access-Control-Allow-Credentials'");
+    // Must NOT wildcard.
+    expect(SERVER_SRC).not.toContain("'Access-Control-Allow-Origin': '*'");
+  });
+
+  // Test 3b: makeFetchHandler is wrapped with withCors so every route gets
+  // CORS handling for free (otherwise a future endpoint added without
+  // remembering CORS would silently break the Side Panel again).
+  test('makeFetchHandler is wrapped with withCors', () => {
+    expect(SERVER_SRC).toMatch(/makeFetchHandler[^=]*=[^=]*withCors\(/);
+  });
+
   // Test 4: /activity/history requires auth via validateAuth
   test('/activity/history requires authentication', () => {
     const historyBlock = sliceBetween(SERVER_SRC, "url.pathname === '/activity/history'", 'Sidebar endpoints');

--- a/browse/test/terminal-agent.test.ts
+++ b/browse/test/terminal-agent.test.ts
@@ -221,3 +221,19 @@ describe('Source-level guard: server.ts /pty-session route', () => {
     expect(route).toContain('buildPtySetCookie');
   });
 });
+
+describe('Source-level guard: terminal-agent /claude-available CORS', () => {
+  // Background: sidepanel-terminal.js fetches /claude-available with
+  // credentials:'include' to decide whether to show the "install Claude
+  // Code" bootstrap card. Without CORS reflection, the fetch throws and
+  // the card stays stuck on "not found" even when claude is installed.
+  test('/claude-available reflects Allow-Origin + Allow-Credentials for chrome-extension origins', () => {
+    const route = AGENT_SRC.slice(AGENT_SRC.indexOf("url.pathname === '/claude-available'"));
+    const responseBlock = route.slice(0, route.indexOf("// /ws"));
+    expect(responseBlock).toContain("origin?.startsWith('chrome-extension://')");
+    expect(responseBlock).toContain("'Access-Control-Allow-Origin'");
+    expect(responseBlock).toContain("'Access-Control-Allow-Credentials'");
+    // Must NOT wildcard.
+    expect(responseBlock).not.toContain("'Access-Control-Allow-Origin': '*'");
+  });
+});


### PR DESCRIPTION
## Summary

- Side Panel fetches to `/health`, `/command`, `/refs`, `/activity/stream`, and terminal-agent's `/claude-available` were failing CORS because none of those responses set `Access-Control-Allow-Origin` or `Access-Control-Allow-Credentials`. Panel stays stuck on "Browse server not ready" and the install-card shows "Claude Code not found" even when `claude` is on PATH.
- Adds a `withCors` middleware in `server.ts` that wraps both `makeFetchHandler` call sites — preflight `OPTIONS` 204 + response-header reflection, **only** for origins starting with `chrome-extension://`. Arbitrary websites still get no CORS headers.
- Same Origin + Credentials reflection on terminal-agent's `/claude-available`. The `/ws` upgrade keeps `Sec-WebSocket-Protocol` auth and doesn't need CORS; `/internal/*` stays loopback + bearer-auth.
- 3 source-pattern tests matching the existing `/refs has no wildcard CORS header` style in `server-auth.test.ts`.

## Repro before fix

```bash
$ ./browse/dist/browse connect       # launch headed
# Open Side Panel in the launched Chromium → DevTools console:
# Access to fetch at 'http://127.0.0.1:34567/health' from origin
# 'chrome-extension://fglemgoabpknaffepocnhgkikfpfjflj' has been blocked
# by CORS policy: No 'Access-Control-Allow-Origin' header is present...
```

After the panel is reloaded, the next blocker surfaces:
```
Access to fetch at 'http://127.0.0.1:53144/claude-available' ... has been
blocked by CORS policy: The value of the 'Access-Control-Allow-Credentials'
header in the response is '' which must be 'true' when the request's
credentials mode is 'include'.
```

## Verification curl

```bash
$ curl -H "Origin: chrome-extension://abc" -D - http://127.0.0.1:34567/health
HTTP/1.1 200 OK
Access-Control-Allow-Origin: chrome-extension://abc
Access-Control-Allow-Credentials: true

$ curl -H "Origin: https://evil.com" -D - http://127.0.0.1:34567/health
HTTP/1.1 200 OK
(no Access-Control-* headers — non-extension origins still blocked)

$ curl -X OPTIONS -H "Origin: chrome-extension://abc" -D - http://127.0.0.1:34567/refs
HTTP/1.1 204 No Content
Access-Control-Allow-Origin: chrome-extension://abc
Access-Control-Allow-Methods: GET, POST, OPTIONS
Access-Control-Allow-Headers: Content-Type, Authorization
Access-Control-Allow-Credentials: true
```

## Test plan
- [x] `bun test browse/test/server-auth.test.ts browse/test/terminal-agent.test.ts` — 3 new tests pass; pre-existing failures unrelated (markers for `Sidebar agent started` etc.)
- [x] Live curl against running headed server — both endpoints return correct CORS headers for chrome-extension origins
- [x] Non-extension origins receive zero CORS headers (security boundary preserved)
- [x] Side Panel reaches "connected" state in real browser; embedded PTY card transitions from "Claude Code not found" to terminal-ready

## Security notes
- Only reflects `Origin` when it starts with `chrome-extension://`. Never wildcards. Arbitrary websites can't read these endpoints' responses.
- `/health` token exposure is unchanged (still gated on headed-mode or chrome-extension origin per the existing logic).
- `/ws` upgrade in terminal-agent is unchanged — still requires `Sec-WebSocket-Protocol` auth + extension Origin check.
- `/internal/grant` and `/internal/revoke` still loopback + Bearer; CORS doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)