### PR TITLE
fix: v1.40.0.0 migration done-marker leaves privacy-map half-patched on jq-less machines (#1581)

### DIFF
--- a/gstack-upgrade/migrations/v1.40.0.0.sh
+++ b/gstack-upgrade/migrations/v1.40.0.0.sh
@@ -13,6 +13,12 @@
 #
 # Idempotent: each insertion is gated on `not already present` so re-running
 # the migration is a no-op.
+#
+# Done-marker discipline (#1581): the marker is only written when every
+# required repair either succeeded or was provably unnecessary. Tracking
+# happens via the `incomplete` flag; on any failure path (missing jq, broken
+# JSON, append failure, mv failure) we set `incomplete=1` and skip the touch
+# so the migration runner retries on the next /gstack-upgrade.
 
 set -u
 
@@ -34,19 +40,30 @@ NEW_PATTERNS=(
 )
 
 added_any=0
+incomplete=0
 
 # ----- .brain-allowlist ---------------------------------------------------
 if [ -f "${ALLOWLIST}" ]; then
   for PATTERN in "${NEW_PATTERNS[@]}"; do
     if ! grep -Fq -- "${PATTERN}" "${ALLOWLIST}" 2>/dev/null; then
       if grep -q '^# ---- USER ADDITIONS BELOW' "${ALLOWLIST}" 2>/dev/null; then
-        sed -i.bak "/^# ---- USER ADDITIONS BELOW/i\\
+        if sed -i.bak "/^# ---- USER ADDITIONS BELOW/i\\
 ${PATTERN}
-" "${ALLOWLIST}" && rm -f "${ALLOWLIST}.bak"
-        added_any=1
+" "${ALLOWLIST}" 2>/dev/null; then
+          rm -f "${ALLOWLIST}.bak"
+          added_any=1
+        else
+          echo "  [v1.40.0.0] WARN: failed to insert ${PATTERN} into ${ALLOWLIST}; will retry on next upgrade." >&2
+          rm -f "${ALLOWLIST}.bak" 2>/dev/null || true
+          incomplete=1
+        fi
       else
-        printf '%s\n' "${PATTERN}" >> "${ALLOWLIST}"
-        added_any=1
+        if printf '%s\n' "${PATTERN}" >> "${ALLOWLIST}" 2>/dev/null; then
+          added_any=1
+        else
+          echo "  [v1.40.0.0] WARN: failed to append ${PATTERN} to ${ALLOWLIST}; will retry on next upgrade." >&2
+          incomplete=1
+        fi
       fi
     fi
   done
@@ -55,19 +72,39 @@ fi
 # ----- .brain-privacy-map.json -------------------------------------------
 if [ -f "${PRIVACY}" ]; then
   if command -v jq >/dev/null 2>&1; then
-    for PATTERN in "${NEW_PATTERNS[@]}"; do
-      if ! jq -e --arg p "${PATTERN}" 'map(select(.pattern == $p)) | length > 0' "${PRIVACY}" >/dev/null 2>&1; then
-        if jq --arg p "${PATTERN}" '. += [{"pattern": $p, "class": "artifact"}]' "${PRIVACY}" > "${PRIVACY}.tmp" 2>/dev/null; then
-          mv "${PRIVACY}.tmp" "${PRIVACY}"
-          added_any=1
-        else
-          rm -f "${PRIVACY}.tmp"
-          echo "  [v1.40.0.0] WARN: jq failed to patch ${PRIVACY}; skipping pattern ${PATTERN}." >&2
+    # Validate JSON shape up front. We won't try to repair a corrupt file —
+    # bail out and leave for manual fix.
+    if ! jq -e . "${PRIVACY}" >/dev/null 2>&1; then
+      echo "  [v1.40.0.0] WARN: ${PRIVACY} is not valid JSON; skipping privacy-map repair. Fix manually or run gstack-artifacts-init." >&2
+      incomplete=1
+    else
+      for PATTERN in "${NEW_PATTERNS[@]}"; do
+        if ! jq -e --arg p "${PATTERN}" 'map(select(.pattern == $p)) | length > 0' "${PRIVACY}" >/dev/null 2>&1; then
+          tmp=$(mktemp "${PRIVACY}.tmp.XXXXXX" 2>/dev/null)
+          if [ -z "${tmp}" ] || [ ! -f "${tmp}" ]; then
+            echo "  [v1.40.0.0] WARN: failed to create tempfile for ${PRIVACY}; skipping pattern ${PATTERN}." >&2
+            incomplete=1
+            continue
+          fi
+          if jq --arg p "${PATTERN}" '. += [{"pattern": $p, "class": "artifact"}]' "${PRIVACY}" > "${tmp}" 2>/dev/null; then
+            if mv "${tmp}" "${PRIVACY}" 2>/dev/null; then
+              added_any=1
+            else
+              echo "  [v1.40.0.0] WARN: failed to rewrite ${PRIVACY}; skipping pattern ${PATTERN}." >&2
+              rm -f "${tmp}"
+              incomplete=1
+            fi
+          else
+            echo "  [v1.40.0.0] WARN: jq mutation failed for ${PRIVACY}; skipping pattern ${PATTERN}." >&2
+            rm -f "${tmp}"
+            incomplete=1
+          fi
         fi
-      fi
-    done
+      done
+    fi
   else
     echo "  [v1.40.0.0] WARN: jq not found; skipping privacy-map repair. Install jq and re-run gstack-upgrade, or run gstack-artifacts-init manually." >&2
+    incomplete=1
   fi
 fi
 
@@ -76,19 +113,27 @@ if [ -f "${GITATTRS}" ]; then
   for PATTERN in "${NEW_PATTERNS[@]}"; do
     RULE="${PATTERN} merge=union"
     if ! grep -Fq -- "${RULE}" "${GITATTRS}" 2>/dev/null; then
-      printf '%s\n' "${RULE}" >> "${GITATTRS}"
-      added_any=1
+      if printf '%s\n' "${RULE}" >> "${GITATTRS}" 2>/dev/null; then
+        added_any=1
+      else
+        echo "  [v1.40.0.0] WARN: failed to append rule to ${GITATTRS}; will retry on next upgrade." >&2
+        incomplete=1
+      fi
     fi
   done
 fi
 
-# Mark done even if no patches needed — a fresh-init user's
-# bin/gstack-artifacts-init now writes the pattern directly, so re-runs
-# should no-op. The touchfile keeps the migration runner from looping.
-touch "${DONE}"
-
-if [ "${added_any}" = "1" ]; then
-  echo "  [v1.40.0.0] allowlist/privacy-map/gitattributes patched for /plan-eng-review test plans (idempotent)" >&2
+if [ "${incomplete}" = "0" ]; then
+  # Mark done — every required repair either succeeded or was provably
+  # unnecessary. A fresh-init user's bin/gstack-artifacts-init now writes the
+  # pattern directly, so re-runs no-op. The touchfile keeps the migration
+  # runner from looping.
+  touch "${DONE}"
+  if [ "${added_any}" = "1" ]; then
+    echo "  [v1.40.0.0] allowlist/privacy-map/gitattributes patched for /plan-eng-review test plans (idempotent)" >&2
+  fi
+else
+  echo "  [v1.40.0.0] INFO: marker not written; gstack-upgrade will retry once prerequisites are met." >&2
 fi
 
 # NEVER `git commit + push` from this migration. The user controls when the

--- a/test/gstack-upgrade-migration-v1_40_0_0.test.ts
+++ b/test/gstack-upgrade-migration-v1_40_0_0.test.ts
@@ -1,0 +1,324 @@
+/**
+ * gstack-upgrade/migrations/v1.40.0.0.sh — migration script unit tests.
+ *
+ * Per #1581: the original script unconditionally `touch`ed its done-marker even
+ * when the jq-gated privacy-map patch was skipped. The fix defers `touch ${DONE}`
+ * until every required repair either succeeded or was provably unnecessary.
+ *
+ * The "regression case" that this file pins is case 2: jq missing + privacy-map
+ * present → no done-marker. Against the buggy script, case 2 fails (marker is
+ * written despite skipped patch); against the fix it passes.
+ *
+ * Strategy: each test sets up an isolated tmpHome with controlled fixture
+ * content, and runs the migration via `spawnSync('bash', [MIGRATION], …)`.
+ * For "jq missing" we point PATH at a curated dir of symlinks to the standard
+ * utilities the script uses, omitting jq. For "jq mutation fails" we point PATH
+ * at a dir containing a jq shim that exits 1.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+const MIGRATION = path.join(
+  ROOT,
+  "gstack-upgrade",
+  "migrations",
+  "v1.40.0.0.sh",
+);
+
+const NEW_PATTERN = "projects/*/*-eng-review-test-plan-*.md";
+const REAL_PATH = "/usr/bin:/bin:/opt/homebrew/bin";
+
+let tmpHome: string;
+let gstackHome: string;
+let migrationDir: string;
+let donePath: string;
+let allowlistPath: string;
+let privacyPath: string;
+let gitattrsPath: string;
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "gstack-mig-v1400-"));
+  gstackHome = path.join(tmpHome, ".gstack");
+  migrationDir = path.join(gstackHome, ".migrations");
+  donePath = path.join(migrationDir, "v1.40.0.0.done");
+  allowlistPath = path.join(gstackHome, ".brain-allowlist");
+  privacyPath = path.join(gstackHome, ".brain-privacy-map.json");
+  gitattrsPath = path.join(gstackHome, ".gitattributes");
+  fs.mkdirSync(gstackHome, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    fs.chmodSync(gstackHome, 0o755);
+    if (fs.existsSync(allowlistPath)) fs.chmodSync(allowlistPath, 0o644);
+    if (fs.existsSync(privacyPath)) fs.chmodSync(privacyPath, 0o644);
+    if (fs.existsSync(gitattrsPath)) fs.chmodSync(gitattrsPath, 0o644);
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  } catch {}
+});
+
+/**
+ * Construct a PATH-style directory of symlinks to standard utilities the
+ * migration script needs (mkdir, grep, sed, mv, rm, mktemp, cat, touch, printf,
+ * command, etc.). Optionally omit jq, or substitute a shim.
+ */
+function makeCuratedPath(opts: { jq?: "missing" | "shim-fail" | "real" } = {}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gstack-mig-path-"));
+  const utils = [
+    "bash",
+    "sh",
+    "mkdir",
+    "grep",
+    "sed",
+    "mv",
+    "rm",
+    "mktemp",
+    "cat",
+    "touch",
+    "printf",
+    "command",
+    "echo",
+    "test",
+    "[",
+    "tee",
+    "true",
+    "false",
+    "ls",
+    "chmod",
+  ];
+  const realDirs = REAL_PATH.split(":");
+  for (const u of utils) {
+    for (const d of realDirs) {
+      const src = path.join(d, u);
+      if (fs.existsSync(src)) {
+        try {
+          fs.symlinkSync(src, path.join(dir, u));
+        } catch {}
+        break;
+      }
+    }
+  }
+  const jq = opts.jq ?? "real";
+  if (jq === "real") {
+    for (const d of realDirs) {
+      const src = path.join(d, "jq");
+      if (fs.existsSync(src)) {
+        try {
+          fs.symlinkSync(src, path.join(dir, "jq"));
+        } catch {}
+        break;
+      }
+    }
+  } else if (jq === "shim-fail") {
+    const shim = path.join(dir, "jq");
+    fs.writeFileSync(
+      shim,
+      `#!/usr/bin/env bash\necho "fake jq: refusing" >&2\nexit 1\n`,
+      { mode: 0o755 },
+    );
+  }
+  // jq === "missing" → don't add anything
+  return dir;
+}
+
+function run(opts: { path?: string } = {}) {
+  const env = {
+    HOME: tmpHome,
+    PATH: opts.path ?? REAL_PATH,
+  };
+  return spawnSync("bash", [MIGRATION], {
+    env,
+    encoding: "utf-8",
+    cwd: tmpHome,
+  });
+}
+
+function freshPrivacyMap() {
+  fs.writeFileSync(
+    privacyPath,
+    JSON.stringify(
+      [{ pattern: "projects/*/*-some-other-*.md", class: "artifact" }],
+      null,
+      2,
+    ),
+  );
+}
+
+function freshAllowlist() {
+  fs.writeFileSync(
+    allowlistPath,
+    "# header\nprojects/*/*-some-other-*.md\n# ---- USER ADDITIONS BELOW\n",
+  );
+}
+
+function freshGitattrs() {
+  fs.writeFileSync(gitattrsPath, "projects/*/*-some-other-*.md merge=union\n");
+}
+
+describe("migrations/v1.40.0.0.sh", () => {
+  test("case 1: jq present, fresh privacy-map — all three files patched, marker written", () => {
+    freshAllowlist();
+    freshPrivacyMap();
+    freshGitattrs();
+
+    const r = run();
+
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(donePath)).toBe(true);
+
+    const allowlist = fs.readFileSync(allowlistPath, "utf-8");
+    expect(allowlist).toContain(NEW_PATTERN);
+
+    const privacy = JSON.parse(fs.readFileSync(privacyPath, "utf-8"));
+    expect(
+      privacy.some(
+        (e: any) => e.pattern === NEW_PATTERN && e.class === "artifact",
+      ),
+    ).toBe(true);
+
+    const gitattrs = fs.readFileSync(gitattrsPath, "utf-8");
+    expect(gitattrs).toContain(`${NEW_PATTERN} merge=union`);
+  });
+
+  test("case 2 (regression for #1581): jq missing, privacy-map exists — marker NOT written, text patches still applied", () => {
+    freshAllowlist();
+    freshPrivacyMap();
+    freshGitattrs();
+
+    const noJq = makeCuratedPath({ jq: "missing" });
+    const r = run({ path: noJq });
+
+    expect(r.status).toBe(0);
+    expect(r.stderr).toMatch(/jq not found/);
+
+    // Done-marker must NOT be written — this is the whole point of the fix.
+    expect(fs.existsSync(donePath)).toBe(false);
+
+    // Text-only patches still landed (they don't need jq).
+    expect(fs.readFileSync(allowlistPath, "utf-8")).toContain(NEW_PATTERN);
+    expect(fs.readFileSync(gitattrsPath, "utf-8")).toContain(
+      `${NEW_PATTERN} merge=union`,
+    );
+
+    // Privacy-map untouched (still missing the new entry).
+    const privacy = JSON.parse(fs.readFileSync(privacyPath, "utf-8"));
+    expect(privacy.some((e: any) => e.pattern === NEW_PATTERN)).toBe(false);
+  });
+
+  test("case 3: jq missing, then jq restored — second run completes patch and writes marker", () => {
+    freshAllowlist();
+    freshPrivacyMap();
+    freshGitattrs();
+
+    // First run with jq missing
+    const noJq = makeCuratedPath({ jq: "missing" });
+    const r1 = run({ path: noJq });
+    expect(r1.status).toBe(0);
+    expect(fs.existsSync(donePath)).toBe(false);
+
+    // Second run with jq restored
+    const r2 = run();
+    expect(r2.status).toBe(0);
+    expect(fs.existsSync(donePath)).toBe(true);
+
+    const privacy = JSON.parse(fs.readFileSync(privacyPath, "utf-8"));
+    expect(
+      privacy.some(
+        (e: any) => e.pattern === NEW_PATTERN && e.class === "artifact",
+      ),
+    ).toBe(true);
+  });
+
+  test("case 4: jq present, privacy-map already has correct entry — idempotent, marker written", () => {
+    freshAllowlist();
+    fs.writeFileSync(
+      privacyPath,
+      JSON.stringify(
+        [{ pattern: NEW_PATTERN, class: "artifact" }],
+        null,
+        2,
+      ),
+    );
+    freshGitattrs();
+
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(donePath)).toBe(true);
+
+    const privacy = JSON.parse(fs.readFileSync(privacyPath, "utf-8"));
+    const matches = privacy.filter((e: any) => e.pattern === NEW_PATTERN);
+    expect(matches.length).toBe(1);
+    expect(matches[0].class).toBe("artifact");
+  });
+
+  test("case 5: jq present, privacy-map file missing — allowlist + gitattrs patched, marker written", () => {
+    freshAllowlist();
+    // No privacy-map file
+    freshGitattrs();
+
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(donePath)).toBe(true);
+    expect(fs.existsSync(privacyPath)).toBe(false);
+
+    expect(fs.readFileSync(allowlistPath, "utf-8")).toContain(NEW_PATTERN);
+    expect(fs.readFileSync(gitattrsPath, "utf-8")).toContain(
+      `${NEW_PATTERN} merge=union`,
+    );
+  });
+
+  test("case 6: jq present, privacy-map JSON malformed — no marker, error logged, no mutation", () => {
+    freshAllowlist();
+    fs.writeFileSync(privacyPath, "{ this is not json [");
+    freshGitattrs();
+
+    const r = run();
+    expect(r.status).toBe(0);
+    // No marker — broken JSON should NOT be papered over.
+    expect(fs.existsSync(donePath)).toBe(false);
+    // Privacy-map content untouched.
+    expect(fs.readFileSync(privacyPath, "utf-8")).toBe("{ this is not json [");
+  });
+
+  test("case 7: jq present but mutation fails (shim exit 1) — no marker, tempfile cleaned up", () => {
+    freshAllowlist();
+    freshPrivacyMap();
+    freshGitattrs();
+
+    const fakeJq = makeCuratedPath({ jq: "shim-fail" });
+    const r = run({ path: fakeJq });
+
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(donePath)).toBe(false);
+
+    // Tempfile cleanup: no leftover *.tmp.* sidecars.
+    const leftovers = fs
+      .readdirSync(gstackHome)
+      .filter((n) => n.startsWith(".brain-privacy-map.json.tmp."));
+    expect(leftovers.length).toBe(0);
+  });
+
+  test("case 8: allowlist append fails (read-only file, no USER ADDITIONS marker) — no marker, warn logged", () => {
+    // Allowlist WITHOUT the "# ---- USER ADDITIONS BELOW" marker — the script
+    // falls into the plain `printf >>` append path. Make the file read-only
+    // so the append fails (sed -i.bak on macOS silently no-ops on read-only
+    // files, so we have to take the printf path to exercise this).
+    fs.writeFileSync(
+      allowlistPath,
+      "# header\nprojects/*/*-some-other-*.md\n",
+    );
+    freshPrivacyMap();
+    freshGitattrs();
+    fs.chmodSync(allowlistPath, 0o444);
+
+    const r = run();
+    expect(r.status).toBe(0);
+    // Marker must NOT be written when a required repair failed.
+    expect(fs.existsSync(donePath)).toBe(false);
+  });
+});


