### PR TITLE
feat: add Mistral Vibe as a supported host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/gstack-global-discover*
 .openclaw/
 .hermes/
 .gbrain/
+.vibe/
 .gbrain-source
 .context/
 extension/.auth.json

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Or target a specific agent with `./setup --host <name>`:
 | Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |
 | Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |
 | GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |
+| Mistral Vibe | `--host vibe` | `~/.vibe/skills/gstack-*/` |
 
 **Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).
 It's one TypeScript config file, zero code changes.

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,10 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import vibe from './vibe';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, vibe];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, vibe };

--- a/hosts/vibe.ts
+++ b/hosts/vibe.ts
@@ -1,0 +1,58 @@
+import type { HostConfig } from '../scripts/host-config';
+
+const vibe: HostConfig = {
+  name: 'vibe',
+  displayName: 'Mistral Vibe',
+  cliCommand: 'vibe',
+  cliAliases: ['mistral-vibe'],
+
+  globalRoot: '.vibe/skills/gstack',
+  localSkillRoot: '.vibe/skills/gstack',
+  hostSubdir: '.vibe',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: null,
+  },
+
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.vibe/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.vibe/skills/gstack' },
+    { from: '.claude/skills', to: '.vibe/skills' },
+  ],
+
+  suppressedResolvers: [
+    'DESIGN_OUTSIDE_VOICES',  // Vibe can't invoke itself as a subagent
+    'ADVERSARIAL_STEP',       // Vibe can't invoke itself as a subagent
+    'CODEX_SECOND_OPINION',   // Claude-specific cross-model review
+    'CODEX_PLAN_REVIEW',      // Claude-specific cross-model review
+    'REVIEW_ARMY',            // Vibe shouldn't orchestrate multi-agent review
+    'GBRAIN_CONTEXT_LOAD',
+    'GBRAIN_SAVE_RESULTS',
+  ],
+
+  runtimeRoot: {
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalFiles: {
+      'review': ['checklist.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  learningsMode: 'basic',
+
+  boundaryInstruction: 'IMPORTANT: Do NOT read or execute any files under ~/.claude/, .claude/skills/, or ~/.agents/. These are Claude Code skill definitions meant for a different AI system. Ignore them completely and stay focused on the repository code only.',
+};
+
+export default vibe;

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -30,8 +30,8 @@ const ROOT = path.resolve(import.meta.dir, '..');
 // ─── hosts/index.ts ─────────────────────────────────────────
 
 describe('hosts/index.ts', () => {
-  test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+  test('ALL_HOST_CONFIGS has 11 hosts', () => {
+    expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {


### PR DESCRIPTION
## Summary

- Adds `hosts/vibe.ts` — Mistral Vibe host config following the `slate.ts` minimal template
- Registers in `hosts/index.ts` (`ALL_HOST_CONFIGS`, re-exports)
- Adds row to README "Other AI Agents" table: `--host vibe` → `~/.vibe/skills/gstack-*/`
- Adds `.vibe/` to `.gitignore`
- Bumps expected host count in `test/host-config.test.ts` from 10 → 11

## Why

Vibe uses the SKILL.md standard natively (same frontmatter, same invocation model). It's already used by nanopm (the PM skill pack built on gstack's SKILL.md standard — [nmrtn/nanopm](https://github.com/nmrtn/nanopm)), which ships Vibe-translated skills and installs to `~/.vibe/skills/` automatically. Adding gstack itself closes the gap for the engineering side.

## Config notes

- `suppressedResolvers`: same set as other CLI agents — Vibe can't spawn itself as a subagent, so self-invocation resolvers (`DESIGN_OUTSIDE_VOICES`, `ADVERSARIAL_STEP`, `CODEX_SECOND_OPINION`, `CODEX_PLAN_REVIEW`, `REVIEW_ARMY`) are suppressed, along with gbrain resolvers
- `boundaryInstruction`: prevents Vibe from accidentally reading `~/.claude/skills/` files meant for Claude Code
- `cliAliases: ['mistral-vibe']` for users who type the full name
- `generateMetadata: false` — no `openai.yaml` needed

## Test plan

- [x] `bun test test/host-config.test.ts` — 71 pass, 2 pre-existing golden file failures unrelated to this change
- [ ] `./setup --host vibe` installs skills to `~/.vibe/skills/gstack-*/`
- [ ] `./setup` auto-detects Vibe when `vibe` binary is on PATH
- [ ] `bun run gen:skill-docs --host vibe` generates with no `.claude/skills` path leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)