### PR TITLE
fix(benchmark): validate timeout flag

### DIFF
--- a/bin/gstack-model-benchmark
+++ b/bin/gstack-model-benchmark
@@ -88,6 +88,20 @@ function parseProviders(s: string | undefined): Array<'claude' | 'gpt' | 'gemini
   return seen.size ? Array.from(seen) : ['claude'];
 }
 
+function parsePositiveIntegerFlag(name: string, def: string): number {
+  const raw = arg(name, def);
+  if (!raw || !/^\+?[1-9]\d*$/.test(raw)) {
+    console.error(`${name} requires a positive integer`);
+    process.exit(1);
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed)) {
+    console.error(`${name} requires a positive integer`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
 function resolvePrompt(positional: string | undefined): string {
   const inline = arg('--prompt');
   if (inline) return inline;
@@ -107,7 +121,7 @@ async function main(): Promise<void> {
   const prompt = resolvePrompt(positional);
   const providers = parseProviders(arg('--models'));
   const workdir = arg('--workdir', process.cwd())!;
-  const timeoutMs = parseInt(arg('--timeout-ms', '300000')!, 10);
+  const timeoutMs = parsePositiveIntegerFlag('--timeout-ms', '300000');
   const output = (arg('--output', 'table') as OutputFormat);
   const skipUnavailable = flag('--skip-unavailable');
   const doJudge = flag('--judge');

--- a/test/benchmark-cli.test.ts
+++ b/test/benchmark-cli.test.ts
@@ -73,6 +73,21 @@ describe('gstack-model-benchmark --dry-run', () => {
     expect(r.stdout).toContain('workdir:    /tmp');
   });
 
+  test('--timeout-ms accepts plus-prefixed positive integers', () => {
+    const r = run(['--prompt', 'hi', '--timeout-ms', '+2500', '--dry-run']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('timeout_ms: 2500');
+  });
+
+  test('--timeout-ms rejects malformed values', () => {
+    for (const value of ['1abc', 'nope', '0', '-1', '1.5', '']) {
+      const r = run(['--prompt', 'hi', '--timeout-ms', value, '--dry-run']);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain('--timeout-ms requires a positive integer');
+      expect(r.stdout).toBe('');
+    }
+  });
+
   test('--judge flag reported in dry-run output', () => {
     const r = run(['--prompt', 'hi', '--judge', '--dry-run']);
     expect(r.status).toBe(0);


### PR DESCRIPTION
## Summary

- reject malformed, non-numeric, zero, negative, decimal, or missing `--timeout-ms` values before benchmark dry-run/provider execution
- keep valid positive integer timeout values working, including plus-prefixed values
- add focused CLI regression coverage for the timeout parser

Fixes #1726

## Validation

- `bun test test/benchmark-cli.test.ts`
- direct CLI proof: invalid `--timeout-ms` values `1abc`, `nope`, `0`, `-1`, `1.5`, and empty all exit 1 with `--timeout-ms requires a positive integer`
- direct CLI proof: `--timeout-ms +2500 --dry-run` reports `timeout_ms: 2500`
- `git diff --check`
- `git merge-tree --write-tree HEAD origin/main`

## Collision check

Before publishing, I searched open issues/PRs for `gstack-model-benchmark --timeout-ms`, malformed benchmark timeout parsing, `timeout_ms NaN`, issue #1726, and open PRs touching `bin/gstack-model-benchmark` / `test/benchmark-cli.test.ts`. No canonical PR covers this timeout validation bug. Open PR #1495 touches the same CLI for an additive Ollama provider and does not validate `--timeout-ms`.
