### PR TITLE
Honor GSTACK_CHROMIUM_PATH on the headless launch and setup paths

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -312,6 +312,12 @@ export class BrowserManager {
 
     this.browser = await chromium.launch({
       headless: useHeadless,
+      // Honor GSTACK_CHROMIUM_PATH on the headless launch path. The headed
+      // path (launchPersistentContext, below) already respects it; this keeps
+      // both modes consistent for custom Chromium builds — e.g. a NixOS system
+      // binary, where Playwright's bundled chrome-headless-shell can't run.
+      // No-op when the env var is unset.
+      ...(process.env.GSTACK_CHROMIUM_PATH ? { executablePath: process.env.GSTACK_CHROMIUM_PATH } : {}),
       // On Windows, Chromium's sandbox fails when the server is spawned through
       // the Bun→Node process chain (GitHub #276). Disable it — local daemon
       // browsing user-specified URLs has marginal sandbox benefit. Also disabled

--- a/setup
+++ b/setup
@@ -256,7 +256,13 @@ ensure_playwright_browser() {
   else
     (
       cd "$SOURCE_GSTACK_DIR"
-      bun --eval 'import { chromium } from "playwright"; const browser = await chromium.launch(); await browser.close();'
+      if [ -n "$GSTACK_CHROMIUM_PATH" ]; then
+        # GSTACK_CHROMIUM_PATH set: verify that custom Chromium instead (e.g. a
+        # NixOS system binary, where Playwright's bundled Chromium can't run).
+        bun --eval 'import { chromium } from "playwright"; const browser = await chromium.launch({ executablePath: process.env.GSTACK_CHROMIUM_PATH, args: ["--no-sandbox"] }); await browser.close();'
+      else
+        bun --eval 'import { chromium } from "playwright"; const browser = await chromium.launch(); await browser.close();'
+      fi
     ) >/dev/null 2>&1
   fi
 }


### PR DESCRIPTION
## Problem

`GSTACK_CHROMIUM_PATH` lets you point gstack at a custom Chromium binary. The headed path (`launchPersistentContext`) already honors it, but two paths ignored it:

- `BrowserManager`'s headless `chromium.launch()` — a custom binary was used in headed mode only.
- `setup`'s `ensure_playwright_browser` self-test — always launched Playwright's bundled Chromium.

On NixOS the bundled `chrome-headless-shell` can't run (it expects `/lib64/ld-linux-x86-64.so.2`, absent on a Nix filesystem), so `./setup` bails before registering sub-skills and headless `browse` fails — even with `GSTACK_CHROMIUM_PATH` set to a working system Chromium.

## Change

- Pass `executablePath` on the headless `chromium.launch()` when `GSTACK_CHROMIUM_PATH` is set.
- `ensure_playwright_browser` verifies that same binary (with `--no-sandbox`) when the env var is set.

Both are no-ops when `GSTACK_CHROMIUM_PATH` is unset — zero impact on normal installs.

## Testing

Verified on a NixOS-style container (Replit): with `GSTACK_CHROMIUM_PATH` pointed at the system Chromium, `./setup` completes and registers all sub-skills, and headless `browse` navigates and screenshots correctly. Without the env var, behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)