### PR TITLE
feat: keep project CLAUDE.md pointing at the latest gstack design doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+### Project CLAUDE.md now auto-points at the latest gstack design doc
+
+Every gstack artifact-writing skill produces a markdown file under `~/.gstack/projects/<slug>/`. Until now, the project's own `CLAUDE.md` had no way to know which artifact was current — every new session had to be told (or guess) which `*-design-*.md` was canonical. This change closes that loop for `/office-hours` as the proof-of-concept, with the pattern available for the other artifact-writing skills to adopt.
+
+After `/office-hours` writes a design doc, it now calls `bin/gstack-claude-md-update --artifact-type design --path <abspath>`, which finds-or-appends a backtick-wrapped pointer line in the project's `CLAUDE.md`. The line is edit-tolerant: the user can move it into any section, under any heading, with any surrounding prose — the helper finds it by content pattern, not by line number. Deleting the pointer triggers a clean re-append at end of file with a self-describing `## Latest gstack artifacts` section. Re-running is idempotent; no duplicate sections accumulate.
+
+**Opt-out:** `gstack-config set claude_md_artifact_pointers false` (default is `true`).
+
+#### Added
+
+- `bin/gstack-claude-md-update` — generic helper. Usage: `gstack-claude-md-update --artifact-type <type> --path <abspath> [--project-root <path>]`. Known artifact types: `design`, `ceo-plan`, `eng-plan`, `design-spec`, `checkpoint` (unrecognized types render verbatim). Resolves project root via `--project-root`, then `git rev-parse --show-toplevel`, then `$PWD`. Silent no-op when `CLAUDE.md` is absent — never creates it unilaterally. Exits 0 on success or opt-out; 1 on usage error.
+- `claude_md_artifact_pointers` config key (default `true`) with documentation in the `gstack-config` `CONFIG_HEADER`.
+
+#### Changed
+
+- `office-hours/SKILL.md.tmpl` (and the regenerated `SKILL.md`) — Phase 5 now calls `gstack-claude-md-update` after writing the design doc.
+
+### Out of scope (deliberately deferred)
+
+- Wiring the helper into `plan-ceo-review`, `plan-eng-review`, `plan-design-review`, `design-consultation`. The pattern is now visible in `office-hours`; happy to follow up in separate PRs if maintainers want each skill adopted.
+- Claude Code hook templates (the skill-side approach is cleaner and works without per-project hook installation).
+
 ## [1.39.2.0] - 2026-05-15
 
 ## **Conductor workspaces wire `GSTACK_*` keys straight into gbrain embeddings and paid evals.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,6 +232,18 @@ For template authoring best practices (natural language over bash-isms, dynamic 
 
 To add a browse command, add it to `browse/src/commands.ts`. To add a snapshot flag, add it to `SNAPSHOT_FLAGS` in `browse/src/snapshot.ts`. Then rebuild.
 
+## Wiring a new skill into the CLAUDE.md artifact-pointer helper
+
+If you're adding a skill that writes an artifact under `~/.gstack/projects/<slug>/` (a plan, a review, a design spec, etc.), call `bin/gstack-claude-md-update` after the write so the project's `CLAUDE.md` stays pointed at the freshest file. Currently wired into `/office-hours`; `/plan-ceo-review`, `/plan-eng-review`, `/plan-design-review`, and `/design-consultation` are candidates for follow-up PRs.
+
+In the skill template, immediately after the artifact is written, add:
+
+```bash
+~/.claude/skills/gstack/bin/gstack-claude-md-update --artifact-type <type> --path "<abspath>" 2>/dev/null || true
+```
+
+Use a known artifact type (`design`, `ceo-plan`, `eng-plan`, `design-spec`, `checkpoint`) so the rendered label is consistent across skills. Unrecognized types render verbatim. The helper is opt-out (`gstack-config set claude_md_artifact_pointers false`), is a silent no-op when CLAUDE.md doesn't exist, and never creates CLAUDE.md unilaterally.
+
 ## Jargon list (V1 writing style)
 
 gstack's Writing Style section (injected into every tier-≥2 skill's preamble)

