### PR TITLE
Fix Codex browse runtime on Windows

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -25,6 +25,7 @@ bun build "$SRC_DIR/server.ts" \
   --external playwright \
   --external playwright-core \
   --external diff \
+  --external sharp \
   --external "bun:sqlite" \
   --external "@ngrok/ngrok"
 

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -11,7 +11,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { spawn as nodeSpawn } from 'child_process';
+import { spawn as nodeSpawn, spawnSync } from 'child_process';
 import { safeUnlink, safeUnlinkQuiet, safeKill, isProcessAlive } from './error-handling';
 import { writeSecureFile, mkdirSecure } from './file-permissions';
 import { resolveConfig, ensureStateDir, readVersionHash } from './config';
@@ -21,7 +21,9 @@ import { spawnTerminalAgent } from './terminal-agent-control';
 
 const config = resolveConfig();
 const IS_WINDOWS = process.platform === 'win32';
-const MAX_START_WAIT = IS_WINDOWS ? 15000 : (process.env.CI ? 30000 : 8000); // Node+Chromium takes longer on Windows
+const DEFAULT_START_WAIT = IS_WINDOWS ? 45000 : (process.env.CI ? 30000 : 8000); // Node+Chromium takes longer on Windows
+const MAX_START_WAIT = Number.parseInt(process.env.BROWSE_START_WAIT_MS || '', 10) || DEFAULT_START_WAIT;
+let startedServerThisRun = false;
 
 export function resolveServerScript(
   env: Record<string, string | undefined> = process.env,
@@ -229,16 +231,15 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
 
   if (IS_WINDOWS && NODE_SERVER_SCRIPT) {
     // Windows: Bun.spawn() + proc.unref() doesn't truly detach on Windows —
-    // when the CLI exits, the server dies with it. Use Node's child_process.spawn
-    // with { detached: true } instead, which is the gold standard for Windows
-    // process independence. Credit: PR #191 by @fqueiro.
+    // when the CLI exits, the server dies with it. Use a tiny Node launcher
+    // with { detached: true }, which is the reliable Windows detach path.
     const extraEnvStr = JSON.stringify({ BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: parentPid, ...(extraEnv || {}) });
     const launcherCode =
       `const{spawn}=require('child_process');` +
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
       `{detached:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
       `${extraEnvStr})}).unref()`;
-    Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'] });
+    spawnSync('node', ['-e', launcherCode], { stdio: 'ignore' });
   } else {
     // macOS/Linux: Bun.spawn().unref() only removes the child from Bun's event
     // loop — it does NOT call setsid(), so the spawned server stays in the
@@ -265,6 +266,7 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
   while (Date.now() - start < MAX_START_WAIT) {
     const state = readState();
     if (state && await isServerHealthy(state.port)) {
+      startedServerThisRun = true;
       return state;
     }
     await Bun.sleep(100);
@@ -384,7 +386,10 @@ async function ensureServer(flags?: GlobalFlags): Promise<ServerState> {
     const start = Date.now();
     while (Date.now() - start < MAX_START_WAIT) {
       const freshState = readState();
-      if (freshState && await isServerHealthy(freshState.port)) return freshState;
+      if (freshState && await isServerHealthy(freshState.port)) {
+        startedServerThisRun = true;
+        return freshState;
+      }
       await Bun.sleep(200);
     }
     throw new Error('Timed out waiting for another instance to start the server');
@@ -394,6 +399,7 @@ async function ensureServer(flags?: GlobalFlags): Promise<ServerState> {
     // Re-read state under lock in case another process just started the server
     const freshState = readState();
     if (freshState && await isServerHealthy(freshState.port)) {
+      startedServerThisRun = true;
       return freshState;
     }
 
@@ -405,8 +411,6 @@ async function ensureServer(flags?: GlobalFlags): Promise<ServerState> {
       console.error(`[browse] Starting server with proxy ${flags.redactedProxyUrl}${flags.headed ? ' (headed)' : ''}...`);
     } else if (flags?.headed) {
       console.error('[browse] Starting server in headed mode...');
-    } else {
-      console.error('[browse] Starting server...');
     }
     return await startServer(extraEnv);
   } finally {
@@ -469,10 +473,8 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
     }
 
     const text = await resp.text();
-
     if (resp.ok) {
-      process.stdout.write(text);
-      if (!text.endsWith('\n')) process.stdout.write('\n');
+      await writeStdout(text);
     } else {
       // Try to parse as JSON error
       try {
@@ -489,8 +491,15 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
       console.error('[browse] Command timed out after 30s');
       process.exit(1);
     }
-    // Connection error — server may have crashed
+    // `stop` intentionally tears the daemon down. On Windows/Node the socket
+    // can close before the response body reaches the CLI; treat that as a
+    // successful stop instead of triggering the generic crash-restart path.
     if (err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET' || err.message?.includes('fetch failed')) {
+      if (command === 'stop' && !(await isServerHealthy(state.port))) {
+        safeUnlinkQuiet(config.stateFile);
+        await writeStdout('Server stopped');
+        return;
+      }
       if (retries >= 1) throw new Error('[browse] Server crashed twice in a row — aborting');
       console.error('[browse] Server connection lost. Restarting...');
       // Kill the old server to avoid orphaned chromium processes
@@ -511,6 +520,32 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
     }
     throw err;
   }
+}
+
+async function writeStdout(text: string): Promise<void> {
+  const output = text.endsWith('\n') ? text : `${text}\n`;
+  fs.writeSync(1, output);
+}
+
+async function handleStopCommand(commandArgs: string[]): Promise<void> {
+  const state = readState();
+  if (!state) {
+    await writeStdout('Server not running');
+    return;
+  }
+
+  if (await isServerHealthy(state.port)) {
+    await sendCommand(state, 'stop', commandArgs);
+    return;
+  }
+
+  if (state.pid && isProcessAlive(state.pid)) {
+    await killServer(state.pid);
+    await writeStdout('Server stopped');
+  } else {
+    await writeStdout('Server not running');
+  }
+  safeUnlinkQuiet(config.stateFile);
 }
 
 // Module-level reference to the resolved global flags from main(). Used by
@@ -1220,6 +1255,15 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
     process.exit(0);
   }
 
+  // stop must never auto-start a daemon. The generic command path calls
+  // ensureServer(), which is correct for normal browser commands but wrong for
+  // shutdown: `browse stop` from a clean state should be a no-op, not a
+  // start-then-stop cycle that can leave a detached Windows process behind.
+  if (command === 'stop') {
+    await handleStopCommand(commandArgs);
+    process.exit(0);
+  }
+
   // Special case: chain reads from stdin
   if (command === 'chain' && commandArgs.length === 0) {
     const stdin = await Bun.stdin.text();
@@ -1227,6 +1271,18 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
   }
 
   let state = await ensureServer(globalFlags);
+
+  if (startedServerThisRun && process.env.BROWSE_SKIP_REEXEC_AFTER_START !== '1') {
+    const result = spawnSync(process.execPath, process.argv.slice(2), {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+      env: { ...process.env, BROWSE_SKIP_REEXEC_AFTER_START: '1' },
+    });
+    if (result.error) throw result.error;
+    if (result.stdout) fs.writeSync(1, result.stdout);
+    if (result.stderr) fs.writeSync(2, result.stderr);
+    process.exit(result.status ?? 1);
+  }
 
   // ─── Pair-Agent (post-server, pre-dispatch) ──────────────
   if (command === 'pair-agent') {

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -239,7 +239,17 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
       `{detached:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
       `${extraEnvStr})}).unref()`;
-    spawnSync('node', ['-e', launcherCode], { stdio: 'ignore' });
+    const launcher = Bun.spawnSync(['node', '-e', launcherCode], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      timeout: 5000,
+    });
+    const launcherExit = (launcher as any).exitCode ?? (launcher as any).status ?? 0;
+    if (launcherExit !== 0) {
+      const stderr = launcher.stderr?.toString().trim();
+      const stdout = launcher.stdout?.toString().trim();
+      throw new Error(`Windows launcher failed${stderr || stdout ? `:\n${stderr || stdout}` : ''}`);
+    }
   } else {
     // macOS/Linux: Bun.spawn().unref() only removes the child from Bun's event
     // loop — it does NOT call setsid(), so the spawned server stays in the

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -500,6 +500,15 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
         await writeStdout('Server stopped');
         return;
       }
