### PR TITLE
fix(config): Include explain level default

### DIFF
--- a/bin/gstack-config
+++ b/bin/gstack-config
@@ -100,6 +100,7 @@ lookup_default() {
     skill_prefix) echo "false" ;;
     checkpoint_mode) echo "explicit" ;;
     checkpoint_push) echo "false" ;;
+    explain_level) echo "default" ;;
     codex_reviews) echo "enabled" ;;
     gstack_contributor) echo "false" ;;
     skip_eng_review) echo "false" ;;
@@ -169,7 +170,7 @@ case "${1:-}" in
     echo ""
     echo "# ─── Active values (including defaults for unset keys) ───"
     for KEY in proactive routing_declined telemetry auto_upgrade update_check \
-               skill_prefix checkpoint_mode checkpoint_push codex_reviews \
+               skill_prefix checkpoint_mode checkpoint_push explain_level codex_reviews \
                gstack_contributor skip_eng_review workspace_root \
                artifacts_sync_mode artifacts_sync_mode_prompted; do
       VALUE=$(grep -E "^${KEY}:" "$CONFIG_FILE" 2>/dev/null | tail -1 | awk '{print $2}' | tr -d '[:space:]' || true)
@@ -185,7 +186,7 @@ case "${1:-}" in
   defaults)
     echo "# gstack-config defaults"
     for KEY in proactive routing_declined telemetry auto_upgrade update_check \
-               skill_prefix checkpoint_mode checkpoint_push codex_reviews \
+               skill_prefix checkpoint_mode checkpoint_push explain_level codex_reviews \
                gstack_contributor skip_eng_review workspace_root \
                artifacts_sync_mode artifacts_sync_mode_prompted; do
       printf '  %-24s %s\n' "$KEY:" "$(lookup_default "$KEY")"

--- a/test/explain-level-config.test.ts
+++ b/test/explain-level-config.test.ts
@@ -5,7 +5,7 @@
  * - `set explain_level default` persists, `get` returns "default"
  * - `set explain_level terse` persists, `get` returns "terse"
  * - `set explain_level garbage` warns + writes "default"
- * - `get explain_level` with unset key returns empty (preamble bash defaults)
+ * - `get explain_level` with unset key returns "default" from the defaults table
  * - Annotated config header documents explain_level
  */
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -59,9 +59,13 @@ describe('gstack-config explain_level', () => {
     expect(run('get', 'explain_level').stdout).toBe('default');
   });
 
-  test('get with unset explain_level returns empty (preamble default takes over)', () => {
-    // No prior set → no config file → empty output
-    expect(run('get', 'explain_level').stdout).toBe('');
+  test('get with unset explain_level returns default from defaults table', () => {
+    expect(run('get', 'explain_level').stdout).toBe('default');
+  });
+
+  test('list and defaults include explain_level', () => {
+    expect(run('list').stdout).toContain('explain_level:');
+    expect(run('defaults').stdout).toContain('explain_level:');
   });
 
   test('config header documents explain_level', () => {


### PR DESCRIPTION
## Summary

- Add `explain_level` to the canonical `gstack-config` defaults table
- Include `explain_level` in `list` and `defaults` output
- Update focused config tests so unset `explain_level` reports the documented default

Fixes #1607.

## Verification

- `bun test test/explain-level-config.test.ts`
- `git diff --check`