### PR TITLE
fix(sync-gbrain): Windows compat — capability check + brain-sync skip

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -788,11 +788,63 @@ function runMemoryIngest(args: CliArgs): StageResult {
   };
 }
 
+/**
+ * Read `artifacts_sync_mode` from `~/.gstack/config.yaml` without shelling
+ * out to gstack-config. Direct YAML parse so Windows can read the value
+ * too — Node/Bun spawnSync can't execute a bash script as a direct child
+ * on Windows (ENOENT), which used to cause runBrainSyncPush to fall
+ * through to the broken gstack-brain-sync invocation and emit a spurious
+ * ERR row in the verdict.
+ *
+ * Returns the user's configured value if present, or "off" (the canonical
+ * default) when the config file is missing or the key isn't set. Treats
+ * any parse error as "off" — fail-closed so we don't run the push stage
+ * against an undefined config state.
+ */
+function readArtifactsSyncMode(): string {
+  const stateDir = process.env.GSTACK_HOME
+    || process.env.GSTACK_STATE_DIR
+    || join(process.env.HOME || process.env.USERPROFILE || "", ".gstack");
+  const configPath = join(stateDir, "config.yaml");
+  if (!existsSync(configPath)) return "off";
+  try {
+    const text = readFileSync(configPath, "utf-8");
+    // Tolerant grep — gstack's config.yaml is shallow (no nesting) so a
+    // line-based parse suffices and avoids pulling in a yaml dep. Match
+    // the canonical `key: value` shape; skip comments.
+    for (const rawLine of text.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith("#")) continue;
+      const m = line.match(/^artifacts_sync_mode\s*:\s*(\S+)\s*$/);
+      if (m && m[1]) return m[1].toLowerCase();
+    }
+  } catch {
+    // Unreadable / parse error — fall through to default.
+  }
+  return "off";
+}
+
 function runBrainSyncPush(args: CliArgs): StageResult {
   const t0 = Date.now();
 
   if (args.mode === "dry-run") {
     return { name: "brain-sync", ran: false, ok: true, duration_ms: 0, summary: "would: gstack-brain-sync --discover-new --once" };
+  }
+
+  // Skip when artifacts_sync_mode is "off" — the user explicitly opted out
+  // (e.g., they're using a separate dotfile / config-sync workflow for
+  // cross-machine state). Pre-2026-05-21 this stage ran anyway and exited
+  // with `result.status === undefined` on Windows because Node/Bun spawnSync
+  // can't execute a bash script directly through ChildProcess — produced
+  // a spurious ERR row in the verdict despite a healthy install.
+  if (readArtifactsSyncMode() === "off") {
+    return {
+      name: "brain-sync",
+      ran: false,
+      ok: true,
+      duration_ms: Date.now() - t0,
+      summary: "skipped (artifacts_sync_mode=off — user opt-out)",
+    };
   }
 
   const brainSyncPath = join(import.meta.dir, "gstack-brain-sync");

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -905,9 +905,16 @@ Capability check (per /plan-eng-review §6):
 
 ```bash
 SLUG="_capability_check_$$"
+# Use --content flag, NOT stdin redirection. Windows Git Bash treats
+# `echo "..." | gbrain put` as writing to /dev/stdin which doesn't exist
+# the same way it does on Unix — gbrain exits with `ENOENT: /dev/stdin`
+# even when the engine is healthy. The --content flag is the canonical
+# v0.18+ interface (per the v1.42.0.0 wave that rewrote all 10 user-
+# facing put_page templates to put + --content); pass-through to stdin
+# was the legacy shape.
 if [ -f ~/.gbrain/config.json ] && \
    gbrain --version 2>/dev/null | grep -q '^gbrain ' && \
-   echo "ping" | gbrain put "$SLUG" >/dev/null 2>&1 && \
+   gbrain put "$SLUG" --content "ping" >/dev/null 2>&1 && \
    gbrain search "ping" 2>/dev/null | grep -q "$SLUG"; then
   CAPABILITY_OK=1
 else

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -185,9 +185,16 @@ Capability check (per /plan-eng-review §6):
 
 ```bash
 SLUG="_capability_check_$$"
+# Use --content flag, NOT stdin redirection. Windows Git Bash treats
+# `echo "..." | gbrain put` as writing to /dev/stdin which doesn't exist
+# the same way it does on Unix — gbrain exits with `ENOENT: /dev/stdin`
+# even when the engine is healthy. The --content flag is the canonical
+# v0.18+ interface (per the v1.42.0.0 wave that rewrote all 10 user-
+# facing put_page templates to put + --content); pass-through to stdin
+# was the legacy shape.
 if [ -f ~/.gbrain/config.json ] && \
    gbrain --version 2>/dev/null | grep -q '^gbrain ' && \
-   echo "ping" | gbrain put "$SLUG" >/dev/null 2>&1 && \
+   gbrain put "$SLUG" --content "ping" >/dev/null 2>&1 && \
    gbrain search "ping" 2>/dev/null | grep -q "$SLUG"; then
   CAPABILITY_OK=1
 else


### PR DESCRIPTION
## Summary

Two Windows-only failures surfaced running `/sync-gbrain` on Git Bash from a freshly-set-up local-stdio gbrain install. Both trace to the same family of issues — Node/Bun `spawnSync` can't directly execute bash scripts on Windows (ENOENT). Same shape as #1571 (different code path).

**1. Capability check fails on Windows.** The `## Step 4: Refresh ## GBrain Search Guidance block` capability check uses:

```bash
echo "ping" | gbrain put "$SLUG" >/dev/null 2>&1
```

Windows Git Bash treats this as writing to `/dev/stdin`, which gbrain rejects with `ENOENT: no such file or directory, open '/dev/stdin'`. `CAPABILITY_OK` always reports `0` on Windows even when the engine is healthy and search works — so the skill removes the `## GBrain Search Guidance` block from `CLAUDE.md` on every run, defeating the whole point of the workflow.

Switching to `gbrain put "$SLUG" --content "ping"` works on both Windows and Unix, and matches the v1.42.0.0 wave (#1571 era) that rewrote all 10 user-facing `put_page` instruction templates to the `put + --content` canonical shape.

**2. `runBrainSyncPush` produces spurious `ERR` rows when `artifacts_sync_mode=off`.** The orchestrator didn't check the user's opt-out before invoking `gstack-brain-sync` (also a bash script). On Windows the spawn fails with `result.status === undefined`, producing this verdict row even with a healthy install + intentional opt-out:

```
ERR    brain-sync   gstack-brain-sync exited undefined (0.0s)
```

New `readArtifactsSyncMode()` parses `~/.gstack/config.yaml` directly via `readFileSync` — no process spawn, fully portable across all platforms. When the key reads `off` (the default), the stage returns `ran=false ok=true summary="skipped (artifacts_sync_mode=off — user opt-out)"`.

## Verified on Windows Git Bash

Before:
```
gstack-gbrain-sync (incremental):
  OK    code         synced gstack-code-… (page_count=386) (7.4s)
  OK    memory       gbrain import: 3 imported, 0 unchanged, 0 failed (2.9s)
  ERR   brain-sync   gstack-brain-sync exited undefined (0.0s)

  2 ok, 1 error, 0 skipped
```

After:
```
gstack-gbrain-sync (incremental):
  OK    code         synced gstack-code-… (page_count=386) (7.0s)
  OK    memory       gbrain import: 1 imported, 0 unchanged, 0 failed (2.7s)
  SKIP  brain-sync   skipped (artifacts_sync_mode=off — user opt-out) (0.0s)

  3 ok, 0 error, 0 skipped
```

Capability check: `CAPABILITY_OK=1` (was `0`).

## Test plan

- [x] Manual verification on Windows Git Bash (alumni-watch repo, local-stdio gbrain v0.35.8.0, pglite engine)
- [x] `bun test test/gstack-gbrain-sync.test.ts` — same 31 pass / 6 fail before and after this PR. The 6 failures (`sourceLocalPath` describe block) are pre-existing Windows-specific test issues — the tests use bash-script shims that Windows Node `spawnSync` can't execute via `ENOENT`. Same root cause family, separate fix needed.
- [ ] Unix sanity check — would appreciate a maintainer running `/sync-gbrain` once on macOS/Linux to confirm both paths still behave (no regression expected; the YAML-parse helper is just a `readFileSync + regex` and the `--content` flag has been the canonical shape since v0.18+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)