### PR DESCRIPTION
# Fix v1.40.0.0 migration done-marker (#1581)

Fixes #1581.

## What this fixes

`gstack-upgrade/migrations/v1.40.0.0.sh` used to unconditionally `touch` its done-marker (`~/.gstack/.migrations/v1.40.0.0.done`) at the end of the script, even when the `.brain-privacy-map.json` patch was skipped because `jq` is missing from the user's PATH. On subsequent runs the script short-circuits at `[ -f "${DONE}" ] && exit 0`, so the privacy-map repair never lands unless the user spots the buried WARN, installs jq, manually removes the marker, and re-runs.

The silent failure path: `.brain-allowlist` and `.gitattributes` get patched on the first pass (they don't need jq), so `/gstack-upgrade` looks successful — but federation sync silently drops `/plan-eng-review` test plans because the privacy-map entry for `projects/*/*-eng-review-test-plan-*.md` was never added.

## The fix

Defer `touch "${DONE}"` until every required repair either succeeded or was provably unnecessary. Track every failure mode via a single `incomplete` flag:

- jq missing when privacy-map exists
- malformed JSON (refuse to mutate corrupt JSON; leave for manual repair)
- jq mutation failure
- `mktemp` failure
- `mv` failure on the rewrite
- allowlist append failure (`printf >>` writing to a read-only file, etc.)
- gitattributes append failure

The marker is written only when `incomplete=0`, so the migration runner retries on the next `/gstack-upgrade` once the prerequisites are met. No manual marker-removal required.

## Tests

8 cases in `test/gstack-upgrade-migration-v1_40_0_0.test.ts`:

| # | Case | What it pins |
|---|------|--------------|
| 1 | happy path | jq present, fresh privacy-map → all three files patched, marker written |
| **2** | **regression for #1581** | **jq missing, privacy-map present → marker NOT written** |
| 3 | recovery | jq missing, then restored → patch lands on second run |
| 4 | idempotency | privacy-map already has correct entry → no mutation, marker written |
| 5 | fresh-init | privacy-map file absent → allowlist + gitattrs patched, marker written |
| 6 | malformed JSON | broken privacy-map → no marker, no mutation |
| 7 | jq mutation failure | fake jq returning 1 → no marker, tempfile cleaned up |
| 8 | allowlist append failure | read-only allowlist → no marker |

Case 2 fails against the unmodified script (verified before applying the fix) and passes against the fix.

```bash
bun test test/gstack-upgrade-migration-v1_40_0_0.test.ts
# 8 pass, 0 fail, 33 expect() calls
```

## Proposed remediation migration (for the next wave)

The in-place fix above helps fresh installs and users who haven't yet upgraded to v1.40.0.0. **It does NOT help users who already ran the buggy version** — their `v1.40.0.0.done` marker is set, and the migration runner's version check (`gstack-upgrade/SKILL.md:206`) won't re-invoke `v1.40.0.0.sh` for users whose installed version is already `>= 1.40.0.0`.

To remediate stuck users automatically, a new migration script needs to ship in the next wave. The script below is idempotent, well-tested (9 cases, all green locally), and ready to drop in at whatever version your next wave assigns. **The filename and the `DONE` path inside need to match the wave version you pick** (e.g. rename to `v1.41.0.0.sh` and update `DONE="${MIGRATION_DIR}/v1.41.0.0.done"`).

I'm holding the remediation back from this PR because pre-claiming a migration version slot conflicts with how you batch community PRs into release waves. If you'd prefer I add it to this PR at a specific version, happy to push a follow-up commit — just tell me which slot you want.

<details>
<summary>Proposed <code>gstack-upgrade/migrations/v1.40.0.1.sh</code> (rename + update DONE name)</summary>

```bash
#!/usr/bin/env bash
# Migration: v1.40.0.1 — remediation for #1581.
#
# v1.40.0.0.sh used to unconditionally `touch` its done-marker even when jq
# was missing, leaving `.brain-privacy-map.json` half-patched. v1.40.0.0.sh
# was patched in a follow-up to defer the done-marker, but users who already
# ran the buggy version have a stale marker and the runner skips v1.40.0.0
# for them. This script re-patches the privacy-map idempotently and also
# repairs entries with wrong class metadata.
#
# Logic:
#   1. Short-circuit on this migration's own done-marker.
#   2. If jq is missing, log a WARN and exit 0 WITHOUT touching the marker —
#      we'll retry on the next /gstack-upgrade.
#   3. If the privacy-map file doesn't exist (fresh-init user), nothing to
#      repair → touch the marker and exit.
#   4. If the privacy-map is malformed JSON, log an ERROR and exit 0 WITHOUT
#      touching the marker. Corrupt JSON is a separate problem; we don't
#      mutate it.
#   5. If the eng-review entry is present AND has the expected class, touch
#      the marker and exit.
#   6. If the eng-review pattern exists but with the wrong class, repair the
#      entry in place (replace, don't duplicate).
#   7. Otherwise (pattern missing), append the canonical entry.
#   8. On any jq mutation failure, do NOT touch the marker — leave for next
#      run.

set -u

GSTACK_HOME="${HOME}/.gstack"
PRIVACY="${GSTACK_HOME}/.brain-privacy-map.json"

MIGRATION_DIR="${GSTACK_HOME}/.migrations"
DONE="${MIGRATION_DIR}/v1.40.0.1.done"   # ← rename to match your wave version

# Must match v1.40.0.0.sh exactly.
EXPECTED_PATTERN='projects/*/*-eng-review-test-plan-*.md'
EXPECTED_CLASS='artifact'

mkdir -p "${MIGRATION_DIR}" 2>/dev/null || true
if [ -f "${DONE}" ]; then
  exit 0
fi

if ! command -v jq >/dev/null 2>&1; then
  echo "  [v1.40.0.1] WARN: jq not found; skipping privacy-map remediation. Install jq and re-run gstack-upgrade." >&2
  exit 0
fi

if [ ! -f "${PRIVACY}" ]; then
  touch "${DONE}"
  exit 0
fi

if ! jq -e . "${PRIVACY}" >/dev/null 2>&1; then
  echo "  [v1.40.0.1] ERROR: ${PRIVACY} is malformed JSON; refusing to mutate. Please repair manually or run gstack-artifacts-init." >&2
  exit 0
fi

if jq -e --arg p "${EXPECTED_PATTERN}" --arg c "${EXPECTED_CLASS}" \
  '[.[] | select(.pattern == $p and .class == $c)] | length > 0' \
  "${PRIVACY}" >/dev/null 2>&1; then
  touch "${DONE}"
  exit 0
fi

pattern_present=0
if jq -e --arg p "${EXPECTED_PATTERN}" \
  '[.[] | select(.pattern == $p)] | length > 0' \
  "${PRIVACY}" >/dev/null 2>&1; then
  pattern_present=1
fi

tmp=$(mktemp "${PRIVACY}.tmp.XXXXXX" 2>/dev/null)
if [ -z "${tmp}" ] || [ ! -f "${tmp}" ]; then
  echo "  [v1.40.0.1] WARN: failed to create tempfile for ${PRIVACY}; will retry on next upgrade." >&2
  exit 0
fi

if [ "${pattern_present}" = "1" ]; then
  if ! jq --arg p "${EXPECTED_PATTERN}" --arg c "${EXPECTED_CLASS}" \
    'map(if .pattern == $p then .class = $c else . end)' \
    "${PRIVACY}" > "${tmp}" 2>/dev/null; then
    echo "  [v1.40.0.1] WARN: jq repair mutation failed for ${PRIVACY}; will retry on next upgrade." >&2
    rm -f "${tmp}"
    exit 0
  fi
else
  if ! jq --arg p "${EXPECTED_PATTERN}" --arg c "${EXPECTED_CLASS}" \
    '. += [{"pattern": $p, "class": $c}]' \
    "${PRIVACY}" > "${tmp}" 2>/dev/null; then
    echo "  [v1.40.0.1] WARN: jq append mutation failed for ${PRIVACY}; will retry on next upgrade." >&2
    rm -f "${tmp}"
    exit 0
  fi
fi

if ! mv "${tmp}" "${PRIVACY}" 2>/dev/null; then
  echo "  [v1.40.0.1] WARN: failed to rewrite ${PRIVACY}; will retry on next upgrade." >&2
  rm -f "${tmp}"
  exit 0
fi

touch "${DONE}"
echo "  [v1.40.0.1] privacy-map remediated for /plan-eng-review test plans (#1581)" >&2

exit 0
```

</details>

<details>
<summary>Proposed <code>test/gstack-upgrade-migration-v1_40_0_1.test.ts</code> (9 cases)</summary>

Available on request — full file is 200 lines. Cases:

1. jq missing → no marker.
2. privacy-map already has correct entry → no mutation, marker written.
3. privacy-map missing the entry → entry appended with correct class.
4. privacy-map has entry with WRONG class → repaired in place (no duplicate).
5. privacy-map has duplicate correct entries → preserved, no mutation.
6. malformed JSON → no marker, error logged.
7. privacy-map file doesn't exist → marker written (nothing to remediate).
8. re-run after success → short-circuits on done-marker, no-op.
9. **stale `v1.40.0.0.done` + missing entry** (the user-visible field flow) → entry added, new marker written.

</details>

## Test plan

- [x] Run `bun test test/gstack-upgrade-migration-v1_40_0_0.test.ts` — 8/8 pass
- [x] Verify case 2 fails against unmodified `v1.40.0.0.sh` (regression test catches the bug)
- [x] Verify full free test suite (`bun test`) still green

## Out of scope

- VERSION bump and CHANGELOG entry — maintainer's call when the next wave ships.
- v1.38.1.0's same unconditional-touch pattern — latent (no jq-gated step), not user-impacting. Worth a separate refactor PR if you want a shared `mark_done()` helper across migrations.
- Repairing corrupt `.brain-privacy-map.json` content — out of scope; we log an error and bail rather than mutate corrupt JSON.
