### PR TITLE
fix(gbrain-sync): sourceLocalPath handles wrapped {sources:[...]} shape from gbrain v0.30+

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -289,11 +289,17 @@ function gbrainSupportsSourcesRename(env?: NodeJS.ProcessEnv): boolean {
  * helper can be exercised without a real gbrain CLI.
  */
 export function sourceLocalPath(sourceId: string, env?: NodeJS.ProcessEnv): string | null {
-  const list = execGbrainJson<Array<{ id: string; local_path?: string }>>(
-    ["sources", "list", "--json"],
-    { baseEnv: env },
-  );
-  if (!list) return null;
+  // gbrain v0.30+ returns {"sources":[...]}; older releases returned a bare
+  // array. Handle both shapes so this works across the compat window. The
+  // sibling helper in lib/gbrain-sources.ts (statusForSourceId) already does
+  // this; the v1.40 hostname-fold migration was the lone holdout and crashed
+  // with `list.find is not a function` on every gbrain v0.30+ install.
+  const raw = execGbrainJson<
+    | Array<{ id: string; local_path?: string }>
+    | { sources?: Array<{ id: string; local_path?: string }> }
+  >(["sources", "list", "--json"], { baseEnv: env });
+  if (!raw) return null;
+  const list = Array.isArray(raw) ? raw : raw.sources || [];
   const found = list.find((s) => s.id === sourceId);
   return found?.local_path ?? null;
 }

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -837,4 +837,40 @@ describe("sourceLocalPath", () => {
     });
     expect(sourceLocalPath("any-id", envWithBindir(bindir))).toBeNull();
   });
+
+  // Regression: gbrain v0.30+ wraps the list as {"sources":[...]} instead of
+  // returning a bare array. The previous implementation crashed with
+  // `list.find is not a function` on every current gbrain install, which
+  // broke `runCodeImport`'s hostname-fold migration on first sync after
+  // upgrading to gstack v1.40 + gbrain v0.30+. Both shapes must work to
+  // keep the compat window intact.
+  it("returns local_path when gbrain wraps the list as {sources: [...]} (v0.30+ shape)", () => {
+    makeShim(bindir, {
+      "sources list --json": {
+        stdout: JSON.stringify({
+          sources: [
+            { id: "other-source", local_path: "/x" },
+            { id: "target-id", local_path: "/repo/wrapped" },
+          ],
+        }),
+      },
+    });
+    expect(sourceLocalPath("target-id", envWithBindir(bindir))).toBe("/repo/wrapped");
+  });
+
+  it("returns null when the wrapped {sources: [...]} shape has no matching id", () => {
+    makeShim(bindir, {
+      "sources list --json": {
+        stdout: JSON.stringify({ sources: [{ id: "other", local_path: "/x" }] }),
+      },
+    });
+    expect(sourceLocalPath("missing-id", envWithBindir(bindir))).toBeNull();
+  });
+
+  it("treats {sources: undefined} the same as an empty list", () => {
+    makeShim(bindir, {
+      "sources list --json": { stdout: JSON.stringify({}) },
+    });
+    expect(sourceLocalPath("any-id", envWithBindir(bindir))).toBeNull();
+  });
 });


### PR DESCRIPTION
## Problem

After upgrading to **gstack v1.40.0.0** + **gbrain v0.30.0.0** or newer (current released gbrain is v0.37.1.0), the first `/sync-gbrain` after upgrade dies before any stage runs:

```
$ /sync-gbrain
[gbrain-sync] mode=incremental engine=pglite
gstack-gbrain-sync fatal: list.find is not a function.
(In 'list.find((s) => s.id === sourceId)', 'list.find' is undefined)
```

## Root cause

`gbrain sources list --json` started wrapping its output as `{"sources":[...]}` in gbrain v0.30+. The v1.40 hostname-fold migration helper `sourceLocalPath()` (added in #1547, `bin/gstack-gbrain-sync.ts:291`) typed the response as a bare array and called `.find()` on it directly:

```ts
// before
const list = execGbrainJson<Array<{ id: string; local_path?: string }>>(...);
if (!list) return null;
const found = list.find((s) => s.id === sourceId);  // crash: list is an object, not an array
```

The sibling helper in `lib/gbrain-sources.ts` (`statusForSourceId`, lines 72-85) already unwraps both shapes correctly — `sourceLocalPath` was the lone holdout because it was added separately in the v1.40 migration work.

Actual output on a current gbrain:

```
$ gbrain sources list --json
{
  "sources": [
    { "id": "default", "name": "default", ... },
    { "id": "gstack-code-myrepo-b6de5213", "local_path": "/Users/me/myrepo", ... }
  ]
}
```

## Fix

Accept both wire shapes (defense against the same regression in either direction):

```ts
const raw = execGbrainJson<
  | Array<{ id: string; local_path?: string }>
  | { sources?: Array<{ id: string; local_path?: string }> }
>(["sources", "list", "--json"], { baseEnv: env });
if (!raw) return null;
const list = Array.isArray(raw) ? raw : raw.sources || [];
const found = list.find((s) => s.id === sourceId);
```

## Tests

Three new cases in the existing `sourceLocalPath` describe block in `test/gstack-gbrain-sync.test.ts`:

1. `returns local_path when gbrain wraps the list as {sources: [...]} (v0.30+ shape)` — the regression.
2. `returns null when the wrapped {sources: [...]} shape has no matching id`.
3. `treats {sources: undefined} the same as an empty list` — defensive case for partial responses.

The existing 3 bare-array tests still pass, locking in backward compat with pre-v0.30 gbrain shims.

**Run:** `bun test test/gstack-gbrain-sync.test.ts` → 38 pass, 0 fail (130 expect() calls).

## Repro on a fresh machine

```bash
# Upgrade gstack to v1.40 (in CHANGELOG, v1.40.0.0 — the hostname-fold migration release)
# Have a working gbrain >= v0.30
cd <any-git-repo>
/sync-gbrain
# → "gstack-gbrain-sync fatal: list.find is not a function"
```

## Found via

Hit this while syncing a freshly-shipped repo against gbrain v0.37.1.0 from a fresh gstack v1.40.0.0 install. Patched locally first; this PR brings the fix upstream.