### PR TITLE
Add Antigravity IDE/CLI support and enhance Windows compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin/gstack-global-discover*
 .factory/
 .kiro/
 .opencode/
+.antigravity/
 .slate/
 .cursor/
 .openclaw/

--- a/browse/src/browser-skill-commands.ts
+++ b/browse/src/browser-skill-commands.ts
@@ -185,7 +185,8 @@ async function handleTest(args: string[], ctx: SkillCommandContext): Promise<str
     throw new Error(`Skill "${name}" has no script.test.ts at ${testFile}`);
   }
 
-  const proc = Bun.spawn(['bun', 'test', testFile], {
+  const bunPath = process.execPath.endsWith('bun') || process.execPath.endsWith('bun.exe') ? process.execPath : 'bun';
+  const proc = Bun.spawn([bunPath, 'test', testFile], {
     cwd: skill.dir,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -372,7 +373,11 @@ export function buildSpawnEnv(opts: BuildEnvOptions): Record<string, string> {
       out[k] = v;
     }
     // Set a minimal PATH if missing.
-    if (!out.PATH) out.PATH = '/usr/local/bin:/usr/bin:/bin';
+    if (!out.PATH) {
+      out.PATH = process.platform === 'win32'
+        ? 'C:\\Windows\\system32;C:\\Windows'
+        : '/usr/local/bin:/usr/bin:/bin';
+    }
   } else {
     // Untrusted: minimal allowlist.
     for (const k of UNTRUSTED_ALLOWLIST) {
@@ -402,12 +407,16 @@ export function buildSpawnEnv(opts: BuildEnvOptions): Record<string, string> {
 }
 
 function resolveMinimalPath(): string {
-  // Prefer the directory bun lives in; fall back to standard system dirs.
-  const fallback = '/usr/local/bin:/usr/bin:/bin';
+  const isWin = process.platform === 'win32';
+  const delimiter = path.delimiter;
+  const fallback = isWin
+    ? 'C:\\Windows\\system32;C:\\Windows'
+    : '/usr/local/bin:/usr/bin:/bin';
+
   const bunPath = process.execPath;
-  if (bunPath && bunPath.includes('/bun')) {
+  if (bunPath && bunPath.toLowerCase().includes('bun')) {
     const dir = path.dirname(bunPath);
-    return `${dir}:${fallback}`;
+    return `${dir}${delimiter}${fallback}`;
   }
   return fallback;
 }

--- a/browse/src/domain-skills.ts
+++ b/browse/src/domain-skills.ts
@@ -33,7 +33,6 @@
  */
 
 import { promises as fs } from 'fs';
-import { open as fsOpen, constants as fsConstants } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { createHash } from 'crypto';
@@ -120,30 +119,13 @@ async function ensureDir(filePath: string): Promise<void> {
 async function appendRow(filePath: string, row: DomainSkillRow): Promise<void> {
   await ensureDir(filePath);
   const line = JSON.stringify(row) + '\n';
-  return new Promise((resolve, reject) => {
-    fsOpen(filePath, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_APPEND, 0o644, (err, fd) => {
-      if (err) return reject(err);
-      const buf = Buffer.from(line, 'utf8');
-      const writeAndSync = () => {
-        // Use fs.writeSync via fd to ensure single write call (atomic with O_APPEND).
-        const fsSync = require('fs');
-        try {
-          fsSync.writeSync(fd, buf, 0, buf.length);
-          fsSync.fsyncSync(fd);
-          fsSync.closeSync(fd);
-          resolve();
-        } catch (e) {
-          try {
-            fsSync.closeSync(fd);
-          } catch {
-            // Ignore close errors after a write failure — original error wins.
-          }
-          reject(e);
-        }
-      };
-      writeAndSync();
-    });
-  });
+  const fileHandle = await fs.open(filePath, 'a');
+  try {
+    await fileHandle.appendFile(line, 'utf8');
+    await fileHandle.sync();
+  } finally {
+    await fileHandle.close();
+  }
 }
 
 /**

--- a/browse/src/xvfb.ts
+++ b/browse/src/xvfb.ts
@@ -87,11 +87,15 @@ export function pickFreeDisplay(
  */
 export function readPidStartTime(pid: number): string {
   if (!isProcessAlive(pid)) return '';
-  const result = Bun.spawnSync(['ps', '-p', String(pid), '-o', 'lstart='], {
-    stdout: 'pipe', stderr: 'pipe', timeout: 2000,
-  });
-  if (result.exitCode !== 0) return '';
-  return result.stdout.toString().trim();
+  try {
+    const result = Bun.spawnSync(['ps', '-p', String(pid), '-o', 'lstart='], {
+      stdout: 'pipe', stderr: 'pipe', timeout: 2000,
+    });
+    if (result.exitCode !== 0) return '';
+    return result.stdout.toString().trim();
+  } catch {
+    return '';
+  }
 }
 
 /**

--- a/browse/test/browser-skill-commands.test.ts
+++ b/browse/test/browser-skill-commands.test.ts
@@ -202,7 +202,11 @@ describe('buildSpawnEnv', () => {
   it('untrusted: PATH is minimal (no /test/bin override)', () => {
     const env = buildSpawnEnv({ trusted: false, port: 1234, skillToken: 'tok' });
     expect(env.PATH).not.toContain('/test/bin');
-    expect(env.PATH).toMatch(/\/(usr\/local\/)?bin/);
+    if (process.platform === 'win32') {
+      expect(env.PATH).toMatch(/\\(system32|bin)/i);
+    } else {
+      expect(env.PATH).toMatch(/\/(usr\/local\/)?bin/);
+    }
   });
 
   it('untrusted: injects GSTACK_PORT + GSTACK_SKILL_TOKEN', () => {

--- a/browse/test/browser-skills-e2e.test.ts
+++ b/browse/test/browser-skills-e2e.test.ts
@@ -30,7 +30,7 @@ beforeAll(() => {
 describe('browser-skills E2E — bundled hackernews-frontpage', () => {
   test('defaultTierPaths resolves bundled tier to <repo>/browser-skills/', () => {
     const tiers = defaultTierPaths();
-    expect(tiers.bundled).toMatch(/\/browser-skills$/);
+    expect(tiers.bundled.replace(/\\/g, '/')).toMatch(/\/browser-skills$/);
     // Bundled tier should exist on disk (the reference skill is shipped).
     expect(require('fs').existsSync(tiers.bundled)).toBe(true);
   });

--- a/browse/test/bun-polyfill.test.ts
+++ b/browse/test/bun-polyfill.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, afterAll } from 'bun:test';
 import * as path from 'path';
 
 // Load the polyfill into a fresh object (don't clobber globalThis.Bun)
-const polyfillPath = path.resolve(import.meta.dir, '../src/bun-polyfill.cjs');
+const polyfillPath = path.resolve(import.meta.dir, '../src/bun-polyfill.cjs').replace(/\\/g, '/');
 
 describe('bun-polyfill', () => {
   // We test the polyfill by requiring it in a subprocess under Node.js
@@ -25,7 +25,7 @@ describe('bun-polyfill', () => {
   test('Bun.spawnSync runs a command and returns stdout', () => {
     const result = Bun.spawnSync(['node', '-e', `
       require('${polyfillPath}');
-      const r = Bun.spawnSync(['echo', 'hello'], { stdout: 'pipe' });
+      const r = Bun.spawnSync([process.execPath, '-e', 'console.log("hello")'], { stdout: 'pipe' });
       console.log(r.stdout.toString().trim());
       console.log('exit:' + r.exitCode);
     `], { stdout: 'pipe', stderr: 'pipe' });
@@ -37,7 +37,7 @@ describe('bun-polyfill', () => {
   test('Bun.spawn launches a process with pid', async () => {
     const result = Bun.spawnSync(['node', '-e', `
       require('${polyfillPath}');
-      const p = Bun.spawn(['echo', 'test'], { stdio: ['pipe', 'pipe', 'pipe'] });
+      const p = Bun.spawn([process.execPath, '-e', 'console.log("test")'], { stdio: ['pipe', 'pipe', 'pipe'] });
       console.log(typeof p.pid === 'number' ? 'HAS_PID' : 'NO_PID');
       console.log(typeof p.kill === 'function' ? 'HAS_KILL' : 'NO_KILL');
       console.log(typeof p.unref === 'function' ? 'HAS_UNREF' : 'NO_UNREF');

--- a/browse/test/domain-skills-storage.test.ts
+++ b/browse/test/domain-skills-storage.test.ts
@@ -14,7 +14,16 @@ async function freshImport() {
 }
 
 beforeEach(async () => {
-  await fs.rm(TMP_HOME, { recursive: true, force: true });
+  const files = [
+    path.join(TMP_HOME, 'global-domain-skills.jsonl'),
+    path.join(TMP_HOME, 'projects', 'test-slug', 'learnings.jsonl'),
+    path.join(TMP_HOME, 'projects', 'other-slug', 'learnings.jsonl')
+  ];
+  for (const f of files) {
+    try {
+      await fs.rm(f, { force: true });
+    } catch {}
+  }
   await fs.mkdir(path.join(TMP_HOME, 'projects', 'test-slug'), { recursive: true });
 });
 

--- a/browse/test/server-auth.test.ts
+++ b/browse/test/server-auth.test.ts
@@ -63,13 +63,13 @@ describe('Server auth security', () => {
 
   // Test 4: /activity/history requires auth via validateAuth
   test('/activity/history requires authentication', () => {
-    const historyBlock = sliceBetween(SERVER_SRC, "url.pathname === '/activity/history'", 'Sidebar endpoints');
+    const historyBlock = sliceBetween(SERVER_SRC, "url.pathname === '/activity/history'", '// ─── Sidebar chat endpoints ripped ──────────────────────────────');
     expect(historyBlock).toContain('validateAuth');
   });
 
   // Test 5: /activity/history has no wildcard CORS header
   test('/activity/history has no wildcard CORS header', () => {
-    const historyBlock = sliceBetween(SERVER_SRC, "url.pathname === '/activity/history'", 'Sidebar endpoints');
+    const historyBlock = sliceBetween(SERVER_SRC, "url.pathname === '/activity/history'", '// ─── Sidebar chat endpoints ripped ──────────────────────────────');
     expect(historyBlock).not.toContain("'*'");
   });
 
@@ -314,7 +314,7 @@ describe('Server auth security', () => {
   // Regression: connect command crashed with "domains is not defined" because
   // a stray `domains,` variable was in the status fetch body (cli.ts:852).
   test('connect command status fetch body has no undefined variable references', () => {
-    const connectBlock = sliceBetween(CLI_SRC, 'Launching headed Chromium', 'Sidebar agent started');
+    const connectBlock = sliceBetween(CLI_SRC, 'Launching headed Chromium', '// sidebar-agent.ts spawn was here. Ripped alongside the chat queue —');
     // The status fetch should use a clean JSON body
     expect(connectBlock).toContain("command: 'status'");
     // Must NOT contain a bare `domains` reference in the fetch body
@@ -336,9 +336,9 @@ describe('Server auth security', () => {
     expect(pairBlock).toContain("BROWSE_PARENT_PID");
     expect(pairBlock).toContain("'0'");
     // The connect command must propagate BROWSE_PARENT_PID=0 to serverEnv
-    const connectBlock = sliceBetween(CLI_SRC, 'Launching headed Chromium', 'Sidebar agent started');
+    const connectBlock = sliceBetween(CLI_SRC, 'Launching headed Chromium', '// sidebar-agent.ts spawn was here. Ripped alongside the chat queue —');
     expect(connectBlock).toContain("BROWSE_PARENT_PID");
-    expect(connectBlock).toContain("serverEnv.BROWSE_PARENT_PID");
+    expect(connectBlock).toContain("BROWSE_PARENT_PID: '0'");
   });
 
   // Regression: newtab returned 403 for scoped tokens because the tab ownership

--- a/browse/test/server-embedder-terminal-port.test.ts
+++ b/browse/test/server-embedder-terminal-port.test.ts
@@ -174,8 +174,7 @@ describe('buildFetchHandler ownsTerminalAgent gate', () => {
     // Resolves browse/src/server.ts relative to this test file so the test
     // works regardless of cwd. import.meta.url is the test file's URL.
     const serverTsPath = path.resolve(
-      new URL(import.meta.url).pathname,
-      '..',
+      import.meta.dir,
       '..',
       'src',
       'server.ts',

--- a/hosts/antigravity.ts
+++ b/hosts/antigravity.ts
@@ -1,0 +1,48 @@
+import type { HostConfig } from '../scripts/host-config';
+
+const antigravity: HostConfig = {
+  name: 'antigravity',
+  displayName: 'Antigravity',
+  cliCommand: 'agy',
+  cliAliases: [],
+
+  globalRoot: '.gemini/antigravity-cli/plugins/gstack/skills/gstack',
+  localSkillRoot: '.antigravity/skills/gstack',
+  hostSubdir: '.antigravity',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: null,
+  },
+
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.gemini/antigravity-cli/plugins/gstack/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.antigravity/skills/gstack' },
+    { from: '.claude/skills', to: '.antigravity/skills' },
+  ],
+
+  suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
+
+  runtimeRoot: {
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'design/dist', 'gstack-upgrade', 'ETHOS.md', 'review/specialists', 'qa/templates', 'qa/references', 'plan-devex-review/dx-hall-of-fame.md'],
+    globalFiles: {
+      'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  learningsMode: 'basic',
+};
+
+export default antigravity;

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,10 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import antigravity from './antigravity';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, antigravity];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, antigravity };

--- a/scripts/host-config-export.ts
+++ b/scripts/host-config-export.ts
@@ -69,12 +69,9 @@ switch (command) {
     for (const config of ALL_HOST_CONFIGS) {
       const commands = [config.cliCommand, ...(config.cliAliases || [])];
       for (const cmd of commands) {
-        try {
-          execSync(`command -v ${shellEscape(cmd)}`, { stdio: 'pipe' });
+        if (Bun.which(cmd)) {
           console.log(config.name);
           break;  // Found this host, move to next
-        } catch {
-          // Binary not found, try next alias
         }
       }
     }

--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -65,7 +65,16 @@ for (const file of SKILL_FILES) {
 console.log('\n  Templates:');
 const TEMPLATES = discoverTemplates(ROOT);
 
+import { getHostConfig } from '../hosts/index';
+const claudeConfig = getHostConfig('claude');
+const skipSkills = new Set(claudeConfig.generation.skipSkills || []);
+
 for (const { tmpl, output } of TEMPLATES) {
+  const dir = tmpl.includes('/') ? tmpl.split('/')[0] : '';
+  if (dir && skipSkills.has(dir)) {
+    console.log(`  ✅ ${tmpl.padEnd(30)} (skipped for primary host)`);
+    continue;
+  }
   const tmplPath = path.join(ROOT, tmpl);
   const outPath = path.join(ROOT, output);
   if (!fs.existsSync(tmplPath)) {

--- a/scripts/test-free-shards.ts
+++ b/scripts/test-free-shards.ts
@@ -106,6 +106,10 @@ const KNOWN_WINDOWS_INCOMPATIBLE: Array<{ file: string; reason: string }> = [
     file: 'browse/test/findport.test.ts',
     reason: 'asserts Bun.serve.stop() is fire-and-forget — Bun behavior differs on Windows for this polyfill',
   },
+  {
+    file: 'test/migration-checkpoint-ownership.test.ts',
+    reason: 'runs POSIX shell scripts via bash and asserts symlink behavior not supported on Windows',
+  },
 ];
 
 export const DEFAULT_SHARD_COUNT = 20;

--- a/setup
+++ b/setup
@@ -54,9 +54,9 @@ _link_or_copy() {
       return 0
     fi
     if [ -d "$src" ]; then
-      cp -R "$src" "$dst"
+      cp -RL "$src" "$dst"
     else
-      cp -f "$src" "$dst"
+      cp -Lf "$src" "$dst"
     fi
   else
     ln -snf "$src" "$dst"
@@ -84,7 +84,7 @@ TEAM_MODE=0
 NO_TEAM_MODE=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, antigravity, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -97,7 +97,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|opencode|auto) ;;
+  claude|codex|kiro|factory|opencode|antigravity|auto) ;;
   openclaw)
     echo ""
     echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
@@ -132,7 +132,7 @@ case "$HOST" in
     echo "GBrain setup and brain skills ship from the GBrain repo."
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, antigravity, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -196,14 +196,16 @@ INSTALL_CODEX=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
 INSTALL_OPENCODE=0
+INSTALL_ANTIGRAVITY=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
   command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
+  command -v agy >/dev/null 2>&1 && INSTALL_ANTIGRAVITY=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ] && [ "$INSTALL_ANTIGRAVITY" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
@@ -216,6 +218,8 @@ elif [ "$HOST" = "factory" ]; then
   INSTALL_FACTORY=1
 elif [ "$HOST" = "opencode" ]; then
   INSTALL_OPENCODE=1
+elif [ "$HOST" = "antigravity" ]; then
+  INSTALL_ANTIGRAVITY=1
 fi
 
 migrate_direct_codex_install() {
@@ -390,6 +394,16 @@ if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
     cd "$SOURCE_GSTACK_DIR"
     bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
     bun_cmd run gen:skill-docs --host opencode
+  )
+fi
+
+# 1e. Generate .antigravity/ Antigravity skill docs
+if [ "$INSTALL_ANTIGRAVITY" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .antigravity/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
+    bun_cmd run gen:skill-docs --host antigravity
   )
 fi
 
@@ -849,6 +863,102 @@ link_opencode_skill_dirs() {
   fi
 }
 
+create_antigravity_runtime_root() {
+  local gstack_dir="$1"
+  local antigravity_gstack="$2"
+  local antigravity_dir="$gstack_dir/.antigravity/skills"
+
+  if [ -L "$antigravity_gstack" ]; then
+    rm -f "$antigravity_gstack"
+  elif [ -d "$antigravity_gstack" ] && [ "$antigravity_gstack" != "$gstack_dir" ]; then
+    # Keep SKILL.md if it exists to avoid deleting the generated skill doc in staging
+    for item in "$antigravity_gstack"/* "$antigravity_gstack"/.*; do
+      basename_item="$(basename "$item")"
+      if [ "$basename_item" != "." ] && [ "$basename_item" != ".." ] && [ "$basename_item" != "SKILL.md" ]; then
+        rm -rf "$item"
+      fi
+    done
+  fi
+
+  mkdir -p "$antigravity_gstack" "$antigravity_gstack/browse" "$antigravity_gstack/design" "$antigravity_gstack/gstack-upgrade" "$antigravity_gstack/review" "$antigravity_gstack/qa" "$antigravity_gstack/plan-devex-review"
+
+  if [ -f "$antigravity_dir/gstack/SKILL.md" ] && [ "$antigravity_dir/gstack/SKILL.md" != "$antigravity_gstack/SKILL.md" ]; then
+    _link_or_copy "$antigravity_dir/gstack/SKILL.md" "$antigravity_gstack/SKILL.md"
+  fi
+  if [ -d "$gstack_dir/bin" ]; then
+    _link_or_copy "$gstack_dir/bin" "$antigravity_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    _link_or_copy "$gstack_dir/browse/dist" "$antigravity_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    _link_or_copy "$gstack_dir/browse/bin" "$antigravity_gstack/browse/bin"
+  fi
+  if [ -d "$gstack_dir/design/dist" ]; then
+    _link_or_copy "$gstack_dir/design/dist" "$antigravity_gstack/design/dist"
+  fi
+  if [ -f "$antigravity_dir/gstack-upgrade/SKILL.md" ]; then
+    _link_or_copy "$antigravity_dir/gstack-upgrade/SKILL.md" "$antigravity_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      _link_or_copy "$gstack_dir/review/$f" "$antigravity_gstack/review/$f"
+    fi
+  done
+  if [ -d "$gstack_dir/review/specialists" ]; then
+    _link_or_copy "$gstack_dir/review/specialists" "$antigravity_gstack/review/specialists"
+  fi
+  if [ -d "$gstack_dir/qa/templates" ]; then
+    _link_or_copy "$gstack_dir/qa/templates" "$antigravity_gstack/qa/templates"
+  fi
+  if [ -d "$gstack_dir/qa/references" ]; then
+    _link_or_copy "$gstack_dir/qa/references" "$antigravity_gstack/qa/references"
+  fi
+  if [ -f "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" ]; then
+    _link_or_copy "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" "$antigravity_gstack/plan-devex-review/dx-hall-of-fame.md"
+  fi
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    _link_or_copy "$gstack_dir/ETHOS.md" "$antigravity_gstack/ETHOS.md"
+  fi
+
+  local plugin_root
+  plugin_root="$(dirname "$(dirname "$antigravity_gstack")")"
+  mkdir -p "$plugin_root"
+  echo '{"name":"gstack","description":"gstack plugin for Antigravity","disabled":false}' > "$plugin_root/plugin.json"
+}
+
+link_antigravity_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local antigravity_dir="$gstack_dir/.antigravity/skills"
+  local linked=()
+
+  if [ ! -d "$antigravity_dir" ]; then
+    echo "  Generating .antigravity/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host antigravity )
+  fi
+
+  if [ ! -d "$antigravity_dir" ]; then
+    echo "  warning: .antigravity/skills/ generation failed — run 'bun run gen:skill-docs --host antigravity' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$antigravity_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        _link_or_copy "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
 # 4. Install for Claude (default)
 SKILLS_BASENAME="$(basename "$INSTALL_SKILLS_DIR")"
 SKILLS_PARENT_BASENAME="$(basename "$(dirname "$INSTALL_SKILLS_DIR")")"
@@ -1052,6 +1162,30 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   echo "gstack ready (opencode)."
   echo "  browse: $BROWSE_BIN"
   echo "  opencode skills: $OPENCODE_SKILLS"
+fi
+
+# 6d. Install for Antigravity
+if [ "$INSTALL_ANTIGRAVITY" -eq 1 ]; then
+  LOCAL_ANTIGRAVITY_ROOT="$SOURCE_GSTACK_DIR/.antigravity"
+  LOCAL_ANTIGRAVITY_GSTACK="$LOCAL_ANTIGRAVITY_ROOT/skills/gstack"
+
+  create_antigravity_runtime_root "$SOURCE_GSTACK_DIR" "$LOCAL_ANTIGRAVITY_GSTACK"
+  link_antigravity_skill_dirs "$SOURCE_GSTACK_DIR" "$LOCAL_ANTIGRAVITY_ROOT/skills"
+
+  for dest_dir in "$HOME/.gemini/antigravity-cli/plugins/gstack" "$HOME/.gemini/antigravity-ide/plugins/gstack"; do
+    mkdir -p "$(dirname "$dest_dir")"
+    if [ -L "$dest_dir" ]; then
+      rm -f "$dest_dir"
+    elif [ -d "$dest_dir" ]; then
+      rm -rf "$dest_dir"
+    fi
+    _link_or_copy "$LOCAL_ANTIGRAVITY_ROOT" "$dest_dir"
+  done
+
+  echo "gstack ready (antigravity)."
+  echo "  browse: $BROWSE_BIN"
+  echo "  antigravity cli plugin: $HOME/.gemini/antigravity-cli/plugins/gstack"
+  echo "  antigravity ide plugin: $HOME/.gemini/antigravity-ide/plugins/gstack"
 fi
 
 # 7. Create .agents/ sidecar symlinks for the real Codex skill target.

--- a/setup
+++ b/setup
@@ -5,7 +5,6 @@ umask 077  # Restrict new files to owner-only (0o600 files, 0o700 dirs)
 
 if ! command -v bun >/dev/null 2>&1; then
   echo "Error: bun is required but not installed." >&2
-  echo "Install with checksum verification:" >&2
   echo '  BUN_VERSION="1.3.10"' >&2
   echo '  tmpfile=$(mktemp)' >&2
   echo '  curl -fsSL "https://bun.sh/install" -o "$tmpfile"' >&2
@@ -1172,7 +1171,7 @@ if [ "$INSTALL_ANTIGRAVITY" -eq 1 ]; then
   create_antigravity_runtime_root "$SOURCE_GSTACK_DIR" "$LOCAL_ANTIGRAVITY_GSTACK"
   link_antigravity_skill_dirs "$SOURCE_GSTACK_DIR" "$LOCAL_ANTIGRAVITY_ROOT/skills"
 
-  for dest_dir in "$HOME/.gemini/antigravity-cli/plugins/gstack" "$HOME/.gemini/antigravity-ide/plugins/gstack"; do
+  for dest_dir in "$HOME/.gemini/antigravity-cli/plugins/gstack" "$HOME/.gemini/antigravity-ide/plugins/gstack" "$HOME/.gemini/antigravity/plugins/gstack"; do
     mkdir -p "$(dirname "$dest_dir")"
     if [ -L "$dest_dir" ]; then
       rm -f "$dest_dir"
@@ -1186,6 +1185,7 @@ if [ "$INSTALL_ANTIGRAVITY" -eq 1 ]; then
   echo "  browse: $BROWSE_BIN"
   echo "  antigravity cli plugin: $HOME/.gemini/antigravity-cli/plugins/gstack"
   echo "  antigravity ide plugin: $HOME/.gemini/antigravity-ide/plugins/gstack"
+  echo "  antigravity agent manager plugin: $HOME/.gemini/antigravity/plugins/gstack"
 fi
 
 # 7. Create .agents/ sidecar symlinks for the real Codex skill target.

--- a/test/artifacts-init-migration.test.ts
+++ b/test/artifacts-init-migration.test.ts
@@ -30,304 +30,287 @@ function runMigration(fakeHome: string): { code: number; stdout: string; stderr:
   };
 }
 
-describe('v1.38.1.0 migration', () => {
-  test('adds patterns to allowlist before USER ADDITIONS marker', () => {
-    const home = setupFakeHome();
-    try {
-      writeFileSync(join(home, '.gstack', '.brain-allowlist'), [
-        'projects/*/learnings.jsonl',
-        'projects/*/designs/*.md',
-        '# ---- USER ADDITIONS BELOW ---- (survives re-init; above is managed)',
-        'projects/*/my-custom.txt',
-      ].join('\n') + '\n');
+if (process.platform === "win32") {
+  describe("v1.38.1.0 migration tests", () => {
+    test.skip("skipped on Windows", () => {});
+  });
+} else {
+  describe('v1.38.1.0 migration', () => {
+    test('adds patterns to allowlist before USER ADDITIONS marker', () => {
+      const home = setupFakeHome();
+      try {
+        writeFileSync(join(home, '.gstack', '.brain-allowlist'), [
+          'projects/*/learnings.jsonl',
+          'projects/*/designs/*.md',
+          '# ---- USER ADDITIONS BELOW ---- (survives re-init; above is managed)',
+          'projects/*/my-custom.txt',
+        ].join('\n') + '\n');
 
-      const r = runMigration(home);
-      expect(r.code).toBe(0);
+        const r = runMigration(home);
+        expect(r.code).toBe(0);
 
-      const content = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
-      expect(content).toContain('projects/*/*-design-*.md');
-      expect(content).toContain('projects/*/*-test-plan-*.md');
-      // New patterns above the user marker
-      const designIdx = content.indexOf('projects/*/*-design-*.md');
-      const markerIdx = content.indexOf('# ---- USER ADDITIONS BELOW');
-      expect(designIdx).toBeLessThan(markerIdx);
-      // User customizations below the marker preserved
-      expect(content).toContain('projects/*/my-custom.txt');
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
+        const content = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
+        expect(content).toContain('projects/*/*-design-*.md');
+        expect(content).toContain('projects/*/*-test-plan-*.md');
+        // New patterns above the user marker
+        const designIdx = content.indexOf('projects/*/*-design-*.md');
+        const markerIdx = content.indexOf('# ---- USER ADDITIONS BELOW');
+        expect(designIdx).toBeLessThan(markerIdx);
+        // User customizations below the marker preserved
+        expect(content).toContain('projects/*/my-custom.txt');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test('adds entries to privacy-map.json via jq (preserves JSON validity)', () => {
+      const home = setupFakeHome();
+      try {
+        writeFileSync(join(home, '.gstack', '.brain-privacy-map.json'), JSON.stringify([
+          { pattern: 'projects/*/learnings.jsonl', class: 'artifact' },
+          { pattern: 'projects/*/designs/*.md', class: 'artifact' },
+        ], null, 2));
+
+        const r = runMigration(home);
+        expect(r.code).toBe(0);
+
+        const raw = readFileSync(join(home, '.gstack', '.brain-privacy-map.json'), 'utf-8');
+        // Valid JSON (would throw if jq emitted malformed output)
+        const parsed = JSON.parse(raw);
+        expect(Array.isArray(parsed)).toBe(true);
+        const patterns = parsed.map((e: any) => e.pattern);
+        expect(patterns).toContain('projects/*/*-design-*.md');
+        expect(patterns).toContain('projects/*/*-test-plan-*.md');
+        // Class preserved on new entries
+        expect(parsed.find((e: any) => e.pattern === 'projects/*/*-design-*.md').class).toBe('artifact');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test('adds union-merge rules to gitattributes', () => {
+      const home = setupFakeHome();
+      try {
+        writeFileSync(join(home, '.gstack', '.gitattributes'), [
+          '*.jsonl merge=jsonl-append',
+          'projects/*/designs/**/*.md merge=union',
+        ].join('\n') + '\n');
+
+        const r = runMigration(home);
+        expect(r.code).toBe(0);
+
+        const content = readFileSync(join(home, '.gstack', '.gitattributes'), 'utf-8');
+        expect(content).toContain('projects/*/*-design-*.md merge=union');
+        expect(content).toContain('projects/*/*-test-plan-*.md merge=union');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test('is idempotent: re-running on already-patched files is a no-op', () => {
+      const home = setupFakeHome();
+      try {
+        writeFileSync(join(home, '.gstack', '.brain-allowlist'), [
+          'projects/*/learnings.jsonl',
+          '# ---- USER ADDITIONS BELOW',
+        ].join('\n') + '\n');
+        writeFileSync(join(home, '.gstack', '.brain-privacy-map.json'), JSON.stringify([
+          { pattern: 'projects/*/learnings.jsonl', class: 'artifact' },
+        ]));
+        writeFileSync(join(home, '.gstack', '.gitattributes'), '*.jsonl merge=jsonl-append\n');
+
+        runMigration(home);
+        // Remove the done marker so re-run actually executes
+        rmSync(join(home, '.gstack', '.migrations'), { recursive: true, force: true });
+
+        const beforeAllowlist = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
+        const beforePrivacy = readFileSync(join(home, '.gstack', '.brain-privacy-map.json'), 'utf-8');
+        const beforeAttrs = readFileSync(join(home, '.gstack', '.gitattributes'), 'utf-8');
+
+        runMigration(home);
+
+        const afterAllowlist = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
+        const afterPrivacy = readFileSync(join(home, '.gstack', '.brain-privacy-map.json'), 'utf-8');
+        const afterAttrs = readFileSync(join(home, '.gstack', '.gitattributes'), 'utf-8');
+
+        expect(afterAllowlist).toBe(beforeAllowlist);
+        // jq may re-emit JSON with different whitespace but the parsed content
+        // must be identical
+        expect(JSON.parse(afterPrivacy)).toEqual(JSON.parse(beforePrivacy));
+        expect(afterAttrs).toBe(beforeAttrs);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test('repairs privacy-map even when allowlist is missing (per-file independence)', () => {
+      const home = setupFakeHome();
+      try {
+        // No .brain-allowlist; only privacy-map present
+        writeFileSync(join(home, '.gstack', '.brain-privacy-map.json'), JSON.stringify([
+          { pattern: 'projects/*/learnings.jsonl', class: 'artifact' },
+        ]));
+
+        const r = runMigration(home);
+        expect(r.code).toBe(0);
+
+        // Privacy-map still patched
+        const parsed = JSON.parse(readFileSync(join(home, '.gstack', '.brain-privacy-map.json'), 'utf-8'));
+        const patterns = parsed.map((e: any) => e.pattern);
+        expect(patterns).toContain('projects/*/*-design-*.md');
+        // Allowlist remains absent (we don't create files that weren't there)
+        expect(existsSync(join(home, '.gstack', '.brain-allowlist'))).toBe(false);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test('migration marker prevents re-running', () => {
+      const home = setupFakeHome();
+      try {
+        writeFileSync(join(home, '.gstack', '.brain-allowlist'), '# ---- USER ADDITIONS BELOW\n');
+        runMigration(home);
+        // Confirm marker file exists
+        expect(existsSync(join(home, '.gstack', '.migrations', 'v1.38.1.0.done'))).toBe(true);
+
+        // Modify allowlist so we can detect if the migration would re-run
+        writeFileSync(join(home, '.gstack', '.brain-allowlist'), '# minimal\n');
+
+        runMigration(home);
+
+        // With the marker present, the migration short-circuits, so the file
+        // we just wrote stays unmodified
+        expect(readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8')).toBe('# minimal\n');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test('handles allowlist without USER ADDITIONS marker (fallback to append)', () => {
+      const home = setupFakeHome();
+      try {
+        writeFileSync(join(home, '.gstack', '.brain-allowlist'), [
+          'projects/*/learnings.jsonl',
+          'projects/*/designs/*.md',
+          // no USER ADDITIONS marker
+        ].join('\n') + '\n');
+
+        const r = runMigration(home);
+        expect(r.code).toBe(0);
+
+        const content = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
+        expect(content).toContain('projects/*/*-design-*.md');
+        expect(content).toContain('projects/*/*-test-plan-*.md');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
   });
 
-  test('adds entries to privacy-map.json via jq (preserves JSON validity)', () => {
-    const home = setupFakeHome();
-    try {
-      writeFileSync(join(home, '.gstack', '.brain-privacy-map.json'), JSON.stringify([
-        { pattern: 'projects/*/learnings.jsonl', class: 'artifact' },
-        { pattern: 'projects/*/designs/*.md', class: 'artifact' },
-      ], null, 2));
+  describe('v1.40.0.0 migration', () => {
+    test('adds eng-review-test-plan pattern to allowlist on top of an installed v1.38.1.0 state', () => {
+      const home = setupFakeHome();
+      try {
+        // Simulate post-v1.38.1.0 state: design + test-plan patterns present,
+        // done-marker set so the v1.38.1.0 migration wouldn't re-run.
+        mkdirSync(join(home, '.gstack', '.migrations'), { recursive: true });
+        writeFileSync(join(home, '.gstack', '.migrations', 'v1.38.1.0.done'), '');
+        writeFileSync(join(home, '.gstack', '.brain-allowlist'), [
+          'projects/*/learnings.jsonl',
+          'projects/*/designs/*.md',
+          'projects/*/*-design-*.md',
+          'projects/*/*-test-plan-*.md',
+          '# ---- USER ADDITIONS BELOW ---- (survives re-init; above is managed)',
+          'projects/*/my-custom.txt',
+        ].join('\n') + '\n');
 
-      const r = runMigration(home);
-      expect(r.code).toBe(0);
+        const r = runMigrationV140(home);
+        expect(r.code).toBe(0);
 
-      const raw = readFileSync(join(home, '.gstack', '.brain-privacy-map.json'), 'utf-8');
-      // Valid JSON (would throw if jq emitted malformed output)
-      const parsed = JSON.parse(raw);
-      expect(Array.isArray(parsed)).toBe(true);
-      const patterns = parsed.map((e: any) => e.pattern);
-      expect(patterns).toContain('projects/*/*-design-*.md');
-      expect(patterns).toContain('projects/*/*-test-plan-*.md');
-      // Class preserved on new entries
-      expect(parsed.find((e: any) => e.pattern === 'projects/*/*-design-*.md').class).toBe('artifact');
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
+        const content = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
+        expect(content).toContain('projects/*/*-eng-review-test-plan-*.md');
+        // New pattern above the user marker.
+        const engRevIdx = content.indexOf('projects/*/*-eng-review-test-plan-*.md');
+        const markerIdx = content.indexOf('# ---- USER ADDITIONS BELOW');
+        expect(engRevIdx).toBeLessThan(markerIdx);
+        // User customizations below the marker preserved.
+        expect(content).toContain('projects/*/my-custom.txt');
+        // v1.40.0.0 done-marker created.
+        expect(existsSync(join(home, '.gstack', '.migrations', 'v1.40.0.0.done'))).toBe(true);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test('adds eng-review-test-plan entry to privacy-map.json via jq', () => {
+      const home = setupFakeHome();
+      try {
+        writeFileSync(join(home, '.gstack', '.brain-privacy-map.json'), JSON.stringify([
+          { pattern: 'projects/*/*-design-*.md', class: 'artifact' },
+          { pattern: 'projects/*/*-test-plan-*.md', class: 'artifact' },
+        ], null, 2));
+
+        const r = runMigrationV140(home);
+        expect(r.code).toBe(0);
+
+        const parsed = JSON.parse(readFileSync(join(home, '.gstack', '.brain-privacy-map.json'), 'utf-8'));
+        const patterns = parsed.map((e: any) => e.pattern);
+        expect(patterns).toContain('projects/*/*-eng-review-test-plan-*.md');
+        expect(parsed.find((e: any) => e.pattern === 'projects/*/*-eng-review-test-plan-*.md').class).toBe('artifact');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test('adds union-merge rule to gitattributes', () => {
+      const home = setupFakeHome();
+      try {
+        writeFileSync(join(home, '.gstack', '.gitattributes'), [
+          'projects/*/*-design-*.md merge=union',
+          'projects/*/*-test-plan-*.md merge=union',
+        ].join('\n') + '\n');
+
+        const r = runMigrationV140(home);
+        expect(r.code).toBe(0);
+
+        const content = readFileSync(join(home, '.gstack', '.gitattributes'), 'utf-8');
+        expect(content).toContain('projects/*/*-eng-review-test-plan-*.md merge=union');
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test('is idempotent: re-running is a no-op', () => {
+      const home = setupFakeHome();
+      try {
+        writeFileSync(join(home, '.gstack', '.brain-allowlist'),
+          'projects/*/*-eng-review-test-plan-*.md\n# ---- USER ADDITIONS BELOW ---- (survives re-init; above is managed)\n');
+
+        const r1 = runMigrationV140(home);
+        expect(r1.code).toBe(0);
+
+        const r2 = runMigrationV140(home);
+        expect(r2.code).toBe(0);
+
+        const content = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
+        const occurrences = content.match(/projects\/\*\/\*-eng-review-test-plan-\*\.md/g) || [];
+        expect(occurrences.length).toBe(1);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+
+    test('writes done-marker even when files are missing', () => {
+      const home = setupFakeHome();
+      try {
+        // No allowlist / privacy-map / gitattributes — fresh-init users with
+        // no federated artifacts yet. Migration should still mark itself done.
+        const r = runMigrationV140(home);
+        expect(r.code).toBe(0);
+        expect(existsSync(join(home, '.gstack', '.migrations', 'v1.40.0.0.done'))).toBe(true);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
   });
-
-  test('adds union-merge rules to gitattributes', () => {
-    const home = setupFakeHome();
-    try {
-      writeFileSync(join(home, '.gstack', '.gitattributes'), [
-        '*.jsonl merge=jsonl-append',
-        'projects/*/designs/**/*.md merge=union',
-      ].join('\n') + '\n');
-
-      const r = runMigration(home);
-      expect(r.code).toBe(0);
-
-      const content = readFileSync(join(home, '.gstack', '.gitattributes'), 'utf-8');
-      expect(content).toContain('projects/*/*-design-*.md merge=union');
-      expect(content).toContain('projects/*/*-test-plan-*.md merge=union');
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
-
-  test('is idempotent: re-running on already-patched files is a no-op', () => {
-    const home = setupFakeHome();
-    try {
-      writeFileSync(join(home, '.gstack', '.brain-allowlist'), [
-        'projects/*/learnings.jsonl',
-        '# ---- USER ADDITIONS BELOW',
-      ].join('\n') + '\n');
-      writeFileSync(join(home, '.gstack', '.brain-privacy-map.json'), JSON.stringify([
-        { pattern: 'projects/*/learnings.jsonl', class: 'artifact' },
-      ]));
-      writeFileSync(join(home, '.gstack', '.gitattributes'), '*.jsonl merge=jsonl-append\n');
-
-      runMigration(home);
-      // Remove the done marker so re-run actually executes
-      rmSync(join(home, '.gstack', '.migrations'), { recursive: true, force: true });
-
-      const beforeAllowlist = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
-      const beforePrivacy = readFileSync(join(home, '.gstack', '.brain-privacy-map.json'), 'utf-8');
-      const beforeAttrs = readFileSync(join(home, '.gstack', '.gitattributes'), 'utf-8');
-
-      runMigration(home);
-
-      const afterAllowlist = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
-      const afterPrivacy = readFileSync(join(home, '.gstack', '.brain-privacy-map.json'), 'utf-8');
-      const afterAttrs = readFileSync(join(home, '.gstack', '.gitattributes'), 'utf-8');
-
-      expect(afterAllowlist).toBe(beforeAllowlist);
-      // jq may re-emit JSON with different whitespace but the parsed content
-      // must be identical
-      expect(JSON.parse(afterPrivacy)).toEqual(JSON.parse(beforePrivacy));
-      expect(afterAttrs).toBe(beforeAttrs);
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
-
-  test('repairs privacy-map even when allowlist is missing (per-file independence)', () => {
-    const home = setupFakeHome();
-    try {
-      // No .brain-allowlist; only privacy-map present
-      writeFileSync(join(home, '.gstack', '.brain-privacy-map.json'), JSON.stringify([
-        { pattern: 'projects/*/learnings.jsonl', class: 'artifact' },
-      ]));
-
-      const r = runMigration(home);
-      expect(r.code).toBe(0);
-
-      // Privacy-map still patched
-      const parsed = JSON.parse(readFileSync(join(home, '.gstack', '.brain-privacy-map.json'), 'utf-8'));
-      const patterns = parsed.map((e: any) => e.pattern);
-      expect(patterns).toContain('projects/*/*-design-*.md');
-      // Allowlist remains absent (we don't create files that weren't there)
-      expect(existsSync(join(home, '.gstack', '.brain-allowlist'))).toBe(false);
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
-
-  test('migration marker prevents re-running', () => {
-    const home = setupFakeHome();
-    try {
-      writeFileSync(join(home, '.gstack', '.brain-allowlist'), '# ---- USER ADDITIONS BELOW\n');
-      runMigration(home);
-      // Confirm marker file exists
-      expect(existsSync(join(home, '.gstack', '.migrations', 'v1.38.1.0.done'))).toBe(true);
-
-      // Modify allowlist so we can detect if the migration would re-run
-      writeFileSync(join(home, '.gstack', '.brain-allowlist'), '# minimal\n');
-
-      runMigration(home);
-
-      // With the marker present, the migration short-circuits, so the file
-      // we just wrote stays unmodified
-      expect(readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8')).toBe('# minimal\n');
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
-
-  test('handles allowlist without USER ADDITIONS marker (fallback to append)', () => {
-    const home = setupFakeHome();
-    try {
-      writeFileSync(join(home, '.gstack', '.brain-allowlist'), [
-        'projects/*/learnings.jsonl',
-        'projects/*/designs/*.md',
-        // no USER ADDITIONS marker
-      ].join('\n') + '\n');
-
-      const r = runMigration(home);
-      expect(r.code).toBe(0);
-
-      const content = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
-      expect(content).toContain('projects/*/*-design-*.md');
-      expect(content).toContain('projects/*/*-test-plan-*.md');
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
-});
-
-// ──────────────────────────────────────────────────────────────────────────
-// v1.40.0.0 — `projects/*/*-eng-review-test-plan-*.md` follow-on for #1452.
-// v1.38.1.0 shipped the design + test-plan patterns but missed
-// /plan-eng-review's filename. Codex review #5 flagged that
-// v1.38.1.0's done-marker prevents users who already upgraded from picking
-// up #1465's allowlist edit, so v1.40.0.0 needs its own migration.
-// ──────────────────────────────────────────────────────────────────────────
-const MIGRATION_V1_40 = join(REPO_ROOT, 'gstack-upgrade', 'migrations', 'v1.40.0.0.sh');
-
-function runMigrationV140(fakeHome: string): { code: number; stdout: string; stderr: string } {
-  const proc = Bun.spawnSync({
-    cmd: ['bash', MIGRATION_V1_40],
-    env: { ...process.env, HOME: fakeHome },
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  return {
-    code: proc.exitCode ?? -1,
-    stdout: new TextDecoder().decode(proc.stdout),
-    stderr: new TextDecoder().decode(proc.stderr),
-  };
 }
-
-describe('v1.40.0.0 migration', () => {
-  test('adds eng-review-test-plan pattern to allowlist on top of an installed v1.38.1.0 state', () => {
-    const home = setupFakeHome();
-    try {
-      // Simulate post-v1.38.1.0 state: design + test-plan patterns present,
-      // done-marker set so the v1.38.1.0 migration wouldn't re-run.
-      mkdirSync(join(home, '.gstack', '.migrations'), { recursive: true });
-      writeFileSync(join(home, '.gstack', '.migrations', 'v1.38.1.0.done'), '');
-      writeFileSync(join(home, '.gstack', '.brain-allowlist'), [
-        'projects/*/learnings.jsonl',
-        'projects/*/designs/*.md',
-        'projects/*/*-design-*.md',
-        'projects/*/*-test-plan-*.md',
-        '# ---- USER ADDITIONS BELOW ---- (survives re-init; above is managed)',
-        'projects/*/my-custom.txt',
-      ].join('\n') + '\n');
-
-      const r = runMigrationV140(home);
-      expect(r.code).toBe(0);
-
-      const content = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
-      expect(content).toContain('projects/*/*-eng-review-test-plan-*.md');
-      // New pattern above the user marker.
-      const engRevIdx = content.indexOf('projects/*/*-eng-review-test-plan-*.md');
-      const markerIdx = content.indexOf('# ---- USER ADDITIONS BELOW');
-      expect(engRevIdx).toBeLessThan(markerIdx);
-      // User customizations below the marker preserved.
-      expect(content).toContain('projects/*/my-custom.txt');
-      // v1.40.0.0 done-marker created.
-      expect(existsSync(join(home, '.gstack', '.migrations', 'v1.40.0.0.done'))).toBe(true);
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
-
-  test('adds eng-review-test-plan entry to privacy-map.json via jq', () => {
-    const home = setupFakeHome();
-    try {
-      writeFileSync(join(home, '.gstack', '.brain-privacy-map.json'), JSON.stringify([
-        { pattern: 'projects/*/*-design-*.md', class: 'artifact' },
-        { pattern: 'projects/*/*-test-plan-*.md', class: 'artifact' },
-      ], null, 2));
-
-      const r = runMigrationV140(home);
-      expect(r.code).toBe(0);
-
-      const parsed = JSON.parse(readFileSync(join(home, '.gstack', '.brain-privacy-map.json'), 'utf-8'));
-      const patterns = parsed.map((e: any) => e.pattern);
-      expect(patterns).toContain('projects/*/*-eng-review-test-plan-*.md');
-      expect(parsed.find((e: any) => e.pattern === 'projects/*/*-eng-review-test-plan-*.md').class).toBe('artifact');
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
-
-  test('adds union-merge rule to gitattributes', () => {
-    const home = setupFakeHome();
-    try {
-      writeFileSync(join(home, '.gstack', '.gitattributes'), [
-        'projects/*/*-design-*.md merge=union',
-        'projects/*/*-test-plan-*.md merge=union',
-      ].join('\n') + '\n');
-
-      const r = runMigrationV140(home);
-      expect(r.code).toBe(0);
-
-      const content = readFileSync(join(home, '.gstack', '.gitattributes'), 'utf-8');
-      expect(content).toContain('projects/*/*-eng-review-test-plan-*.md merge=union');
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
-
-  test('is idempotent: re-running is a no-op', () => {
-    const home = setupFakeHome();
-    try {
-      writeFileSync(join(home, '.gstack', '.brain-allowlist'),
-        'projects/*/*-eng-review-test-plan-*.md\n# ---- USER ADDITIONS BELOW ---- (survives re-init; above is managed)\n');
-
-      const r1 = runMigrationV140(home);
-      expect(r1.code).toBe(0);
-
-      const r2 = runMigrationV140(home);
-      expect(r2.code).toBe(0);
-
-      const content = readFileSync(join(home, '.gstack', '.brain-allowlist'), 'utf-8');
-      const occurrences = content.match(/projects\/\*\/\*-eng-review-test-plan-\*\.md/g) || [];
-      expect(occurrences.length).toBe(1);
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
-
-  test('writes done-marker even when files are missing', () => {
-    const home = setupFakeHome();
-    try {
-      // No allowlist / privacy-map / gitattributes — fresh-init users with
-      // no federated artifacts yet. Migration should still mark itself done.
-      const r = runMigrationV140(home);
-      expect(r.code).toBe(0);
-      expect(existsSync(join(home, '.gstack', '.migrations', 'v1.40.0.0.done'))).toBe(true);
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
-});

--- a/test/codex-resume-flag-semantics.test.ts
+++ b/test/codex-resume-flag-semantics.test.ts
@@ -15,8 +15,8 @@
 import { describe, test, expect } from 'bun:test';
 import { spawnSync } from 'child_process';
 
-const codexPath = spawnSync('which', ['codex'], { encoding: 'utf-8' }).stdout.trim();
-const codexAvailable = codexPath.length > 0;
+const codexPath = Bun.which('codex');
+const codexAvailable = !!codexPath;
 
 describe.skipIf(!codexAvailable)(
   'codex exec resume — flag semantics (live CLI smoke; closes #1270 regex-only gap)',

--- a/test/context-save-hardening.test.ts
+++ b/test/context-save-hardening.test.ts
@@ -20,6 +20,12 @@ import * as os from 'os';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 
+if (process.platform === 'win32') {
+  describe('context-save-hardening tests', () => {
+    test.skip('skipped on Windows', () => {});
+  });
+} else {
+
 // The exact sanitize+collision bash used by context-save/SKILL.md Step 4.
 // Kept in sync with context-save/SKILL.md.tmpl. If the template changes
 // this helper out of alignment, the title-sanitize tests fail — intended.
@@ -347,3 +353,4 @@ describe('migration v1.1.3.0: HOME guard', () => {
     expect(result.stdout.toString().trim()).toBe('');
   });
 });
+}

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -225,7 +225,7 @@ describe('gen-skill-docs', () => {
     // Every skill should be FRESH
     for (const skill of CLAUDE_GENERATED_SKILLS) {
       const file = skill.dir === '.' ? 'SKILL.md' : `${skill.dir}/SKILL.md`;
-      expect(output).toContain(`FRESH: ${file}`);
+      expect(output.replace(/\\/g, '/')).toContain(`FRESH: ${file}`);
     }
     expect(output).not.toContain('STALE');
   });
@@ -1747,7 +1747,7 @@ describe('Codex generation (--host codex)', () => {
     const output = result.stdout.toString();
     // Every Codex skill should be FRESH
     for (const skill of CODEX_SKILLS) {
-      expect(output).toContain(`FRESH: .agents/skills/${skill.codexName}/SKILL.md`);
+      expect(output.replace(/\\/g, '/')).toContain(`FRESH: .agents/skills/${skill.codexName}/SKILL.md`);
     }
     expect(output).not.toContain('STALE');
   });
@@ -2051,7 +2051,7 @@ describe('Factory generation (--host factory)', () => {
     expect(result.exitCode).toBe(0);
     const output = result.stdout.toString();
     for (const skill of FACTORY_SKILLS) {
-      expect(output).toContain(`FRESH: .factory/skills/${skill.factoryName}/SKILL.md`);
+      expect(output.replace(/\\/g, '/')).toContain(`FRESH: .factory/skills/${skill.factoryName}/SKILL.md`);
     }
     expect(output).not.toContain('STALE');
   });
@@ -2159,9 +2159,9 @@ describe('--host all', () => {
     expect(result.exitCode).toBe(0);
     const output = result.stdout.toString();
     // All hosts should appear in output
-    expect(output).toContain('FRESH: SKILL.md');           // claude
+    expect(output.replace(/\\/g, '/')).toContain('FRESH: SKILL.md');           // claude
     for (const hostConfig of getExternalHosts()) {
-      expect(output).toContain(`FRESH: ${hostConfig.hostSubdir}/skills/`);
+      expect(output.replace(/\\/g, '/')).toContain(`FRESH: ${hostConfig.hostSubdir}/skills/`);
     }
   });
 });
@@ -2273,16 +2273,17 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('rm -f "$target"');
   });
 
-  test('setup supports --host auto|claude|codex|kiro|opencode', () => {
+  test('setup supports --host auto|claude|codex|kiro|opencode|antigravity', () => {
     expect(setupContent).toContain('--host');
-    expect(setupContent).toContain('claude|codex|kiro|factory|opencode|auto');
+    expect(setupContent).toContain('claude|codex|kiro|factory|opencode|antigravity|auto');
   });
 
-  test('auto mode detects claude, codex, kiro, and opencode binaries', () => {
+  test('auto mode detects claude, codex, kiro, opencode, and antigravity binaries', () => {
     expect(setupContent).toContain('command -v claude');
     expect(setupContent).toContain('command -v codex');
     expect(setupContent).toContain('command -v kiro-cli');
     expect(setupContent).toContain('command -v opencode');
+    expect(setupContent).toContain('command -v agy');
   });
 
   // T1: Sidecar skip guard — prevents .agents/skills/gstack from being linked as a skill

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -22,6 +22,7 @@ import {
   slate,
   cursor,
   openclaw,
+  antigravity,
 } from '../hosts/index';
 import { HOST_PATHS } from '../scripts/resolvers/types';
 
@@ -30,8 +31,8 @@ const ROOT = path.resolve(import.meta.dir, '..');
 // ─── hosts/index.ts ─────────────────────────────────────────
 
 describe('hosts/index.ts', () => {
-  test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+  test('ALL_HOST_CONFIGS has 11 hosts', () => {
+    expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {
@@ -53,6 +54,7 @@ describe('hosts/index.ts', () => {
     expect(slate.name).toBe('slate');
     expect(cursor.name).toBe('cursor');
     expect(openclaw.name).toBe('openclaw');
+    expect(antigravity.name).toBe('antigravity');
   });
 
   test('getHostConfig returns correct config', () => {
@@ -374,11 +376,15 @@ describe('host-config-export.ts CLI', () => {
     expect(exitCode).toBe(1);
   });
 
-  test('detect finds claude (since we are running in claude)', () => {
+  test('detect finds active hosts on PATH', () => {
     const { stdout, exitCode } = run('detect');
     expect(exitCode).toBe(0);
-    // claude binary should be on PATH in this environment
-    expect(stdout).toContain('claude');
+    const detected = stdout.split('\n').filter(Boolean);
+    const expectedHostsOnPath = ALL_HOST_CONFIGS.filter(c => {
+      const commands = [c.cliCommand, ...(c.cliAliases || [])];
+      return commands.some(cmd => Bun.which(cmd));
+    }).map(c => c.name);
+    expect(detected).toEqual(expectedHostsOnPath);
   });
 
   test('unknown command exits 1', () => {

--- a/test/regression-pr1169-build-app-sed.test.ts
+++ b/test/regression-pr1169-build-app-sed.test.ts
@@ -23,139 +23,145 @@ import { spawnSync } from "node:child_process";
 const ROOT = path.resolve(import.meta.dir, "..");
 const SCRIPT = path.join(ROOT, "scripts/build-app.sh");
 
-describe("PR #1169 bug #2: build-app.sh sed escape for $APP_NAME", () => {
-  test("escape sequence produces sed-safe output for `&`, `/`, `\\` in APP_NAME", () => {
-    // Mirror the script's escape sequence and run it in isolation against a
-    // hostile name. The escape sequence at line ~98 is:
-    //   APP_NAME_SED_ESCAPED=$(printf '%s' "$APP_NAME" | sed 's/[&/\]/\\&/g')
-    // We assert the resulting string can then be used as a sed replacement
-    // safely — round-trip via a real `sed s///` against a stub strings file.
+if (process.platform === "win32") {
+  describe("PR #1169 build-app.sh tests", () => {
+    test.skip("skipped on Windows", () => {});
+  });
+} else {
+  describe("PR #1169 bug #2: build-app.sh sed escape for $APP_NAME", () => {
+    test("escape sequence produces sed-safe output for `&`, `/`, `\\` in APP_NAME", () => {
+      // Mirror the script's escape sequence and run it in isolation against a
+      // hostile name. The escape sequence at line ~98 is:
+      //   APP_NAME_SED_ESCAPED=$(printf '%s' "$APP_NAME" | sed 's/[&/\]/\\&/g')
+      // We assert the resulting string can then be used as a sed replacement
+      // safely — round-trip via a real `sed s///` against a stub strings file.
 
-    const inputs: string[] = [
-      "Foo/Bar&Baz",      // slash + ampersand
-      "Cool\\App",        // backslash
-      "Plain Name",        // no metachars (baseline)
-      "A/B\\C&D",          // all three at once
-      "End/",              // trailing slash
-      "&Start",            // leading ampersand
-    ];
+      const inputs: string[] = [
+        "Foo/Bar&Baz",      // slash + ampersand
+        "Cool\\App",        // backslash
+        "Plain Name",        // no metachars (baseline)
+        "A/B\\C&D",          // all three at once
+        "End/",              // trailing slash
+        "&Start",            // leading ampersand
+      ];
 
-    for (const appName of inputs) {
-      // Bug #2 invariant: the escaped string, used as the replacement half
-      // of `sed s/<needle>/<replacement>/g`, results in the literal appName
-      // appearing in the output.
-      const result = spawnSync(
-        "bash",
-        ["-c",
-          `set -eu
-           APP_NAME="$1"
-           APP_NAME_SED_ESCAPED=$(printf '%s' "$APP_NAME" | sed 's/[&/\\]/\\\\&/g')
-           printf 'Google Chrome for Testing' | sed "s/Google Chrome for Testing/\${APP_NAME_SED_ESCAPED}/g"
-          `,
-          "_",
-          appName,
-        ],
-        { encoding: "utf-8" }
+      for (const appName of inputs) {
+        // Bug #2 invariant: the escaped string, used as the replacement half
+        // of `sed s/<needle>/<replacement>/g`, results in the literal appName
+        // appearing in the output.
+        const result = spawnSync(
+          "bash",
+          ["-c",
+            `set -eu
+             APP_NAME="$1"
+             APP_NAME_SED_ESCAPED=$(printf '%s' "$APP_NAME" | sed 's/[&/\\]/\\\\&/g')
+             printf 'Google Chrome for Testing' | sed "s/Google Chrome for Testing/\${APP_NAME_SED_ESCAPED}/g"
+            `,
+            "_",
+            appName,
+          ],
+          { encoding: "utf-8" }
+        );
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toBe(appName);
+        expect(result.stderr).toBe("");
+      }
+    });
+
+    test("script body still routes APP_NAME through the escape helper before sed", () => {
+      // Belt-and-braces static check: the rebrand block must contain BOTH the
+      // escape line and the sed line referencing the escaped variable.
+      const body = fs.readFileSync(SCRIPT, "utf-8");
+      expect(body).toMatch(/APP_NAME_SED_ESCAPED=\$\(printf '%s' "\$APP_NAME" \| sed/);
+      expect(body).toMatch(/sed -i ''\s*"s\/Google Chrome for Testing\/\$\{APP_NAME_SED_ESCAPED\}\/g"/);
+    });
+
+    test("no bare `$APP_NAME` interpolation directly into the rebrand sed", () => {
+      // Ensure no future refactor reintroduces the bug by interpolating
+      // $APP_NAME straight into the s/// replacement.
+      const body = fs.readFileSync(SCRIPT, "utf-8");
+      expect(body).not.toMatch(/sed -i ''\s*"s\/Google Chrome for Testing\/\$APP_NAME\//);
+      expect(body).not.toMatch(/sed -i ''\s*"s\/Google Chrome for Testing\/\$\{APP_NAME\}\//);
+    });
+  });
+
+  describe("PR #1169 bug #3: build-app.sh DMG_TMP mktemp failure guard", () => {
+    test("mktemp -d for DMG_TMP is followed by an explicit failure handler", () => {
+      const body = fs.readFileSync(SCRIPT, "utf-8");
+      // The script must assign DMG_TMP and immediately check for failure on
+      // the SAME line via `||`, then validate the path is non-empty and a real
+      // directory before cp.
+      const guard = body.match(
+        /DMG_TMP=\$\(mktemp -d\)\s*\|\|\s*\{[^}]*exit\s+\d/
+      );
+      expect(guard).not.toBeNull();
+    });
+
+    test("DMG_TMP is also validated as non-empty AND a directory before cp", () => {
+      const body = fs.readFileSync(SCRIPT, "utf-8");
+      // After mktemp, a defensive check should reject empty or non-directory
+      // paths (covers cases where mktemp succeeds but returns garbage).
+      expect(body).toMatch(
+        /\[\s*-z\s+"\$DMG_TMP"\s*\][^\n]*\|\|\s*\[\s*!\s+-d\s+"\$DMG_TMP"\s*\]/
+      );
+    });
+
+    test("no `cp -a ... \"$DMG_TMP/\"` before the validation block", () => {
+      const body = fs.readFileSync(SCRIPT, "utf-8");
+      // The cp must come AFTER the validation. Find the line offsets.
+      const mktempIdx = body.search(/DMG_TMP=\$\(mktemp -d\)/);
+      const validationIdx = body.search(
+        /\[\s*-z\s+"\$DMG_TMP"\s*\]/
+      );
+      const cpIdx = body.search(/cp -a "\$APP_DIR" "\$DMG_TMP\//);
+      expect(mktempIdx).toBeGreaterThan(-1);
+      expect(validationIdx).toBeGreaterThan(mktempIdx);
+      expect(cpIdx).toBeGreaterThan(validationIdx);
+    });
+
+    test("runtime: escape function refuses to leave DMG_TMP empty (fake-mktemp PATH stub)", () => {
+      // Codex strongly preferred runtime testing here. The full build-app.sh
+      // depends on xcrun/hdiutil/PlistBuddy — too heavy for CI. Instead, we
+      // extract just the failure-guard shape and run it with a fake mktemp
+      // that always exits 1. Asserts the script exits non-zero before cp.
+
+      const fakeBin = fs.mkdtempSync(path.join("/tmp", "pr1169-fakebin-"));
+      fs.writeFileSync(
+        path.join(fakeBin, "mktemp"),
+        "#!/bin/sh\nexit 1\n",
+        { mode: 0o755 }
       );
 
-      expect(result.status).toBe(0);
-      expect(result.stdout).toBe(appName);
-      expect(result.stderr).toBe("");
-    }
+      // The guard, isolated. Mirrors the actual script's logic. Use a regular
+      // string + array of lines so the embedded bash backticks/dollars don't
+      // get interpreted by the JS template-literal parser.
+      const guardScript = [
+        'set -u',
+        'DMG_TMP=$(mktemp -d) || { echo "ERROR: mktemp -d failed — refusing to continue so we don\'t cp into the filesystem root." >&2; exit 1; }',
+        'if [ -z "$DMG_TMP" ] || [ ! -d "$DMG_TMP" ]; then',
+        '  echo "ERROR: mktemp -d returned an invalid path (\'$DMG_TMP\')." >&2',
+        '  exit 1',
+        'fi',
+        '# If we got here, we would run the cp block, which is the bug.',
+        'echo "REACHED_CP_BLOCK_WHICH_IS_THE_BUG" >&2',
+        'exit 0',
+      ].join('\n');
+
+      const result = spawnSync(
+        "bash",
+        ["-c", guardScript],
+        {
+          encoding: "utf-8",
+          env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` },
+        }
+      );
+
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toMatch(/mktemp -d failed|invalid path/);
+      expect(result.stderr).not.toMatch(/REACHED_CP_BLOCK_WHICH_IS_THE_BUG/);
+    });
   });
-
-  test("script body still routes APP_NAME through the escape helper before sed", () => {
-    // Belt-and-braces static check: the rebrand block must contain BOTH the
-    // escape line and the sed line referencing the escaped variable.
-    const body = fs.readFileSync(SCRIPT, "utf-8");
-    expect(body).toMatch(/APP_NAME_SED_ESCAPED=\$\(printf '%s' "\$APP_NAME" \| sed/);
-    expect(body).toMatch(/sed -i ''\s*"s\/Google Chrome for Testing\/\$\{APP_NAME_SED_ESCAPED\}\/g"/);
-  });
-
-  test("no bare `$APP_NAME` interpolation directly into the rebrand sed", () => {
-    // Ensure no future refactor reintroduces the bug by interpolating
-    // $APP_NAME straight into the s/// replacement.
-    const body = fs.readFileSync(SCRIPT, "utf-8");
-    expect(body).not.toMatch(/sed -i ''\s*"s\/Google Chrome for Testing\/\$APP_NAME\//);
-    expect(body).not.toMatch(/sed -i ''\s*"s\/Google Chrome for Testing\/\$\{APP_NAME\}\//);
-  });
-});
-
-describe("PR #1169 bug #3: build-app.sh DMG_TMP mktemp failure guard", () => {
-  test("mktemp -d for DMG_TMP is followed by an explicit failure handler", () => {
-    const body = fs.readFileSync(SCRIPT, "utf-8");
-    // The script must assign DMG_TMP and immediately check for failure on
-    // the SAME line via `||`, then validate the path is non-empty and a real
-    // directory before cp.
-    const guard = body.match(
-      /DMG_TMP=\$\(mktemp -d\)\s*\|\|\s*\{[^}]*exit\s+\d/
-    );
-    expect(guard).not.toBeNull();
-  });
-
-  test("DMG_TMP is also validated as non-empty AND a directory before cp", () => {
-    const body = fs.readFileSync(SCRIPT, "utf-8");
-    // After mktemp, a defensive check should reject empty or non-directory
-    // paths (covers cases where mktemp succeeds but returns garbage).
-    expect(body).toMatch(
-      /\[\s*-z\s+"\$DMG_TMP"\s*\][^\n]*\|\|\s*\[\s*!\s+-d\s+"\$DMG_TMP"\s*\]/
-    );
-  });
-
-  test("no `cp -a ... \"$DMG_TMP/\"` before the validation block", () => {
-    const body = fs.readFileSync(SCRIPT, "utf-8");
-    // The cp must come AFTER the validation. Find the line offsets.
-    const mktempIdx = body.search(/DMG_TMP=\$\(mktemp -d\)/);
-    const validationIdx = body.search(
-      /\[\s*-z\s+"\$DMG_TMP"\s*\]/
-    );
-    const cpIdx = body.search(/cp -a "\$APP_DIR" "\$DMG_TMP\//);
-    expect(mktempIdx).toBeGreaterThan(-1);
-    expect(validationIdx).toBeGreaterThan(mktempIdx);
-    expect(cpIdx).toBeGreaterThan(validationIdx);
-  });
-
-  test("runtime: escape function refuses to leave DMG_TMP empty (fake-mktemp PATH stub)", () => {
-    // Codex strongly preferred runtime testing here. The full build-app.sh
-    // depends on xcrun/hdiutil/PlistBuddy — too heavy for CI. Instead, we
-    // extract just the failure-guard shape and run it with a fake mktemp
-    // that always exits 1. Asserts the script exits non-zero before cp.
-
-    const fakeBin = fs.mkdtempSync(path.join("/tmp", "pr1169-fakebin-"));
-    fs.writeFileSync(
-      path.join(fakeBin, "mktemp"),
-      "#!/bin/sh\nexit 1\n",
-      { mode: 0o755 }
-    );
-
-    // The guard, isolated. Mirrors the actual script's logic. Use a regular
-    // string + array of lines so the embedded bash backticks/dollars don't
-    // get interpreted by the JS template-literal parser.
-    const guardScript = [
-      'set -u',
-      'DMG_TMP=$(mktemp -d) || { echo "ERROR: mktemp -d failed — refusing to continue so we don\'t cp into the filesystem root." >&2; exit 1; }',
-      'if [ -z "$DMG_TMP" ] || [ ! -d "$DMG_TMP" ]; then',
-      '  echo "ERROR: mktemp -d returned an invalid path (\'$DMG_TMP\')." >&2',
-      '  exit 1',
-      'fi',
-      '# If we got here, we would run the cp block, which is the bug.',
-      'echo "REACHED_CP_BLOCK_WHICH_IS_THE_BUG" >&2',
-      'exit 0',
-    ].join('\n');
-
-    const result = spawnSync(
-      "bash",
-      ["-c", guardScript],
-      {
-        encoding: "utf-8",
-        env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` },
-      }
-    );
-
-    fs.rmSync(fakeBin, { recursive: true, force: true });
-
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toMatch(/mktemp -d failed|invalid path/);
-    expect(result.stderr).not.toMatch(/REACHED_CP_BLOCK_WHICH_IS_THE_BUG/);
-  });
-});
+}

--- a/test/setup-conductor-worktree.test.ts
+++ b/test/setup-conductor-worktree.test.ts
@@ -7,195 +7,201 @@ import * as os from 'os';
 const ROOT = path.resolve(import.meta.dir, '..');
 const SETUP_SCRIPT = path.join(ROOT, 'setup');
 
-describe('setup: Conductor worktree guard', () => {
-  test('setup contains the real-dir guard before the symlink-or-copy into ~/.claude/skills/', () => {
-    const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
-    const guardIdx = content.indexOf('_SKIP_CLAUDE_REGISTER=0');
-    // v1.36.0.0: symlink work routes through _link_or_copy helper for Windows fallback.
-    const lnIdx = content.indexOf('_link_or_copy "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"');
-    expect(guardIdx).toBeGreaterThan(-1);
-    expect(lnIdx).toBeGreaterThan(-1);
-    expect(guardIdx).toBeLessThan(lnIdx);
+if (process.platform === "win32") {
+  describe("setup: Conductor worktree guard tests", () => {
+    test.skip("skipped on Windows", () => {});
   });
+} else {
+  describe('setup: Conductor worktree guard', () => {
+    test('setup contains the real-dir guard before the symlink-or-copy into ~/.claude/skills/', () => {
+      const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
+      const guardIdx = content.indexOf('_SKIP_CLAUDE_REGISTER=0');
+      // v1.36.0.0: symlink work routes through _link_or_copy helper for Windows fallback.
+      const lnIdx = content.indexOf('_link_or_copy "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"');
+      expect(guardIdx).toBeGreaterThan(-1);
+      expect(lnIdx).toBeGreaterThan(-1);
+      expect(guardIdx).toBeLessThan(lnIdx);
+    });
 
-  test('guard resolves the existing real dir with `pwd -P` and compares against source', () => {
-    const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
-    expect(content).toContain('[ -d "$CLAUDE_GSTACK_LINK" ] && [ ! -L "$CLAUDE_GSTACK_LINK" ]');
-    expect(content).toContain('cd "$CLAUDE_GSTACK_LINK" 2>/dev/null && pwd -P');
-    expect(content).toContain('"$_EXISTING_REAL" != "$SOURCE_GSTACK_DIR"');
-  });
+    test('guard resolves the existing real dir with `pwd -P` and compares against source', () => {
+      const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
+      expect(content).toContain('[ -d "$CLAUDE_GSTACK_LINK" ] && [ ! -L "$CLAUDE_GSTACK_LINK" ]');
+      expect(content).toContain('cd "$CLAUDE_GSTACK_LINK" 2>/dev/null && pwd -P');
+      expect(content).toContain('"$_EXISTING_REAL" != "$SOURCE_GSTACK_DIR"');
+    });
 
-  test('skip branch prints "registration skipped" + remediation hint', () => {
-    const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
-    expect(content).toContain('Skipping Claude skill registration');
-    expect(content).toContain('claude registration skipped');
-    expect(content).toContain('rm -rf $CLAUDE_GSTACK_LINK');
-  });
+    test('skip branch prints "registration skipped" + remediation hint', () => {
+      const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
+      expect(content).toContain('Skipping Claude skill registration');
+      expect(content).toContain('claude registration skipped');
+      expect(content).toContain('rm -rf $CLAUDE_GSTACK_LINK');
+    });
 
-  // Reproduce the BSD/macOS `ln -snf` behavior that caused the bug, then
-  // confirm the guard avoids it. This is a behavioral test of the guard logic
-  // running in an isolated tmpdir — not the full setup script.
-  test('BSD ln -snf into an existing real dir creates a child symlink (bug reproduces)', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-guard-'));
-    try {
-      const source = path.join(tmp, 'source-worktree');
-      const dest = path.join(tmp, 'dest-real-dir');
-      fs.mkdirSync(source);
-      fs.mkdirSync(dest);
-      // The buggy invocation: target dest is an existing real dir.
-      const result = spawnSync('ln', ['-snf', source, dest], { encoding: 'utf-8' });
-      expect(result.status).toBe(0);
-      // Child symlink leaked inside dest.
-      const leaked = path.join(dest, path.basename(source));
-      expect(fs.existsSync(leaked)).toBe(true);
-      expect(fs.lstatSync(leaked).isSymbolicLink()).toBe(true);
-      expect(fs.readlinkSync(leaked)).toBe(source);
-      // dest itself stayed a real directory (not replaced).
-      expect(fs.lstatSync(dest).isSymbolicLink()).toBe(false);
-      expect(fs.lstatSync(dest).isDirectory()).toBe(true);
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
-  });
+    // Reproduce the BSD/macOS `ln -snf` behavior that caused the bug, then
+    // confirm the guard avoids it. This is a behavioral test of the guard logic
+    // running in an isolated tmpdir — not the full setup script.
+    test('BSD ln -snf into an existing real dir creates a child symlink (bug reproduces)', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-guard-'));
+      try {
+        const source = path.join(tmp, 'source-worktree');
+        const dest = path.join(tmp, 'dest-real-dir');
+        fs.mkdirSync(source);
+        fs.mkdirSync(dest);
+        // The buggy invocation: target dest is an existing real dir.
+        const result = spawnSync('ln', ['-snf', source, dest], { encoding: 'utf-8' });
+        expect(result.status).toBe(0);
+        // Child symlink leaked inside dest.
+        const leaked = path.join(dest, path.basename(source));
+        expect(fs.existsSync(leaked)).toBe(true);
+        expect(fs.lstatSync(leaked).isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(leaked)).toBe(source);
+        // dest itself stayed a real directory (not replaced).
+        expect(fs.lstatSync(dest).isSymbolicLink()).toBe(false);
+        expect(fs.lstatSync(dest).isDirectory()).toBe(true);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
 
-  test('guard logic refuses to ln when dest is a real dir pointing elsewhere', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-guard-'));
-    try {
-      const source = path.join(tmp, 'source-worktree');
-      const dest = path.join(tmp, 'dest-real-dir');
-      fs.mkdirSync(source);
-      fs.mkdirSync(dest);
-      // Inline the guard logic from setup. If it triggers, $_SKIP=1 is echoed
-      // and no ln is performed; otherwise ln runs and we'd see the leak.
-      const script = `
-        set -e
-        SOURCE_GSTACK_DIR='${source}'
-        CLAUDE_GSTACK_LINK='${dest}'
-        _SKIP_CLAUDE_REGISTER=0
-        if [ -d "$CLAUDE_GSTACK_LINK" ] && [ ! -L "$CLAUDE_GSTACK_LINK" ]; then
-          _EXISTING_REAL=$(cd "$CLAUDE_GSTACK_LINK" 2>/dev/null && pwd -P || echo "")
-          if [ -n "$_EXISTING_REAL" ] && [ "$_EXISTING_REAL" != "$SOURCE_GSTACK_DIR" ]; then
-            _SKIP_CLAUDE_REGISTER=1
+    test('guard logic refuses to ln when dest is a real dir pointing elsewhere', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-guard-'));
+      try {
+        const source = path.join(tmp, 'source-worktree');
+        const dest = path.join(tmp, 'dest-real-dir');
+        fs.mkdirSync(source);
+        fs.mkdirSync(dest);
+        // Inline the guard logic from setup. If it triggers, $_SKIP=1 is echoed
+        // and no ln is performed; otherwise ln runs and we'd see the leak.
+        const script = `
+          set -e
+          SOURCE_GSTACK_DIR='${source}'
+          CLAUDE_GSTACK_LINK='${dest}'
+          _SKIP_CLAUDE_REGISTER=0
+          if [ -d "$CLAUDE_GSTACK_LINK" ] && [ ! -L "$CLAUDE_GSTACK_LINK" ]; then
+            _EXISTING_REAL=$(cd "$CLAUDE_GSTACK_LINK" 2>/dev/null && pwd -P || echo "")
+            if [ -n "$_EXISTING_REAL" ] && [ "$_EXISTING_REAL" != "$SOURCE_GSTACK_DIR" ]; then
+              _SKIP_CLAUDE_REGISTER=1
+            fi
           fi
-        fi
-        if [ "$_SKIP_CLAUDE_REGISTER" -eq 1 ]; then
-          echo "SKIP"
-        else
-          ln -snf "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"
-          echo "LINKED"
-        fi
-      `;
-      const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8' });
-      expect(result.status).toBe(0);
-      expect(result.stdout.trim()).toBe('SKIP');
-      // No child symlink leaked.
-      const leaked = path.join(dest, path.basename(source));
-      expect(fs.existsSync(leaked)).toBe(false);
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
-  });
-
-  test('guard allows ln when dest does not exist (fresh install path)', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-guard-'));
-    try {
-      const source = path.join(tmp, 'source-worktree');
-      const dest = path.join(tmp, 'fresh-dest');
-      fs.mkdirSync(source);
-      const script = `
-        set -e
-        SOURCE_GSTACK_DIR='${source}'
-        CLAUDE_GSTACK_LINK='${dest}'
-        _SKIP_CLAUDE_REGISTER=0
-        if [ -d "$CLAUDE_GSTACK_LINK" ] && [ ! -L "$CLAUDE_GSTACK_LINK" ]; then
-          _EXISTING_REAL=$(cd "$CLAUDE_GSTACK_LINK" 2>/dev/null && pwd -P || echo "")
-          if [ -n "$_EXISTING_REAL" ] && [ "$_EXISTING_REAL" != "$SOURCE_GSTACK_DIR" ]; then
-            _SKIP_CLAUDE_REGISTER=1
+          if [ "$_SKIP_CLAUDE_REGISTER" -eq 1 ]; then
+            echo "SKIP"
+          else
+            ln -snf "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"
+            echo "LINKED"
           fi
-        fi
-        if [ "$_SKIP_CLAUDE_REGISTER" -eq 1 ]; then
-          echo "SKIP"
-        else
-          ln -snf "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"
-          echo "LINKED"
-        fi
-      `;
-      const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8' });
-      expect(result.status).toBe(0);
-      expect(result.stdout.trim()).toBe('LINKED');
-      expect(fs.lstatSync(dest).isSymbolicLink()).toBe(true);
-      expect(fs.readlinkSync(dest)).toBe(source);
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
-  });
+        `;
+        const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8' });
+        expect(result.status).toBe(0);
+        expect(result.stdout.trim()).toBe('SKIP');
+        // No child symlink leaked.
+        const leaked = path.join(dest, path.basename(source));
+        expect(fs.existsSync(leaked)).toBe(false);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
 
-  test('guard allows ln when dest is an existing symlink (upgrade-in-place path)', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-guard-'));
-    try {
-      const source = path.join(tmp, 'new-source');
-      const oldSource = path.join(tmp, 'old-source');
-      const dest = path.join(tmp, 'dest-symlink');
-      fs.mkdirSync(source);
-      fs.mkdirSync(oldSource);
-      fs.symlinkSync(oldSource, dest);
-      // Existing symlink: -L is true, so the guard does NOT trigger. ln -snf
-      // should atomically retarget the symlink to the new source.
-      const script = `
-        set -e
-        SOURCE_GSTACK_DIR='${source}'
-        CLAUDE_GSTACK_LINK='${dest}'
-        _SKIP_CLAUDE_REGISTER=0
-        if [ -d "$CLAUDE_GSTACK_LINK" ] && [ ! -L "$CLAUDE_GSTACK_LINK" ]; then
-          _EXISTING_REAL=$(cd "$CLAUDE_GSTACK_LINK" 2>/dev/null && pwd -P || echo "")
-          if [ -n "$_EXISTING_REAL" ] && [ "$_EXISTING_REAL" != "$SOURCE_GSTACK_DIR" ]; then
-            _SKIP_CLAUDE_REGISTER=1
+    test('guard allows ln when dest does not exist (fresh install path)', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-guard-'));
+      try {
+        const source = path.join(tmp, 'source-worktree');
+        const dest = path.join(tmp, 'fresh-dest');
+        fs.mkdirSync(source);
+        const script = `
+          set -e
+          SOURCE_GSTACK_DIR='${source}'
+          CLAUDE_GSTACK_LINK='${dest}'
+          _SKIP_CLAUDE_REGISTER=0
+          if [ -d "$CLAUDE_GSTACK_LINK" ] && [ ! -L "$CLAUDE_GSTACK_LINK" ]; then
+            _EXISTING_REAL=$(cd "$CLAUDE_GSTACK_LINK" 2>/dev/null && pwd -P || echo "")
+            if [ -n "$_EXISTING_REAL" ] && [ "$_EXISTING_REAL" != "$SOURCE_GSTACK_DIR" ]; then
+              _SKIP_CLAUDE_REGISTER=1
+            fi
           fi
-        fi
-        if [ "$_SKIP_CLAUDE_REGISTER" -eq 1 ]; then
-          echo "SKIP"
-        else
-          ln -snf "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"
-          echo "LINKED"
-        fi
-      `;
-      const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8' });
-      expect(result.status).toBe(0);
-      expect(result.stdout.trim()).toBe('LINKED');
-      expect(fs.readlinkSync(dest)).toBe(source);
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
-  });
+          if [ "$_SKIP_CLAUDE_REGISTER" -eq 1 ]; then
+            echo "SKIP"
+          else
+            ln -snf "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"
+            echo "LINKED"
+          fi
+        `;
+        const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8' });
+        expect(result.status).toBe(0);
+        expect(result.stdout.trim()).toBe('LINKED');
+        expect(fs.lstatSync(dest).isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(dest)).toBe(source);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
 
-  test('guard allows ln when dest is a real dir already pointing to source (self-rerun)', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-guard-'));
-    try {
-      const source = path.join(tmp, 'source-worktree');
-      fs.mkdirSync(source);
-      // Mirror setup's SOURCE_GSTACK_DIR resolution (`pwd -P`) so the comparison
-      // is fair on macOS where /tmp itself is a symlink to /private/tmp.
-      const resolvedSource = fs.realpathSync(source);
-      // Degenerate case: existing real dir IS the source.
-      const dest = source;
-      const script = `
-        set -e
-        SOURCE_GSTACK_DIR='${resolvedSource}'
-        CLAUDE_GSTACK_LINK='${dest}'
-        _SKIP_CLAUDE_REGISTER=0
-        if [ -d "$CLAUDE_GSTACK_LINK" ] && [ ! -L "$CLAUDE_GSTACK_LINK" ]; then
-          _EXISTING_REAL=$(cd "$CLAUDE_GSTACK_LINK" 2>/dev/null && pwd -P || echo "")
-          if [ -n "$_EXISTING_REAL" ] && [ "$_EXISTING_REAL" != "$SOURCE_GSTACK_DIR" ]; then
-            _SKIP_CLAUDE_REGISTER=1
+    test('guard allows ln when dest is an existing symlink (upgrade-in-place path)', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-guard-'));
+      try {
+        const source = path.join(tmp, 'new-source');
+        const oldSource = path.join(tmp, 'old-source');
+        const dest = path.join(tmp, 'dest-symlink');
+        fs.mkdirSync(source);
+        fs.mkdirSync(oldSource);
+        fs.symlinkSync(oldSource, dest);
+        // Existing symlink: -L is true, so the guard does NOT trigger. ln -snf
+        // should atomically retarget the symlink to the new source.
+        const script = `
+          set -e
+          SOURCE_GSTACK_DIR='${source}'
+          CLAUDE_GSTACK_LINK='${dest}'
+          _SKIP_CLAUDE_REGISTER=0
+          if [ -d "$CLAUDE_GSTACK_LINK" ] && [ ! -L "$CLAUDE_GSTACK_LINK" ]; then
+            _EXISTING_REAL=$(cd "$CLAUDE_GSTACK_LINK" 2>/dev/null && pwd -P || echo "")
+            if [ -n "$_EXISTING_REAL" ] && [ "$_EXISTING_REAL" != "$SOURCE_GSTACK_DIR" ]; then
+              _SKIP_CLAUDE_REGISTER=1
+            fi
           fi
-        fi
-        echo "skip=$_SKIP_CLAUDE_REGISTER"
-      `;
-      const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8' });
-      expect(result.status).toBe(0);
-      expect(result.stdout.trim()).toBe('skip=0');
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
+          if [ "$_SKIP_CLAUDE_REGISTER" -eq 1 ]; then
+            echo "SKIP"
+          else
+            ln -snf "$SOURCE_GSTACK_DIR" "$CLAUDE_GSTACK_LINK"
+            echo "LINKED"
+          fi
+        `;
+        const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8' });
+        expect(result.status).toBe(0);
+        expect(result.stdout.trim()).toBe('LINKED');
+        expect(fs.readlinkSync(dest)).toBe(source);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    test('guard allows ln when dest is a real dir already pointing to source (self-rerun)', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-setup-guard-'));
+      try {
+        const source = path.join(tmp, 'source-worktree');
+        fs.mkdirSync(source);
+        // Mirror setup's SOURCE_GSTACK_DIR resolution (`pwd -P`) so the comparison
+        // is fair on macOS where /tmp itself is a symlink to /private/tmp.
+        const resolvedSource = fs.realpathSync(source);
+        // Degenerate case: existing real dir IS the source.
+        const dest = source;
+        const script = `
+          set -e
+          SOURCE_GSTACK_DIR='${resolvedSource}'
+          CLAUDE_GSTACK_LINK='${dest}'
+          _SKIP_CLAUDE_REGISTER=0
+          if [ -d "$CLAUDE_GSTACK_LINK" ] && [ ! -L "$CLAUDE_GSTACK_LINK" ]; then
+            _EXISTING_REAL=$(cd "$CLAUDE_GSTACK_LINK" 2>/dev/null && pwd -P || echo "")
+            if [ -n "$_EXISTING_REAL" ] && [ "$_EXISTING_REAL" != "$SOURCE_GSTACK_DIR" ]; then
+              _SKIP_CLAUDE_REGISTER=1
+            fi
+          fi
+          echo "skip=$_SKIP_CLAUDE_REGISTER"
+        `;
+        const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8' });
+        expect(result.status).toBe(0);
+        expect(result.stdout.trim()).toBe('skip=0');
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
   });
-});
+}


### PR DESCRIPTION
…rdening

Antigravity integration:
- New hosts/antigravity.ts host config (CLI binary: agy)
- Setup script: auto-detect, runtime root creation, skill linking
- Install to both ~/.gemini/antigravity-ide/ and ~/.gemini/antigravity-cli/
- plugin.json manifest, 47 skills generated with .antigravity/ paths
- Added .antigravity/ to .gitignore

Windows compatibility:
- browser-skill-commands: platform-aware PATH, path.delimiter, execPath
- domain-skills: async/await refactor (replaced callback fs.open pattern)
- xvfb: try/catch around Unix-only ps command
- host-config-export: Bun.which() instead of shell command -v
- server-embedder-terminal-port: import.meta.dir instead of URL.pathname

Test hardening:
- Backslash normalization in path assertions (gen-skill-docs, browser-skills-e2e)
- Platform-aware test skips (context-save, setup-conductor-worktree, artifacts-init, regression-pr1169)
- process.execPath instead of echo in bun-polyfill tests
- Dynamic host detection in host-config detect test
- Updated server-auth sliceBetween markers
- Added migration-checkpoint-ownership to Windows-incompatible list