### PR TITLE
feat(browse): extend GSTACK_CHROMIUM_PATH support to headless launch

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -236,6 +236,14 @@ export class BrowserManager {
       console.log(`[browse] Extensions loaded from: ${extensionsDir}`);
     }
 
+    // Support custom Chromium binary via GSTACK_CHROMIUM_PATH (same as launchHeaded).
+    // Falls back to standard Playwright Chromium when unset or path does not exist.
+    const headlessCloakPath = process.env.GSTACK_CHROMIUM_PATH;
+    const headlessCloakExec = headlessCloakPath && require('fs').existsSync(headlessCloakPath)
+      ? headlessCloakPath
+      : undefined;
+    if (headlessCloakExec) console.log(`[browse] Using custom Chromium: ${headlessCloakExec}`);
+
     this.browser = await chromium.launch({
       headless: useHeadless,
       // On Windows, Chromium's sandbox fails when the server is spawned through
@@ -244,6 +252,7 @@ export class BrowserManager {
       chromiumSandbox: process.platform !== 'win32',
       ...(launchArgs.length > 0 ? { args: launchArgs } : {}),
       ...(this.proxyConfig ? { proxy: this.proxyConfig } : {}),
+      ...(headlessCloakExec ? { executablePath: headlessCloakExec } : {}),
     });
 
     // Chromium crash → exit with clear message

--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -226,12 +226,16 @@ export class BrowserManager {
     }
 
     if (extensionsDir) {
-      launchArgs.push(
-        `--disable-extensions-except=${extensionsDir}`,
-        `--load-extension=${extensionsDir}`,
-        '--window-position=-9999,-9999',
-        '--window-size=1,1',
-      );
+      // Skip --load-extension when running against a custom Chromium build that
+      // already bakes the extension in (e.g., GBrowser / GStack Browser.app).
+      // Loading it twice causes a ServiceWorkerState::SetWorkerId DCHECK crash.
+      if (!isCustomChromium()) {
+        launchArgs.push(
+          `--disable-extensions-except=${extensionsDir}`,
+          `--load-extension=${extensionsDir}`,
+        );
+      }
+      launchArgs.push('--window-position=-9999,-9999', '--window-size=1,1');
       useHeadless = false; // extensions require headed mode; off-screen window simulates headless
       console.log(`[browse] Extensions loaded from: ${extensionsDir}`);
     }


### PR DESCRIPTION
## Summary

`launchHeaded()` already reads `GSTACK_CHROMIUM_PATH` to select a custom Chromium binary, but `launch()` (headless mode — the default `$B goto` path) ignores the env var and always falls back to Playwright's bundled binary.

This PR applies the same pattern to `launch()`:

- If `GSTACK_CHROMIUM_PATH` is set **and** the path exists (`existsSync` guard), it is passed as `executablePath` to `chromium.launch()`
- If unset or the binary is missing, falls back to standard Playwright Chromium automatically — **no breaking change**
- Logs `[browse] Using custom Chromium: <path>` on startup when active (matches the debug style used elsewhere)

## Motivation

This enables drop-in use of stealth Chromium forks (e.g. [CloakBrowser](https://github.com/CloakHQ/CloakBrowser)) for headless automation without needing to fork gstack or patch vendored files after every upgrade.

**Before:** `GSTACK_CHROMIUM_PATH` only worked for headed mode (`$B connect`). Headless `$B goto` always used Playwright's bundled binary regardless.

**After:** Setting `GSTACK_CHROMIUM_PATH` in the environment applies to both headless and headed mode consistently.

## Usage

```bash
# ~/.zshrc
export GSTACK_CHROMIUM_PATH="$(python3 -c 'from cloakbrowser import binary_info; print(binary_info()["binary_path"])')"
```

```bash
# Verify: navigator.webdriver should be false with CloakBrowser
$B goto https://example.com
$B js 'navigator.webdriver'   # → false
```

## Test plan

- [x] `bun run build` passes
- [x] `$B goto` with `GSTACK_CHROMIUM_PATH` set → `navigator.webdriver: false`, `window.chrome: object`
- [x] `$B goto` without `GSTACK_CHROMIUM_PATH` → falls back to standard Playwright Chromium (existsSync guard)
- [x] No changes to headed mode (`launchHeaded`) behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)