### PR TITLE
fix(timeline): validate read limit

### DIFF
--- a/bin/gstack-timeline-read
+++ b/bin/gstack-timeline-read
@@ -17,11 +17,21 @@ BRANCH=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --since) SINCE="$2"; shift 2 ;;
-    --limit) LIMIT="$2"; shift 2 ;;
+    --limit)
+      if [[ $# -lt 2 ]]; then
+        echo "gstack-timeline-read: --limit requires a positive integer" >&2
+        exit 1
+      fi
+      LIMIT="$2"; shift 2 ;;
     --branch) BRANCH="$2"; shift 2 ;;
     *) shift ;;
   esac
 done
+
+if ! [[ "$LIMIT" =~ ^0*[1-9][0-9]*$ ]]; then
+  echo "gstack-timeline-read: --limit requires a positive integer" >&2
+  exit 1
+fi
 
 TIMELINE_FILE="$GSTACK_HOME/projects/$SLUG/timeline.jsonl"
 

--- a/test/timeline.test.ts
+++ b/test/timeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { execFileSync, execSync, ExecSyncOptionsWithStringEncoding } from 'child_process';
+import { execFileSync, execSync, ExecSyncOptionsWithStringEncoding, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -54,6 +54,20 @@ function runReadArgs(args: string[] = []): string {
   } catch {
     return '';
   }
+}
+
+function runReadResult(args: string[] = []): { stdout: string; stderr: string; exitCode: number } {
+  const result = spawnSync(path.join(BIN, 'gstack-timeline-read'), args, {
+    cwd: ROOT,
+    env: { ...process.env, GSTACK_HOME: tmpDir },
+    encoding: 'utf-8',
+    timeout: 15000,
+  });
+  return {
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+    exitCode: result.status ?? 1,
+  };
 }
 
 beforeEach(() => {
@@ -175,5 +189,17 @@ describe('gstack-timeline-read', () => {
 
     expect(unlimitedEvents).toBe(5);
     expect(limitedEvents).toBe(2);
+  });
+
+  test('rejects malformed --limit values', () => {
+    runLog(JSON.stringify({ skill: 'review', event: 'completed', branch: 'main', outcome: 'approved', ts: '2026-03-28T10:00:00Z' }));
+
+    for (const value of ['1abc', 'nope', '0', '-1', '1.5']) {
+      const result = runReadResult(['--limit', value]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('gstack-timeline-read: --limit requires a positive integer');
+    }
   });
 });


### PR DESCRIPTION
## Summary

- reject malformed `gstack-timeline-read --limit` values before the formatter pipeline
- keep valid positive integer limits working, including the existing output path
- add timeline CLI coverage for malformed, zero, negative, and decimal limits

## Validation

- `bun test --timeout 20000 test/timeline.test.ts`
- `bash -n bin/gstack-timeline-read`
- direct repro: `./bin/gstack-timeline-read --limit 1abc` exits 1 with `gstack-timeline-read: --limit requires a positive integer`; `--limit 1` still returns one recent event
- `git diff --check`
- `git merge-tree --write-tree HEAD origin/main`

Fixes #1723