### PR TITLE
fix: sourceLocalPath handles wrapped {sources:[...]} shape from gbrain v0.20+

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -287,13 +287,20 @@ function gbrainSupportsSourcesRename(env?: NodeJS.ProcessEnv): boolean {
  * `env` is the environment passed to the spawned `gbrain` process; defaults
  * to `process.env`. Tests inject a PATH that points at a gbrain shim so the
  * helper can be exercised without a real gbrain CLI.
+ *
+ * Shape note: `gbrain sources list --json` returns `{sources: [...]}` (v0.20+);
+ * older versions returned a flat array. Accept both for forward/backward compat
+ * (mirrors `probeSource`/`sourcePageCount` in lib/gbrain-sources.ts).
  */
 export function sourceLocalPath(sourceId: string, env?: NodeJS.ProcessEnv): string | null {
-  const list = execGbrainJson<Array<{ id: string; local_path?: string }>>(
+  const raw = execGbrainJson<unknown>(
     ["sources", "list", "--json"],
     { baseEnv: env },
   );
-  if (!list) return null;
+  if (!raw) return null;
+  const list: Array<{ id?: string; local_path?: string }> = Array.isArray(raw)
+    ? (raw as Array<{ id?: string; local_path?: string }>)
+    : ((raw as { sources?: Array<{ id?: string; local_path?: string }> }).sources ?? []);
   const found = list.find((s) => s.id === sourceId);
   return found?.local_path ?? null;
 }

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -837,4 +837,29 @@ describe("sourceLocalPath", () => {
     });
     expect(sourceLocalPath("any-id", envWithBindir(bindir))).toBeNull();
   });
+
+  // gbrain v0.20+ wraps the response as `{sources: [...]}`. Older versions
+  // returned a flat array. sourceLocalPath was returning null (or crashing
+  // with `list.find is not a function` upstream) because it only handled
+  // the flat-array shape. Pin both shapes here.
+  it("handles {sources: [...]} wrapped shape (gbrain v0.20+)", () => {
+    makeShim(bindir, {
+      "sources list --json": {
+        stdout: JSON.stringify({
+          sources: [
+            { id: "other-source", local_path: "/x" },
+            { id: "target-id", local_path: "/repo/match" },
+          ],
+        }),
+      },
+    });
+    expect(sourceLocalPath("target-id", envWithBindir(bindir))).toBe("/repo/match");
+  });
+
+  it("returns null when the source is missing in the wrapped shape", () => {
+    makeShim(bindir, {
+      "sources list --json": { stdout: JSON.stringify({ sources: [] }) },
+    });
+    expect(sourceLocalPath("missing-id", envWithBindir(bindir))).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

`bin/gstack-gbrain-sync.ts:sourceLocalPath()` (added in v1.40.0.0 as part of the hostname-fold migration helpers) types the gbrain response as a flat `Array<{ id, local_path }>` and calls `.find()` on it directly. gbrain v0.20+ returns `{sources: [...]}` (object wrapping the array), not a flat array.

Result: `/sync-gbrain` crashes immediately on the orchestrator's first call to `sourceLocalPath` with:

```
gstack-gbrain-sync fatal: list.find is not a function.
(In 'list.find((s) => s.id === sourceId)', 'list.find' is undefined)
```

The sibling helpers `probeSource` and `sourcePageCount` in `lib/gbrain-sources.ts` already handle the wrapped shape correctly (parse `{sources?: Array<...>}`, fall back to `[]`). This PR brings `sourceLocalPath` in line.

The fix accepts both shapes (flat array OR `{sources: [...]}`) for backward compatibility with any older gbrain still in the wild.

## Reproduction

- gstack v1.40.0.0 + gbrain v0.35.0.0 on Windows (MINGW64). Likely reproduces on macOS/Linux too — this is a pure data-shape bug, not a platform issue.
- Invoke `/sync-gbrain` in any repo that already has registered sources (e.g., from `gbrain sources add ... --path ...`).
- Orchestrator crashes before completing stage 1.

Workaround for affected users until this lands: skip the orchestrator and call `gbrain sync --all --no-pull --yes` directly.

## Test plan

- [x] New regression test `handles {sources: [...]} wrapped shape (gbrain v0.20+)` mocks the actual v0.20+ response shape and asserts the lookup succeeds.
- [x] New regression test `returns null when the source is missing in the wrapped shape` covers the empty-array case.
- [x] Existing tests preserved (flat-array shape still supported for backward compat).
- [ ] CI verifies on Linux (the existing `makeShim` infra uses `#!/bin/sh` shebang scripts so the test pattern doesn't run on Windows directly; pre-existing limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)