### PR TITLE
fix(analytics): avg duration handles both quoted and unquoted duration_s

### DIFF
--- a/bin/gstack-analytics
+++ b/bin/gstack-analytics
@@ -168,7 +168,9 @@ echo "$SKILL_COUNTS" | while read -r COUNT SKILL; do
       # Extract duration_s value using split on "duration_s":
       n = split($0, parts, "\"duration_s\":")
       if (n >= 2) {
-        # parts[2] starts with the value, e.g. "142,"
+        # parts[2] starts with the value: unquoted (142,...) or quoted ("142",...).
+        # Strip a leading double-quote so the digit-extraction below handles both forms.
+        sub(/^"/, "", parts[2])
         gsub(/[^0-9.].*/, "", parts[2])
         if (parts[2]+0 > 0) { total += parts[2]; count++ }
       }

--- a/test/gstack-analytics-avg-duration.test.ts
+++ b/test/gstack-analytics-avg-duration.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const BIN = path.join(ROOT, 'bin', 'gstack-analytics');
+
+// Verifies the per-skill avg-duration calculation in the bash dashboard
+// (bin/gstack-analytics) parses both unquoted and quoted "duration_s"
+// values from skill-usage.jsonl. The completion-status preamble (and
+// gstack-codex-probe) emit quoted strings; gstack-telemetry-log emits
+// unquoted numbers. The previous awk regex stripped from the leading
+// quote, silently yielding avg=0 for quoted-only skills.
+describe('gstack-analytics avg duration parsing', () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-analytics-test-'));
+    fs.mkdirSync(path.join(stateDir, 'analytics'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  function run(jsonl: string[]): string {
+    fs.writeFileSync(
+      path.join(stateDir, 'analytics', 'skill-usage.jsonl'),
+      jsonl.join('\n') + '\n',
+    );
+    const r = spawnSync('bash', [BIN, 'all'], {
+      env: { ...process.env, GSTACK_STATE_DIR: stateDir },
+      encoding: 'utf-8',
+    });
+    if (r.status !== 0) {
+      throw new Error(`gstack-analytics failed (status ${r.status}): ${r.stderr}`);
+    }
+    return r.stdout;
+  }
+
+  // Pull "(avg <value>)" out of a /skill row.
+  function avgFor(report: string, skill: string): string {
+    const re = new RegExp(`/${skill}\\b[^\\n]*\\(avg ([^)]+)\\)`);
+    const m = report.match(re);
+    if (!m) throw new Error(`no avg row for /${skill} in:\n${report}`);
+    return m[1];
+  }
+
+  test('quoted "duration_s" values are averaged (regression: previously read as 0)', () => {
+    const output = run([
+      '{"skill":"review","duration_s":"120","outcome":"success","ts":"2026-05-25T10:00:00Z"}',
+      '{"skill":"review","duration_s":"180","outcome":"success","ts":"2026-05-25T11:00:00Z"}',
+      '{"skill":"review","duration_s":"60","outcome":"success","ts":"2026-05-25T12:00:00Z"}',
+    ]);
+    // (120+180+60)/3 = 120s = 2m
+    expect(avgFor(output, 'review')).toBe('2m');
+  });
+
+  test('unquoted numeric "duration_s" values are averaged', () => {
+    const output = run([
+      '{"skill":"qa","duration_s":300,"outcome":"success","ts":"2026-05-25T13:00:00Z"}',
+      '{"skill":"qa","duration_s":420,"outcome":"success","ts":"2026-05-25T14:00:00Z"}',
+    ]);
+    // (300+420)/2 = 360s = 6m
+    expect(avgFor(output, 'qa')).toBe('6m');
+  });
+
+  test('mixed quoted and unquoted values average together', () => {
+    const output = run([
+      '{"skill":"ship","duration_s":"30","outcome":"success","ts":"2026-05-25T10:00:00Z"}',
+      '{"skill":"ship","duration_s":50,"outcome":"success","ts":"2026-05-25T11:00:00Z"}',
+    ]);
+    // (30+50)/2 = 40s — under 60 so shown in seconds, exercising both paths.
+    expect(avgFor(output, 'ship')).toBe('40s');
+  });
+
+  test('total time sums quoted and unquoted across all skills', () => {
+    const output = run([
+      '{"skill":"review","duration_s":"120","outcome":"success","ts":"2026-05-25T10:00:00Z"}',
+      '{"skill":"qa","duration_s":300,"outcome":"success","ts":"2026-05-25T13:00:00Z"}',
+    ]);
+    // 120+300 = 420s = 7m
+    expect(output).toContain('Total time: 7m');
+  });
+});


### PR DESCRIPTION
## Summary

`gstack-analytics` (the local-usage dashboard) silently displayed `(avg 0s)` next to any `/skill` whose completion events emit `"duration_s"` as a quoted JSON string. The completion-status preamble that every skill runs ([`scripts/resolvers/preamble/generate-completion-status.ts:70`](https://github.com/garrytan/gstack/blob/main/scripts/resolvers/preamble/generate-completion-status.ts#L70)) and [`bin/gstack-codex-probe:84`](https://github.com/garrytan/gstack/blob/main/bin/gstack-codex-probe#L84) both emit `"duration_s":"<N>"`, so the dominant in-the-wild case rendered as `0s` and most per-skill averages in the dashboard have been wrong since this code path was added. `bin/gstack-telemetry-log` emits the unquoted numeric form, which is why the bug wasn't visible for every skill.

The companion `Total time:` line at the bottom of the dashboard was always correct — it uses a different parser, so the bug was confined to the per-`/skill` `(avg X)` column.

## Current behavior on upstream main

Repro on `origin/main` (`cf50443b`):

```bash
mkdir -p /tmp/repro/.gstack/analytics
cat > /tmp/repro/.gstack/analytics/skill-usage.jsonl <<'JSONL'
{"skill":"review","duration_s":"120","outcome":"success","ts":"2026-05-25T10:00:00Z"}
{"skill":"review","duration_s":"180","outcome":"success","ts":"2026-05-25T11:00:00Z"}
{"skill":"review","duration_s":"60","outcome":"success","ts":"2026-05-25T12:00:00Z"}
{"skill":"qa","duration_s":300,"outcome":"success","ts":"2026-05-25T13:00:00Z"}
{"skill":"qa","duration_s":420,"outcome":"success","ts":"2026-05-25T14:00:00Z"}
JSONL
GSTACK_STATE_DIR=/tmp/repro/.gstack bin/gstack-analytics all
```

Before:

```
gstack usage (all time)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  /review               ████████████████████  3 runs  (avg 0s)   <-- WRONG, should be 2m
  /qa                   █████████████  2 runs  (avg 6m)
Total time: 18m
```

`Total time: 18m` matches the real sum (`120 + 180 + 60 + 300 + 420 = 1080s = 18m`), confirming the total-time parser is already correct. Only the per-skill `(avg ...)` column is broken.

## Root cause

The `AVG_DUR` block in [`bin/gstack-analytics:165-177`](https://github.com/garrytan/gstack/blob/main/bin/gstack-analytics#L165-L177) splits each line on the literal `"duration_s":` prefix and then strips non-numeric characters from `parts[2]`:

```awk
n = split($0, parts, "\"duration_s\":")
if (n >= 2) {
  gsub(/[^0-9.].*/, "", parts[2])      # greedy .*
  if (parts[2]+0 > 0) { total += parts[2]; count++ }
}
```

- Unquoted form `600,"ts":...` → `gsub` matches at the comma → `parts[2]` becomes `600` → accumulates.
- Quoted form `"600","ts":...` → `gsub` matches at the leading `"` (position 0), and the trailing `.*` consumes the rest of the line → `parts[2]` becomes the empty string → `"" + 0 > 0` is false → never accumulates → `count` stays `0` → average renders as `0`.

`TOTAL_DURATION` ([`bin/gstack-analytics:114-125`](https://github.com/garrytan/gstack/blob/main/bin/gstack-analytics#L114-L125)) uses `-F'[:,]'` field splitting and a non-greedy `gsub(/[^0-9.]/, "", val)`, which isolates the value before stripping. That parser handles both forms and isn't affected.

## Fix

Strip an optional leading double-quote with `sub(/^"/, "", parts[2])` before the existing `gsub` so quoted and unquoted forms take the same path through the existing digit-extraction:

```awk
sub(/^"/, "", parts[2])                # NEW
gsub(/[^0-9.].*/, "", parts[2])
```

Three lines in `bin/gstack-analytics` (one new statement + two-line comment update). No producer-side changes — the parser fix accommodates both emitter formats that are already in the wild, so existing JSONL files on users' disks render correctly without migration.

Edge cases verified by hand:

| Input value | After `sub(/^"/)` | After `gsub(/[^0-9.].*/)` | Accumulated? |
|---|---|---|---|
| `600,"ts":...` (unquoted) | `600,"ts":...` | `600` | yes |
| `"600","ts":...` (quoted) | `600","ts":...` | `600` | yes (was: no) |
| `null,"ts":...` | `null,"ts":...` | `` (empty) | no — `"" + 0 > 0` is false |
| `"1.5","ts":...` (decimal) | `1.5","ts":...` | `1.5` | yes |

## Validation

After the fix, same repro renders correctly:

```
  /review               ████████████████████  3 runs  (avg 2m)   <-- (120+180+60)/3 = 120s = 2m
  /qa                   █████████████  2 runs  (avg 6m)
Total time: 18m
```

New regression test in `test/gstack-analytics-avg-duration.test.ts` exercises four cases (quoted-only, unquoted-only, mixed quoted+unquoted for the same skill, and total-time aggregation). I confirmed it fails on the pre-fix tree (`expected "2m", got "0s"`) by stashing the patch and re-running, then passes after popping the stash.

```
$ bun test test/gstack-analytics-avg-duration.test.ts
 4 pass
 0 fail
 4 expect() calls

$ bun test test/telemetry.test.ts test/gstack-analytics-avg-duration.test.ts
 39 pass
 0 fail
 87 expect() calls

$ bun test
exit 0
```

## Scope

`bin/gstack-analytics` (3 lines) + 1 new test file. No SKILL.md/template changes, no VERSION/CHANGELOG bumps (per the wave-process note in CONTRIBUTING.md). The producer-side emitters (`generate-completion-status.ts`, `gstack-codex-probe`, `gstack-telemetry-log`) are untouched — fixing the parser keeps existing JSONL on users' machines readable without a migration.