### PR TITLE
design: bump per-image OpenAI timeout from 120s to 240s

### DIFF
--- a/design/src/evolve.ts
+++ b/design/src/evolve.ts
@@ -52,7 +52,8 @@ export async function evolve(options: EvolveOptions): Promise<void> {
   ].join("\n");
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 120_000);
+  // 240s — matches generate.ts; see comment there for rationale.
+  const timeout = setTimeout(() => controller.abort(), 240_000);
 
   try {
     const response = await fetch("https://api.openai.com/v1/responses", {

--- a/design/src/generate.ts
+++ b/design/src/generate.ts
@@ -37,7 +37,10 @@ async function callImageGeneration(
   quality: string,
 ): Promise<{ responseId: string; imageData: string }> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 120_000);
+  // 240s: gpt-image-1 at quality:"high" size:"1536x1024" routinely takes
+  // 60-180s and can spike past 120s under provider load (observed in
+  // production). 240s gives ~2x headroom while staying under user patience.
+  const timeout = setTimeout(() => controller.abort(), 240_000);
 
   try {
     const response = await fetch("https://api.openai.com/v1/responses", {

--- a/design/src/iterate.ts
+++ b/design/src/iterate.ts
@@ -82,7 +82,8 @@ async function callWithThreading(
   feedback: string,
 ): Promise<{ responseId: string; imageData: string }> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 120_000);
+  // 240s — matches generate.ts; see comment there for rationale.
+  const timeout = setTimeout(() => controller.abort(), 240_000);
 
   try {
     const response = await fetch("https://api.openai.com/v1/responses", {
@@ -130,7 +131,8 @@ async function callFresh(
   prompt: string,
 ): Promise<{ responseId: string; imageData: string }> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 120_000);
+  // 240s — matches generate.ts; see comment there for rationale.
+  const timeout = setTimeout(() => controller.abort(), 240_000);
 
   try {
     const response = await fetch("https://api.openai.com/v1/responses", {

--- a/design/src/variants.ts
+++ b/design/src/variants.ts
@@ -58,7 +58,8 @@ export async function generateVariant(
     skipLeadingDelay = false;
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 120_000);
+    // 240s — matches generate.ts; see comment there for rationale.
+    const timeout = setTimeout(() => controller.abort(), 240_000);
 
     try {
       const response = await fetchFn("https://api.openai.com/v1/responses", {


### PR DESCRIPTION
## Summary

The hardcoded 120s `setTimeout(() => controller.abort(), 120_000)` in `design/src/{generate,iterate,variants,evolve}.ts` fires too often against `gpt-image-1` at the default `quality: "high"` + `size: "1536x1024"`. Real session today (mid-2026): all 3 `design variants` calls timed out at exactly 120s while the OpenAI API was actively processing the request. Direct `curl --max-time 240` to the same endpoint with the same payload returned 200 in 33s.

```
✗ variant-A.png: Timeout (120s)
✗ variant-B.png: Timeout (120s)
✗ variant-C.png: Timeout (120s)
0/3 variants generated (123.0s)
```

Bumping each call to 240s.

## Why 240s

- Observed gpt-image-1 wall times at `high + 1536x1024`: typically 60-180s, occasionally 200s+ under provider load.
- 240s gives ~2x headroom over the typical worst-case while staying under the threshold where users walk away.
- Lower options I considered: 180s would have caught most spikes but still cliffs in the tail. 240s is the sweet spot.

## Sites touched

- `design/src/generate.ts:40`
- `design/src/iterate.ts:85, 133`
- `design/src/variants.ts:61`
- `design/src/evolve.ts:55`

Each carries a brief comment pointing back to `generate.ts` for the rationale.

## What I deliberately did NOT change

- **Quality default stays `high`.** That's what produces the polished mockups skill users expect. The timeout was the cliff, not the quality.
- **No shared-constant refactor.** Could promote to `design/src/constants.ts` or a `GSTACK_DESIGN_TIMEOUT_MS` env var, but I'm keeping this PR small. Happy to follow up if you want the env-var or shared-constant change in a separate PR.

## Verification

```
bun install               # 230 packages, no issues
bun build --compile design/src/cli.ts --outfile /tmp/test-bin
# [120ms] compile /tmp/test-bin → succeeds
```

No test changes — the timeout itself isn't easily unit-testable without injecting a stub clock or a slow mock fetch, and the existing `design/test/` suite doesn't cover it today.

## Repro

```sh
$D variants --brief "<any dense brief>" --count 3 --output-dir /tmp/
# Reliably reproduces 120s timeouts on busy OpenAI hours
```

(Filed by ionianFury — happened to me mid-`/plan-design-review` today.)