### PR TITLE
fix: detect PgBouncer transaction-mode pooler and set GBRAIN_PREPARE=true

### DIFF
--- a/bin/gstack-gbrain-detect
+++ b/bin/gstack-gbrain-detect
@@ -18,7 +18,8 @@
  *     "gstack_brain_sync_mode": "off"|"artifacts-only"|"full",
  *     "gstack_brain_git": true|false,
  *     "gstack_artifacts_remote": "https://..." | "",
- *     "gbrain_local_status": "ok"|"no-cli"|"missing-config"|"broken-config"|"broken-db"
+ *     "gbrain_local_status": "ok"|"no-cli"|"missing-config"|"broken-config"|"broken-db",
+ *     "gbrain_pooler_mode": "transaction"|"session"|null
  *   }
  *
  * Backward compatibility (per plan codex #5): the 9 pre-existing fields stay
@@ -42,6 +43,7 @@ import {
   resolveGbrainBin,
   readGbrainVersion,
 } from "../lib/gbrain-local-status";
+import { isTransactionModePooler } from "../lib/gbrain-exec";
 
 const STATE_DIR = process.env.GSTACK_HOME || join(userHome(), ".gstack");
 const SCRIPT_DIR = __dirname;
@@ -96,6 +98,17 @@ function detectConfig(): { exists: boolean; engine: "pglite" | "postgres" | null
     return { exists: true, engine: parsed.engine };
   }
   return { exists: true, engine: null };
+}
+
+// --- pooler mode detection (#1435) ---
+//
+// Reads DATABASE_URL from ~/.gbrain/config.json and checks whether it targets
+// a PgBouncer transaction-mode pooler (port 6543). Surfaced so /sync-gbrain
+// and /setup-gbrain can advise users when search may require GBRAIN_PREPARE.
+function detectPoolerMode(): "transaction" | "session" | "unknown" | null {
+  const parsed = tryReadJSON(GBRAIN_CONFIG) as { database_url?: string } | null;
+  if (!parsed?.database_url) return null;
+  return isTransactionModePooler(parsed.database_url) ? "transaction" : "session";
 }
 
 // --- gbrain doctor health (any nonzero exit or non-"ok"/"warnings" status → false) ---
@@ -215,6 +228,7 @@ function main(): void {
     gstack_brain_git: detectBrainGit(),
     gstack_artifacts_remote: detectArtifactsRemote(),
     gbrain_local_status: localEngineStatus({ noCache }),
+    gbrain_pooler_mode: detectPoolerMode(),
   };
 
   process.stdout.write(JSON.stringify(out, null, 2) + "\n");

--- a/bin/gstack-gbrain-detect
+++ b/bin/gstack-gbrain-detect
@@ -19,13 +19,14 @@
  *     "gstack_brain_git": true|false,
  *     "gstack_artifacts_remote": "https://..." | "",
  *     "gbrain_local_status": "ok"|"no-cli"|"missing-config"|"broken-config"|"broken-db",
