### PR TITLE
Keep prefixed skill names in runtime projections

### DIFF
--- a/bin/gstack-relink
+++ b/bin/gstack-relink
@@ -43,6 +43,8 @@ _cleanup_skill_entry() {
     rm -f "$entry"
   elif [ -d "$entry" ] && [ -L "$entry/SKILL.md" ]; then
     rm -rf "$entry"
+  elif [ -d "$entry" ] && [ -f "$entry/SKILL.md" ] && [ "$(find "$entry" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" = "1" ]; then
+    rm -rf "$entry"
   fi
 }
 
@@ -65,34 +67,40 @@ for skill_dir in "$INSTALL_DIR"/*/; do
   # Skip non-skill directories
   case "$skill" in bin|browse|design|docs|extension|lib|node_modules|scripts|test|.git|.github) continue ;; esac
   [ -f "$skill_dir/SKILL.md" ] || continue
+  skill_name=$(grep -m1 '^name:' "$skill_dir/SKILL.md" 2>/dev/null | sed 's/^name:[[:space:]]*//' | tr -d '[:space:]' || true)
+  [ -z "$skill_name" ] && skill_name="$skill"
 
   if [ "$PREFIX" = "true" ]; then
     # Don't double-prefix directories already named gstack-*
-    case "$skill" in
-      gstack-*) link_name="$skill" ;;
-      *)        link_name="gstack-$skill" ;;
+    case "$skill_name" in
+      gstack-*) link_name="$skill_name" ;;
+      *)        link_name="gstack-$skill_name" ;;
     esac
     # Remove old flat entry if it exists (and isn't the same as the new link)
-    [ "$link_name" != "$skill" ] && _cleanup_skill_entry "$SKILLS_DIR/$skill"
+    [ "$link_name" != "$skill_name" ] && _cleanup_skill_entry "$SKILLS_DIR/$skill_name"
   else
-    link_name="$skill"
+    link_name="$skill_name"
     # Don't remove gstack-* dirs that are their real name (e.g., gstack-upgrade)
-    case "$skill" in
+    case "$skill_name" in
       gstack-*) ;; # Already the real name, no old prefixed link to clean
-      *)        _cleanup_skill_entry "$SKILLS_DIR/gstack-$skill" ;;
+      *)        _cleanup_skill_entry "$SKILLS_DIR/gstack-$skill_name" ;;
     esac
   fi
   target="$SKILLS_DIR/$link_name"
   # Upgrade old directory symlinks to real directories
   [ -L "$target" ] && rm -f "$target"
-  # Create real directory with symlinked SKILL.md (absolute path)
+  # Create real directory. Flat names can symlink the source SKILL.md.
+  # Prefixed names get a projected SKILL.md with rewritten frontmatter so
+  # prefix mode does not dirty the source checkout.
   mkdir -p "$target"
-  ln -snf "$INSTALL_DIR/$skill/SKILL.md" "$target/SKILL.md"
+  rm -f "$target/SKILL.md"
+  if [ "$link_name" != "$skill_name" ]; then
+    sed "1,/^---$/s/^name:[[:space:]]*${skill_name}[[:space:]]*$/name: ${link_name}/" "$INSTALL_DIR/$skill/SKILL.md" > "$target/SKILL.md"
+  else
+    ln -snf "$INSTALL_DIR/$skill/SKILL.md" "$target/SKILL.md"
+  fi
   SKILL_COUNT=$((SKILL_COUNT + 1))
 done
-
-# Patch SKILL.md name: fields to match prefix setting
-"$INSTALL_DIR/bin/gstack-patch-names" "$INSTALL_DIR" "$PREFIX"
 
 if [ "$PREFIX" = "true" ]; then
   echo "Relinked $SKILL_COUNT skills as gstack-*"

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -651,14 +651,14 @@ if (failures.length > 0 && HOST_ARG_VAL === 'all') {
 }
 // Single host dry-run failure already handled above
 
