### PR TITLE
fix: sourceLocalPath handles wrapped {sources:[...]} shape from gbrain v0.18.0+

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -289,11 +289,14 @@ function gbrainSupportsSourcesRename(env?: NodeJS.ProcessEnv): boolean {
  * helper can be exercised without a real gbrain CLI.
  */
 export function sourceLocalPath(sourceId: string, env?: NodeJS.ProcessEnv): string | null {
-  const list = execGbrainJson<Array<{ id: string; local_path?: string }>>(
-    ["sources", "list", "--json"],
-    { baseEnv: env },
-  );
-  if (!list) return null;
+  const raw = execGbrainJson<
+    | Array<{ id: string; local_path?: string }>
+    | { sources?: Array<{ id: string; local_path?: string }> }
+  >(["sources", "list", "--json"], { baseEnv: env });
+  if (!raw) return null;
+  // gbrain v0.18.0+ returns {sources: [...]}; older versions returned a raw array.
+  // Defensive against both shapes so this works on any gbrain version.
+  const list = Array.isArray(raw) ? raw : raw.sources ?? [];
   const found = list.find((s) => s.id === sourceId);
   return found?.local_path ?? null;
 }

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -812,7 +812,24 @@ describe("sourceLocalPath", () => {
     rmSync(bindir, { recursive: true, force: true });
   });
 
-  it("returns local_path when the source exists", () => {
+  // gbrain v0.18.0+ returns {sources: [...]}; this is the live contract.
+  it("returns local_path when the source exists (gbrain v0.18.0+ wrapped shape)", () => {
+    makeShim(bindir, {
+      "sources list --json": {
+        stdout: JSON.stringify({
+          sources: [
+            { id: "other-source", local_path: "/x" },
+            { id: "target-id", local_path: "/repo/match" },
+          ],
+        }),
+      },
+    });
+    expect(sourceLocalPath("target-id", envWithBindir(bindir))).toBe("/repo/match");
+  });
+
+  // Pre-v0.18.0 gbrain returned a raw array. Keep back-compat so the helper
+  // works regardless of which gbrain the user has on PATH.
+  it("returns local_path when the source exists (pre-v0.18.0 raw-array shape)", () => {
     makeShim(bindir, {
       "sources list --json": {
         stdout: JSON.stringify([
@@ -824,7 +841,14 @@ describe("sourceLocalPath", () => {
     expect(sourceLocalPath("target-id", envWithBindir(bindir))).toBe("/repo/match");
   });
 
-  it("returns null when the source is missing", () => {
+  it("returns null when the source is missing (wrapped shape)", () => {
+    makeShim(bindir, {
+      "sources list --json": { stdout: JSON.stringify({ sources: [] }) },
+    });
+    expect(sourceLocalPath("missing-id", envWithBindir(bindir))).toBeNull();
+  });
+
+  it("returns null when the source is missing (raw-array shape)", () => {
     makeShim(bindir, {
       "sources list --json": { stdout: "[]" },
     });


### PR DESCRIPTION
Closes #1609

## What

`gbrain sources list --json` has returned `{sources: [...]}` since gbrain v0.18.0 (commit [`90c5d93`](https://github.com/garrytan/gbrain/commit/90c5d93), "multi-source brains," 2026-04-22). `sourceLocalPath()` in `bin/gstack-gbrain-sync.ts:291` typed the response as a raw `Array<...>` and called `.find()` directly, crashing `/sync-gbrain --full`:

```
gstack-gbrain-sync fatal: list.find is not a function.
  (In 'list.find((s) => s.id === sourceId)', 'list.find' is undefined)
```

The bug only surfaces on full reindex (`runCodeImport` is the only caller of `sourceLocalPath`), so the cheap incremental path users hit via the hourly LaunchAgent didn't trigger it. That's why it's been latent.

## How

Defensive against both shapes — works on any gbrain version, wrapped (v0.18.0+) or raw array (older):

```ts
export function sourceLocalPath(sourceId: string, env?: NodeJS.ProcessEnv): string | null {
  const raw = execGbrainJson<
    | Array<{ id: string; local_path?: string }>
    | { sources?: Array<{ id: string; local_path?: string }> }
  >(["sources", "list", "--json"], { baseEnv: env });
  if (!raw) return null;
  const list = Array.isArray(raw) ? raw : raw.sources ?? [];
  const found = list.find((s) => s.id === sourceId);
  return found?.local_path ?? null;
}
```

## Why CI didn't catch it

The existing 3 unit tests for `sourceLocalPath` all use the **raw-array shape** in their fixtures:
```ts
stdout: JSON.stringify([{ id: "...", local_path: "..." }])
```
The function passes them because the mock matches the function's (wrong) type assumption. The real gbrain CLI returns the wrapped shape, and the function crashes there.

This PR updates the fixtures to use the live wrapped shape **and** keeps the raw-array tests for back-compat. Net: 5 tests cover both shapes.

```
bun test test/gstack-gbrain-sync.test.ts -t "sourceLocalPath"
 5 pass
 0 fail
```

Pre-fix code fails 2 of these (the new wrapped-shape tests). Post-fix passes all 5.

## Audit of other call sites

I grepped for every consumer of `gbrain sources list --json` across `bin/` and `lib/`:

| Call site | Status |
|---|---|
| `bin/gstack-gbrain-sync.ts:292` (this PR) | ❌ → ✅ |
| `lib/gbrain-sources.ts:54` (`probeSource`) | ✅ already unwraps `.sources` |
| `lib/gbrain-sources.ts:165` (`sourcePageCount`) | ✅ already unwraps `.sources` |
| `bin/gstack-gbrain-source-wireup:215,298` (shell) | ✅ uses `jq '.sources[]'` |
| `lib/gbrain-local-status.ts:224` | ✅ only checks exit code, doesn't parse |

So this is the **only** broken call site. The lib code does it right; the orchestrator should ideally use `lib/gbrain-sources.ts` directly (a future refactor — not in this PR to keep the diff minimal).

## Suggested follow-up: contract test

Worth adding `test/contract/gbrain-cli.test.ts` that runs against a real `gbrain` binary in CI (probably gated on a `GSTACK_CONTRACT_TEST=1` env var so unit tests stay fast). That would catch any future JSON shape drift between gstack and gbrain at PR time instead of in users' terminals. Happy to write this in a follow-up if the maintainer wants it.

## Test plan

- [x] `bun test test/gstack-gbrain-sync.test.ts -t "sourceLocalPath"` — 5/5 pass
- [x] Verified on the reporter's machine (gstack v1.40.0.0 + gbrain v0.33.1.0): patched orchestrator runs successfully where the unpatched version crashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)