### PR TITLE
feat(plan-ceo-review): add /absolute-brainstorm branch to mid-session detection

### DIFF
--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -1029,13 +1029,30 @@ Follow its instructions from top to bottom, **skipping these sections** (already
 
 Execute every other section at full depth. When the loaded skill's instructions are complete, continue with the next step below.
 
-If they choose B: tell the user to run `/absolute-brainstorm` directly in their
-next message — it's a sibling skill, not a sub-invocation. Note current Step 0A
-progress, pause this review, and pick up once they return with the brainstorm's
-output.
-
 Note current Step 0A progress so you don't re-ask questions already answered.
-After completion, re-run the design doc check and resume the review.
+After option A completes, re-run the design doc check and resume the review.
+
+If they choose B:
+
+Write a handoff note to `~/.gstack/projects/$SLUG/$(date -u +%Y%m%d-%H%M%S)-$BRANCH-ceo-handoff-brainstorm.md`
+with:
+- Current Step 0A progress (the questions already answered)
+- The specific proposal the user wanted vetted
+- A note that the review paused for `/absolute-brainstorm`
+
+Then say: "Saved a handoff note. Run `/absolute-brainstorm` in your next
+message. When you come back to `/plan-ceo-review`, I'll read the handoff
+plus the brainstorm output and pick up Step 0A from where we left off."
+
+**STOP here and wait for the user's next message.** Do not continue with
+the rest of `/plan-ceo-review` in this turn — `/absolute-brainstorm` is
+a sibling skill, not a sub-invocation, so control must return to the user
+before any further work in this review happens.
+
+When the user returns to `/plan-ceo-review`, the standard handoff-note
+check at the top of this skill will read `*-ceo-handoff-brainstorm.md` the
+same way it reads other handoff notes, and the review resumes from the
+recorded Step 0A point with the brainstorm's output as additional input.
 
 When reading TODOS.md, specifically:
 * Note any TODOs this plan touches, blocks, or unlocks

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -994,13 +994,17 @@ If none was produced (user may have cancelled), proceed with standard review.
 
 **Mid-session detection:** During Step 0A (Premise Challenge), if the user can't
 articulate the problem, keeps changing the problem statement, answers with "I'm not
-sure," or is clearly exploring rather than reviewing — offer `/office-hours`:
+sure," or is clearly exploring rather than reviewing — offer two branches:
 
-> "It sounds like you're still figuring out what to build — that's totally fine, but
-> that's what /office-hours is designed for. Want to run /office-hours right now?
-> We'll pick up right where we left off."
+> "It sounds like you're still figuring out what to build — that's totally fine.
+> Two ways to handle it:
+> - `/office-hours` — broad design interview, opens the problem back up
+> - `/absolute-brainstorm` — precise design-interview gate for adopting a specific
+>   new proposal, when you have a concrete idea you want vetted before scoping it in
+>
+> Which one fits where you are right now?"
 
-Options: A) Yes, run /office-hours now. B) No, keep going.
+Options: A) Run /office-hours. B) Run /absolute-brainstorm. C) No, keep going.
 If they keep going, proceed normally — no guilt, no re-asking.
 
 If they choose A:
@@ -1024,6 +1028,11 @@ Follow its instructions from top to bottom, **skipping these sections** (already
 - Plan Status Footer
 
 Execute every other section at full depth. When the loaded skill's instructions are complete, continue with the next step below.
+
+If they choose B: tell the user to run `/absolute-brainstorm` directly in their
+next message — it's a sibling skill, not a sub-invocation. Note current Step 0A
+progress, pause this review, and pick up once they return with the brainstorm's
+output.
 
 Note current Step 0A progress so you don't re-ask questions already answered.
 After completion, re-run the design doc check and resume the review.

--- a/plan-ceo-review/SKILL.md.tmpl
+++ b/plan-ceo-review/SKILL.md.tmpl
@@ -164,18 +164,27 @@ context to pick up where we left off."
 
 **Mid-session detection:** During Step 0A (Premise Challenge), if the user can't
 articulate the problem, keeps changing the problem statement, answers with "I'm not
-sure," or is clearly exploring rather than reviewing — offer `/office-hours`:
+sure," or is clearly exploring rather than reviewing — offer two branches:
 
-> "It sounds like you're still figuring out what to build — that's totally fine, but
-> that's what /office-hours is designed for. Want to run /office-hours right now?
-> We'll pick up right where we left off."
+> "It sounds like you're still figuring out what to build — that's totally fine.
+> Two ways to handle it:
+> - `/office-hours` — broad design interview, opens the problem back up
+> - `/absolute-brainstorm` — precise design-interview gate for adopting a specific
+>   new proposal, when you have a concrete idea you want vetted before scoping it in
+>
+> Which one fits where you are right now?"
 
-Options: A) Yes, run /office-hours now. B) No, keep going.
+Options: A) Run /office-hours. B) Run /absolute-brainstorm. C) No, keep going.
 If they keep going, proceed normally — no guilt, no re-asking.
 
 If they choose A:
 
 {{INVOKE_SKILL:office-hours}}
