### PR TITLE
feat(plan-eng-review): add Step 0.5 — existing-capability check before new substrate code

### DIFF
--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -907,7 +907,22 @@ If the complexity check triggers (8+ files or 2+ new classes/services), STOP bef
 
 **STOP.** Do NOT proceed to Section 1 (Architecture review), edit the plan file with a proposed scope reduction, or call ExitPlanMode until the user responds. Naming the 80% solution in chat prose and continuing — or loading the AskUserQuestion schema via ToolSearch and then never invoking it — is the failure mode this gate exists to prevent.
 
-If the complexity check does not trigger, present your Step 0 findings and proceed directly to Section 1.
+If the complexity check does not trigger, present your Step 0 findings and proceed directly to Step 0.5.
+
+### Step 0.5: Existing-capability check (gbrain / autopilot / integration recipes)
+
+If the plan touches a knowledge-graph or agent-runtime substrate (gbrain, OpenClaw, Hermes, a similar recipe-driven system), run this 60-second check BEFORE designing new code under `ops/<substrate>/`:
+
+```bash
+# gbrain example — substitute the substrate's equivalent CLI / launchd label
+ssh <host> 'gbrain integrations list && launchctl list | grep -i gbrain'
+```
+
+The recipe-driven substrates (gbrain especially) ship a senses + reflexes system that IS the signal-detector / autopilot / ingest pattern. Most "wire X into the flow" plans should be **configuring an existing recipe** (or writing a markdown recipe modeled on an existing one), NOT building new infrastructure. If a recipe exists `AVAILABLE` → configure it. If a recipe is `CONFIGURED` but dormant → investigate why. If no recipe exists → write a markdown recipe modeled on a sibling recipe (e.g. `imessage-to-brain`), submit upstream. Only propose new ops/ code if all three branches fail.
+
+This step exists because the failure mode is real: a 2026-05-17 hash-lemma plan proposed extracting a JSONL queue lib + producer + consumer bin + LaunchAgent + OAuth-DCR migration to wire "signal-detector on every Slack message" — when the gbrain `integrations` system already shipped the pattern. The 60-second check would have flagged the wrong-buildout at scope-lock.
+
+For substrates with no equivalent capability surface (pure web apps, libraries, CLIs), skip this step.
 
 Always work through the full interactive review: one section at a time (Architecture → Code Quality → Tests → Performance) with at most 8 top issues per section.
 

--- a/plan-eng-review/SKILL.md.tmpl
+++ b/plan-eng-review/SKILL.md.tmpl
@@ -117,7 +117,22 @@ If the complexity check triggers (8+ files or 2+ new classes/services), STOP bef
 
 **STOP.** Do NOT proceed to Section 1 (Architecture review), edit the plan file with a proposed scope reduction, or call ExitPlanMode until the user responds. Naming the 80% solution in chat prose and continuing — or loading the AskUserQuestion schema via ToolSearch and then never invoking it — is the failure mode this gate exists to prevent.
 
-If the complexity check does not trigger, present your Step 0 findings and proceed directly to Section 1.
+If the complexity check does not trigger, present your Step 0 findings and proceed directly to Step 0.5.
+
+### Step 0.5: Existing-capability check (gbrain / autopilot / integration recipes)
+
+If the plan touches a knowledge-graph or agent-runtime substrate (gbrain, OpenClaw, Hermes, a similar recipe-driven system), run this 60-second check BEFORE designing new code under `ops/<substrate>/`:
+
+```bash
+# gbrain example — substitute the substrate's equivalent CLI / launchd label
+ssh <host> 'gbrain integrations list && launchctl list | grep -i gbrain'
+```
+
+The recipe-driven substrates (gbrain especially) ship a senses + reflexes system that IS the signal-detector / autopilot / ingest pattern. Most "wire X into the flow" plans should be **configuring an existing recipe** (or writing a markdown recipe modeled on an existing one), NOT building new infrastructure. If a recipe exists `AVAILABLE` → configure it. If a recipe is `CONFIGURED` but dormant → investigate why. If no recipe exists → write a markdown recipe modeled on a sibling recipe (e.g. `imessage-to-brain`), submit upstream. Only propose new ops/ code if all three branches fail.
+
+This step exists because the failure mode is real: a 2026-05-17 hash-lemma plan proposed extracting a JSONL queue lib + producer + consumer bin + LaunchAgent + OAuth-DCR migration to wire "signal-detector on every Slack message" — when the gbrain `integrations` system already shipped the pattern. The 60-second check would have flagged the wrong-buildout at scope-lock.
+
+For substrates with no equivalent capability surface (pure web apps, libraries, CLIs), skip this step.
 
 Always work through the full interactive review: one section at a time (Architecture → Code Quality → Tests → Performance) with at most 8 top issues per section.
 


### PR DESCRIPTION
## What

Adds a **Step 0.5: Existing-capability check** to `/plan-eng-review`, between the Step 0 Scope Challenge and Section 1 (Architecture review).

When a plan proposes new code under `ops/<substrate>/` (gbrain, OpenClaw, Hermes, or similar recipe-driven substrates), the reviewer must first run a 60-second check:

```bash
ssh <host> 'gbrain integrations list && launchctl list | grep -i gbrain'
```

Recipe-driven substrates ship a senses + reflexes system that IS the signal-detector / autopilot / ingest pattern. Most "wire X into the flow" plans should be **configuring an existing recipe** (or writing a markdown recipe modeled on an existing one), NOT building new infrastructure. The new step codifies the three decision branches: configure if AVAILABLE, investigate if CONFIGURED-but-dormant, write a markdown recipe if no recipe exists, build new code only if all three fail.

## Why

Real incident, 2026-05-17 on a downstream user's hash-lemma project: `/plan-eng-review` accepted a plan to extract a JSONL queue lib + producer + consumer bin + LaunchAgent + OAuth-DCR migration to wire "signal-detector on every Slack message" — when gbrain's `integrations` system (11 senses + 1 reflex) already shipped exactly that pattern, recipe-based. The user's instinct caught it (*"this feels like a wrong buildout vs the garry way"*), but the eng-review didn't.

Garry's own writings in [docs/ethos/thin_harness_fat_skills](https://github.com/garrytan/gbrain/blob/main/docs/ethos/thin_harness_fat_skills) and [docs/ethos/markdown_skills_as_recipes](https://github.com/garrytan/gbrain/blob/main/docs/ethos/markdown_skills_as_recipes) explicitly name this as the anti-pattern: "fat harness with thin skills," "REST API wrappers as tools," "push intelligence UP to skills, execution DOWN to deterministic tooling." The 60-second check operationalizes the rule at the review-skill level.

Net savings (this case): ~3-5 days of misdirected code, replaced with one markdown recipe (slack-to-brain) submitted upstream separately.

## Coverage

- Substrates this affects: gbrain, OpenClaw, Hermes (recipe-driven agent / knowledge-graph runtimes)
- Substrates this skips: pure web apps, libraries, CLIs — no capability surface to check against

## Test plan

- [x] `bun run gen:skill-docs` regenerates SKILL.md without errors
- [x] Diff confirms Step 0.5 inserted between Step 0 and Section 1 in both .tmpl and .md
- [ ] Manual: run `/plan-eng-review` on a plan touching ops/gbrain — verify Step 0.5 fires and the 60-second check shows in the review output
- [ ] Validation: confirm Substep doesn't fire on a non-substrate plan (e.g. a pure web-app feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)