### PR TITLE
fix(make-pdf): give TOC headings stable ids so --toc anchors and page numbers resolve

### DIFF
--- a/make-pdf/src/render.ts
+++ b/make-pdf/src/render.ts
@@ -106,14 +106,21 @@ export function render(opts: RenderOptions): RenderResult {
       })
     : "";
 
-  const tocBlock = opts.toc
-    ? buildTocBlock(typographicHtml)
-    : "";
+  // When a TOC is requested, give the body's headings stable ids so the TOC
+  // anchors (#toc-N) and Paged.js page-number targets resolve to them. With no
+  // TOC, the body is untouched (no ids injected).
+  let bodyHtml = typographicHtml;
+  let tocBlock = "";
+  if (opts.toc) {
+    const withIds = assignTocIds(typographicHtml);
+    bodyHtml = withIds.html;
+    tocBlock = buildTocBlock(withIds.headings);
+  }
 
   // Wrap body in .chapter sections at H1 boundaries if chapter breaks are on.
   const chapterHtml = opts.noChapterBreaks
-    ? `<section class="chapter">${typographicHtml}</section>`
-    : wrapChaptersByH1(typographicHtml);
+    ? `<section class="chapter">${bodyHtml}</section>`
+    : wrapChaptersByH1(bodyHtml);
 
   const watermarkBlock = opts.watermark
     ? `<div class="watermark">${escapeHtml(opts.watermark)}</div>`
