### PR TITLE
feat(browse): accept screenshot --clip=x,y,w,h (equals-sign syntax)

### DIFF
--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -442,8 +442,8 @@ export async function handleMetaCommand(
         } else if (args[i] === '--selector') {
           flagSelector = args[++i];
           if (!flagSelector) throw new Error('Usage: screenshot --selector <css> [path]');
-        } else if (args[i] === '--clip') {
-          const coords = args[++i];
+        } else if (args[i] === '--clip' || args[i].startsWith('--clip=')) {
+          const coords = args[i] === '--clip' ? args[++i] : args[i].slice('--clip='.length);
           if (!coords) throw new Error('Usage: screenshot --clip x,y,w,h [path]');
           const parts = coords.split(',').map(Number);
           if (parts.length !== 4 || parts.some(isNaN))


### PR DESCRIPTION
## What

\`screenshot --clip\` already accepts the space-separated form:

\`\`\`bash
browse screenshot --clip 100,200,300,400 out.png
\`\`\`

This PR adds the GNU long-option \`--flag=value\` form alongside, so both work:

\`\`\`bash
browse screenshot --clip 100,200,300,400 out.png    # existing, unchanged
browse screenshot --clip=100,200,300,400 out.png    # new
\`\`\`

## Why

- **Programmatic generation**: when assembling commands in a script or template, the equals-sign form is unambiguous (no need to track whether the next argv element is the value or a separate flag). The space form is fine when typed by hand but easy to break when generated.
- **Convention**: GNU long-options have supported both forms for decades; most CLIs that use long-options accept both, and it's what users reach for first.
- **No behavior change for existing callers** — the equals form is purely additive.

## Diff

Two lines in \`browse/src/meta-commands.ts\`:

\`\`\`diff
-        } else if (args[i] === '--clip') {
-          const coords = args[++i];
+        } else if (args[i] === '--clip' || args[i].startsWith('--clip=')) {
+          const coords = args[i] === '--clip' ? args[++i] : args[i].slice('--clip='.length);
\`\`\`

## Scope

Only \`--clip\` is touched here because that's the flag I hit the limitation on. The same handler has \`--viewport\`, \`--selector\`, \`--base64\` which could benefit from the same treatment — happy to do a follow-up PR that generalizes if you'd prefer that over one-off patches, but I figured a small targeted change was easier to review first.

## Test plan

- [x] \`browse screenshot --clip=10,20,300,400 /tmp/out.png\` — produces the cropped screenshot
- [x] \`browse screenshot --clip 10,20,300,400 /tmp/out.png\` — still works (regression check)
- [x] \`browse screenshot --clip\` (no value) — still throws \`Usage: screenshot --clip x,y,w,h [path]\` (error path covers both new and old syntax)
- [x] \`browse screenshot --clip=abc,def,ghi,jkl out.png\` — still throws the existing NaN guard