### PR TITLE
fix(paths): Guard Claude plugin data fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,8 +102,8 @@ bun run skill:check      # health dashboard for all skills
 - **Windows**: curated Windows-safe subset runs on `windows-latest` via the
   `windows-free-tests` CI job. Setup script (`./setup`) requires Git Bash or
   MSYS today; native PowerShell support is a future expansion. The `bin/gstack-paths`
-  helper resolves state roots through `CLAUDE_PLUGIN_DATA` / `GSTACK_HOME` so plugin
-  installs work on every platform.
+  helper resolves state roots through `GSTACK_HOME` / guarded `CLAUDE_PLUGIN_DATA` so
+  plugin installs work on every platform without borrowing another plugin's data dir.
 
 ## Key conventions
 
@@ -111,5 +111,5 @@ bun run skill:check      # health dashboard for all skills
 - Run `bun run gen:skill-docs --host codex` to regenerate Codex-specific output.
 - The browse binary provides headless browser access. Use `$B <command>` in skills.
 - Safety skills (careful, freeze, guard) use inline advisory prose — always confirm before destructive operations.
-- State paths resolve via `bin/gstack-paths` (sourced via `eval "$(...)"`). Honors `GSTACK_HOME`, `CLAUDE_PLUGIN_DATA`, `CLAUDE_PLANS_DIR`.
+- State paths resolve via `bin/gstack-paths` (sourced via `eval "$(...)"`). Honors `GSTACK_HOME`, gstack-owned `CLAUDE_PLUGIN_DATA`, and `CLAUDE_PLANS_DIR`.
 - The `claude` CLI binary resolves via `browse/src/claude-bin.ts` (`Bun.which()` + `GSTACK_CLAUDE_BIN` override). Set `GSTACK_CLAUDE_BIN=wsl` plus `GSTACK_CLAUDE_BIN_ARGS='["claude"]'` to run Claude through WSL on Windows.

--- a/bin/gstack-paths
+++ b/bin/gstack-paths
@@ -5,11 +5,12 @@
 #
 # Resolves three roots with explicit fallback chains so skills work the same
 # whether installed as a Claude Code plugin (CLAUDE_PLUGIN_DATA / CLAUDE_PLANS_DIR
-# set), a global ~/.claude/skills/gstack/ install, or a local checkout under
+# set with CLAUDE_PLUGIN_ROOT pointing at gstack), a global ~/.claude/skills/gstack/
+# install, or a local checkout under
 # CI / container env where HOME may be unset.
 #
 # Chains:
-#   GSTACK_STATE_ROOT: GSTACK_HOME -> CLAUDE_PLUGIN_DATA -> $HOME/.gstack -> .gstack
+#   GSTACK_STATE_ROOT: GSTACK_HOME -> guarded CLAUDE_PLUGIN_DATA -> $HOME/.gstack -> .gstack
 #   PLAN_ROOT:         GSTACK_PLAN_DIR -> CLAUDE_PLANS_DIR -> $HOME/.claude/plans -> .claude/plans
 #   TMP_ROOT:          TMPDIR -> TMP -> .gstack/tmp (and mkdir -p, best-effort)
 #
@@ -18,10 +19,22 @@
 # expansions ("$GSTACK_STATE_ROOT", not $GSTACK_STATE_ROOT).
 set -u
 
+_gstack_plugin_data_is_ours() {
+  [ -n "${CLAUDE_PLUGIN_DATA:-}" ] || return 1
+  [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || return 1
+
+  # CLAUDE_PLUGIN_DATA is process-global. In skill installs it can belong to a
+  # different plugin, so only trust it when the plugin root looks like gstack.
+  [ -f "$CLAUDE_PLUGIN_ROOT/bin/gstack-paths" ] && return 0
+  [ "${CLAUDE_PLUGIN_ROOT##*/}" = "gstack" ] && return 0
+
+  return 1
+}
+
 # State root: where gstack writes projects/, sessions/, analytics/.
 if [ -n "${GSTACK_HOME:-}" ]; then
   _state_root="$GSTACK_HOME"
-elif [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
+elif _gstack_plugin_data_is_ours; then
   _state_root="$CLAUDE_PLUGIN_DATA"
 elif [ -n "${HOME:-}" ]; then
   _state_root="$HOME/.gstack"

--- a/test/gstack-paths.test.ts
+++ b/test/gstack-paths.test.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect } from 'bun:test';
 import { spawnSync } from 'child_process';
 import * as path from 'path';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const BIN = path.join(ROOT, 'bin', 'gstack-paths');
@@ -41,11 +43,38 @@ describe('gstack-paths', () => {
     expect(got.GSTACK_STATE_ROOT).toBe('/tmp/explicit-state');
   });
 
-  test('CLAUDE_PLUGIN_DATA wins over HOME when GSTACK_HOME unset', () => {
+  test('CLAUDE_PLUGIN_DATA is ignored without a gstack plugin root', () => {
     const got = run({
       CLAUDE_PLUGIN_DATA: '/tmp/plugin-data',
       HOME: '/tmp/home',
     });
+    expect(got.GSTACK_STATE_ROOT).toBe('/tmp/home/.gstack');
+  });
+
+  test('CLAUDE_PLUGIN_DATA is ignored for a foreign plugin root', () => {
+    const foreignRoot = mkdtempSync(path.join(tmpdir(), 'other-plugin-'));
+    mkdirSync(path.join(foreignRoot, 'bin'));
+
+    const got = run({
+      CLAUDE_PLUGIN_DATA: '/tmp/plugin-data',
+      CLAUDE_PLUGIN_ROOT: foreignRoot,
+      HOME: '/tmp/home',
+    });
+
+    expect(got.GSTACK_STATE_ROOT).toBe('/tmp/home/.gstack');
+  });
+
+  test('CLAUDE_PLUGIN_DATA wins over HOME for a gstack plugin root', () => {
+    const gstackRoot = mkdtempSync(path.join(tmpdir(), 'gstack-plugin-'));
+    mkdirSync(path.join(gstackRoot, 'bin'));
+    writeFileSync(path.join(gstackRoot, 'bin', 'gstack-paths'), '#!/usr/bin/env bash\n');
+
+    const got = run({
+      CLAUDE_PLUGIN_DATA: '/tmp/plugin-data',
+      CLAUDE_PLUGIN_ROOT: gstackRoot,
+      HOME: '/tmp/home',
+    });
+
     expect(got.GSTACK_STATE_ROOT).toBe('/tmp/plugin-data');
   });
 


### PR DESCRIPTION
## Summary

- Guard `CLAUDE_PLUGIN_DATA` so `gstack-paths` only uses it when `CLAUDE_PLUGIN_ROOT` identifies the gstack plugin root.
- Fall back to `$HOME/.gstack` when gstack is running as a skill and the process inherited another plugin's data directory.
- Update path resolver docs and regression coverage for missing/foreign/gstack plugin roots.

Fixes #1569

## Tests

- `bun test test/gstack-paths.test.ts`
- `git diff --check`