### PR TITLE
fix(browse): daemon resilience on loaded machines — Bun ConnectionRefused, stop/restart response flush, startup + git-root timeouts

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -489,8 +489,18 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
       console.error('[browse] Command timed out after 30s');
       process.exit(1);
     }
-    // Connection error — server may have crashed
-    if (err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET' || err.message?.includes('fetch failed')) {
+    // Connection error — server may have crashed.
+    // The compiled CLI runs on Bun, whose fetch reports a refused/dropped
+    // socket as err.code 'ConnectionRefused' / 'ConnectionClosed' (message
+    // "Unable to connect. Is the computer able to access the url?"), NOT Node's
+    // ECONNREFUSED/ECONNRESET. Match both, or daemon crashes leak the raw Bun
+    // error and exit 1 instead of triggering the restart-and-retry below.
+    const isConnError =
+      err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET' ||
+      err.code === 'ConnectionRefused' || err.code === 'ConnectionClosed' ||
+      err.message?.includes('fetch failed') ||
+      err.message?.includes('Unable to connect');
+    if (isConnError) {
       if (retries >= 1) throw new Error('[browse] Server crashed twice in a row — aborting');
       console.error('[browse] Server connection lost. Restarting...');
       // Kill the old server to avoid orphaned chromium processes

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -21,7 +21,13 @@ import { spawnTerminalAgent } from './terminal-agent-control';
 
 const config = resolveConfig();
 const IS_WINDOWS = process.platform === 'win32';
-const MAX_START_WAIT = IS_WINDOWS ? 15000 : (process.env.CI ? 30000 : 8000); // Node+Chromium takes longer on Windows
+// Cold Chromium launch measured ~5.7s at load avg 10 on a dev machine running
+// many servers; at load 12+ it exceeds the old 8s budget, so the CLI gave up
+// while the (detached) daemon was still booting → "Server failed to start
+// within 8s". 15s matches the Windows budget and gives real headroom; the poll
+// loop returns the instant the daemon is healthy, so this only costs time in a
+// genuine-failure case.
+const MAX_START_WAIT = IS_WINDOWS ? 15000 : (process.env.CI ? 30000 : 15000); // Node+Chromium takes longer on Windows
 
 export function resolveServerScript(
   env: Record<string, string | undefined> = process.env,

--- a/browse/src/config.ts
+++ b/browse/src/config.ts
@@ -34,7 +34,12 @@ export function getGitRoot(): string | null {
     const proc = Bun.spawnSync(['git', 'rev-parse', '--show-toplevel'], {
       stdout: 'pipe',
       stderr: 'pipe',
-      timeout: 2_000, // Don't hang if .git is broken
+      // Raised from 2s: under heavy machine load `git rev-parse` routinely
+      // takes >2s (measured 6.3s spikes). Timing out here returns null →
+      // resolveConfig falls back to process.cwd() → state files scatter across
+      // cwds (split-brain daemons; `goto` and `url` hit different servers). 8s
+      // still bounds a genuinely broken .git from hanging the CLI forever.
+      timeout: 8_000,
     });
     if (proc.exitCode !== 0) return null;
     return proc.stdout.toString().trim() || null;

--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -421,15 +421,25 @@ export async function handleMetaCommand(
     }
 
     case 'stop': {
-      await shutdown();
+      // Defer shutdown so the response flushes before process.exit() (same
+      // reason as 'restart' below). Otherwise the CLI sees a dropped socket;
+      // and now that connection-loss triggers the crash-retry path, that would
+      // resurrect a fresh daemon only to stop it again. Send the 200, then exit.
+      setTimeout(() => { void shutdown(); }, 100);
       return 'Server stopped';
     }
 
     case 'restart': {
-      // Signal that we want a restart — the CLI will detect exit and restart
+      // Signal that we want a restart — the CLI will detect exit and restart.
       console.log('[browse] Restart requested. Exiting for CLI to restart.');
-      await shutdown();
-      return 'Restarting...';
+      // Defer shutdown one tick so this HTTP response actually flushes before
+      // process.exit(). shutdown() exits inline (server.ts), so the old
+      // `await shutdown(); return 'Restarting...'` never sent a response — the
+      // CLI saw a dropped socket and `browse restart` errored out. The daemon
+      // now exits ~100ms after the CLI gets its 200; the next browse command
+      // lazily cold-starts a fresh one.
+      setTimeout(() => { void shutdown(); }, 100);
+      return 'Restarting... (daemon exiting; next browse command starts a fresh one)';
     }
 
     // ─── Visual ────────────────────────────────────────


### PR DESCRIPTION
## Problem

On a dev machine under sustained load (think 10 local servers + compiles, load avg 12+), the `browse` daemon was unreliable in three distinct ways:

1. `browse restart` and `browse stop` printed `Unable to connect. Is the computer able to access the url?` and exited 1 instead of doing their job.
2. `browse goto <url>` intermittently failed with `Server failed to start within 8s`, even though the daemon came up a second later.
3. `goto` would report a 200 but `url` returned `about:blank` — the two commands talking to different daemons.

All three are timeout/error-handling assumptions that hold on an idle machine and break under load. Root causes, with measurements from a load-~12 box:

## Root causes + fixes

**1. Bun reports refused/dropped sockets differently than Node.** The compiled CLI runs on Bun, whose `fetch` throws `err.code === 'ConnectionRefused'` / `'ConnectionClosed'` (message `"Unable to connect..."`), not Node's `ECONNREFUSED`/`ECONNRESET`. The crash-retry guard in `sendCommand` (`cli.ts`) only matched the Node codes, so a mid-command daemon drop leaked the raw Bun error and exited 1 instead of restarting-and-retrying. Broadened the guard to match both. (The repo's own e2e helpers already check for both `'ConnectionRefused'` and `'Unable to connect'`, so this shape was known elsewhere.)

**2. `stop` / `restart` never flushed their HTTP response.** Both handlers did `await shutdown(); return '...'`, but `shutdown()` calls `process.exit()` inline — so the `return` was dead code and the response never reached the CLI. The CLI saw a dropped socket; combined with (1) that surfaced as the raw error. Deferred `shutdown()` one tick (`setTimeout(..., 100)`) so the 200 flushes first, then the daemon exits and the next command lazily cold-starts.

**3. Startup + git-root timeouts too tight under load.**
- `MAX_START_WAIT` was 8s on macOS/Linux. A cold Chromium launch measured ~5.7s at load 10 and exceeds 8s at load 12+, so the CLI abandoned a daemon that was still booting. Raised to 15s (matches the existing Windows budget). The poll loop returns the instant the daemon is healthy, so this only costs time in a genuine failure.
- `getGitRoot()`'s `git rev-parse` timeout was 2s; under load it spikes past that (~6s observed), returns null, and `resolveConfig` falls back to `process.cwd()`. That scatters `.gstack/browse.json` across cwds, so `goto` and `url` hit different daemons. Raised to 8s (still bounds a genuinely broken `.git`).

## Test plan

- [x] `browse restart` → exits 0, prints a clear message, next command cold-starts a fresh daemon
- [x] `browse stop` → exits 0, daemon and Chromium fully torn down (0 leftover processes)
- [x] `browse goto` / `url` / `screenshot` → green, single daemon, no stray state files
- [x] Targeted rebuild (`bun build --compile browse/src/cli.ts`) + daemon reload from source, verified end-to-end on macOS/arm64, Bun 1.2.18
- [x] No existing tests asserted the old stop/restart strings

Changes are source-only across `browse/src/{cli,config,meta-commands}.ts`. No dependency or build-script changes.