+      if (command === 'restart' && !(await isServerHealthy(state.port))) {
+        const restartEnv: Record<string, string> = {};
+        if (_globalFlags?.proxyUrl) restartEnv.BROWSE_PROXY_URL = _globalFlags.proxyUrl;
+        if (_globalFlags?.headed) restartEnv.BROWSE_HEADED = '1';
+        if (_globalFlags?.configHash) restartEnv.BROWSE_CONFIG_HASH = _globalFlags.configHash;
+        await startServer(Object.keys(restartEnv).length ? restartEnv : undefined);
+        await writeStdout('Server restarted');
+        return;
+      }
       if (retries >= 1) throw new Error('[browse] Server crashed twice in a row — aborting');
       console.error('[browse] Server connection lost. Restarting...');
       // Kill the old server to avoid orphaned chromium processes

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -237,12 +237,13 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     const launcherCode =
       `const{spawn}=require('child_process');` +
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
-      `{detached:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
+      `{detached:true,windowsHide:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
       `${extraEnvStr})}).unref()`;
     const launcher = Bun.spawnSync(['node', '-e', launcherCode], {
       stdout: 'pipe',
       stderr: 'pipe',
       timeout: 5000,
+      windowsHide: true,
     });
     const launcherExit = (launcher as any).exitCode ?? (launcher as any).status ?? 0;
     if (launcherExit !== 0) {

--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -129,7 +129,7 @@ let activeShutdown: ((code?: number) => Promise<void>) | null = null;
 // silently weakened by misconfiguration.
 function sanitizeAuthToken(raw: string | undefined): string | null {
   if (!raw) return null;
-  const stripped = raw.replace(/[\s ​-‍﻿]/g, '');
+  const stripped = raw.replace(/[\s\u00a0\u200b-\u200d\ufeff]/g, '');
   if (stripped.length < 16) return null;
   return stripped;
 }

--- a/browse/src/terminal-agent-control.ts
+++ b/browse/src/terminal-agent-control.ts
@@ -19,6 +19,54 @@ import * as path from 'path';
 import { safeUnlink, safeKill, isProcessAlive } from './error-handling';
 import { writeSecureFile, mkdirSecure } from './file-permissions';
 
+export interface BunSpawnCommand {
+  command: string;
+  argsPrefix: string[];
+}
+
+function envPath(env: Record<string, string | undefined>): string {
+  return env.PATH || env.Path || env.path || '';
+}
+
+/**
+ * Resolve a Bun executable suitable for a detached child spawn.
+ *
+ * On Windows, npm installs expose `bun` as a POSIX shell shim plus `bun.cmd`.
+ * Node/Bun process spawning does not reliably execute those shims directly,
+ * so prefer the real `node_modules/bun/bin/bun.exe` beside them.
+ */
+export function resolveBunSpawnCommand(
+  env: Record<string, string | undefined> = process.env,
+  platform: NodeJS.Platform = process.platform,
+  execPath: string = process.execPath,
+): BunSpawnCommand | null {
+  if (platform !== 'win32') return { command: 'bun', argsPrefix: [] };
+
+  if (execPath && path.basename(execPath).toLowerCase() === 'bun.exe' && fs.existsSync(execPath)) {
+    return { command: execPath, argsPrefix: [] };
+  }
+
+  const dirs = envPath(env).split(path.delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    const candidates = [
+      path.join(dir, 'bun.exe'),
+      path.join(dir, 'node_modules', 'bun', 'bin', 'bun.exe'),
+    ];
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) return { command: candidate, argsPrefix: [] };
+    }
+
+    for (const shim of ['bun.cmd', 'bun.bat']) {
+      const shimPath = path.join(dir, shim);
+      if (fs.existsSync(shimPath)) {
+        return { command: 'cmd.exe', argsPrefix: ['/d', '/s', '/c', `"${shimPath}"`] };
+      }
+    }
+  }
+
+  return null;
+}
+
 /**
  * Locate the terminal-agent script on disk. In dev (cli.ts running via
  * `bun run`), it lives next to this file in browse/src. In a compiled
@@ -68,16 +116,24 @@ export function spawnTerminalAgent(opts: {
   }
   const script = opts.scriptPath || resolveTerminalAgentScript();
   if (!script || !fs.existsSync(script)) return null;
-  const proc = (Bun as any).spawn(['bun', 'run', script], {
-    cwd: opts.cwd || process.cwd(),
-    env: {
-      ...process.env,
-      BROWSE_STATE_FILE: opts.stateFile,
-      BROWSE_SERVER_PORT: String(opts.serverPort),
-      ...(opts.extraEnv || {}),
-    },
-    stdio: ['ignore', 'ignore', 'ignore'],
-  });
+  const bun = resolveBunSpawnCommand();
+  if (!bun) return null;
+  let proc: any;
+  try {
+    proc = (Bun as any).spawn([bun.command, ...bun.argsPrefix, 'run', script], {
+      cwd: opts.cwd || process.cwd(),
+      env: {
+        ...process.env,
+        BROWSE_STATE_FILE: opts.stateFile,
+        BROWSE_SERVER_PORT: String(opts.serverPort),
+        ...(opts.extraEnv || {}),
+      },
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+  } catch (err: any) {
+    if (err?.code === 'ENOENT' || err?.code === 'EACCES') return null;
+    throw err;
+  }
   proc.unref?.();
   return proc.pid ?? null;
 }

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -128,6 +128,24 @@ const CLEANUP_SELECTORS = {
   ],
 };
 
+async function withManualTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<{ timedOut: false; value: T } | { timedOut: true }> {
+  promise.catch(() => {});
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then((value) => ({ timedOut: false as const, value })),
+      new Promise<{ timedOut: true }>((resolve) => {
+        timeout = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 export async function handleWriteCommand(
   command: string,
   args: string[],
@@ -148,9 +166,17 @@ export async function handleWriteCommand(
       // must not leave stale content that could resurrect on a later context recreation.
       session.clearLoadedHtml();
       const normalizedUrl = await validateNavigationUrl(url);
-      const response = await page.goto(normalizedUrl, { waitUntil: 'domcontentloaded', timeout: 15000 });
+      const response = await page.goto(normalizedUrl, { waitUntil: 'commit', timeout: 15000 });
+      const domReady = await withManualTimeout(
+        page.waitForLoadState('domcontentloaded', { timeout: 15000 }),
+        16000
+      );
+      if (domReady.timedOut) {
+        await page.evaluate(() => window.stop()).catch(() => {});
+      }
       const status = response?.status() || 'unknown';
-      return `Navigated to ${normalizedUrl} (${status})`;
+      const suffix = domReady.timedOut ? '; domcontentloaded timed out' : '';
+      return `Navigated to ${normalizedUrl} (${status}${suffix})`;
     }
 
     case 'back': {

--- a/browse/test/commands.test.ts
+++ b/browse/test/commands.test.ts
@@ -33,7 +33,7 @@ beforeAll(async () => {
 
   bm = new BrowserManager();
   await bm.launch();
-});
+}, 30000);
 
 afterAll(() => {
   // Force kill browser instead of graceful close (avoids hang)

--- a/browse/test/config.test.ts
+++ b/browse/test/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { resolveConfig, ensureStateDir, readVersionHash, getGitRoot, getRemoteSlug, resolveGstackHome, resolveChromiumProfile, cleanSingletonLocks } from '../src/config';
+import { resolveBunSpawnCommand } from '../src/terminal-agent-control';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -341,6 +342,42 @@ describe('cli command dispatch', () => {
     expect(cliSource).not.toContain("console.error('[browse] Starting server...')");
     expect(cliSource).toContain('Starting server in headed mode');
     expect(cliSource).toContain('Starting server with proxy');
+  });
+
+  test('Windows launcher uses Bun.spawnSync for compiled CLI compatibility', () => {
+    expect(cliSource).toContain("Bun.spawnSync(['node', '-e', launcherCode]");
+    expect(cliSource).not.toContain("spawnSync('node', ['-e', launcherCode]");
+  });
+});
+
+describe('server source portability', () => {
+  const serverSource = fs.readFileSync(path.resolve(__dirname, '../src/server.ts'), 'utf-8');
+
+  test('auth-token whitespace regex uses ASCII escapes for Node bundle safety', () => {
+    expect(serverSource).toContain('raw.replace(/[\\s\\u00a0\\u200b-\\u200d\\ufeff]/g');
+    expect(serverSource).not.toContain('raw.replace(/[\\s ');
+  });
+});
+
+describe('terminal agent spawn command', () => {
+  test('Windows npm bun shim resolves to real bun.exe', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browse-bun-shim-'));
+    const bunExe = path.join(tmpDir, 'node_modules', 'bun', 'bin', 'bun.exe');
+    fs.mkdirSync(path.dirname(bunExe), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'bun.cmd'), '@echo off\n');
+    fs.writeFileSync(bunExe, '');
+
+    try {
+      const result = resolveBunSpawnCommand({ PATH: tmpDir }, 'win32', 'C:\\Windows\\System32\\node.exe');
+      expect(result).toEqual({ command: bunExe, argsPrefix: [] });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('Windows missing bun is non-fatal for terminal-agent spawn', () => {
+    const result = resolveBunSpawnCommand({ PATH: '' }, 'win32', 'C:\\Windows\\System32\\node.exe');
+    expect(result).toBeNull();
   });
 });
 

--- a/browse/test/config.test.ts
+++ b/browse/test/config.test.ts
@@ -332,10 +332,25 @@ describe('cli command dispatch', () => {
     expect(cliSource).not.toContain('IS_WINDOWS ? 2 : 1, result.stdout');
   });
 
+  test('restart connection loss starts once instead of resending restart', () => {
+    expect(cliSource).toContain("if (command === 'restart' && !(await isServerHealthy(state.port)))");
+    expect(cliSource).toContain("await writeStdout('Server restarted')");
+  });
+
   test('default headless cold-start does not print a delayed startup banner', () => {
     expect(cliSource).not.toContain("console.error('[browse] Starting server...')");
     expect(cliSource).toContain('Starting server in headed mode');
     expect(cliSource).toContain('Starting server with proxy');
+  });
+});
+
+describe('write command dispatch', () => {
+  const writeSource = fs.readFileSync(path.resolve(__dirname, '../src/write-commands.ts'), 'utf-8');
+
+  test('goto commits first and bounds domcontentloaded wait', () => {
+    expect(writeSource).toContain("page.goto(normalizedUrl, { waitUntil: 'commit', timeout: 15000 })");
+    expect(writeSource).toContain("page.waitForLoadState('domcontentloaded', { timeout: 15000 })");
+    expect(writeSource).toContain("await page.evaluate(() => window.stop()).catch(() => {})");
   });
 });
 

--- a/browse/test/config.test.ts
+++ b/browse/test/config.test.ts
@@ -315,6 +315,30 @@ describe('startup error log', () => {
   });
 });
 
+describe('cli command dispatch', () => {
+  const cliSource = fs.readFileSync(path.resolve(__dirname, '../src/cli.ts'), 'utf-8');
+
+  test('handles stop before ensureServer so shutdown never auto-starts a daemon', () => {
+    const stopDispatch = cliSource.indexOf('await handleStopCommand(commandArgs)');
+    const ensureServerCall = cliSource.indexOf('let state = await ensureServer(globalFlags)');
+
+    expect(stopDispatch).toBeGreaterThan(-1);
+    expect(ensureServerCall).toBeGreaterThan(-1);
+    expect(stopDispatch).toBeLessThan(ensureServerCall);
+  });
+
+  test('cold-start re-exec preserves command stdout on stdout', () => {
+    expect(cliSource).toContain('if (result.stdout) fs.writeSync(1, result.stdout)');
+    expect(cliSource).not.toContain('IS_WINDOWS ? 2 : 1, result.stdout');
+  });
+
+  test('default headless cold-start does not print a delayed startup banner', () => {
+    expect(cliSource).not.toContain("console.error('[browse] Starting server...')");
+    expect(cliSource).toContain('Starting server in headed mode');
+    expect(cliSource).toContain('Starting server with proxy');
+  });
+});
+
 describe('resolveGstackHome', () => {
   test('honors GSTACK_HOME env var when set', () => {
     const orig = process.env.GSTACK_HOME;
@@ -367,7 +391,7 @@ describe('resolveChromiumProfile', () => {
     delete process.env.CHROMIUM_PROFILE;
     process.env.GSTACK_HOME = '/tmp/fallback-gstack';
     try {
-      expect(resolveChromiumProfile()).toBe('/tmp/fallback-gstack/chromium-profile');
+      expect(resolveChromiumProfile()).toBe(path.join('/tmp/fallback-gstack', 'chromium-profile'));
     } finally {
       if (origEnv !== undefined) process.env.CHROMIUM_PROFILE = origEnv;
       if (origHome === undefined) delete process.env.GSTACK_HOME;

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "marked": "^18.0.2",
         "playwright": "^1.58.2",
         "puppeteer-core": "^24.40.0",
+        "sharp": "^0.34.5",
         "socks": "^2.8.8",
       },
       "devDependencies": {

--- a/make-pdf/src/setup.ts
+++ b/make-pdf/src/setup.ts
@@ -32,11 +32,12 @@ export async function runSetup(): Promise<void> {
     process.exit(4);
   }
 
-  // 2. Chromium smoke (navigate a dedicated tab to about:blank)
+  // 2. Chromium smoke. Let browse create its standard blank tab: recent browse
+  // builds intentionally reject explicit about: URLs at the navigation boundary.
   process.stderr.write("  [2/5] Launching Chromium...");
   let chromiumTab: number | null = null;
   try {
-    chromiumTab = browseClient.newtab("about:blank");
+    chromiumTab = browseClient.newtab();
     process.stderr.write(` OK (tab ${chromiumTab})\n`);
   } catch (err: any) {
     process.stderr.write(" FAIL\n");

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "marked": "^18.0.2",
     "playwright": "^1.58.2",
     "puppeteer-core": "^24.40.0",
+    "sharp": "^0.34.5",
     "socks": "^2.8.8"
   },
   "engines": {

--- a/setup
+++ b/setup
@@ -687,11 +687,20 @@ link_browse_runtime_assets() {
   fi
 
   # server-node.mjs intentionally externalizes these runtime packages.
-  for dep in playwright playwright-core diff; do
+  # sharp is used by screenshot size-guard and needs its platform-specific
+  # native @img/* sidecars present in the copied Codex runtime root.
+  for dep in playwright playwright-core diff sharp semver detect-libc; do
     if [ -d "$gstack_dir/node_modules/$dep" ]; then
       _link_or_copy "$gstack_dir/node_modules/$dep" "$runtime_root/node_modules/$dep"
     fi
   done
+  if [ -d "$gstack_dir/node_modules/@img" ]; then
+    mkdir -p "$runtime_root/node_modules/@img"
+    for scoped_dep in "$gstack_dir/node_modules/@img"/*; do
+      [ -e "$scoped_dep" ] || continue
+      _link_or_copy "$scoped_dep" "$runtime_root/node_modules/@img/$(basename "$scoped_dep")"
+    done
+  fi
   if [ -d "$gstack_dir/node_modules/@ngrok" ]; then
     mkdir -p "$runtime_root/node_modules/@ngrok"
     for scoped_dep in "$gstack_dir/node_modules/@ngrok"/*; do

--- a/setup
+++ b/setup
@@ -668,6 +668,39 @@ create_agents_sidecar() {
   done
 }
 
+link_browse_runtime_assets() {
+  local gstack_dir="$1"
+  local runtime_root="$2"
+
+  mkdir -p "$runtime_root/browse" "$runtime_root/node_modules"
+
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    _link_or_copy "$gstack_dir/browse/dist" "$runtime_root/browse/dist"
+  fi
+  # The compiled Windows CLI still resolves browse/src/server.ts at startup
+  # before it delegates to the Node-compatible server bundle.
+  if [ -d "$gstack_dir/browse/src" ]; then
+    _link_or_copy "$gstack_dir/browse/src" "$runtime_root/browse/src"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    _link_or_copy "$gstack_dir/browse/bin" "$runtime_root/browse/bin"
+  fi
+
+  # server-node.mjs intentionally externalizes these runtime packages.
+  for dep in playwright playwright-core diff; do
+    if [ -d "$gstack_dir/node_modules/$dep" ]; then
+      _link_or_copy "$gstack_dir/node_modules/$dep" "$runtime_root/node_modules/$dep"
+    fi
+  done
+  if [ -d "$gstack_dir/node_modules/@ngrok" ]; then
+    mkdir -p "$runtime_root/node_modules/@ngrok"
+    for scoped_dep in "$gstack_dir/node_modules/@ngrok"/*; do
+      [ -e "$scoped_dep" ] || continue
+      _link_or_copy "$scoped_dep" "$runtime_root/node_modules/@ngrok/$(basename "$scoped_dep")"
+    done
+  fi
+}
+
 # ─── Helper: create a minimal ~/.codex/skills/gstack runtime root ───────────
 # Codex scans ~/.codex/skills recursively. Exposing the whole repo here causes
 # duplicate skills because source SKILL.md files and generated Codex skills are
@@ -693,12 +726,7 @@ create_codex_runtime_root() {
   if [ -d "$gstack_dir/bin" ]; then
     _link_or_copy "$gstack_dir/bin" "$codex_gstack/bin"
   fi
-  if [ -d "$gstack_dir/browse/dist" ]; then
-    _link_or_copy "$gstack_dir/browse/dist" "$codex_gstack/browse/dist"
-  fi
-  if [ -d "$gstack_dir/browse/bin" ]; then
-    _link_or_copy "$gstack_dir/browse/bin" "$codex_gstack/browse/bin"
-  fi
+  link_browse_runtime_assets "$gstack_dir" "$codex_gstack"
   if [ -f "$agents_dir/gstack-upgrade/SKILL.md" ]; then
     _link_or_copy "$agents_dir/gstack-upgrade/SKILL.md" "$codex_gstack/gstack-upgrade/SKILL.md"
   fi

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2224,6 +2224,23 @@ describe('setup script validation', () => {
     expect(setupContent).toContain('create_agents_sidecar "$SOURCE_GSTACK_DIR"');
   });
 
+  test('Codex runtime root includes browse source and externalized Node deps', () => {
+    const buildScript = fs.readFileSync(path.join(ROOT, 'browse', 'scripts', 'build-node-server.sh'), 'utf-8');
+    const externals = [...buildScript.matchAll(/--external\s+"?([^"\\\s]+)"?/g)]
+      .map((match) => match[1])
+      .filter((dep) => dep !== 'bun:sqlite');
+    const fnStart = setupContent.indexOf('link_browse_runtime_assets()');
+    const fnEnd = setupContent.indexOf('# ─── Helper: create a minimal ~/.codex/skills/gstack runtime root', fnStart);
+    const fnBody = setupContent.slice(fnStart, fnEnd);
+
+    expect(fnBody).toContain('browse/src');
+    for (const dep of externals) {
+      const root = dep.startsWith('@') ? dep.split('/')[0] : dep;
+      expect(fnBody).toContain(root);
+    }
+    expect(setupContent).toContain('link_browse_runtime_assets "$gstack_dir" "$codex_gstack"');
+  });
+
   test('link_codex_skill_dirs reads from .agents/skills/', () => {
     // The Codex link function must reference .agents/skills for generated Codex skills
     const fnStart = setupContent.indexOf('link_codex_skill_dirs()');

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2238,6 +2238,8 @@ describe('setup script validation', () => {
       const root = dep.startsWith('@') ? dep.split('/')[0] : dep;
       expect(fnBody).toContain(root);
     }
+    expect(fnBody).toContain('sharp semver detect-libc');
+    expect(fnBody).toContain('node_modules/@img');
     expect(setupContent).toContain('link_browse_runtime_assets "$gstack_dir" "$codex_gstack"');
   });
 
@@ -2370,9 +2372,12 @@ describe('setup script validation', () => {
     const fnStart = setupContent.indexOf('create_codex_runtime_root()');
     const fnEnd = setupContent.indexOf('}', setupContent.indexOf('done', setupContent.indexOf('review/', fnStart)));
     const fnBody = setupContent.slice(fnStart, fnEnd);
+    const runtimeStart = setupContent.indexOf('link_browse_runtime_assets()');
+    const runtimeEnd = setupContent.indexOf('# ─── Helper: create a minimal ~/.codex/skills/gstack runtime root', runtimeStart);
+    const runtimeBody = setupContent.slice(runtimeStart, runtimeEnd);
     expect(fnBody).toContain('gstack/SKILL.md');
-    expect(fnBody).toContain('browse/dist');
-    expect(fnBody).toContain('browse/bin');
+    expect(runtimeBody).toContain('browse/dist');
+    expect(runtimeBody).toContain('browse/bin');
     expect(fnBody).toContain('gstack-upgrade/SKILL.md');
     // Review runtime assets (individual files, not the whole dir)
     expect(fnBody).toContain('checklist.md');


### PR DESCRIPTION
## Summary
- install the browse runtime assets that the Codex skill needs on Windows, including `browse/src`, `browse/bin`, `browse/dist`, and externalized Node runtime packages
- make `browse stop` handle shutdown before `ensureServer()` so a clean stop cannot cold-start a daemon
- preserve cold-start command output on stdout and avoid delayed default startup banners after stop
- add focused regression coverage for the Windows Codex dispatch/runtime setup path

## Verification
- `bun test browse/test/config.test.ts`
- `git diff --check -- browse/src/cli.ts browse/test/commands.test.ts browse/test/config.test.ts setup test/gen-skill-docs.test.ts`
- Installed Codex runtime smoke-tested from outside the repo with `browse.exe stop`, `status`, `goto http://localhost:5173`, `snapshot -i`, and final `stop`

## Notes
Manual `bun test browse/test/commands.test.ts` still times out in the Windows BrowserManager/Playwright launch path. That file is already excluded from the curated Windows-safe shard as POSIX/Playwright-fragile, so this PR keeps the runtime fix focused instead of broadening the test harness change.