### PR TITLE
fix(gbrain-lib): pin LC_ALL=C in varname validator (macOS locale guard)

### DIFF
--- a/bin/gstack-gbrain-lib.sh
+++ b/bin/gstack-gbrain-lib.sh
@@ -27,8 +27,22 @@
 # restore), D16 (pooler URL paste hygiene with redacted preview).
 
 # _gstack_gbrain_validate_varname <name> — returns 0 if usable, 2 otherwise.
+# `local LC_ALL=C` is load-bearing twice over:
+#   1. In many macOS shells the default locale (e.g. en_US.UTF-8) makes `case`
+#      glob brackets like `[A-Z]` match lowercase letters too. Without the
+#      LC_ALL=C pin, names like `lower-case` pass validation and then trip
+#      `printf -v "$varname"` and `export "$varname"` with "not a valid
+#      identifier" errors the caller can't easily distinguish from other
+#      failures.
+#   2. `local` is required because this file is documented as a sourced helper
+#      (see header), so a bare `LC_ALL=C` would mutate the caller's locale for
+#      the rest of the process — silently affecting downstream `sort`, `tr`,
+#      and any locale-aware glob in the same shell.
+# Together they give ASCII-only bracket semantics on both macOS and Linux
+# (matching the documented `[A-Z_][A-Z0-9_]*` contract) without leaking.
 _gstack_gbrain_validate_varname() {
   local name="$1"
+  local LC_ALL=C
   case "$name" in
     [A-Z_][A-Z0-9_]*) return 0 ;;
     *) return 2 ;;


### PR DESCRIPTION
## Summary

- `_gstack_gbrain_validate_varname` in `bin/gstack-gbrain-lib.sh` uses `case "$name" in [A-Z_][A-Z0-9_]*)` to validate that callers pass an ASCII-uppercase identifier
- On macOS, the default user locale (`en_US.UTF-8`) makes bash `case` glob brackets locale-collation-sensitive, so `[A-Z]` matches lowercase letters too — `lower-case` passes the check
- The function then trips `printf -v "$varname"` and `export "$varname"` with `not a valid identifier` errors that surface as confusing mid-prompt failures (instead of the clean `invalid var name '…' (must match [A-Z_][A-Z0-9_]*)` message the validator was supposed to emit)
- Fix: pin `LC_ALL=C` for the duration of the function so the bracket expression has ASCII-only semantics on both macOS and Linux, matching the documented `[A-Z_][A-Z0-9_]*` contract

The existing test `test/gbrain-lib-verify.test.ts` → `'rejects invalid var names (must match [A-Z_][A-Z0-9_]*)'` already covers the macOS repro shape. It passes silently on Linux CI (whose default is typically `C` / `POSIX`) and fails on macOS dev boxes — so this PR is the source-side fix that makes that test pass on every platform without changing the test.

## Repro (macOS, default user locale)

```bash
$ bash -c 'name="lower-case"; case "$name" in [A-Z_][A-Z0-9_]*) echo "MATCHED";; *) echo "NO MATCH";; esac'
MATCHED                                # ← bug

$ LC_ALL=C bash -c 'name="lower-case"; case "$name" in [A-Z_][A-Z0-9_]*) echo "MATCHED";; *) echo "NO MATCH";; esac'
NO MATCH                               # ← desired
```

Before the fix:

```bash
$ . bin/gstack-gbrain-lib.sh && read_secret_to_env "lower-case" "Prompt: " <<< "anything"
Prompt: bin/gstack-gbrain-lib.sh: line 89: printf: `lower-case': not a valid identifier
bin/gstack-gbrain-lib.sh: line 91: export: `lower-case': not a valid identifier
```

After the fix the validator rejects on the first line with the documented error message before either `printf -v` or `export` runs.

## Test plan

- [x] `bun test test/gbrain-lib-verify.test.ts` passes (22/22) on macOS Sonoma + bash 3.2 (system) and bash 5.x (homebrew). Linux CI was already green.
- [x] Manual: `_gstack_gbrain_validate_varname lower-case; echo $?` returns `2`; `_gstack_gbrain_validate_varname FOO_BAR; echo $?` returns `0`.
- [x] No other call sites of the validator changed.
- [ ] Reviewers may want to confirm no other `case` glob in `bin/` is similarly locale-sensitive (I grep'd; the rest of the script uses literal strings or `=~` regex, which also honors `LC_COLLATE` in bash 4+ but isn't used for `[A-Z]`-style ranges in this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)