### PR TITLE
fix(ci): avoid piping Bun installer into shell

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,12 @@ variables:
 
 .setup-bun: &setup-bun
   - apt-get update -qq && apt-get install -qq -y curl jq git
-  - curl -fsSL https://bun.sh/install | bash -s "bun-v$BUN_VERSION"
+  - |
+    BUN_INSTALL_SCRIPT="$(mktemp)"
+    trap 'rm -f "$BUN_INSTALL_SCRIPT"' EXIT
+    curl -fsSL https://bun.sh/install -o "$BUN_INSTALL_SCRIPT"
+    test -s "$BUN_INSTALL_SCRIPT"
+    bash "$BUN_INSTALL_SCRIPT" "bun-v$BUN_VERSION"
   - export PATH="$HOME/.bun/bin:$PATH"
 
 version-gate:

--- a/test/gitlab-ci-safety.test.ts
+++ b/test/gitlab-ci-safety.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(import.meta.dir, '..');
+
+describe('GitLab CI installer safety', () => {
+  test('does not pipe the remote Bun installer directly into a shell', () => {
+    const ci = readFileSync(join(ROOT, '.gitlab-ci.yml'), 'utf-8');
+    const offenders = ci
+      .split('\n')
+      .map((line, index) => ({ line: index + 1, text: line.trim() }))
+      .filter(({ text }) => /bun\.sh\/install/.test(text))
+      .filter(({ text }) => /\bcurl\b.*\|\s*(bash|sh)\b/.test(text));
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #1706.

## Reviewer Guide

Small GitLab CI hardening patch. Review targets:

- `.gitlab-ci.yml` — replaces the direct `curl | bash` Bun installer with a download-first flow.
- `test/gitlab-ci-safety.test.ts` — adds a static regression check so `bun.sh/install` is not piped directly into `bash` or `sh` again.

## Why

The GitLab CI Bun setup step piped the remote installer straight into a shell:

```sh
curl -fsSL https://bun.sh/install | bash -s "bun-v$BUN_VERSION"
```

This PR keeps the existing `BUN_VERSION` behavior but changes the flow to:

1. download the installer to a `mktemp` file
2. verify the downloaded file is non-empty
3. execute that file with the pinned Bun version
4. clean it up via `trap`

No GitHub Actions, release/version, or job-rule behavior changes are intended.

## Verification

- `bun test test/gitlab-ci-safety.test.ts test/audit-compliance.test.ts` — 10 pass, 0 fail
- `git diff --check`