### PR TITLE
feat: add GitHub Copilot CLI as a host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ supabase/.temp/
 
 # Throughput analysis — local-only, regenerate via scripts/garry-output-comparison.ts
 docs/throughput-*.json
+.copilot/

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Or target a specific agent with `./setup --host <name>`:
 | Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |
 | Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |
 | GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |
+| GitHub Copilot CLI | `--host copilot` | `~/.copilot/skills/gstack-*/` |
 
 **Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).
 It's one TypeScript config file, zero code changes.

--- a/hosts/copilot.ts
+++ b/hosts/copilot.ts
@@ -1,0 +1,49 @@
+import type { HostConfig } from '../scripts/host-config';
+
+const copilot: HostConfig = {
+  name: 'copilot',
+  displayName: 'GitHub Copilot CLI',
+  cliCommand: 'copilot',
+  cliAliases: [],
+
+  globalRoot: '.copilot/skills/gstack',
+  localSkillRoot: '.copilot/skills/gstack',
+  hostSubdir: '.copilot',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: null,
+  },
+
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.copilot/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.copilot/skills/gstack' },
+    { from: '.claude/skills', to: '.copilot/skills' },
+  ],
+
+  suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
+
+  runtimeRoot: {
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'design/dist', 'gstack-upgrade', 'ETHOS.md', 'review/specialists', 'qa/templates', 'qa/references', 'plan-devex-review/dx-hall-of-fame.md'],
+    globalFiles: {
+      'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  coAuthorTrailer: 'Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>',
+  learningsMode: 'basic',
+};
+
+export default copilot;

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,10 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import copilot from './copilot';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, copilot];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, copilot };

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -30,8 +30,8 @@ const ROOT = path.resolve(import.meta.dir, '..');
 // ─── hosts/index.ts ─────────────────────────────────────────
 
 describe('hosts/index.ts', () => {
-  test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+  test('ALL_HOST_CONFIGS has 11 hosts', () => {
+    expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {


### PR DESCRIPTION
Adds the `copilot` host config following docs/ADDING_A_HOST.md:

- hosts/copilot.ts: HostConfig with .copilot/ subdir, allowlist frontmatter (name+description), .claude/skills -> .copilot/skills path rewrites, GBRAIN_* suppressed resolvers, and the documented Copilot co-author trailer.
- hosts/index.ts: register in ALL_HOST_CONFIGS and re-exports.
- .gitignore: ignore generated .copilot/ output.
- test/host-config.test.ts: bump host count 10 -> 11.
- README.md: add install row for --host copilot.

Verified with:
  bun run gen:skill-docs --host copilot bun test test/gen-skill-docs.test.ts test/host-config.test.ts (host-related assertions pass; pre-existing timeouts on slow WSL FS and an upstream package.json/VERSION skew are unrelated.)