--- a/bin/gstack-claude-md-update
+++ b/bin/gstack-claude-md-update
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# gstack-claude-md-update — keep the project's CLAUDE.md pointing at the latest
+# gstack-generated artifact (design doc, CEO plan, eng plan, etc.).
+#
+# Called by artifact-writing skills (office-hours, plan-ceo-review, plan-eng-review,
+# plan-design-review, design-consultation) at the end of artifact generation. The
+# behavior is opt-out via `gstack-config set claude_md_artifact_pointers false`.
+#
+# Usage:
+#   gstack-claude-md-update --artifact-type <type> --path <abspath> [--project-root <path>]
+#
+# Artifact types (label rendered in CLAUDE.md):
+#   design        — "design doc"
+#   ceo-plan      — "CEO plan"
+#   eng-plan      — "engineering plan"
+#   design-spec   — "design spec"
+#   checkpoint    — "checkpoint"
+#   (unrecognized types are rendered verbatim — extensible by callers)
+#
+# Behavior:
+#   - Looks for a "- Latest <label>:" line ANYWHERE in CLAUDE.md and updates the
+#     backtick-wrapped path on that line in place. User can freely move the line
+#     between sections; it's matched by content, not position.
+#   - If the line doesn't exist, looks for a "## Latest gstack artifacts" heading
+#     and appends the line under it.
+#   - If neither line nor heading exists, appends a fresh section to end of file.
+#   - If CLAUDE.md doesn't exist in the project root, exits silently (don't create
+#     CLAUDE.md unilaterally — that's invasive).
+#   - Idempotent: re-running with the same path is a no-op; re-running with a new
+#     path updates in place; no duplicate sections accumulate.
+#
+# Project root resolution (in order):
+#   1. --project-root flag
+#   2. git rev-parse --show-toplevel
+#   3. $PWD
+#
+# Env overrides:
+#   GSTACK_HOME           — see gstack-config
+#   GSTACK_CMU_DEBUG=1    — log to stderr what the helper is doing (no-op otherwise)
+#
+# Exit codes:
+#   0 — success (or no-op due to opt-out / missing CLAUDE.md)
+#   1 — usage error or write failure
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GSTACK_CONFIG_BIN="$SCRIPT_DIR/gstack-config"
+
+ARTIFACT_TYPE=""
+ARTIFACT_PATH=""
+PROJECT_ROOT=""
+
+log_debug() {
+  [ "${GSTACK_CMU_DEBUG:-0}" = "1" ] && printf '[gstack-claude-md-update] %s\n' "$*" >&2
+  return 0
+}
+
+# Parse args
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --artifact-type) ARTIFACT_TYPE="${2:-}"; shift 2 ;;
+    --path) ARTIFACT_PATH="${2:-}"; shift 2 ;;
+    --project-root) PROJECT_ROOT="${2:-}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,40p' "$0" | sed 's|^# \{0,1\}||'
+      exit 0
+      ;;
+    *)
+      echo "Error: unknown arg: $1" >&2
+      echo "Usage: gstack-claude-md-update --artifact-type <type> --path <abspath> [--project-root <path>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$ARTIFACT_TYPE" ] || [ -z "$ARTIFACT_PATH" ]; then
+  echo "Error: --artifact-type and --path are required" >&2
+  exit 1
+fi
+
+# Opt-out check — default true (feature on)
+ENABLED=$("$GSTACK_CONFIG_BIN" get claude_md_artifact_pointers 2>/dev/null || echo "true")
+if [ "$ENABLED" = "false" ]; then
+  log_debug "opted out via claude_md_artifact_pointers=false"
+  exit 0
+fi
+
+# Resolve project root
+if [ -z "$PROJECT_ROOT" ]; then
+  PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+fi
+[ -z "$PROJECT_ROOT" ] && PROJECT_ROOT="$PWD"
+
+CLAUDE_MD="$PROJECT_ROOT/CLAUDE.md"
+
+if [ ! -f "$CLAUDE_MD" ]; then
+  log_debug "no CLAUDE.md at $CLAUDE_MD — skipping (helper does not create CLAUDE.md unilaterally)"
+  exit 0
+fi
+
+# Map artifact type to display label
+case "$ARTIFACT_TYPE" in
+  design)      LABEL="design doc" ;;
+  ceo-plan)    LABEL="CEO plan" ;;
+  eng-plan)    LABEL="engineering plan" ;;
+  design-spec) LABEL="design spec" ;;
+  checkpoint)  LABEL="checkpoint" ;;
+  *)           LABEL="$ARTIFACT_TYPE" ;;
+esac
+
+# Normalize artifact path: prefer ~ if under $HOME for portability
+NORMALIZED_PATH="$ARTIFACT_PATH"
+case "$ARTIFACT_PATH" in
+  "$HOME"/*) NORMALIZED_PATH="~${ARTIFACT_PATH#$HOME}" ;;
+esac
+
+# Build the canonical pointer line
+NEW_LINE="- Latest $LABEL: \`$NORMALIZED_PATH\`"
+
+# Pattern: matches "- Latest <label>:" optionally followed by anything (the old path).
+# The label is escaped in case it contains regex metacharacters (it doesn't for known types, but be safe).
+ESCAPED_LABEL=$(printf '%s' "$LABEL" | sed 's|[][\.*^$/]|\\&|g')
+LINE_PATTERN="^- Latest ${ESCAPED_LABEL}:"
+
+# Decision tree:
+#   1. Line exists anywhere → replace it in place
+#   2. "## Latest gstack artifacts" heading exists → append line under heading
+#   3. Neither → append fresh section to end of file
+
+if grep -qE "$LINE_PATTERN" "$CLAUDE_MD"; then
+  log_debug "updating in place: $NEW_LINE"
+  tmpfile=$(mktemp)
+  # Replace each matching line wholesale. Use # as sed delimiter (path may contain /).
+  awk -v pat="$LINE_PATTERN" -v new="$NEW_LINE" '
+    $0 ~ pat { print new; next }
+    { print }
+  ' "$CLAUDE_MD" > "$tmpfile" && mv "$tmpfile" "$CLAUDE_MD"
+elif grep -qE "^## Latest gstack artifacts" "$CLAUDE_MD"; then
+  log_debug "appending under existing heading: $NEW_LINE"
+  tmpfile=$(mktemp)
+  # Walk the file. When we enter the gstack-artifacts section, just print through
+  # until we hit the next ## heading (or EOF), then insert the new line right
+  # before that boundary. Section grows downward; no fancy bullet-block detection.
+  awk -v new="$NEW_LINE" '
+    BEGIN { in_section = 0; inserted = 0 }
+    /^## Latest gstack artifacts/ && !inserted {
+      print
+      in_section = 1
+      next
+    }
+    in_section && /^## / && !inserted {
+      print new
+      print ""
+      inserted = 1
+      in_section = 0
+      print
+      next
+    }
+    { print }
+    END {
+      if (in_section && !inserted) print new
+    }
+  ' "$CLAUDE_MD" > "$tmpfile" && mv "$tmpfile" "$CLAUDE_MD"
+else
+  log_debug "appending fresh section: $NEW_LINE"
+  {
+    printf '\n'
+    printf '## Latest gstack artifacts\n'
+    printf '\n'
+    printf 'Auto-managed by `gstack-claude-md-update`. Move these lines anywhere in CLAUDE.md and the helper will keep finding and updating them. Opt out with `gstack-config set claude_md_artifact_pointers false`.\n'
+    printf '\n'
+    printf '%s\n' "$NEW_LINE"
+  } >> "$CLAUDE_MD"
+fi
+
+exit 0

--- a/bin/gstack-config
+++ b/bin/gstack-config
@@ -73,6 +73,17 @@ CONFIG_HEADER='# gstack configuration — edit freely, changes take effect on ne
 #                           # Set to true once the privacy gate has asked the user.
 #                           # Flip back to false to be re-prompted.
 #
+# ─── CLAUDE.md artifact pointers ─────────────────────────────────────
+# claude_md_artifact_pointers: true
+#                           # When true, artifact-writing skills (currently /office-hours;
+#                           # other artifact skills can opt in) call
+#                           # `gstack-claude-md-update` after generating an artifact, which
+#                           # keeps a "Latest <type>" pointer line in the project's CLAUDE.md
+#                           # pointing at the freshest artifact file.
+#                           # Edit-tolerant: move the pointer line anywhere in CLAUDE.md and
+#                           # the helper still finds it by content. Idempotent. Never creates
+#                           # CLAUDE.md if absent. Set to false to disable.
+#
 # ─── Advanced ────────────────────────────────────────────────────────
 # codex_reviews: enabled    # disabled = skip Codex adversarial reviews in /ship
 # gstack_contributor: false # true = file field reports when gstack misbehaves
@@ -107,6 +118,7 @@ lookup_default() {
     cross_project_learnings) echo "" ;; # intentionally empty → unset triggers first-time prompt
     artifacts_sync_mode) echo "off" ;;
     artifacts_sync_mode_prompted) echo "false" ;;
+    claude_md_artifact_pointers) echo "true" ;;
     *) echo "" ;;
   esac
 }

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -1587,6 +1587,14 @@ Write to `~/.gstack/projects/{slug}/{user}-{branch}-design-{datetime}.md`.
 After writing the design doc, tell the user:
 **"Design doc saved to: {full path}. Other skills (/plan-ceo-review, /plan-eng-review) will find it automatically."**
 
+Then update the project's CLAUDE.md with a pointer to the new design doc, so future Claude sessions discover it immediately:
+
+```bash
+~/.claude/skills/gstack/bin/gstack-claude-md-update --artifact-type design --path "<absolute path to the design doc just written>" 2>/dev/null || true
+```
+
+The helper is opt-out (`gstack-config set claude_md_artifact_pointers false` to disable); silent no-op when CLAUDE.md is absent or when opted out. See `bin/gstack-claude-md-update --help` for details.
+
 ### Startup mode design doc template:
 
 ```markdown

--- a/office-hours/SKILL.md.tmpl
+++ b/office-hours/SKILL.md.tmpl
@@ -521,6 +521,14 @@ Write to `~/.gstack/projects/{slug}/{user}-{branch}-design-{datetime}.md`.
 After writing the design doc, tell the user:
 **"Design doc saved to: {full path}. Other skills (/plan-ceo-review, /plan-eng-review) will find it automatically."**
 
+Then update the project's CLAUDE.md with a pointer to the new design doc, so future Claude sessions discover it immediately:
+
+```bash
+~/.claude/skills/gstack/bin/gstack-claude-md-update --artifact-type design --path "<absolute path to the design doc just written>" 2>/dev/null || true
+```
+
+The helper is opt-out (`gstack-config set claude_md_artifact_pointers false` to disable); silent no-op when CLAUDE.md is absent or when opted out. See `bin/gstack-claude-md-update --help` for details.
+
 ### Startup mode design doc template:
 
 ```markdown


### PR DESCRIPTION
## Why

After running `/office-hours`, the design doc lives in `~/.gstack/projects/<slug>/`. The project's `CLAUDE.md` doesn't know about it. The next session, a new Claude has to guess (or be told) which design is canonical. Multiply by every artifact-writing skill (CEO review, eng review, design review) and the "which file is current?" question becomes a tax on every session.

## What this PR does

Adds `bin/gstack-claude-md-update`, a small helper that finds-or-appends a backtick-wrapped artifact pointer in the project's `CLAUDE.md`. Wires it into `/office-hours` at the end of Phase 5. Pattern is now available for other artifact-writing skills to adopt.

**Edit-tolerant:** the user can move the pointer line into any section, under any heading, with any surrounding prose. The helper finds it by content pattern, not by line number. Deleting the pointer triggers a clean re-append at end of file under a `## Latest gstack artifacts` heading. Re-runs are idempotent; no duplicate sections accumulate.

**Never creates `CLAUDE.md` unilaterally** — silent no-op if absent. The helper is a citizen, not an installer.

## Opt-out

```bash
gstack-config set claude_md_artifact_pointers false
```

Default is `true`. Config key documented in the `gstack-config` `CONFIG_HEADER`.

## Helper usage

```
gstack-claude-md-update --artifact-type <type> --path <abspath> [--project-root <path>]
```

Known artifact types (rendered label in CLAUDE.md):
- `design` → "design doc"
- `ceo-plan` → "CEO plan"
- `eng-plan` → "engineering plan"
- `design-spec` → "design spec"
- `checkpoint` → "checkpoint"
- (unrecognized types render verbatim — extensible by callers)

Project root resolution order: `--project-root` flag → `git rev-parse --show-toplevel` → `\$PWD`.

## Test plan

- [x] Pipe-tested the helper standalone with synthetic invocations covering: missing CLAUDE.md (silent no-op), empty CLAUDE.md (appends fresh section), in-place update with newer path, second artifact type added to existing section (stacks bullets under same heading), user-moved pointer line in custom section (still found and updated), opt-out via config (no file change).
- [x] Ran `bun run gen:skill-docs --host all` to regenerate `office-hours/SKILL.md` from the updated `.tmpl`.
- [x] Verified `bun run skill:check` reports `✅ office-hours/SKILL.md.tmpl → office-hours/SKILL.md` (unrelated pre-existing failures on `claude/SKILL.md` and a couple host folders remain — independent of this PR; verified by `git stash` + re-running check).
- [x] Verified `git status` shows only the 6 intended files (no spurious regen artifacts).
- [x] End-to-end dogfooded the underlying approach on a real project: ran `/office-hours` on a new repo, observed CLAUDE.md gained the pointer line and survived a manual move to a different section across a second invocation.

## Out of scope (deliberately deferred to keep this PR reviewable)

- Wiring into `plan-ceo-review`, `plan-eng-review`, `plan-design-review`, `design-consultation`. Happy to follow up in separate PRs if you accept the pattern.
- Claude Code hook templates (the skill-side approach is cleaner — no per-project hook installation, no watcher-startup-timing caveats).
- Renaming or restructuring existing `CLAUDE.md` sections that gstack already appends to (skill routing).

## Known cosmetic limitation

When inserting a second artifact bullet into an existing `## Latest gstack artifacts` section that had a trailing blank before the next heading, the two bullets end up separated by a blank line instead of being adjacent. Markdown renders identically; not worth more `awk` complexity in this PR. Easy follow-up if it bothers anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)