@@ -252,22 +259,20 @@ function buildCoverBlock(opts: {
 }
 
 /**
- * Scan HTML for H1/H2/H3 headings and emit a TOC placeholder.
- * Page numbers are filled in by Paged.js (when --toc is passed and Paged.js
- * polyfill is injected).
+ * Emit a TOC section from the headings collected by assignTocIds. Each entry
+ * links to the matching heading id and carries a page-number placeholder that
+ * Paged.js fills in (when --toc is passed and the Paged.js polyfill is injected).
  */
-function buildTocBlock(html: string): string {
-  const headings = extractHeadings(html);
+function buildTocBlock(headings: Array<{ id: string; level: number; text: string }>): string {
   if (headings.length === 0) return "";
 
-  const items = headings.map((h, i) => {
+  const items = headings.map((h) => {
     const level = h.level >= 2 ? "level-2" : "level-1";
-    const id = `toc-${i}`;
     return [
       `  <li class="${level}">`,
-      `    <span class="toc-title"><a href="#${id}">${escapeHtml(h.text)}</a></span>`,
+      `    <span class="toc-title"><a href="#${h.id}">${escapeHtml(h.text)}</a></span>`,
       `    <span class="toc-dots"></span>`,
-      `    <span class="toc-page" data-toc-target="${id}"></span>`,
+      `    <span class="toc-page" data-toc-target="${h.id}"></span>`,
       `  </li>`,
     ].join("\n");
   }).join("\n");
@@ -282,16 +287,34 @@ function buildTocBlock(html: string): string {
   ].join("\n");
 }
 
-function extractHeadings(html: string): Array<{ level: number; text: string }> {
-  const re = /<(h[1-3])[^>]*>([\s\S]*?)<\/\1>/gi;
-  const headings: Array<{ level: number; text: string }> = [];
-  let match;
-  while ((match = re.exec(html)) !== null) {
-    const level = parseInt(match[1].slice(1), 10);
-    const text = decodeTextEntities(stripTags(match[2]).trim());
-    if (text) headings.push({ level, text });
-  }
-  return headings;
+/**
+ * Assign stable ids to the H1-H3 headings (in document order) so the TOC's
+ * in-page anchors (#toc-N) and Paged.js page-number targets resolve to them.
+ * A heading that already declares an id keeps it, and the TOC points at that
+ * id instead of injecting a duplicate. Returns the id-annotated HTML and the
+ * heading list the TOC is built from. Empty-text headings are skipped and
+ * never consume a toc-N index, matching the prior extraction behavior.
+ */
+function assignTocIds(html: string): {
+  html: string;
+  headings: Array<{ id: string; level: number; text: string }>;
+} {
+  const headings: Array<{ id: string; level: number; text: string }> = [];
+  let i = 0;
+  const out = html.replace(
+    /<(h[1-3])\b([^>]*)>([\s\S]*?)<\/\1>/gi,
+    (full: string, tag: string, attrs: string, inner: string) => {
+      const text = decodeTextEntities(stripTags(inner).trim());
+      if (!text) return full; // skip empty headings; do not consume an index
+      const level = parseInt(tag.slice(1), 10);
+      const existing = attrs.match(/\bid\s*=\s*["']([^"']*)["']/i);
+      const id = existing ? existing[1] : `toc-${i}`;
+      headings.push({ id, level, text });
+      i++;
+      return existing ? full : `<${tag}${attrs} id="${id}">${inner}</${tag}>`;
+    },
+  );
+  return { html: out, headings };
 }
 
 /**

--- a/make-pdf/test/render.test.ts
+++ b/make-pdf/test/render.test.ts
@@ -227,6 +227,44 @@ describe("render (end-to-end)", () => {
     expect(result.html).toContain("Two");
   });
 
+  test("TOC anchors and page-number targets resolve to heading ids in the body", () => {
+    const result = render({
+      markdown: `# One\n\n## Sub\n\nbody\n\n# Two\n\nbody\n`,
+      toc: true,
+    });
+    const hrefs = [...result.html.matchAll(/href="#(toc-\d+)"/g)].map((m) => m[1]);
+    const targets = [...result.html.matchAll(/data-toc-target="(toc-\d+)"/g)].map((m) => m[1]);
+    const headingIds = [...result.html.matchAll(/<h[1-3][^>]*\bid="([^"]+)"/g)].map((m) => m[1]);
+
+    // Three headings produce three TOC entries, and the page targets mirror the anchors.
+    expect(hrefs).toHaveLength(3);
+    expect(targets).toEqual(hrefs);
+
+    // Every anchor and page target resolves to a real heading id in the body,
+    // assigned in document order (so Paged.js can count pages against them).
+    expect(headingIds).toEqual(["toc-0", "toc-1", "toc-2"]);
+    for (const id of hrefs) expect(headingIds).toContain(id);
+  });
+
+  test("does not inject heading ids when toc is off", () => {
+    const result = render({ markdown: `# One\n\n## Sub\n\nbody\n`, toc: false });
+    expect(result.html).not.toContain(`id="toc-`);
+  });
+
+  test("TOC reuses a heading's existing id instead of duplicating it", () => {
+    const result = render({
+      markdown: `<h2 id="intro">Intro</h2>\n\nbody\n`,
+      toc: true,
+    });
+    // The TOC entry points at the heading's own id, and no toc-N id is injected.
+    expect(result.html).toContain(`href="#intro"`);
+    expect(result.html).not.toContain(`id="toc-0"`);
+    // Exactly one id on the heading (no duplicate id attribute).
+    const introHeading = result.html.match(/<h2[^>]*>Intro<\/h2>/);
+    expect(introHeading).not.toBeNull();
+    expect((introHeading![0].match(/\bid=/g) || []).length).toBe(1);
+  });
+
   test("strips dangerous HTML from untrusted markdown", () => {
     const result = render({
       markdown: `# Safe\n\n<script>alert('xss')</script>\n\nBody.`,


### PR DESCRIPTION
## Summary

`make-pdf --toc` built a table of contents whose entries linked to, and whose page-number spans targeted, element ids (`toc-0`, `toc-1`, ...) that were never assigned to any heading. Every TOC anchor was a dead in-page link and every page-number target was unresolvable, so Paged.js had nothing to fill the `.toc-page` spans against.

Fixes #1689.

## Current behavior on upstream main

On `origin/main` (`920a13a1`):

```
TOC anchor hrefs:    [ "#toc-0", "#toc-1", "#toc-2" ]
heading ids in body: []
```

The TOC entries point at `#toc-0` / `#toc-1` / `#toc-2`, but no heading in the body carries any of those ids (they come straight from `marked` and `wrapChaptersByH1`, neither of which assigns ids).

## Fix

Replace `extractHeadings` with `assignTocIds`, which walks the H1-H3 headings in document order, assigns `id="toc-N"` to each, and returns both the id annotated body HTML and the heading list. `render()` uses the annotated HTML for the body when a TOC is requested and builds the TOC from the same list, so anchors and `data-toc-target` ids resolve to real headings. A heading that already declares an id keeps it (the TOC points at that id), so no duplicate id is emitted.

With no TOC the body is untouched (no ids injected), so non-TOC output is byte-identical to before.

## Validation

After the fix:

```
hrefs: ["#toc-0","#toc-1","#toc-2"] | heading ids: ["toc-0","toc-1","toc-2"] | all resolve: true
```

Tests (the make-pdf-gate unit step, `bun test make-pdf/test/*.test.ts`):

```
90 pass, 0 fail
```

Three new regression tests cover: anchors and page targets resolving to heading ids in document order, reuse of an existing heading id without duplication, and no id injection when the TOC is off.

The P0 combined-features gate (`make-pdf/test/e2e/combined-gate.test.ts`) runs `generate ... --quiet` with no `--toc`. Since the change is entirely behind `if (opts.toc)` and `--toc` defaults to false, the gate's rendered HTML (and extracted text) is unchanged.

## Scope

`make-pdf/src/render.ts` only (`render`, `buildTocBlock`, and `extractHeadings` to `assignTocIds`), plus three regression tests. No template, VERSION, or CHANGELOG changes.