+
+If they choose B: tell the user to run `/absolute-brainstorm` directly in their
+next message — it's a sibling skill, not a sub-invocation. Note current Step 0A
+progress, pause this review, and pick up once they return with the brainstorm's
+output.
 
 Note current Step 0A progress so you don't re-ask questions already answered.
 After completion, re-run the design doc check and resume the review.

--- a/plan-ceo-review/SKILL.md.tmpl
+++ b/plan-ceo-review/SKILL.md.tmpl
@@ -181,13 +181,30 @@ If they choose A:
 
 {{INVOKE_SKILL:office-hours}}
 
-If they choose B: tell the user to run `/absolute-brainstorm` directly in their
-next message — it's a sibling skill, not a sub-invocation. Note current Step 0A
-progress, pause this review, and pick up once they return with the brainstorm's
-output.
-
 Note current Step 0A progress so you don't re-ask questions already answered.
-After completion, re-run the design doc check and resume the review.
+After option A completes, re-run the design doc check and resume the review.
+
+If they choose B:
+
+Write a handoff note to `~/.gstack/projects/$SLUG/$(date -u +%Y%m%d-%H%M%S)-$BRANCH-ceo-handoff-brainstorm.md`
+with:
+- Current Step 0A progress (the questions already answered)
+- The specific proposal the user wanted vetted
+- A note that the review paused for `/absolute-brainstorm`
+
+Then say: "Saved a handoff note. Run `/absolute-brainstorm` in your next
+message. When you come back to `/plan-ceo-review`, I'll read the handoff
+plus the brainstorm output and pick up Step 0A from where we left off."
+
+**STOP here and wait for the user's next message.** Do not continue with
+the rest of `/plan-ceo-review` in this turn — `/absolute-brainstorm` is
+a sibling skill, not a sub-invocation, so control must return to the user
+before any further work in this review happens.
+
+When the user returns to `/plan-ceo-review`, the standard handoff-note
+check at the top of this skill will read `*-ceo-handoff-brainstorm.md` the
+same way it reads other handoff notes, and the review resumes from the
+recorded Step 0A point with the brainstorm's output as additional input.
 
 When reading TODOS.md, specifically:
 * Note any TODOs this plan touches, blocks, or unlocks


### PR DESCRIPTION
## Summary

When `/plan-ceo-review` detects a mid-session pivot during Step 0A (Premise Challenge) — user can't articulate the problem, keeps changing it, or is clearly exploring rather than reviewing — the skill currently offers a single branch (`/office-hours`). This PR adds `/absolute-brainstorm` as a sibling option so users get the choice that fits where they are:

- **`/office-hours`** — broad design interview, opens the problem back up (existing behavior)
- **`/absolute-brainstorm`** — precise design-interview gate for adopting a specific new proposal, when the user already has a concrete idea they want vetted before scoping it in

## Motivation

`/absolute-brainstorm` is now adopted as a workflow alongside `/office-hours` for handling new proposals that surface mid-review. The two skills serve different intents:
- `/office-hours` reopens the problem ("what should we build?")
- `/absolute-brainstorm` vets a specific candidate ("should we adopt this proposal?")

Surfacing both makes the choice explicit instead of routing every pivot through `/office-hours`. `/absolute-brainstorm` is a sibling skill, not a sub-invocation — the user runs it directly in their next message and returns to the review with the brainstorm's output.

## Changes

Edits canonical source `plan-ceo-review/SKILL.md.tmpl`; the generated `plan-ceo-review/SKILL.md` is regenerated via `bun run scripts/gen-skill-docs.ts`.

- Branched the mid-session prompt: A) `/office-hours`, B) `/absolute-brainstorm`, C) keep going
- Added handoff prose for choice B (sibling skill, not sub-invocation)
- Preserved the "Mid-session detection" header and "still figuring out" phrasing required by `test/skill-validation.test.ts`

## Test plan

- [x] `bun test test/skill-validation.test.ts` — 327 pass, 0 fail
- [x] `bun test test/gen-skill-docs.test.ts` — 387 pass, 0 fail
- [x] `bun run scripts/gen-skill-docs.ts` regenerates cleanly (no diff drift)
- [ ] Reviewer: confirm `/absolute-brainstorm` skill exists in the consuming installation, or land this alongside the skill itself

Note: this PR adds the offer in `/plan-ceo-review`; the `/absolute-brainstorm` skill is upstream-adopted in the consumer's installation. If gstack ships its own `/absolute-brainstorm` skill later, no further changes needed here.