### PR TITLE
fix(gbrain): parse nested filter: blocks in SKILL.md manifests so list queries stay repo-scoped

### DIFF
--- a/lib/gstack-memory-helpers.ts
+++ b/lib/gstack-memory-helpers.ts
@@ -396,6 +396,7 @@ function extractGbrainBlock(frontmatter: string): GbrainManifest | null {
       const globM = body.match(/(?:^|\n)\s*glob\s*:\s*"?([^"\n]+?)"?\s*$/m);
       const sortM = body.match(/(?:^|\n)\s*sort\s*:\s*([^\n]+)/);
       const tailM = body.match(/(?:^|\n)\s*tail\s*:\s*(\d+)/);
+      const filterMap = parseFilterMap(body);
 
       if (idM) q.id = idM[1].trim();
       if (kindM) {
@@ -408,6 +409,7 @@ function extractGbrainBlock(frontmatter: string): GbrainManifest | null {
       if (globM) q.glob = globM[1].trim();
       if (sortM) q.sort = sortM[1].trim();
       if (tailM) q.tail = parseInt(tailM[1], 10);
+      if (filterMap) q.filter = filterMap;
 
       if (q.id && q.kind && q.render_as) {
         queries.push(q as GbrainManifestQuery);
@@ -416,6 +418,39 @@ function extractGbrainBlock(frontmatter: string): GbrainManifest | null {
   }
 
   return { schema, context_queries: queries };
+}
+
+/**
+ * Parse a nested `filter:` block map out of a single context_queries item body.
+ *
+ * The block is a YAML map nested under the `filter:` key:
+ *
+ *   filter:
+ *     type: timeline
+ *     tags_contains: "repo:{repo_slug}"
+ *
+ * Each sub-key sits one indent level deeper than `filter:`. Surrounding quotes
+ * are stripped and template vars ({repo_slug}, now-7d, ...) are left intact for
+ * downstream substitution, matching how dispatchList stringifies each value
+ * into a `--filter k=v` argument. Returns undefined when there is no `filter:`
+ * block or it is empty.
+ */
+function parseFilterMap(body: string): Record<string, string> | undefined {
+  const lines = body.split("\n");
+  const filterIdx = lines.findIndex((l) => /^\s*filter\s*:\s*$/.test(l));
+  if (filterIdx === -1) return undefined;
+  const filterIndent = lines[filterIdx].match(/^\s*/)![0].length;
+
+  const filter: Record<string, string> = {};
+  for (let i = filterIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") continue; // tolerate blank lines within the block
+    const indent = line.match(/^\s*/)![0].length;
+    if (indent <= filterIndent) break; // dedent to a sibling key ends the block
+    const kv = line.match(/^\s*([A-Za-z0-9_]+)\s*:\s*"?(.*?)"?\s*$/);
+    if (kv) filter[kv[1]] = kv[2].trim();
+  }
+  return Object.keys(filter).length > 0 ? filter : undefined;
 }
 
 // ── Public: withErrorContext ──────────────────────────────────────────────

--- a/test/gstack-memory-helpers.test.ts
+++ b/test/gstack-memory-helpers.test.ts
@@ -244,6 +244,62 @@ body
     expect(m!.context_queries[0].id).toBe("complete");
     rmSync(dir, { recursive: true, force: true });
   });
