### PR TITLE
fix: Windows + Bun-on-Windows compatibility (2 patches)

### DIFF
--- a/setup
+++ b/setup
@@ -30,6 +30,11 @@ case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*|Windows_NT) IS_WINDOWS=1 ;;
 esac
 
+# Windows: binaries are compiled with .exe suffix
+if [ "$IS_WINDOWS" -eq 1 ]; then
+  BROWSE_BIN="$SOURCE_GSTACK_DIR/browse/dist/browse.exe"
+fi
+
 # ─── Symlink-or-copy helper ───────────────────────────────────
 # On macOS/Linux: create a symlink (existing behavior).
 # On Windows without Developer Mode (MSYS2/Git Bash): plain ln -snf silently


### PR DESCRIPTION
## Summary

Two independent patches to make `bash ./setup` succeed on Windows when Bun is used as the shell.

- **fix(setup): `.exe` suffix for `BROWSE_BIN` on Windows** — `bun build --compile` produces `browse/dist/browse.exe` on Windows, but `BROWSE_BIN` defaults to the suffix-less path, so post-build verification cannot find the binary and setup fails on every fresh install / upgrade.
- **fix(build): drop bash group syntax incompatible with Bun on Windows** — `{ git rev-parse HEAD 2>/dev/null || true; } > .version` is rejected by Bun's bundled shell on Windows as `bun: command not found: {`. `setup.sh` already populates `.version` when missing, and `chmod +x` is a no-op on NTFS, so the trailing portion of the build script can be removed without regression.

## Test plan

- [x] Win11 Pro 26200, Bun v1.3.14, Git Bash 2.53: `bash ./setup --no-prefix` exits 0 with final line `gstack ready (claude). linked skills: ... 44`
- [x] `browse/dist/browse.exe` discovered by `BROWSE_BIN` after build
- [ ] macOS / Linux regression check would be appreciated — patches are either `IS_WINDOWS`-guarded or remove already-redundant logic, so should be inert on other platforms

Happy to squash on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)