### PR TITLE
fix(gbrain-sync): --full produces an empty code index on first run of a new repo

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -589,26 +589,51 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
     };
   }
 
-  // Step 2: Run sync or reindex.
-  const syncArgs = args.mode === "full"
-    ? ["reindex-code", "--source", sourceId, "--yes"]
-    : ["sync", "--strategy", "code", "--source", sourceId];
-
-  const syncResult = spawnGbrain(syncArgs, {
+  // Step 2: Always run the page-creating file walk first, then (for --full)
+  // a full re-embed.
+  //
+  // `gbrain reindex-code` only RE-EMBEDS pages that already exist; it never
+  // walks the filesystem. On a freshly-registered source (0 pages) a --full
+  // run that called reindex-code alone found nothing ("No code pages to
+  // reindex"), finished in ~1s, and left the code index permanently empty
+  // while still reporting OK. The page-creating walk is `sync --strategy
+  // code`, so --full must run it FIRST, then reindex-code, to honor the
+  // documented "full walk + reindex" contract for both fresh and populated
+  // sources.
+  const walkResult = spawnGbrain(["sync", "--strategy", "code", "--source", sourceId], {
     stdio: args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"],
     timeout: 35 * 60 * 1000,
     baseEnv: gbrainEnv,
   });
 
-  if (syncResult.status !== 0) {
+  if (walkResult.status !== 0) {
     return {
       name: "code",
       ran: true,
       ok: false,
       duration_ms: Date.now() - t0,
-      summary: `gbrain ${syncArgs.join(" ")} exited ${syncResult.status}`,
+      summary: `gbrain sync --strategy code --source ${sourceId} exited ${walkResult.status}`,
       detail: { source_id: sourceId, source_path: root, status: "failed" },
     };
+  }
+
+  if (args.mode === "full") {
+    const reindexResult = spawnGbrain(["reindex-code", "--source", sourceId, "--yes"], {
+      stdio: args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"],
+      timeout: 35 * 60 * 1000,
+      baseEnv: gbrainEnv,
+    });
+
+    if (reindexResult.status !== 0) {
+      return {
+        name: "code",
+        ran: true,
+        ok: false,
+        duration_ms: Date.now() - t0,
+        summary: `gbrain reindex-code --source ${sourceId} exited ${reindexResult.status}`,
+        detail: { source_id: sourceId, source_path: root, status: "failed" },
+      };
+    }
   }
 
   // Step 3: Pin this worktree's CWD to the source via .gbrain-source. Subsequent


### PR DESCRIPTION
## Problem

The first `/sync-gbrain --full` on a new repo produces a code index with
**0 pages** while the stage reports `OK`. Semantic code search
(`gbrain code-def` / `code-refs` / `search`) then silently returns nothing
for that repo.

`gstack-gbrain-sync.ts:runCodeImport` selects the code-stage command by
mode:

```ts
const syncArgs = args.mode === "full"
  ? ["reindex-code", "--source", sourceId, "--yes"]      // re-embeds EXISTING pages
  : ["sync", "--strategy", "code", "--source", sourceId]; // the walk that CREATES pages
```

`gbrain reindex-code` only re-embeds pages that already exist; it never
walks the filesystem. On a source registered moments earlier (0 pages),
the `--full` branch runs `reindex-code`, gbrain prints "No code pages to
reindex", finishes in about a second, and the index stays empty. The
page-creating walk (`sync --strategy code`) only runs on the incremental
path.

This also contradicts the skill's own documented contract: the `--full`
help text says "First-run; full walk + reindex" — but the code does
reindex only, no walk.

## Fix

`--full` runs the file-walk sync first (creating/refreshing pages), then
`reindex-code` for the full re-embed. Incremental keeps the walk only.
This matches the documented "full walk + reindex" contract and is correct
for both freshly-registered and already-populated sources.

## Verification

Reproduced and fixed end-to-end: with a freshly-registered source,
`--full` on the unpatched code finished in about a second with 0 pages;
with the fix it runs the real walk and the source fully populates
(hundreds of pages, multi-minute walk as expected).

## Notes

- Companion PR: #1583 (a classifier false-`broken-db` bug found during the
  same investigation; that one gates this skill from even reaching the
  orchestrator inside web-app repos).
- Secondary observation: the code stage reported `OK` with `page_count=0`.
  Worth considering a WARN/fail in the verdict block when a code sync
  completes with 0 pages on a non-empty repo, so this class of silent
  emptiness can't recur unnoticed. Not included here to keep the PR
  focused.
