### PR TITLE
feat: add Junie (JetBrains) as a supported host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/gstack-global-discover
 .openclaw/
 .hermes/
 .gbrain/
+.junie/
 .gbrain-source
 .context/
 extension/.auth.json

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Or target a specific agent with `./setup --host <name>`:
 | Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |
 | Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |
 | GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |
+| Junie | `--host junie` | `~/.junie/skills/gstack-*/` |
 
 **Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).
 It's one TypeScript config file, zero code changes.

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,10 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import junie from './junie';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, junie];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, junie };

--- a/hosts/junie.ts
+++ b/hosts/junie.ts
@@ -1,0 +1,49 @@
+import type { HostConfig } from '../scripts/host-config';
+
+const junie: HostConfig = {
+  name: 'junie',
+  displayName: 'Junie',
+  cliCommand: 'junie',
+  cliAliases: [],
+
+  globalRoot: '.junie/skills/gstack',
+  localSkillRoot: '.junie/skills/gstack',
+  hostSubdir: '.junie',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: null,
+  },
+
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.junie/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.junie/skills/gstack' },
+    { from: '.claude/skills', to: '.junie/skills' },
+    { from: 'CLAUDE.md', to: 'AGENTS.md' },
+  ],
+
+  suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
+
+  runtimeRoot: {
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalFiles: {
+      'review': ['checklist.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  learningsMode: 'basic',
+};
+
+export default junie;

--- a/setup
+++ b/setup
@@ -84,7 +84,7 @@ TEAM_MODE=0
 NO_TEAM_MODE=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, junie, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -132,7 +132,17 @@ case "$HOST" in
     echo "GBrain setup and brain skills ship from the GBrain repo."
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
+  junie)
+    echo ""
+    echo "Installing gstack for Junie (JetBrains AI agent)..."
+    echo ""
+    PATH="$PATH:$HOME/.bun/bin" bun run gen:skill-docs --host junie
+    echo ""
+    echo "Skills generated in .junie/skills/gstack-*/"
+    echo "Add a gstack section to your AGENTS.md listing the available skills."
+    echo ""
+    exit 0 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, junie, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────

--- a/setup
+++ b/setup
@@ -24,6 +24,8 @@ FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
 OPENCODE_SKILLS="$HOME/.config/opencode/skills"
 OPENCODE_GSTACK="$OPENCODE_SKILLS/gstack"
+JUNIE_SKILLS="$HOME/.junie/skills"
+JUNIE_GSTACK="$JUNIE_SKILLS/gstack"
 
 IS_WINDOWS=0
 case "$(uname -s)" in
@@ -132,16 +134,7 @@ case "$HOST" in
     echo "GBrain setup and brain skills ship from the GBrain repo."
     echo ""
     exit 0 ;;
-  junie)
-    echo ""
-    echo "Installing gstack for Junie (JetBrains AI agent)..."
-    echo ""
-    PATH="$PATH:$HOME/.bun/bin" bun run gen:skill-docs --host junie
-    echo ""
-    echo "Skills generated in .junie/skills/gstack-*/"
-    echo "Add a gstack section to your AGENTS.md listing the available skills."
-    echo ""
-    exit 0 ;;
+  junie) ;;
   *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, junie, or auto)" >&2; exit 1 ;;
 esac
 
@@ -206,6 +199,7 @@ INSTALL_CODEX=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
 INSTALL_OPENCODE=0
+INSTALL_JUNIE=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
@@ -226,6 +220,8 @@ elif [ "$HOST" = "factory" ]; then
   INSTALL_FACTORY=1
 elif [ "$HOST" = "opencode" ]; then
   INSTALL_OPENCODE=1
+elif [ "$HOST" = "junie" ]; then
+  INSTALL_JUNIE=1
 fi
 
 migrate_direct_codex_install() {
@@ -1031,6 +1027,46 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   echo "gstack ready (opencode)."
   echo "  browse: $BROWSE_BIN"
   echo "  opencode skills: $OPENCODE_SKILLS"
+fi
+
+# 6d. Install for Junie
+link_junie_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local junie_dir="$gstack_dir/.junie/skills"
+  local linked=()
+
+  if [ ! -d "$junie_dir" ]; then
+    echo "  Generating .junie/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host junie )
+  fi
+
+  if [ ! -d "$junie_dir" ]; then
+    echo "  warning: .junie/skills/ generation failed — run 'bun run gen:skill-docs --host junie' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$junie_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        _link_or_copy "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+if [ "$INSTALL_JUNIE" -eq 1 ]; then
+  mkdir -p "$JUNIE_SKILLS"
+  link_junie_skill_dirs "$SOURCE_GSTACK_DIR" "$JUNIE_SKILLS"
+  echo "gstack ready (junie)."
+  echo "  junie skills: $JUNIE_SKILLS"
 fi
 
 # 7. Create .agents/ sidecar symlinks for the real Codex skill target.

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -30,8 +30,8 @@ const ROOT = path.resolve(import.meta.dir, '..');
 // ─── hosts/index.ts ─────────────────────────────────────────
 
 describe('hosts/index.ts', () => {
-  test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+  test('ALL_HOST_CONFIGS has 11 hosts', () => {
+    expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {


### PR DESCRIPTION
## Summary

Adds [Junie](https://www.jetbrains.com/junie/) — JetBrains' AI coding agent — as a supported gstack host.

## Changes

- **`hosts/junie.ts`** — new `HostConfig`: skills install to `.junie/skills/gstack`, `CLAUDE.md` → `AGENTS.md` path rewrite, GBrain resolvers suppressed (Junie uses `AGENTS.md` not `CLAUDE.md`)
- **`hosts/index.ts`** — registered `junie` in `ALL_HOST_CONFIGS` and re-exports (10 → 11 hosts)
- **`.gitignore`** — added `.junie/` alongside other host dirs
- **`README.md`** — added Junie row to the "Other AI Agents" host table (`--host junie` → `~/.junie/skills/gstack-*/`)
- **`test/host-config.test.ts`** — updated host count assertion (10 → 11)

## Verification

```
bun run gen:skill-docs --host junie   # 55,980 lines generated, no .claude/skills leakage
bun test test/host-config.test.ts     # 59 pass; 14 pre-existing CLI failures unrelated to this change
```

## Install

```bash
git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.junie/skills/gstack
cd ~/.junie/skills/gstack && ./setup --host junie
```