### PR TITLE
fix(browse): enable Chromium sandbox in headed mode

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -324,6 +324,11 @@ export class BrowserManager {
       viewport: null,  // Use browser's default viewport (real window size)
       userAgent: this.customUserAgent || customUA,
       ...(executablePath ? { executablePath } : {}),
+      // Match the headless launch path: enable Chromium's multi-process sandbox
+      // everywhere except Windows (where Bun→Node spawn breaks it — see launch()).
+      // Without this, Playwright defaults to --no-sandbox and Chromium shows a
+      // yellow "security will suffer" info bar.
+      chromiumSandbox: process.platform !== 'win32',
       // Playwright adds flags that block extension loading
       ignoreDefaultArgs: [
         '--disable-extensions',
@@ -975,6 +980,7 @@ export class BrowserManager {
         headless: false,
         args: launchArgs,
         viewport: null,
+        chromiumSandbox: process.platform !== 'win32',
         ignoreDefaultArgs: [
           '--disable-extensions',
           '--disable-component-extensions-with-background-pages',


### PR DESCRIPTION
The two headed launchPersistentContext() call sites in BrowserManager omitted the chromiumSandbox option, so Playwright defaulted to passing --no-sandbox even on macOS and Linux where the sandbox works correctly. Chromium then displays the yellow "unsupported command-line flag — security will suffer" info bar, and any renderer exploit (V8, Skia, libwebp, …) can escape straight to the user's account.

The headless launch() path at line 179 already passes `chromiumSandbox: process.platform !== 'win32'`. This brings the two headed sites in line — preserving the Windows exemption (where the Bun→Node spawn chain breaks the sandbox, per GitHub #276).