- *     "gbrain_pooler_mode": "transaction"|"session"|null
+ *     "gbrain_pooler_mode": "transaction"|"session"|"unknown"|null
  *   }
  *
  * Backward compatibility (per plan codex #5): the 9 pre-existing fields stay
- * identical in name + type + value semantics. One new field added:
- * gbrain_local_status. Key order may differ from the bash version's `jq -n`
- * output — downstream parsers must not depend on key order (none currently do).
+ * identical in name + type + value semantics. Two additive fields are present:
+ * gbrain_local_status and gbrain_pooler_mode. Key order may differ from the
+ * bash version's `jq -n` output — downstream parsers must not depend on key
+ * order (none currently do).
  *
  * Env:
  *   GSTACK_HOME      — override ~/.gstack for state lookups (used by tests).
@@ -43,7 +44,7 @@ import {
   resolveGbrainBin,
   readGbrainVersion,
 } from "../lib/gbrain-local-status";
-import { isTransactionModePooler } from "../lib/gbrain-exec";
+import { detectSupabasePoolMode } from "../lib/gbrain-exec";
 
 const STATE_DIR = process.env.GSTACK_HOME || join(userHome(), ".gstack");
 const SCRIPT_DIR = __dirname;
@@ -102,13 +103,13 @@ function detectConfig(): { exists: boolean; engine: "pglite" | "postgres" | null
 
 // --- pooler mode detection (#1435) ---
 //
-// Reads DATABASE_URL from ~/.gbrain/config.json and checks whether it targets
-// a PgBouncer transaction-mode pooler (port 6543). Surfaced so /sync-gbrain
-// and /setup-gbrain can advise users when search may require GBRAIN_PREPARE.
+// Reads DATABASE_URL + persisted Supabase pool_mode from ~/.gbrain/config.json.
+// URL shape alone does not distinguish session vs transaction poolers, so we
+// surface "unknown" until setup persists the real pool_mode.
 function detectPoolerMode(): "transaction" | "session" | "unknown" | null {
-  const parsed = tryReadJSON(GBRAIN_CONFIG) as { database_url?: string } | null;
+  const parsed = tryReadJSON(GBRAIN_CONFIG) as { database_url?: string; pool_mode?: string } | null;
   if (!parsed?.database_url) return null;
-  return isTransactionModePooler(parsed.database_url) ? "transaction" : "session";
+  return detectSupabasePoolMode(parsed.database_url, parsed.pool_mode);
 }
 
 // --- gbrain doctor health (any nonzero exit or non-"ok"/"warnings" status → false) ---

--- a/bin/gstack-gbrain-supabase-provision
+++ b/bin/gstack-gbrain-supabase-provision
@@ -339,7 +339,7 @@ cmd_pooler_url() {
   # Prefer the singular Session Pooler config when Supabase returns an
   # array (response shape can vary by project state). Fall back to the
   # first PRIMARY entry if no "session" pool_mode is present.
-  local db_user db_host db_port db_name
+  local db_user db_host db_port db_name pool_mode
   local first_or_session
   if printf '%s' "$resp" | jq -e 'type == "array"' >/dev/null 2>&1; then
     first_or_session=$(printf '%s' "$resp" | jq '[.[] | select(.pool_mode == "session")][0] // .[0]')
@@ -351,6 +351,7 @@ cmd_pooler_url() {
   db_host=$(printf '%s' "$first_or_session" | jq -r '.db_host // empty')
   db_port=$(printf '%s' "$first_or_session" | jq -r '.db_port // empty')
   db_name=$(printf '%s' "$first_or_session" | jq -r '.db_name // empty')
+  pool_mode=$(printf '%s' "$first_or_session" | jq -r '.pool_mode // empty')
 
   if [ -z "$db_user" ] || [ -z "$db_host" ] || [ -z "$db_port" ] || [ -z "$db_name" ]; then
     die "pooler-url: missing pooler config fields (db_user/db_host/db_port/db_name); re-poll or check project state"
@@ -359,7 +360,11 @@ cmd_pooler_url() {
   local url="postgresql://${db_user}:${DB_PASS}@${db_host}:${db_port}/${db_name}"
 
   if $json_mode; then
-    jq -n --arg ref "$ref" --arg pooler_url "$url" '{ref: $ref, pooler_url: $pooler_url}'
+    jq -n \
+      --arg ref "$ref" \
+      --arg pooler_url "$url" \
+      --arg pool_mode "$pool_mode" \
+      '{ref: $ref, pooler_url: $pooler_url, pool_mode: (if $pool_mode == "" then null else $pool_mode end)}'
   else
     # Non-JSON mode prints the URL; callers capturing it into a variable
     # keep it in process memory only.

--- a/lib/gbrain-exec.ts
+++ b/lib/gbrain-exec.ts
@@ -55,6 +55,26 @@ export interface BuildGbrainEnvOptions {
 }
 
 /**
+ * Detect whether a DATABASE_URL targets a PgBouncer transaction-mode pooler.
+ *
+ * Supabase transaction-mode poolers conventionally run on port 6543 at
+ * `*.pooler.supabase.com`. When gbrain connects through one of these, it
+ * auto-disables prepared statements — but search requires them (#1435).
+ * Returns `true` when the URL looks like a transaction-mode pooler so the
+ * caller can set `GBRAIN_PREPARE=true` to re-enable prepared statements.
+ */
+export function isTransactionModePooler(url: string): boolean {
+  try {
+    // DATABASE_URLs use postgresql:// scheme which URL() doesn't natively
+    // parse host/port from, so swap to http:// for reliable parsing.
+    const parsed = new URL(url.replace(/^postgres(ql)?:\/\//, "http://"));
+    return parsed.port === "6543";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Build an env dict with DATABASE_URL seeded from
  * `${GBRAIN_HOME:-$HOME/.gbrain}/config.json`. Returns the base env
  * unchanged when:
@@ -62,6 +82,11 @@ export interface BuildGbrainEnvOptions {
  *   - the config file is missing or unparseable,
  *   - the config has no `database_url`,
  *   - the caller already set DATABASE_URL to the same value.
+ *
+ * When the effective DATABASE_URL targets a PgBouncer transaction-mode
+ * pooler (port 6543), sets `GBRAIN_PREPARE=true` so gbrain re-enables
+ * prepared statements needed for search (#1435). Caller can override
+ * with `GBRAIN_PREPARE=false` in the base env.
  *
  * Always returns a fresh object — mutating the returned env never
  * affects the caller's env. Tests assert on effective values, not
@@ -84,14 +109,31 @@ export function buildGbrainEnv(opts: BuildGbrainEnvOptions = {}): NodeJS.Process
     return out;
   }
   if (!cfg.database_url) return out;
-  if (baseEnv.DATABASE_URL === cfg.database_url) return out;
 
   const hadCaller = baseEnv.DATABASE_URL !== undefined;
-  out.DATABASE_URL = cfg.database_url;
-  if (opts.announce) {
-    const note = hadCaller ? " (overrode value from caller env / .env.local)" : "";
-    process.stderr.write(`[gbrain-exec] seeded DATABASE_URL from ${configPath}${note}\n`);
+  const alreadyMatch = baseEnv.DATABASE_URL === cfg.database_url;
+  if (!alreadyMatch) {
+    out.DATABASE_URL = cfg.database_url;
+    if (opts.announce) {
+      const note = hadCaller ? " (overrode value from caller env / .env.local)" : "";
+      process.stderr.write(`[gbrain-exec] seeded DATABASE_URL from ${configPath}${note}\n`);
+    }
   }
+
+  // PgBouncer transaction-mode pooler detection (#1435): when the effective
+  // DATABASE_URL targets port 6543 (Supabase transaction-mode convention),
+  // gbrain auto-disables prepared statements — but search needs them.
+  // Set GBRAIN_PREPARE=true unless the caller explicitly opted out.
+  const effectiveUrl = out.DATABASE_URL || cfg.database_url;
+  if (effectiveUrl && !out.GBRAIN_PREPARE && isTransactionModePooler(effectiveUrl)) {
+    out.GBRAIN_PREPARE = "true";
+    if (opts.announce) {
+      process.stderr.write(
+        `[gbrain-exec] set GBRAIN_PREPARE=true (port 6543 transaction-mode pooler detected)\n`,
+      );
+    }
+  }
+
   return out;
 }
 

--- a/lib/gbrain-exec.ts
+++ b/lib/gbrain-exec.ts
@@ -38,6 +38,7 @@ import { spawnSync, spawn, execFileSync, type SpawnSyncReturns, type ChildProces
 
 interface GbrainConfig {
   database_url?: string;
+  pool_mode?: string;
 }
 
 export interface BuildGbrainEnvOptions {
@@ -54,23 +55,26 @@ export interface BuildGbrainEnvOptions {
   announce?: boolean;
 }
 
+export type GbrainPoolMode = "transaction" | "session" | "unknown" | null;
+
 /**
- * Detect whether a DATABASE_URL targets a PgBouncer transaction-mode pooler.
+ * Resolve the Supabase pooler mode for a DATABASE_URL.
  *
- * Supabase transaction-mode poolers conventionally run on port 6543 at
- * `*.pooler.supabase.com`. When gbrain connects through one of these, it
- * auto-disables prepared statements — but search requires them (#1435).
- * Returns `true` when the URL looks like a transaction-mode pooler so the
- * caller can set `GBRAIN_PREPARE=true` to re-enable prepared statements.
+ * URL shape alone does not distinguish Session vs Transaction poolers in
+ * Supabase. When `pool_mode` has been persisted alongside the URL, trust it;
+ * otherwise report `unknown` for `*.pooler.supabase.com` URLs and `null` for
+ * non-pooler / unparseable URLs.
  */
-export function isTransactionModePooler(url: string): boolean {
+export function detectSupabasePoolMode(url: string, configuredMode?: string | null): GbrainPoolMode {
   try {
     // DATABASE_URLs use postgresql:// scheme which URL() doesn't natively
     // parse host/port from, so swap to http:// for reliable parsing.
     const parsed = new URL(url.replace(/^postgres(ql)?:\/\//, "http://"));
-    return parsed.port === "6543";
+    if (!parsed.hostname.toLowerCase().endsWith(".pooler.supabase.com")) return null;
+    if (configuredMode === "transaction" || configuredMode === "session") return configuredMode;
+    return "unknown";
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -80,13 +84,13 @@ export function isTransactionModePooler(url: string): boolean {
  * unchanged when:
  *   - `GSTACK_RESPECT_ENV_DATABASE_URL=1` (intentional opt-out),
  *   - the config file is missing or unparseable,
- *   - the config has no `database_url`,
- *   - the caller already set DATABASE_URL to the same value.
+ *   - the config has no `database_url`.
  *
- * When the effective DATABASE_URL targets a PgBouncer transaction-mode
- * pooler (port 6543), sets `GBRAIN_PREPARE=true` so gbrain re-enables
- * prepared statements needed for search (#1435). Caller can override
- * with `GBRAIN_PREPARE=false` in the base env.
+ * When the effective DATABASE_URL points at a Supabase pooler and the gbrain
+ * config persists `pool_mode: "transaction"`, sets `GBRAIN_PREPARE=true` so
+ * gbrain keeps prepared statements enabled for search (#1435). Session-mode
+ * poolers and pooler URLs without persisted mode metadata are left unchanged.
+ * Caller can still override with `GBRAIN_PREPARE=false` in the base env.
  *
  * Always returns a fresh object — mutating the returned env never
  * affects the caller's env. Tests assert on effective values, not
@@ -120,16 +124,15 @@ export function buildGbrainEnv(opts: BuildGbrainEnvOptions = {}): NodeJS.Process
     }
   }
 
-  // PgBouncer transaction-mode pooler detection (#1435): when the effective
-  // DATABASE_URL targets port 6543 (Supabase transaction-mode convention),
-  // gbrain auto-disables prepared statements — but search needs them.
-  // Set GBRAIN_PREPARE=true unless the caller explicitly opted out.
+  // Search needs prepared statements under Supabase transaction poolers, but
+  // URL shape alone does not tell us whether a pooler URL is transaction or
+  // session mode. Only auto-enable when setup persisted the actual pool_mode.
   const effectiveUrl = out.DATABASE_URL || cfg.database_url;
-  if (effectiveUrl && !out.GBRAIN_PREPARE && isTransactionModePooler(effectiveUrl)) {
+  if (effectiveUrl && !out.GBRAIN_PREPARE && detectSupabasePoolMode(effectiveUrl, cfg.pool_mode) === "transaction") {
     out.GBRAIN_PREPARE = "true";
     if (opts.announce) {
       process.stderr.write(
-        `[gbrain-exec] set GBRAIN_PREPARE=true (port 6543 transaction-mode pooler detected)\n`,
+        `[gbrain-exec] set GBRAIN_PREPARE=true (Supabase transaction pool_mode detected)\n`,
       );
     }
   }

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -1023,9 +1023,24 @@ INFLIGHT_REF=$(echo "$result" | jq -r .ref)
 pooler=$(~/.claude/skills/gstack/bin/gstack-gbrain-supabase-provision \
   pooler-url "$INFLIGHT_REF" --json)
 GBRAIN_DATABASE_URL=$(echo "$pooler" | jq -r .pooler_url)
+GBRAIN_POOL_MODE=$(echo "$pooler" | jq -r '.pool_mode // empty')
 export GBRAIN_DATABASE_URL
 gbrain init --non-interactive --json
-unset SUPABASE_ACCESS_TOKEN DB_PASS GBRAIN_DATABASE_URL INFLIGHT_REF
+if [ -n "$GBRAIN_POOL_MODE" ] && [ -f "$HOME/.gbrain/config.json" ]; then
+  export GBRAIN_POOL_MODE
+  python3 - <<'PY'
+import json, os
+from pathlib import Path
+
+config_path = Path(os.path.expanduser("~/.gbrain/config.json"))
+pool_mode = os.environ.get("GBRAIN_POOL_MODE")
+if pool_mode and config_path.exists():
+    config = json.loads(config_path.read_text())
+    config["pool_mode"] = pool_mode
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+PY
+fi
+unset SUPABASE_ACCESS_TOKEN DB_PASS GBRAIN_DATABASE_URL GBRAIN_POOL_MODE INFLIGHT_REF
 trap - INT TERM
 ```
 

--- a/setup-gbrain/SKILL.md.tmpl
+++ b/setup-gbrain/SKILL.md.tmpl
@@ -303,9 +303,24 @@ INFLIGHT_REF=$(echo "$result" | jq -r .ref)
 pooler=$(~/.claude/skills/gstack/bin/gstack-gbrain-supabase-provision \
   pooler-url "$INFLIGHT_REF" --json)
 GBRAIN_DATABASE_URL=$(echo "$pooler" | jq -r .pooler_url)
+GBRAIN_POOL_MODE=$(echo "$pooler" | jq -r '.pool_mode // empty')
 export GBRAIN_DATABASE_URL
 gbrain init --non-interactive --json
-unset SUPABASE_ACCESS_TOKEN DB_PASS GBRAIN_DATABASE_URL INFLIGHT_REF
+if [ -n "$GBRAIN_POOL_MODE" ] && [ -f "$HOME/.gbrain/config.json" ]; then
+  export GBRAIN_POOL_MODE
+  python3 - <<'PY'
+import json, os
+from pathlib import Path
+
+config_path = Path(os.path.expanduser("~/.gbrain/config.json"))
+pool_mode = os.environ.get("GBRAIN_POOL_MODE")
+if pool_mode and config_path.exists():
+    config = json.loads(config_path.read_text())
+    config["pool_mode"] = pool_mode
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+PY
+fi
+unset SUPABASE_ACCESS_TOKEN DB_PASS GBRAIN_DATABASE_URL GBRAIN_POOL_MODE INFLIGHT_REF
 trap - INT TERM
 ```
 

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -905,13 +905,25 @@ Capability check (per /plan-eng-review §6):
 
 ```bash
 SLUG="_capability_check_$$"
+CAPABILITY_OK=0
 if [ -f ~/.gbrain/config.json ] && \
-   gbrain --version 2>/dev/null | grep -q '^gbrain ' && \
-   echo "ping" | gbrain put "$SLUG" >/dev/null 2>&1 && \
-   gbrain search "ping" 2>/dev/null | grep -q "$SLUG"; then
-  CAPABILITY_OK=1
-else
-  CAPABILITY_OK=0
+   gbrain --version 2>/dev/null | grep -q '^gbrain '; then
+  # GBRAIN_PREPARE=true ensures prepared statements stay enabled when
+  # connecting through a PgBouncer transaction-mode pooler (port 6543).
+  # Without it, search silently returns no results (#1435).
+  export GBRAIN_PREPARE=true
+  if echo "ping" | gbrain put "$SLUG" >/dev/null 2>&1; then
+    # Retry search up to 3 times with 1s delay — under transaction-mode
+    # pooling the search index may not be visible on the next connection
+    # immediately after the put.
+    for _attempt in 1 2 3; do
+      if gbrain search "ping" 2>/dev/null | grep -q "$SLUG"; then
+        CAPABILITY_OK=1
+        break
+      fi
+      sleep 1
+    done
+  fi
 fi
 gbrain delete "$SLUG" 2>/dev/null || true
 ```

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -908,14 +908,13 @@ SLUG="_capability_check_$$"
 CAPABILITY_OK=0
 if [ -f ~/.gbrain/config.json ] && \
    gbrain --version 2>/dev/null | grep -q '^gbrain '; then
-  # GBRAIN_PREPARE=true ensures prepared statements stay enabled when
-  # connecting through a PgBouncer transaction-mode pooler (port 6543).
-  # Without it, search silently returns no results (#1435).
+  # GBRAIN_PREPARE=true keeps prepared statements enabled for pooled
+  # Supabase setups where URL-only detection cannot tell session from
+  # transaction mode. Without it, search can silently return no results.
   export GBRAIN_PREPARE=true
   if echo "ping" | gbrain put "$SLUG" >/dev/null 2>&1; then
-    # Retry search up to 3 times with 1s delay — under transaction-mode
-    # pooling the search index may not be visible on the next connection
-    # immediately after the put.
+    # Retry search up to 3 times with 1s delay because pooled setups may
+    # not expose the search index on the very next connection after put.
     for _attempt in 1 2 3; do
       if gbrain search "ping" 2>/dev/null | grep -q "$SLUG"; then
         CAPABILITY_OK=1

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -188,14 +188,13 @@ SLUG="_capability_check_$$"
 CAPABILITY_OK=0
 if [ -f ~/.gbrain/config.json ] && \
    gbrain --version 2>/dev/null | grep -q '^gbrain '; then
-  # GBRAIN_PREPARE=true ensures prepared statements stay enabled when
-  # connecting through a PgBouncer transaction-mode pooler (port 6543).
-  # Without it, search silently returns no results (#1435).
+  # GBRAIN_PREPARE=true keeps prepared statements enabled for pooled
+  # Supabase setups where URL-only detection cannot tell session from
+  # transaction mode. Without it, search can silently return no results.
   export GBRAIN_PREPARE=true
   if echo "ping" | gbrain put "$SLUG" >/dev/null 2>&1; then
-    # Retry search up to 3 times with 1s delay — under transaction-mode
-    # pooling the search index may not be visible on the next connection
-    # immediately after the put.
+    # Retry search up to 3 times with 1s delay because pooled setups may
+    # not expose the search index on the very next connection after put.
     for _attempt in 1 2 3; do
       if gbrain search "ping" 2>/dev/null | grep -q "$SLUG"; then
         CAPABILITY_OK=1

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -185,13 +185,25 @@ Capability check (per /plan-eng-review §6):
 
 ```bash
 SLUG="_capability_check_$$"
+CAPABILITY_OK=0
 if [ -f ~/.gbrain/config.json ] && \
-   gbrain --version 2>/dev/null | grep -q '^gbrain ' && \
-   echo "ping" | gbrain put "$SLUG" >/dev/null 2>&1 && \
-   gbrain search "ping" 2>/dev/null | grep -q "$SLUG"; then
-  CAPABILITY_OK=1
-else
-  CAPABILITY_OK=0
+   gbrain --version 2>/dev/null | grep -q '^gbrain '; then
+  # GBRAIN_PREPARE=true ensures prepared statements stay enabled when
+  # connecting through a PgBouncer transaction-mode pooler (port 6543).
+  # Without it, search silently returns no results (#1435).
+  export GBRAIN_PREPARE=true
+  if echo "ping" | gbrain put "$SLUG" >/dev/null 2>&1; then
+    # Retry search up to 3 times with 1s delay — under transaction-mode
+    # pooling the search index may not be visible on the next connection
+    # immediately after the put.
+    for _attempt in 1 2 3; do
+      if gbrain search "ping" 2>/dev/null | grep -q "$SLUG"; then
+        CAPABILITY_OK=1
+        break
+      fi
+      sleep 1
+    done
+  fi
 fi
 gbrain delete "$SLUG" 2>/dev/null || true
 ```

--- a/test/build-gbrain-env.test.ts
+++ b/test/build-gbrain-env.test.ts
@@ -15,7 +15,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { buildGbrainEnv } from "../lib/gbrain-exec";
+import { buildGbrainEnv, isTransactionModePooler } from "../lib/gbrain-exec";
 
 describe("buildGbrainEnv", () => {
   let home: string;
@@ -116,5 +116,75 @@ describe("buildGbrainEnv", () => {
     const baseEnv = { HOME: home, DATABASE_URL: "postgresql://gbrain/db" };
     const result = buildGbrainEnv({ baseEnv });
     expect(result.DATABASE_URL).toBe("postgresql://gbrain/db");
+  });
+
+  // --- GBRAIN_PREPARE auto-detection (#1435) ---
+
+  it("sets GBRAIN_PREPARE=true when DATABASE_URL targets port 6543 (transaction-mode pooler)", () => {
+    const poolerUrl = "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres";
+    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: poolerUrl }));
+    const baseEnv = { HOME: home };
+    const result = buildGbrainEnv({ baseEnv });
+    expect(result.DATABASE_URL).toBe(poolerUrl);
+    expect(result.GBRAIN_PREPARE).toBe("true");
+  });
+
+  it("does not set GBRAIN_PREPARE when DATABASE_URL targets port 5432 (session-mode pooler)", () => {
+    const sessionUrl = "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:5432/postgres";
+    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: sessionUrl }));
+    const baseEnv = { HOME: home };
+    const result = buildGbrainEnv({ baseEnv });
+    expect(result.GBRAIN_PREPARE).toBeUndefined();
+  });
+
+  it("does not set GBRAIN_PREPARE for pglite (no port in URL)", () => {
+    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: "postgresql://gbrain/db" }));
+    const baseEnv = { HOME: home };
+    const result = buildGbrainEnv({ baseEnv });
+    expect(result.GBRAIN_PREPARE).toBeUndefined();
+  });
+
+  it("respects caller's explicit GBRAIN_PREPARE=false (opt-out)", () => {
+    const poolerUrl = "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres";
+    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: poolerUrl }));
+    const baseEnv = { HOME: home, GBRAIN_PREPARE: "false" };
+    const result = buildGbrainEnv({ baseEnv });
+    expect(result.GBRAIN_PREPARE).toBe("false");
+  });
+
+  it("sets GBRAIN_PREPARE even when caller DATABASE_URL already matches config on port 6543", () => {
+    const poolerUrl = "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres";
+    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: poolerUrl }));
+    const baseEnv = { HOME: home, DATABASE_URL: poolerUrl };
+    const result = buildGbrainEnv({ baseEnv });
+    expect(result.GBRAIN_PREPARE).toBe("true");
+  });
+});
+
+describe("isTransactionModePooler", () => {
+  it("returns true for Supabase transaction-mode pooler URL (port 6543)", () => {
+    expect(isTransactionModePooler(
+      "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
+    )).toBe(true);
+  });
+
+  it("returns false for session-mode pooler URL (port 5432)", () => {
+    expect(isTransactionModePooler(
+      "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:5432/postgres"
+    )).toBe(false);
+  });
+
+  it("returns false for pglite-style URL (no port)", () => {
+    expect(isTransactionModePooler("postgresql://gbrain/db")).toBe(false);
+  });
+
+  it("returns false for unparseable URL", () => {
+    expect(isTransactionModePooler("not-a-url")).toBe(false);
+  });
+
+  it("handles postgres:// scheme (without 'ql')", () => {
+    expect(isTransactionModePooler(
+      "postgres://postgres.abc:pw@host:6543/postgres"
+    )).toBe(true);
   });
 });

--- a/test/build-gbrain-env.test.ts
+++ b/test/build-gbrain-env.test.ts
@@ -15,7 +15,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { buildGbrainEnv, isTransactionModePooler } from "../lib/gbrain-exec";
+import { buildGbrainEnv, detectSupabasePoolMode } from "../lib/gbrain-exec";
 
 describe("buildGbrainEnv", () => {
   let home: string;
@@ -120,25 +120,28 @@ describe("buildGbrainEnv", () => {
 
   // --- GBRAIN_PREPARE auto-detection (#1435) ---
 
-  it("sets GBRAIN_PREPARE=true when DATABASE_URL targets port 6543 (transaction-mode pooler)", () => {
+  it("sets GBRAIN_PREPARE=true when config persists pool_mode=transaction for a pooled URL", () => {
     const poolerUrl = "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres";
-    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: poolerUrl }));
+    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: poolerUrl, pool_mode: "transaction" }));
     const baseEnv = { HOME: home };
     const result = buildGbrainEnv({ baseEnv });
     expect(result.DATABASE_URL).toBe(poolerUrl);
     expect(result.GBRAIN_PREPARE).toBe("true");
   });
 
-  it("does not set GBRAIN_PREPARE when DATABASE_URL targets port 5432 (session-mode pooler)", () => {
-    const sessionUrl = "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:5432/postgres";
-    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: sessionUrl }));
+  it("does not set GBRAIN_PREPARE when config persists pool_mode=session for the same pooled URL", () => {
+    const sessionUrl = "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres";
+    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: sessionUrl, pool_mode: "session" }));
     const baseEnv = { HOME: home };
     const result = buildGbrainEnv({ baseEnv });
     expect(result.GBRAIN_PREPARE).toBeUndefined();
   });
 