+
+  it("parses a nested filter: block on a list query", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gstack-test-"));
+    const file = join(dir, "filtered.md");
+    writeFileSync(
+      file,
+      `---
+name: investigate
+gbrain:
+  schema: 1
+  context_queries:
+    - id: prior-investigations
+      kind: list
+      filter:
+        type: timeline
+        tags_contains: "repo:{repo_slug}"
+        content_contains: "investigate"
+      sort: updated_at_desc
+      limit: 5
+      render_as: "## Prior investigations in this repo"
+    - id: recent-no-filter
+      kind: list
+      sort: created_at_desc
+      limit: 3
+      render_as: "## Recent (no filter)"
+---
+
+body
+`
+    );
+
+    const m = parseSkillManifest(file);
+    expect(m).not.toBeNull();
+    expect(m!.context_queries).toHaveLength(2);
+
+    // The filter: sub-block is parsed into a key/value map, with quotes
+    // stripped and template vars left intact for downstream substitution.
+    const filtered = m!.context_queries[0];
+    expect(filtered.id).toBe("prior-investigations");
+    expect(filtered.filter).toEqual({
+      type: "timeline",
+      tags_contains: "repo:{repo_slug}",
+      content_contains: "investigate",
+    });
+    // Sibling fields on the same item still parse alongside the filter.
+    expect(filtered.sort).toBe("updated_at_desc");
+    expect(filtered.limit).toBe(5);
+    expect(filtered.render_as).toBe("## Prior investigations in this repo");
+
+    // A list query with no filter: leaves filter undefined (no regression).
+    expect(m!.context_queries[1].id).toBe("recent-no-filter");
+    expect(m!.context_queries[1].filter).toBeUndefined();
+    expect(m!.context_queries[1].sort).toBe("created_at_desc");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
 });
 
 // ── withErrorContext ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`parseSkillManifest` (the runtime read path in `lib/gstack-memory-helpers.ts`, called from the gstack preamble at every skill start) parsed every `gbrain.context_queries` field except `filter:`. Any `kind: list` query that declared a `filter:` block in its `SKILL.md` manifest therefore ran **unfiltered**, pulling pages of every type from every repo into the agent's startup context instead of the repo scoped set the manifest asked for.

This silently defeats the F7 design intent documented in `bin/gstack-brain-context-load.ts`: "every default query carries an explicit `repo:` filter so cross-repo contamination is the non-default path." Because the unfiltered query still succeeds, no `(unavailable)` marker is rendered, so the wrong data is injected with no signal that anything went wrong.

Fixes #1687.

## Affected skills

Four shipped skills declare a `filter:` block on a `kind: list` query in their generated `SKILL.md`:

- `investigate` (`prior-investigations`)
- `office-hours` (`prior-sessions`)
- `plan-ceo-review` (`recent-reviews`)
- `design-consultation` (`brand-guidelines`)

## Root cause

`extractGbrainBlock` matched `id`, `kind`, `render_as`, `query`, `limit`, `glob`, `sort`, and `tail`, but never `filter`. The `GbrainManifestQuery.filter` type, `defaultManifest`, and `dispatchList` all support filters; only the parser dropped them.

## Fix

Add `parseFilterMap`, a zero dependency block-map parser that reads the keys nested under `filter:`, strips surrounding quotes, and leaves template vars (`{repo_slug}`, `now-7d`, ...) intact so `dispatchList` stringifies them into the expected filter arguments. Queries without a `filter:` block are unchanged (filter stays `undefined`).

## Validation

Before (on `origin/main` `920a13a1`):

```
$ bun -e 'import {parseSkillManifest} from "./lib/gstack-memory-helpers.ts"; console.log(parseSkillManifest("investigate/SKILL.md").context_queries[0].filter)'
undefined
```

After:

```
investigate:          prior-investigations -> {"type":"timeline","tags_contains":"repo:{repo_slug}","content_contains":"investigate"}
office-hours:         prior-sessions       -> {"type":"ceo-plan","tags_contains":"repo:{repo_slug}"}
plan-ceo-review:      recent-reviews       -> {"type":"timeline","tags_contains":"repo:{repo_slug}","content_contains":"plan-ceo-review"}
design-consultation:  brand-guidelines     -> {"type":"ceo-plan","tags_contains":"repo:{repo_slug}","content_contains":"brand"}
```

Tests:

```
bun test test/gstack-memory-helpers.test.ts   ->  26 pass, 0 fail
```

A new regression test ("parses a nested filter: block on a list query") covers the nested `filter:` map alongside sibling fields and asserts a no-filter list query still leaves `filter` undefined. The `test/gstack-brain-context-load.test.ts` consumer suite passes (one subprocess spawn test is sensitive to machine load and passes in isolation; it exercises a filesystem only manifest, which this change does not touch).

## Scope

Single function plus two call sites in `lib/gstack-memory-helpers.ts`, and one regression test. No template, VERSION, or CHANGELOG changes.
