### PR TITLE
fix(artifacts): reject malformed remote paths

### DIFF
--- a/bin/gstack-artifacts-url
+++ b/bin/gstack-artifacts-url
@@ -49,6 +49,19 @@ strip_git() {
   echo "${1%.git}"
 }
 
+valid_owner_repo() {
+  local owner_repo="$1"
+  case "$owner_repo" in
+    ""|/*|*/|*//*)
+      return 1
+      ;;
+  esac
+  case "$owner_repo" in
+    */*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Parse to (host, owner_repo) regardless of input shape.
 parse_url() {
   local u="$1"
@@ -82,7 +95,7 @@ parse_url() {
       exit 3
       ;;
   esac
-  if [ -z "$host" ] || [ -z "$owner_repo" ] || [ "$owner_repo" = "$u" ]; then
+  if [ -z "$host" ] || ! valid_owner_repo "$owner_repo"; then
     echo "gstack-artifacts-url: failed to parse host/owner from: $u" >&2
     exit 3
   fi

--- a/test/gstack-artifacts-url.test.ts
+++ b/test/gstack-artifacts-url.test.ts
@@ -67,6 +67,24 @@ describe('gstack-artifacts-url', () => {
     expect(r.stderr).toContain('unrecognized URL form');
   });
 
+  test('rejects remotes without both owner and repo path segments', () => {
+    const malformed = [
+      'https://github.com',
+      'https://github.com/owner',
+      'https://github.com/owner/',
+      'https://github.com/owner//repo',
+      'git@github.com:owner',
+      'ssh://git@github.com',
+      'ssh://git@github.com/owner',
+    ];
+
+    for (const url of malformed) {
+      const r = run(['--to', 'ssh', url]);
+      expect(r.code, url).toBe(3);
+      expect(r.stderr, url).toContain('failed to parse host/owner');
+    }
+  });
+
   test('rejects missing args with exit 2', () => {
     expect(run([]).code).toBe(2);
     expect(run(['--to']).code).toBe(2);


### PR DESCRIPTION
## Summary

- reject artifact remote URLs that do not contain both owner and repo path segments
- keep valid GitHub/GitLab-style remotes working, including deeper self-hosted paths
- add regression coverage for host-only and owner-only malformed inputs

Fixes #1597.

## Root cause

`parse_url()` stripped `.git` and only checked that `host` and `owner_repo`
were non-empty. For inputs like `https://github.com` or
`ssh://git@github.com`, parameter expansion assigned `github.com` to both the
host and path-like value, so the helper generated bogus remotes instead of
failing.

## Testing

- `bun test test/gstack-artifacts-url.test.ts`
- `bun test test/gstack-artifacts-init.test.ts -t "only gh authed"`
- `git diff --check`