-  it("does not set GBRAIN_PREPARE for pglite (no port in URL)", () => {
-    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: "postgresql://gbrain/db" }));
+  it("does not set GBRAIN_PREPARE when a pooled URL has no persisted pool_mode yet", () => {
+    writeFileSync(
+      join(gbrainHome, "config.json"),
+      JSON.stringify({ database_url: "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres" }),
+    );
     const baseEnv = { HOME: home };
     const result = buildGbrainEnv({ baseEnv });
     expect(result.GBRAIN_PREPARE).toBeUndefined();
@@ -146,45 +149,57 @@ describe("buildGbrainEnv", () => {
 
   it("respects caller's explicit GBRAIN_PREPARE=false (opt-out)", () => {
     const poolerUrl = "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres";
-    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: poolerUrl }));
+    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: poolerUrl, pool_mode: "transaction" }));
     const baseEnv = { HOME: home, GBRAIN_PREPARE: "false" };
     const result = buildGbrainEnv({ baseEnv });
     expect(result.GBRAIN_PREPARE).toBe("false");
   });
 
-  it("sets GBRAIN_PREPARE even when caller DATABASE_URL already matches config on port 6543", () => {
+  it("sets GBRAIN_PREPARE even when caller DATABASE_URL already matches config and pool_mode=transaction", () => {
     const poolerUrl = "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres";
-    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: poolerUrl }));
+    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ database_url: poolerUrl, pool_mode: "transaction" }));
     const baseEnv = { HOME: home, DATABASE_URL: poolerUrl };
     const result = buildGbrainEnv({ baseEnv });
     expect(result.GBRAIN_PREPARE).toBe("true");
   });
 });
 
