### PR TITLE
fix(extension): defer composing reset to stop CJK IME double-send

### DIFF
--- a/extension/sidepanel-terminal.js
+++ b/extension/sidepanel-terminal.js
@@ -442,10 +442,15 @@
     if (ta) {
       ta.addEventListener('compositionstart', () => { composing = true; });
       ta.addEventListener('compositionend', (e) => {
-        composing = false;
         if (e.data && ws && ws.readyState === WebSocket.OPEN) {
           ws.send(new TextEncoder().encode(e.data));
         }
+        // Reset on the next tick. Browsers fire the trailing `input` event
+        // (→ term.onData) immediately AFTER compositionend, for the same
+        // composed string. Clearing `composing` synchronously lets that
+        // event through, double-sending CJK input (e.g. "在在这里这里").
+        // Deferring keeps onData suppressed for that trailing event.
+        setTimeout(() => { composing = false; }, 0);
       });
     }
 


### PR DESCRIPTION
## Problem

Typing CJK (Chinese / Japanese) through an IME in the sidebar terminal chat
sends every committed segment twice. Typing "在这里我可以做什么" renders as
"在在这里这里我我可以可以做做什么什么".

## Root cause

The IME composition handling added for the Korean work (#1272, PR #1297) lives
in `extension/sidepanel-terminal.js`, but it clears `composing = false`
**synchronously** inside the `compositionend` handler, before sending.

Browsers fire the trailing `input` event (→ xterm `term.onData`) immediately
*after* `compositionend`, carrying the same composed string. By then `composing`
is already `false`, so the `if (composing) return;` guard in `onData` no longer
suppresses it, and the text is `ws.send`-ed a second time.

Korean composition (tested in #1297) doesn't surface this, but languages that
commit per-segment and fire a trailing `input` event — Chinese, Japanese — get
every segment doubled.

## Fix

Defer the `composing = false` reset to the next tick with `setTimeout(…, 0)`,
so the `onData` event that fires right after `compositionend` is still
suppressed. One-line behavioral change; the Korean path from #1297 is
unaffected.

## Testing

Manually verified in the GStack Browser sidebar (v1.44). Before:
"在这里我可以做什么" rendered as "在在这里这里我我可以可以做做什么什么".
After the fix: renders once, correctly. English input/output unaffected.