-// After all hosts processed, warn if prefix patches may need re-applying
+// After all hosts processed, warn if prefix projections may need refreshing.
 if (!DRY_RUN) {
   try {
     const configPath = path.join(process.env.HOME || '', '.gstack', 'config.yaml');
     if (fs.existsSync(configPath)) {
       const config = fs.readFileSync(configPath, 'utf-8');
       if (/^skill_prefix:\s*true/m.test(config)) {
-        console.log('\nNote: skill_prefix is true. Run gstack-relink to re-apply name: patches.');
+        console.log('\nNote: skill_prefix is true. Run gstack-relink to refresh runtime skill projections.');
       }
     }
   } catch { /* non-fatal */ }

--- a/setup
+++ b/setup
@@ -468,12 +468,17 @@ link_claude_skill_dirs() {
       if [ -L "$target" ]; then
         rm -f "$target"
       fi
-      # Create real directory with symlinked SKILL.md (absolute path)
+      # Create real directory. Flat names can symlink the source SKILL.md.
+      # Prefixed names get a projected SKILL.md with rewritten frontmatter so
+      # prefix mode does not dirty the source checkout.
       # Use mkdir -p unconditionally (idempotent) to avoid TOCTOU race
       mkdir -p "$target"
-      # Validate target isn't a symlink before creating the link
-      if [ -L "$target/SKILL.md" ]; then rm "$target/SKILL.md"; fi
-      _link_or_copy "$gstack_dir/$dir_name/SKILL.md" "$target/SKILL.md"
+      rm -f "$target/SKILL.md"
+      if [ "$link_name" != "$skill_name" ]; then
+        sed "1,/^---$/s/^name:[[:space:]]*${skill_name}[[:space:]]*$/name: ${link_name}/" "$gstack_dir/$dir_name/SKILL.md" > "$target/SKILL.md"
+      else
+        _link_or_copy "$gstack_dir/$dir_name/SKILL.md" "$target/SKILL.md"
+      fi
       linked+=("$link_name")
     fi
   done
@@ -535,6 +540,10 @@ cleanup_old_claude_symlinks() {
             removed+=("$skill_name")
             ;;
         esac
+      # Remove one-file projected runtime directories from the opposite mode.
+      elif [ -d "$old_target" ] && [ -f "$old_target/SKILL.md" ] && [ "$(find "$old_target" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" = "1" ]; then
+        rm -rf "$old_target"
+        removed+=("$skill_name")
       # Windows install pattern: real dir with real-file SKILL.md (no symlink
       # available, so we can't readlink to verify provenance). The outer loop
       # iterates known gstack skill names from "$gstack_dir"/*, so a name match
@@ -583,6 +592,10 @@ cleanup_prefixed_claude_symlinks() {
             removed+=("gstack-$skill_name")
             ;;
         esac
+      # Remove one-file projected runtime directories from prefix mode.
+      elif [ -d "$prefixed_target" ] && [ -f "$prefixed_target/SKILL.md" ] && [ "$(find "$prefixed_target" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" = "1" ]; then
+        rm -rf "$prefixed_target"
+        removed+=("gstack-$skill_name")
       # Windows install pattern: real dir with real-file SKILL.md. Same
       # reasoning as cleanup_old_claude_symlinks — directory name match plus
       # IS_WINDOWS is safe during a mode flip.
@@ -885,14 +898,11 @@ if [ "$INSTALL_CLAUDE" -eq 1 ]; then
     else
       cleanup_prefixed_claude_symlinks "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
     fi
-    # Patch name: fields BEFORE creating symlinks so link_claude_skill_dirs
-    # reads the correct (patched) name: values for symlink naming
-    "$SOURCE_GSTACK_DIR/bin/gstack-patch-names" "$SOURCE_GSTACK_DIR" "$SKILL_PREFIX"
     link_claude_skill_dirs "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
     link_claude_root_skill_alias "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
-    # Self-healing: re-run gstack-relink to ensure name: fields and directory
-    # names are consistent with the config. This catches cases where an interrupted
-    # setup, stale git state, or gen:skill-docs left name: fields out of sync.
+    # Self-healing: re-run gstack-relink to ensure directory names are
+    # consistent with the config. This catches interrupted setup or stale
+    # runtime projection state without mutating source skill files.
     GSTACK_RELINK="$SOURCE_GSTACK_DIR/bin/gstack-relink"
     if [ -x "$GSTACK_RELINK" ]; then
       GSTACK_SKILLS_DIR="$INSTALL_SKILLS_DIR" GSTACK_INSTALL_DIR="$SOURCE_GSTACK_DIR" "$GSTACK_RELINK" >/dev/null 2>&1 || true
@@ -959,7 +969,6 @@ if [ "$INSTALL_CLAUDE" -eq 1 ]; then
       else
         cleanup_prefixed_claude_symlinks "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
       fi
-      "$SOURCE_GSTACK_DIR/bin/gstack-patch-names" "$SOURCE_GSTACK_DIR" "$SKILL_PREFIX"
       link_claude_skill_dirs "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
       link_claude_root_skill_alias "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
       GSTACK_RELINK="$SOURCE_GSTACK_DIR/bin/gstack-relink"

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2233,14 +2233,17 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('gstack*');
   });
 
-  test('link_claude_skill_dirs creates real directories with absolute SKILL.md symlinks', () => {
-    // Claude links should be real directories with absolute SKILL.md symlinks
-    // to ensure Claude Code discovers them as top-level skills (not nested under gstack/)
+  test('link_claude_skill_dirs creates real directories with clean SKILL.md projections', () => {
+    // Claude links should be real directories to ensure Claude Code discovers
+    // them as top-level skills. Flat entries symlink SKILL.md; prefixed
+    // entries use projected SKILL.md files so source skill files stay clean.
     const fnStart = setupContent.indexOf('link_claude_skill_dirs()');
     const fnEnd = setupContent.indexOf('}', setupContent.indexOf('linked[@]}', fnStart));
     const fnBody = setupContent.slice(fnStart, fnEnd);
     expect(fnBody).toContain('mkdir -p "$target"');
-    // v1.36.0.0: routes through _link_or_copy helper for Windows fallback (cp on MSYS2/Git Bash).
+    expect(fnBody).toContain('if [ "$link_name" != "$skill_name" ]');
+    expect(fnBody).toContain('name: ${link_name}');
+    // v1.36.0.0: flat entries route through _link_or_copy helper for Windows fallback.
     expect(fnBody).toContain('_link_or_copy "$gstack_dir/$dir_name/SKILL.md" "$target/SKILL.md"');
   });
 

--- a/test/relink.test.ts
+++ b/test/relink.test.ts
@@ -36,6 +36,12 @@ function run(cmd: string, env: Record<string, string> = {}, expectFail = false):
   }
 }
 
+function readSkillName(skillDir: string): string | null {
+  const content = fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf-8');
+  const match = content.match(/^name:\s*(.+)$/m);
+  return match ? match[1].trim() : null;
+}
+
 // Create a mock gstack install directory with skill subdirs
 function setupMockInstall(skills: string[]): void {
   installDir = path.join(tmpDir, 'gstack-install');
@@ -143,8 +149,10 @@ describe('gstack-relink (#578)', () => {
     }
   });
 
-  // Same invariant for prefixed mode
-  test('prefixed skills are real directories with SKILL.md symlinks, not dir symlinks', () => {
+  // Same directory invariant for prefixed mode. The SKILL.md itself is a
+  // projection copy so its frontmatter can use the prefixed name without
+  // mutating the source checkout.
+  test('prefixed skills are real directories with projected SKILL.md files', () => {
     setupMockInstall(['qa', 'ship']);
     run(`${path.join(installDir, 'bin', 'gstack-config')} set skill_prefix true`, {
       GSTACK_INSTALL_DIR: installDir,
@@ -159,7 +167,8 @@ describe('gstack-relink (#578)', () => {
       const skillMdPath = path.join(skillPath, 'SKILL.md');
       expect(fs.lstatSync(skillPath).isDirectory()).toBe(true);
       expect(fs.lstatSync(skillPath).isSymbolicLink()).toBe(false);
-      expect(fs.lstatSync(skillMdPath).isSymbolicLink()).toBe(true);
+      expect(fs.lstatSync(skillMdPath).isSymbolicLink()).toBe(false);
+      expect(readSkillName(skillPath)).toBe(skill);
     }
   });
 
@@ -470,15 +479,8 @@ describe('upgrade migrations', () => {
   });
 });
 
-describe('gstack-patch-names (#620/#578)', () => {
-  // Helper to read name: from SKILL.md frontmatter
-  function readSkillName(skillDir: string): string | null {
-    const content = fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf-8');
-    const match = content.match(/^name:\s*(.+)$/m);
-    return match ? match[1].trim() : null;
-  }
-
-  test('prefix=true patches name: field in SKILL.md', () => {
+describe('gstack prefix projection (#620/#578)', () => {
+  test('prefix=true projects prefixed names without mutating source SKILL.md', () => {
     setupMockInstall(['qa', 'ship', 'review']);
     run(`${path.join(installDir, 'bin', 'gstack-config')} set skill_prefix true`, {
       GSTACK_INSTALL_DIR: installDir,
@@ -488,13 +490,17 @@ describe('gstack-patch-names (#620/#578)', () => {
       GSTACK_INSTALL_DIR: installDir,
       GSTACK_SKILLS_DIR: skillsDir,
     });
-    // Verify name: field is patched with gstack- prefix
-    expect(readSkillName(path.join(installDir, 'qa'))).toBe('gstack-qa');
-    expect(readSkillName(path.join(installDir, 'ship'))).toBe('gstack-ship');
-    expect(readSkillName(path.join(installDir, 'review'))).toBe('gstack-review');
+    // Source names stay canonical.
+    expect(readSkillName(path.join(installDir, 'qa'))).toBe('qa');
+    expect(readSkillName(path.join(installDir, 'ship'))).toBe('ship');
+    expect(readSkillName(path.join(installDir, 'review'))).toBe('review');
+    // Runtime projections expose the prefixed names.
+    expect(readSkillName(path.join(skillsDir, 'gstack-qa'))).toBe('gstack-qa');
+    expect(readSkillName(path.join(skillsDir, 'gstack-ship'))).toBe('gstack-ship');
+    expect(readSkillName(path.join(skillsDir, 'gstack-review'))).toBe('gstack-review');
   });
 
-  test('prefix=false restores name: field in SKILL.md', () => {
+  test('prefix=false restores flat runtime entries without source mutation', () => {
     setupMockInstall(['qa', 'ship']);
     // First, prefix them
     run(`${path.join(installDir, 'bin', 'gstack-config')} set skill_prefix true`, {
@@ -505,7 +511,8 @@ describe('gstack-patch-names (#620/#578)', () => {
       GSTACK_INSTALL_DIR: installDir,
       GSTACK_SKILLS_DIR: skillsDir,
     });
-    expect(readSkillName(path.join(installDir, 'qa'))).toBe('gstack-qa');
+    expect(readSkillName(path.join(installDir, 'qa'))).toBe('qa');
+    expect(readSkillName(path.join(skillsDir, 'gstack-qa'))).toBe('gstack-qa');
     // Now switch to flat mode
     run(`${path.join(installDir, 'bin', 'gstack-config')} set skill_prefix false`, {
       GSTACK_INSTALL_DIR: installDir,
@@ -515,9 +522,11 @@ describe('gstack-patch-names (#620/#578)', () => {
       GSTACK_INSTALL_DIR: installDir,
       GSTACK_SKILLS_DIR: skillsDir,
     });
-    // Verify name: field is restored to unprefixed
+    // Verify source stayed unprefixed and runtime entries are flat.
     expect(readSkillName(path.join(installDir, 'qa'))).toBe('qa');
     expect(readSkillName(path.join(installDir, 'ship'))).toBe('ship');
+    expect(readSkillName(path.join(skillsDir, 'qa'))).toBe('qa');
+    expect(fs.existsSync(path.join(skillsDir, 'gstack-qa'))).toBe(false);
   });
 
   test('gstack-upgrade name: not double-prefixed', () => {
@@ -532,8 +541,9 @@ describe('gstack-patch-names (#620/#578)', () => {
     });
     // gstack-upgrade should keep its name, NOT become gstack-gstack-upgrade
     expect(readSkillName(path.join(installDir, 'gstack-upgrade'))).toBe('gstack-upgrade');
-    // Regular skill should be prefixed
-    expect(readSkillName(path.join(installDir, 'qa'))).toBe('gstack-qa');
+    // Regular source skill stays canonical; runtime projection is prefixed.
+    expect(readSkillName(path.join(installDir, 'qa'))).toBe('qa');
+    expect(readSkillName(path.join(skillsDir, 'gstack-qa'))).toBe('gstack-qa');
   });
 
   test('SKILL.md without frontmatter is a no-op', () => {


### PR DESCRIPTION
## Summary
- keep source SKILL.md frontmatter canonical when Claude prefix mode is enabled
- write prefixed name metadata into runtime projection files instead
- clean up one-file projected runtime directories when switching prefix modes

## Verification
- bun test test/relink.test.ts
- bash -n setup && bash -n bin/gstack-relink
- ./setup --host claude --prefix -q

## Notes
This preserves native GStack projection for Claude/Codex while avoiding dirty source checkouts after setup/relink.