### PR TITLE
fix(gbrain-sync): wrap bash-shebang script spawn through `bash` on Windows

### DIFF
--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -32,7 +32,7 @@
 import { existsSync, statSync, mkdirSync, writeFileSync, readFileSync, unlinkSync, renameSync } from "fs";
 import { join, dirname } from "path";
 import { execSync, spawnSync } from "child_process";
-import { homedir, hostname } from "os";
+import { homedir, hostname, platform } from "os";
 import { createHash } from "crypto";
 
 import "../lib/conductor-env-shim";
@@ -949,6 +949,29 @@ function runMemoryIngest(args: CliArgs): StageResult {
   };
 }
 
+/**
+ * Spawn a bash-shebang script with platform-aware invocation.
+ *
+ * On POSIX (Linux/macOS), spawnSync can exec a `#!/usr/bin/env bash` script
+ * directly — the kernel reads the shebang and invokes bash.
+ *
+ * On Windows, spawnSync can't honor a POSIX shebang and fails to spawn — the
+ * resulting SpawnSyncReturns has `status: null` and `error: ENOENT` (or
+ * similar). We explicitly route through `bash <script>` on Windows so the
+ * same script runs identically across platforms. Assumes Git Bash / WSL /
+ * MSYS2 `bash` is on PATH, which is already required by gstack-gbrain-detect.
+ */
+function spawnBashScript(
+  scriptPath: string,
+  args: string[],
+  options: Parameters<typeof spawnSync>[2],
+): ReturnType<typeof spawnSync> {
+  if (platform() === "win32") {
+    return spawnSync("bash", [scriptPath, ...args], options);
+  }
+  return spawnSync(scriptPath, args, options);
+}
+
 function runBrainSyncPush(args: CliArgs): StageResult {
   const t0 = Date.now();
 
@@ -961,11 +984,11 @@ function runBrainSyncPush(args: CliArgs): StageResult {
     return { name: "brain-sync", ran: false, ok: true, duration_ms: 0, summary: "skipped (gstack-brain-sync not installed)" };
   }
 
-  spawnSync(brainSyncPath, ["--discover-new"], {
+  spawnBashScript(brainSyncPath, ["--discover-new"], {
     stdio: args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"],
     timeout: 60 * 1000,
   });
-  const result = spawnSync(brainSyncPath, ["--once"], {
+  const result = spawnBashScript(brainSyncPath, ["--once"], {
     stdio: args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"],
     timeout: 60 * 1000,
   });
@@ -975,7 +998,12 @@ function runBrainSyncPush(args: CliArgs): StageResult {
     ran: true,
     ok: result.status === 0,
     duration_ms: Date.now() - t0,
-    summary: result.status === 0 ? "curated artifacts pushed" : `gstack-brain-sync exited ${result.status}`,
+    summary:
+      result.status === 0
+        ? "curated artifacts pushed"
+        : result.status === null
+          ? `gstack-brain-sync failed to spawn (${result.error?.message ?? "no error message"})`
+          : `gstack-brain-sync exited ${result.status}`,
   };
 }
 


### PR DESCRIPTION
## Summary

On Windows, `runBrainSyncPush` (in `bin/gstack-gbrain-sync.ts`) fails to spawn `gstack-brain-sync` (a `#!/usr/bin/env bash` script) because Windows can't honor POSIX shebangs through Node's `spawnSync`. The summary template prints `gstack-brain-sync exited undefined` and every Windows user running `/sync-gbrain` — or the auto-fire preamble hook on every gstack skill start — sees a spurious stage-3 error even though the underlying script is functional.

## Root cause

[`bin/gstack-gbrain-sync.ts:964-971`](https://github.com/garrytan/gstack/blob/main/bin/gstack-gbrain-sync.ts#L964-L971) calls `spawnSync(brainSyncPath, [...])` on a `#!/usr/bin/env bash` script directly. On Linux/macOS the kernel honors the shebang and the spawn succeeds; on Windows, the OS can't honor a POSIX shebang and the spawn fails — `result.status` is `null`, `result.error` is set.

## Fix

Extract a `spawnBashScript(scriptPath, args, options)` helper:
- On Linux/macOS: unchanged behavior (`spawnSync(scriptPath, args, options)`)
- On Windows: explicitly invoke `spawnSync("bash", [scriptPath, ...args], options)` so the script is interpreted by Git Bash / WSL / MSYS2 `bash` on PATH

`bash` on PATH is already a hard requirement for `gstack-gbrain-detect`, so no new dependency.

Also improves the failure summary template to distinguish:
- `result.status === 0` → `curated artifacts pushed`
- `result.status === null` → `gstack-brain-sync failed to spawn (${error.message})`
- otherwise → `gstack-brain-sync exited ${status}`

Useful diagnostics for any future spawn failure (timeout, signal kill, etc.) regardless of platform.

## Test plan

Smoke-tested on Windows 11 + Git Bash + gstack 1.45.0.0 + Supabase remote MCP engine.

**Before fix:**
```
$ bun bin/gstack-gbrain-sync.ts --incremental
[gbrain-sync] mode=incremental engine=supabase
...
gstack-gbrain-sync (incremental):
  OK    code         synced gstack-code-liquid-acre-... (page_count=0) (8.2s)
  OK    memory       gbrain import: 1 imported, 0 unchanged, 0 failed (2.5s)
  ERR   brain-sync   gstack-brain-sync exited undefined

  2 ok, 1 error, 0 skipped
```

**After fix:**
```
$ bun bin/gstack-gbrain-sync.ts --incremental
[gbrain-sync] mode=incremental engine=supabase
...
gstack-gbrain-sync (incremental):
  OK    code         synced gstack-code-liquid-acre-... (page_count=0) (7.8s)
  OK    memory       gbrain import: 2 imported, 0 unchanged, 0 failed (3.9s)
  OK    brain-sync   curated artifacts pushed (2.3s)

  3 ok, 0 error, 0 skipped
```

- [x] Smoke test on Windows 11 (above)
- [ ] Verify no regression on Linux/macOS (POSIX path is unchanged — the `platform() !== "win32"` branch is identical to prior behavior)
- [ ] CI green

## Notes

- Only `runBrainSyncPush` is patched. Other `spawnSync` callers in this file invoke `bun` (a `.exe` on Windows) and aren't affected.
- No changes to the existing memory/code stages.
- `bash` invocation uses the same name resolution gstack already relies on — no path muddling.

## Context

Surfaced during a Windows dev-machine setup session for a downstream project that uses gstack as its skill layer. Full audit log of the discovery is at the downstream repo if helpful — happy to share the `_observations-log.md` entry on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)