### PR TITLE
fix(gstack-paths): shell-quote output so eval is safe for paths with spaces

### DIFF
--- a/bin/gstack-paths
+++ b/bin/gstack-paths
@@ -13,10 +13,16 @@
 #   PLAN_ROOT:         GSTACK_PLAN_DIR -> CLAUDE_PLANS_DIR -> $HOME/.claude/plans -> .claude/plans
 #   TMP_ROOT:          TMPDIR -> TMP -> .gstack/tmp (and mkdir -p, best-effort)
 #
-# Security: output values are not sanitized — callers may receive paths with
-# shell-special characters if env vars contain them. Skills should always quote
-# expansions ("$GSTACK_STATE_ROOT", not $GSTACK_STATE_ROOT).
+# Output values are shell-quoted so eval "$(gstack-paths)" is safe for paths
+# containing spaces, $, ;, backticks, and other metacharacters. Single quotes
+# are used for portability (POSIX sh / bash / zsh / dash).
 set -u
+
+# Wrap a path in single quotes, escaping any embedded single quotes.
+# Produces output safe for: eval "$(gstack-paths)"
+_shell_quote() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
 
 # State root: where gstack writes projects/, sessions/, analytics/.
 if [ -n "${GSTACK_HOME:-}" ]; then
@@ -56,6 +62,6 @@ fi
 # will discover that on their own write attempt. Don't fail the eval here.
 mkdir -p "$_tmp_root" 2>/dev/null || true
 
-echo "GSTACK_STATE_ROOT=$_state_root"
-echo "PLAN_ROOT=$_plan_root"
-echo "TMP_ROOT=$_tmp_root"
+printf 'GSTACK_STATE_ROOT=%s\n' "$(_shell_quote "$_state_root")"
+printf 'PLAN_ROOT=%s\n' "$(_shell_quote "$_plan_root")"
+printf 'TMP_ROOT=%s\n' "$(_shell_quote "$_tmp_root")"


### PR DESCRIPTION
## Problem

`GSTACK_HOME` (and the other path roots) may contain spaces or shell metacharacters — for example an iCloud-synced directory under `Library/Mobile Documents/`.

The current bare `echo` emits unquoted output:

```
GSTACK_STATE_ROOT=/Users/me/Library/Mobile Documents/Obsidian/GStack
```

When skills do `eval "$(gstack-paths)"`, bash/zsh split on the first space:
- `GSTACK_STATE_ROOT` gets set to `/Users/me/Library/Mobile`
- The shell then tries to execute `Documents/Obsidian/GStack` as a command

Result: `command not found` and `GSTACK_STATE_ROOT` left truncated/wrong.

## Fix

Add a POSIX-compatible `_shell_quote` helper that wraps each value in single quotes and properly escapes any embedded single quotes (the standard `'\''\''` form). Replace the three `echo` lines with `printf`.

Output now looks like:

```
GSTACK_STATE_ROOT='/Users/me/Library/Mobile Documents/Obsidian/GStack'
PLAN_ROOT='/Users/me/.claude/plans'
TMP_ROOT='/var/folders/...'
```

Safe for paths containing: spaces, `$`, `;`, backticks, double quotes, single quotes.

Works in sh / bash / zsh / dash (no `printf %q` which is bash/zsh-only).

## Testing

Verified with:
- Normal path (no spaces) — behaviour unchanged
- Path with spaces — now works
- Actual iCloud vault path (`Library/Mobile Documents/iCloud~md~obsidian/...`) — now works

## Notes

The existing comment said _"output values are not sanitized"_ — that warning is now removed since the output is sanitized. No other call sites need changing; the output contract (`eval "$(gstack-paths)"`) is preserved.