### PR TITLE
Validate skill bash snippets in tests

### DIFF
--- a/test/helpers/skill-parser.ts
+++ b/test/helpers/skill-parser.ts
@@ -14,6 +14,7 @@ import { ALL_COMMANDS } from '../../browse/src/commands';
 import { parseSnapshotArgs } from '../../browse/src/snapshot';
 import * as fs from 'fs';
 import * as path from 'path';
+import { spawnSync } from 'child_process';
 
 /** CLI-only commands: valid $B invocations that are handled by the CLI, not the server */
 const CLI_COMMANDS = new Set([
@@ -32,6 +33,18 @@ export interface ValidationResult {
   invalid: BrowseCommand[];
   snapshotFlagErrors: Array<{ command: BrowseCommand; error: string }>;
   warnings: string[];
+}
+
+export interface BashBlock {
+  file: string;
+  line: number;
+  content: string;
+}
+
+export interface BashSyntaxError {
+  file: string;
+  line: number;
+  message: string;
 }
 
 /**
@@ -97,6 +110,74 @@ export function extractBrowseCommands(skillPath: string): BrowseCommand[] {
   }
 
   return commands;
+}
+
+/**
+ * Extract bash/sh fenced code blocks from a markdown file.
+ */
+export function extractBashBlocks(markdownPath: string): BashBlock[] {
+  const content = fs.readFileSync(markdownPath, 'utf-8');
+  const blocks: BashBlock[] = [];
+  const fencePattern = /```(?:bash|sh)\s*\n([\s\S]*?)```/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = fencePattern.exec(content)) !== null) {
+    blocks.push({
+      file: markdownPath,
+      line: content.slice(0, match.index).split('\n').length,
+      content: match[1],
+    });
+  }
+
+  return blocks;
+}
+
+/**
+ * Template/example bash snippets often contain placeholders such as <url>.
+ * Skip those so bash -n only validates snippets intended to be runnable as-is.
+ */
+export function isConcreteBashBlock(content: string): boolean {
+  return !/<[^>\n]+>|\{\{|\.\.\./.test(content);
+}
+
+/**
+ * Validate concrete bash/sh fenced code blocks with bash -n.
+ */
+export function validateBashSyntax(markdownPaths: string[]): BashSyntaxError[] {
+  const errors: BashSyntaxError[] = [];
+
+  for (const markdownPath of markdownPaths) {
+    const blocks = extractBashBlocks(markdownPath).filter(block => isConcreteBashBlock(block.content));
+    if (blocks.length === 0) continue;
+
+    // Fast path: one bash parser process per markdown file. On failure, fall back
+    // to per-block checks so the reported line points at the offending fence.
+    const combined = blocks
+      .map(block => `\n# ${markdownPath}:${block.line}\n${block.content}`)
+      .join('\n');
+    const aggregate = spawnSync('bash', ['-n'], {
+      input: combined,
+      encoding: 'utf-8',
+    });
+    if (aggregate.status === 0) continue;
+
+    for (const block of blocks) {
+      const result = spawnSync('bash', ['-n'], {
+        input: block.content,
+        encoding: 'utf-8',
+      });
+
+      if (result.status !== 0) {
+        errors.push({
+          file: markdownPath,
+          line: block.line,
+          message: (result.stderr || result.stdout || 'bash -n failed').trim(),
+        });
+      }
+    }
+  }
+
+  return errors;
 }
 
 /**

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -1,11 +1,31 @@
 import { describe, test, expect } from 'bun:test';
-import { validateSkill, extractRemoteSlugPatterns, extractWeightsFromTable } from './helpers/skill-parser';
+import { validateSkill, extractRemoteSlugPatterns, extractWeightsFromTable, validateBashSyntax } from './helpers/skill-parser';
 import { ALL_COMMANDS, COMMAND_DESCRIPTIONS, READ_COMMANDS, WRITE_COMMANDS, META_COMMANDS } from '../browse/src/commands';
 import { SNAPSHOT_FLAGS } from '../browse/src/snapshot';
 import * as fs from 'fs';
 import * as path from 'path';
 
 const ROOT = path.resolve(import.meta.dir, '..');
+
+function collectSkillMarkdown(root: string): string[] {
+  const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'build', '.claude']);
+  const results: string[] = [];
+
+  function visit(dir: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!ignoredDirs.has(entry.name)) visit(path.join(dir, entry.name));
+        continue;
+      }
+      if (entry.isFile() && (entry.name === 'SKILL.md' || entry.name === 'SKILL.md.tmpl')) {
+        results.push(path.join(dir, entry.name));
+      }
+    }
+  }
+
+  visit(root);
+  return results;
+}
 
 describe('SKILL.md command validation', () => {
   test('all $B commands in SKILL.md are valid browse commands', () => {
@@ -205,6 +225,15 @@ describe('Usage string consistency', () => {
 });
 
 describe('Generated SKILL.md freshness', () => {
+  test('concrete bash snippets in SKILL.md files parse with bash -n', () => {
+    const errors = validateBashSyntax(collectSkillMarkdown(ROOT)).map(err => ({
+      file: path.relative(ROOT, err.file),
+      line: err.line,
+      message: err.message,
+    }));
+    expect(errors).toEqual([]);
+  });
+
   test('no unresolved {{placeholders}} in generated SKILL.md', () => {
     const content = fs.readFileSync(path.join(ROOT, 'SKILL.md'), 'utf-8');
     const unresolved = content.match(/\{\{\w+\}\}/g);


### PR DESCRIPTION
## Summary
- add a SKILL.md freshness test that runs `bash -n` over concrete `bash`/`sh` fenced snippets
- skip placeholder/example snippets such as `<url>`, `{{PLACEHOLDER}}`, and ellipsis blocks
- batch syntax checks per markdown file for speed, then fall back to per-block checks for actionable file/line errors

Fixes #1667.

## Test plan
- `bun test test/skill-parser.test.ts test/skill-validation.test.ts`

Note: I also tried `bun test`; it did not complete cleanly on this checkout due existing unrelated failures/timeouts, including a missing `.factory/skills/gstack-ship/SKILL.md` golden fixture and a timeout in `browse/test/security-audit-r2.test.ts`.