-describe("isTransactionModePooler", () => {
-  it("returns true for Supabase transaction-mode pooler URL (port 6543)", () => {
-    expect(isTransactionModePooler(
-      "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
-    )).toBe(true);
+describe("detectSupabasePoolMode", () => {
+  it("returns transaction when pool_mode=transaction is persisted for a pooled URL", () => {
+    expect(
+      detectSupabasePoolMode(
+        "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres",
+        "transaction",
+      ),
+    ).toBe("transaction");
   });
 
-  it("returns false for session-mode pooler URL (port 5432)", () => {
-    expect(isTransactionModePooler(
-      "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:5432/postgres"
-    )).toBe(false);
+  it("returns session when pool_mode=session is persisted for a 6543 pooled URL", () => {
+    expect(
+      detectSupabasePoolMode(
+        "postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres",
+        "session",
+      ),
+    ).toBe("session");
   });
 
-  it("returns false for pglite-style URL (no port)", () => {
-    expect(isTransactionModePooler("postgresql://gbrain/db")).toBe(false);
+  it("returns unknown for pooled URLs without persisted mode metadata", () => {
+    expect(
+      detectSupabasePoolMode("postgresql://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres"),
+    ).toBe("unknown");
   });
 
-  it("returns false for unparseable URL", () => {
-    expect(isTransactionModePooler("not-a-url")).toBe(false);
+  it("returns null for non-pooler URLs", () => {
+    expect(detectSupabasePoolMode("postgresql://gbrain/db")).toBeNull();
+  });
+
+  it("returns null for unparseable URLs", () => {
+    expect(detectSupabasePoolMode("not-a-url")).toBeNull();
   });
 
   it("handles postgres:// scheme (without 'ql')", () => {
-    expect(isTransactionModePooler(
-      "postgres://postgres.abc:pw@host:6543/postgres"
-    )).toBe(true);
+    expect(
+      detectSupabasePoolMode("postgres://postgres.abc:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres"),
+    ).toBe("unknown");
   });
 });

--- a/test/gbrain-detect-install.test.ts
+++ b/test/gbrain-detect-install.test.ts
@@ -110,6 +110,65 @@ describe('gstack-gbrain-detect', () => {
     }
   });
 
+  test('reports gbrain_pooler_mode=transaction when setup persisted pool_mode=transaction', () => {
+    fs.mkdirSync(path.join(tmpHomeReal, '.gbrain'));
+    fs.writeFileSync(
+      path.join(tmpHomeReal, '.gbrain', 'config.json'),
+      JSON.stringify({
+        engine: 'postgres',
+        database_url: 'postgresql://postgres.ref:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres',
+        pool_mode: 'transaction',
+      })
+    );
+    const emptyBin = fs.mkdtempSync(path.join(os.tmpdir(), 'empty-bin-'));
+    try {
+      const r = run(DETECT, [], { env: { PATH: `${emptyBin}:${SAFE_PATH}` } });
+      const j = JSON.parse(r.stdout);
+      expect(j.gbrain_pooler_mode).toBe('transaction');
+    } finally {
+      fs.rmSync(emptyBin, { recursive: true, force: true });
+    }
+  });
+
+  test('reports gbrain_pooler_mode=session when the same pooled URL persists pool_mode=session', () => {
+    fs.mkdirSync(path.join(tmpHomeReal, '.gbrain'));
+    fs.writeFileSync(
+      path.join(tmpHomeReal, '.gbrain', 'config.json'),
+      JSON.stringify({
+        engine: 'postgres',
+        database_url: 'postgresql://postgres.ref:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres',
+        pool_mode: 'session',
+      })
+    );
+    const emptyBin = fs.mkdtempSync(path.join(os.tmpdir(), 'empty-bin-'));
+    try {
+      const r = run(DETECT, [], { env: { PATH: `${emptyBin}:${SAFE_PATH}` } });
+      const j = JSON.parse(r.stdout);
+      expect(j.gbrain_pooler_mode).toBe('session');
+    } finally {
+      fs.rmSync(emptyBin, { recursive: true, force: true });
+    }
+  });
+
+  test('reports gbrain_pooler_mode=unknown for pooled URLs without persisted pool_mode', () => {
+    fs.mkdirSync(path.join(tmpHomeReal, '.gbrain'));
+    fs.writeFileSync(
+      path.join(tmpHomeReal, '.gbrain', 'config.json'),
+      JSON.stringify({
+        engine: 'postgres',
+        database_url: 'postgresql://postgres.ref:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres',
+      })
+    );
+    const emptyBin = fs.mkdtempSync(path.join(os.tmpdir(), 'empty-bin-'));
+    try {
+      const r = run(DETECT, [], { env: { PATH: `${emptyBin}:${SAFE_PATH}` } });
+      const j = JSON.parse(r.stdout);
+      expect(j.gbrain_pooler_mode).toBe('unknown');
+    } finally {
+      fs.rmSync(emptyBin, { recursive: true, force: true });
+    }
+  });
+
   test('malformed config returns null engine, does not crash', () => {
     fs.mkdirSync(path.join(tmpHomeReal, '.gbrain'));
     fs.writeFileSync(path.join(tmpHomeReal, '.gbrain', 'config.json'), 'not valid json{');

--- a/test/gbrain-detect-shape.test.ts
+++ b/test/gbrain-detect-shape.test.ts
@@ -10,7 +10,8 @@
  * Asserts:
  *   1. All 9 pre-existing keys are present
  *   2. Each pre-existing key has the same primitive type/union as the bash version
- *   3. The new key (gbrain_local_status) is present and a string
+ *   3. The additive keys (gbrain_local_status, gbrain_pooler_mode) are present
+ *      with the documented types
  *   4. Output is parseable JSON
  *   5. No keys removed/renamed
  */
@@ -58,6 +59,7 @@ interface DetectShape {
   gstack_brain_git: boolean;
   gstack_artifacts_remote: string;
   gbrain_local_status: string;
+  gbrain_pooler_mode: string | null;
 }
 
 describe("bin/gstack-gbrain-detect — shape regression", () => {
@@ -75,7 +77,7 @@ describe("bin/gstack-gbrain-detect — shape regression", () => {
     }
   });
 
-  it("contains all 9 pre-existing keys + the new gbrain_local_status key", () => {
+  it("contains all 9 pre-existing keys plus the additive gbrain fields", () => {
     const tmp = mkdtempSync(join(tmpdir(), "detect-shape-"));
     try {
       const out = runDetect({
@@ -96,8 +98,9 @@ describe("bin/gstack-gbrain-detect — shape regression", () => {
       expect(parsed).toHaveProperty("gstack_brain_git");
       expect(parsed).toHaveProperty("gstack_artifacts_remote");
 
-      // 1 new key (added by this fix):
+      // Additive keys for newer detect consumers.
       expect(parsed).toHaveProperty("gbrain_local_status");
+      expect(parsed).toHaveProperty("gbrain_pooler_mode");
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -130,8 +133,10 @@ describe("bin/gstack-gbrain-detect — shape regression", () => {
       expect(typeof parsed.gstack_brain_sync_mode).toBe("string");
       expect(typeof parsed.gstack_artifacts_remote).toBe("string");
 
-      // New field: string enum
+      // Additive fields
       expect(typeof parsed.gbrain_local_status).toBe("string");
+      const poolerModeType = parsed.gbrain_pooler_mode === null ? "null" : typeof parsed.gbrain_pooler_mode;
+      expect(poolerModeType === "string" || poolerModeType === "null").toBe(true);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -179,6 +184,21 @@ describe("bin/gstack-gbrain-detect — shape regression", () => {
       expect(["ok", "no-cli", "missing-config", "broken-config", "broken-db"]).toContain(
         parsed.gbrain_local_status,
       );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("gbrain_pooler_mode is null or one of the documented values", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "detect-shape-"));
+    try {
+      const out = runDetect({
+        HOME: tmp,
+        PATH: "/usr/bin:/bin",
+        GSTACK_HOME: tmp,
+      });
+      const parsed = JSON.parse(out) as DetectShape;
+      expect([null, "transaction", "session", "unknown"]).toContain(parsed.gbrain_pooler_mode);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/gbrain-supabase-provision.test.ts
+++ b/test/gbrain-supabase-provision.test.ts
@@ -366,6 +366,7 @@ describe('pooler-url', () => {
     expect(j.pooler_url).toBe(
       `postgresql://postgres.${REF}:my-real-password@aws-0-us-east-1.pooler.supabase.com:6543/postgres`
     );
+    expect(j.pool_mode).toBe('session');
     // The API's templated connection_string is NOT what we output.
     expect(j.pooler_url).not.toContain('[PASSWORD]');
   });
@@ -387,6 +388,7 @@ describe('pooler-url', () => {
     const j = JSON.parse(r.stdout);
     // Picked session entry with port 5432 (for this fixture)
     expect(j.pooler_url).toContain(':5432/postgres');
+    expect(j.pool_mode).toBe('session');
   });
 
   test('fails cleanly when pooler config is missing required fields', async () => {


### PR DESCRIPTION
## Summary

Fixes #1435 — `/sync-gbrain` capability check fails under PgBouncer transaction mode because `gbrain search` silently returns no results when prepared statements are disabled.

- **`lib/gbrain-exec.ts`**: `buildGbrainEnv()` now detects port 6543 in DATABASE_URL and auto-sets `GBRAIN_PREPARE=true` in the env for all gbrain spawns. Single chokepoint fix — every gstack-originated gbrain call inherits it. Callers can override with `GBRAIN_PREPARE=false`.
- **`sync-gbrain/SKILL.md{,.tmpl}`**: Capability check exports `GBRAIN_PREPARE=true` and retries search up to 3x with 1s delay for async index propagation under connection pooling.
- **`bin/gstack-gbrain-detect`**: Surfaces `gbrain_pooler_mode` ("transaction" | "session" | null) in the preamble probe JSON for downstream skill visibility.

## Test plan

- [ ] New unit tests for `isTransactionModePooler()` — port 6543, 5432, no-port, unparseable, postgres:// scheme
- [ ] New unit tests for `buildGbrainEnv()` GBRAIN_PREPARE auto-detection — pooler URL sets it, session URL doesn't, caller opt-out respected, already-matching URL still sets it
- [ ] Existing `buildGbrainEnv` tests still pass (DATABASE_URL seeding behavior unchanged)
- [ ] Manual: on a PgBouncer transaction-mode setup, run `/sync-gbrain` and verify the capability check passes and `## GBrain Search Guidance` block is written to CLAUDE.md

---

Continuous collaboration, powered by [ClosedLoop.AI](https://closedloop.ai) ([GitHub](https://github.com/closedloop-ai/claude-plugins))

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>