### PR TITLE
Fix Codex skill loading errors from unquoted descriptions

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -2,7 +2,7 @@
 name: gstack
 preamble-tier: 1
 version: 1.1.0
-description: Fast headless browser for QA testing and site dogfooding. (gstack)
+description: "Fast headless browser for QA testing and site dogfooding. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -2,7 +2,7 @@
 name: autoplan
 preamble-tier: 3
 version: 1.0.0
-description: Auto-review pipeline — reads the full CEO, design, eng, and DX review skills from disk and runs them sequentially with auto-decisions using 6 decision principles. (gstack)
+description: "Auto-review pipeline — reads the full CEO, design, eng, and DX review skills from disk and runs them sequentially with auto-decisions using 6 decision principles. (gstack)"
 benefits-from: [office-hours]
 triggers:
   - run all reviews

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -2,7 +2,7 @@
 name: benchmark-models
 preamble-tier: 1
 version: 1.0.0
-description: Cross-model benchmark for gstack skills. (gstack)
+description: "Cross-model benchmark for gstack skills. (gstack)"
 triggers:
   - cross model benchmark
   - compare claude gpt gemini

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -2,7 +2,7 @@
 name: benchmark
 preamble-tier: 1
 version: 1.0.0
-description: Performance regression detection using the browse daemon. (gstack)
+description: "Performance regression detection using the browse daemon. (gstack)"
 triggers:
   - performance benchmark
   - check page speed

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -2,7 +2,7 @@
 name: browse
 preamble-tier: 1
 version: 1.1.0
-description: Fast headless browser for QA testing and site dogfooding. (gstack)
+description: "Fast headless browser for QA testing and site dogfooding. (gstack)"
 triggers:
   - browse a page
   - headless browser

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -2,7 +2,7 @@
 name: canary
 preamble-tier: 2
 version: 1.0.0
-description: Post-deploy canary monitoring. (gstack)
+description: "Post-deploy canary monitoring. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/careful/SKILL.md
+++ b/careful/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: careful
 version: 0.1.0
-description: Safety guardrails for destructive commands. (gstack)
+description: "Safety guardrails for destructive commands. (gstack)"
 triggers:
   - be careful
   - warn before destructive

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -2,7 +2,7 @@
 name: codex
 preamble-tier: 3
 version: 1.0.0
-description: OpenAI Codex CLI wrapper — three modes. (gstack)
+description: "OpenAI Codex CLI wrapper — three modes. (gstack)"
 triggers:
   - codex review
   - second opinion

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -2,7 +2,7 @@
 name: context-restore
 preamble-tier: 2
 version: 1.0.0
-description: Restore working context saved earlier by /context-save. (gstack)
+description: "Restore working context saved earlier by /context-save. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -2,7 +2,7 @@
 name: context-save
 preamble-tier: 2
 version: 1.0.0
-description: Save working context. (gstack)
+description: "Save working context. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -2,7 +2,7 @@
 name: cso
 preamble-tier: 2
 version: 2.0.0
-description: Chief Security Officer mode. (gstack)
+description: "Chief Security Officer mode. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -2,7 +2,7 @@
 name: design-consultation
 preamble-tier: 3
 version: 1.0.0
-description: Design consultation: understands your product, researches the landscape, proposes a complete design system (aesthetic, typography, color, layout, spacing, motion), and generates font+color preview... (gstack)
+description: "Design consultation: understands your product, researches the landscape, proposes a complete design system (aesthetic, typography, color, layout, spacing, motion), and generates font+color preview... (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -2,7 +2,7 @@
 name: design-html
 preamble-tier: 2
 version: 1.0.0
-description: Design finalization: generates production-quality Pretext-native HTML/CSS. (gstack)
+description: "Design finalization: generates production-quality Pretext-native HTML/CSS. (gstack)"
 triggers:
   - build the design
   - code the mockup

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -2,7 +2,7 @@
 name: design-review
 preamble-tier: 4
 version: 2.0.0
-description: Designer's eye QA: finds visual inconsistency, spacing issues, hierarchy problems, AI slop patterns, and slow interactions — then fixes them. (gstack)
+description: "Designer's eye QA: finds visual inconsistency, spacing issues, hierarchy problems, AI slop patterns, and slow interactions — then fixes them. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -2,7 +2,7 @@
 name: design-shotgun
 preamble-tier: 2
 version: 1.0.0
-description: Design shotgun: generate multiple AI design variants, open a comparison board, collect structured feedback, and iterate. (gstack)
+description: "Design shotgun: generate multiple AI design variants, open a comparison board, collect structured feedback, and iterate. (gstack)"
 triggers:
   - explore design variants
   - show me design options

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -2,7 +2,7 @@
 name: devex-review
 preamble-tier: 3
 version: 1.0.0
-description: Live developer experience audit. (gstack)
+description: "Live developer experience audit. (gstack)"
 triggers:
   - live dx audit
   - test developer experience

--- a/document-generate/SKILL.md
+++ b/document-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: document-generate
 preamble-tier: 2
 version: 1.0.0
-description: Generate missing documentation from scratch for a feature, module, or entire project. (gstack)
+description: "Generate missing documentation from scratch for a feature, module, or entire project. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -2,7 +2,7 @@
 name: document-release
 preamble-tier: 2
 version: 1.0.0
-description: Post-ship documentation update. (gstack)
+description: "Post-ship documentation update. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/freeze/SKILL.md
+++ b/freeze/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: freeze
 version: 0.1.0
-description: Restrict file edits to a specific directory for the session. (gstack)
+description: "Restrict file edits to a specific directory for the session. (gstack)"
 triggers:
   - freeze edits to directory
   - lock editing scope

--- a/gstack-upgrade/SKILL.md
+++ b/gstack-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gstack-upgrade
 version: 1.1.0
-description: Upgrade gstack to the latest version.
+description: "Upgrade gstack to the latest version."
 triggers:
   - upgrade gstack
   - update gstack version

--- a/guard/SKILL.md
+++ b/guard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: guard
 version: 0.1.0
-description: Full safety mode: destructive command warnings + directory-scoped edits. (gstack)
+description: "Full safety mode: destructive command warnings + directory-scoped edits. (gstack)"
 triggers:
   - full safety mode
   - guard against mistakes

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -2,7 +2,7 @@
 name: health
 preamble-tier: 2
 version: 1.0.0
-description: Code quality dashboard. (gstack)
+description: "Code quality dashboard. (gstack)"
 triggers:
   - code health check
   - quality dashboard

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -2,7 +2,7 @@
 name: investigate
 preamble-tier: 2
 version: 1.0.0
-description: Systematic debugging with root cause investigation. (gstack)
+description: "Systematic debugging with root cause investigation. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/ios-clean/SKILL.md
+++ b/ios-clean/SKILL.md
@@ -2,7 +2,7 @@
 name: ios-clean
 preamble-tier: 3
 version: 1.0.0
-description: Remove the DebugBridge SPM package and all #if DEBUG wiring from an iOS app. (gstack)
+description: "Remove the DebugBridge SPM package and all #if DEBUG wiring from an iOS app. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/ios-design-review/SKILL.md
+++ b/ios-design-review/SKILL.md
@@ -2,7 +2,7 @@
 name: ios-design-review
 preamble-tier: 3
 version: 1.0.0
-description: Visual design audit for iOS apps on real hardware. (gstack)
+description: "Visual design audit for iOS apps on real hardware. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/ios-fix/SKILL.md
+++ b/ios-fix/SKILL.md
@@ -2,7 +2,7 @@
 name: ios-fix
 preamble-tier: 3
 version: 1.0.0
-description: Autonomous iOS bug fixer. (gstack)
+description: "Autonomous iOS bug fixer. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/ios-qa/SKILL.md
+++ b/ios-qa/SKILL.md
@@ -2,7 +2,7 @@
 name: ios-qa
 preamble-tier: 3
 version: 1.0.0
-description: Live-device iOS QA for SwiftUI apps. (gstack)
+description: "Live-device iOS QA for SwiftUI apps. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/ios-sync/SKILL.md
+++ b/ios-sync/SKILL.md
@@ -2,7 +2,7 @@
 name: ios-sync
 preamble-tier: 3
 version: 1.0.0
-description: Regenerate the iOS debug bridge against the latest upstream gstack templates. (gstack)
+description: "Regenerate the iOS debug bridge against the latest upstream gstack templates. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -2,7 +2,7 @@
 name: land-and-deploy
 preamble-tier: 4
 version: 1.0.0
-description: Land and deploy workflow. (gstack)
+description: "Land and deploy workflow. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: landing-report
 version: 0.1.0
-description: Read-only queue dashboard for workspace-aware ship. (gstack)
+description: "Read-only queue dashboard for workspace-aware ship. (gstack)"
 triggers:
   - landing report
   - version queue

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -2,7 +2,7 @@
 name: learn
 preamble-tier: 2
 version: 1.0.0
-description: Manage project learnings.
+description: "Manage project learnings."
 triggers:
   - show learnings
   - what have we learned

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -2,7 +2,7 @@
 name: make-pdf
 preamble-tier: 1
 version: 1.0.0
-description: Turn any markdown file into a publication-quality PDF. (gstack)
+description: "Turn any markdown file into a publication-quality PDF. (gstack)"
 triggers:
   - markdown to pdf
   - generate pdf

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -2,7 +2,7 @@
 name: office-hours
 preamble-tier: 3
 version: 2.0.0
-description: YC Office Hours — two modes. (gstack)
+description: "YC Office Hours — two modes. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: open-gstack-browser
 version: 0.2.0
-description: Launch GStack Browser — AI-controlled Chromium with the sidebar extension baked in.
+description: "Launch GStack Browser — AI-controlled Chromium with the sidebar extension baked in."
 triggers:
   - open gstack browser
   - launch chromium

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pair-agent
 version: 0.1.0
-description: Pair a remote AI agent with your browser. (gstack)
+description: "Pair a remote AI agent with your browser. (gstack)"
 triggers:
   - pair with agent
   - connect remote agent

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -3,7 +3,7 @@ name: plan-ceo-review
 preamble-tier: 3
 interactive: true
 version: 1.0.0
-description: CEO/founder-mode plan review. (gstack)
+description: "CEO/founder-mode plan review. (gstack)"
 benefits-from: [office-hours]
 allowed-tools:
   - Read

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -3,7 +3,7 @@ name: plan-design-review
 preamble-tier: 3
 interactive: true
 version: 2.0.0
-description: Designer's eye plan review — interactive, like CEO and Eng review. (gstack)
+description: "Designer's eye plan review — interactive, like CEO and Eng review. (gstack)"
 allowed-tools:
   - Read
   - Edit

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -3,7 +3,7 @@ name: plan-devex-review
 preamble-tier: 3
 interactive: true
 version: 2.0.0
-description: Interactive developer experience plan review. (gstack)
+description: "Interactive developer experience plan review. (gstack)"
 benefits-from: [office-hours]
 allowed-tools:
   - Read

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -3,7 +3,7 @@ name: plan-eng-review
 preamble-tier: 3
 interactive: true
 version: 1.0.0
-description: Eng manager-mode plan review. (gstack)
+description: "Eng manager-mode plan review. (gstack)"
 benefits-from: [office-hours]
 allowed-tools:
   - Read

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -2,7 +2,7 @@
 name: plan-tune
 preamble-tier: 2
 version: 1.0.0
-description: Self-tuning question sensitivity + developer psychographic for gstack (v1: observational). (gstack)
+description: "Self-tuning question sensitivity + developer psychographic for gstack (v1: observational). (gstack)"
 triggers:
   - tune questions
   - stop asking me that

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -2,7 +2,7 @@
 name: qa-only
 preamble-tier: 4
 version: 1.0.0
-description: Report-only QA testing. (gstack)
+description: "Report-only QA testing. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -2,7 +2,7 @@
 name: qa
 preamble-tier: 4
 version: 2.0.0
-description: Systematically QA test a web application and fix bugs found. (gstack)
+description: "Systematically QA test a web application and fix bugs found. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -2,7 +2,7 @@
 name: retro
 preamble-tier: 2
 version: 2.0.0
-description: Weekly engineering retrospective. (gstack)
+description: "Weekly engineering retrospective. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -2,7 +2,7 @@
 name: review
 preamble-tier: 4
 version: 1.0.0
-description: Pre-landing PR review. (gstack)
+description: "Pre-landing PR review. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/scrape/SKILL.md
+++ b/scrape/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scrape
 version: 1.0.0
-description: Pull data from a web page. (gstack)
+description: "Pull data from a web page. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -342,6 +342,10 @@ export function buildTrimmedDescription(parts: CatalogParts): string {
   return `${lead}${suffix}`;
 }
 
+function yamlInlineString(value: string): string {
+  return JSON.stringify(value);
+}
+
 /** Build the body section that holds the routing/voice prose. */
 export function buildWhenToInvokeSection(parts: CatalogParts): string {
   const lines: string[] = ['## When to invoke this skill', ''];
@@ -398,7 +402,7 @@ export function applyCatalogTrim(content: string, skillName: string): { content:
   // Replace description in frontmatter — keep trailing newline so the next
   // YAML field doesn't collide on the same line as the description value.
   const newDesc = buildTrimmedDescription(parts);
-  const newFrontmatter = frontmatter.replace(descMatch[0], `description: ${newDesc}\n`);
+  const newFrontmatter = frontmatter.replace(descMatch[0], `description: ${yamlInlineString(newDesc)}\n`);
   let newContent = '---\n' + newFrontmatter + content.slice(fmEnd);
 
   // Insert body section after frontmatter (after the closing ---\n and any

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -2,7 +2,7 @@
 name: setup-browser-cookies
 preamble-tier: 1
 version: 1.0.0
-description: Import cookies from your real Chromium browser into the headless browse session. (gstack)
+description: "Import cookies from your real Chromium browser into the headless browse session. (gstack)"
 triggers:
   - import browser cookies
   - login to test site

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -2,7 +2,7 @@
 name: setup-deploy
 preamble-tier: 2
 version: 1.0.0
-description: Configure deployment settings for /land-and-deploy.
+description: "Configure deployment settings for /land-and-deploy."
 triggers:
   - configure deploy
   - setup deployment

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -2,7 +2,7 @@
 name: setup-gbrain
 preamble-tier: 2
 version: 1.0.0
-description: Set up gbrain for this coding agent: install the CLI, initialize a local PGLite or Supabase brain, register MCP, capture per-remote trust policy. (gstack)
+description: "Set up gbrain for this coding agent: install the CLI, initialize a local PGLite or Supabase brain, register MCP, capture per-remote trust policy. (gstack)"
 triggers:
   - setup gbrain
   - install gbrain

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -2,7 +2,7 @@
 name: ship
 preamble-tier: 4
 version: 1.0.0
-description: Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR. (gstack)
+description: "Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/skillify/SKILL.md
+++ b/skillify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skillify
 version: 1.0.0
-description: Codify the most recent successful /scrape flow into a permanent browser-skill on disk. (gstack)
+description: "Codify the most recent successful /scrape flow into a permanent browser-skill on disk. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec
 version: 0.1.0
-description: Turn vague intent into a precise, executable spec in five phases. (gstack)
+description: "Turn vague intent into a precise, executable spec in five phases. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-gbrain
 preamble-tier: 2
 version: 1.0.0
-description: Keep gbrain current with this repo's code and refresh agent search guidance in CLAUDE.md. Wraps the gstack-gbrain-sync orchestrator with state (gstack)
+description: "Keep gbrain current with this repo's code and refresh agent search guidance in CLAUDE.md. Wraps the gstack-gbrain-sync orchestrator with state (gstack)"
 triggers:
   - sync gbrain
   - refresh gbrain

--- a/test/catalog-mode-full.test.ts
+++ b/test/catalog-mode-full.test.ts
@@ -13,7 +13,7 @@
  *      the conditional gate is in the pipeline.
  *   2. Smoke: running with --catalog-mode=full produces a frontmatter
  *      `description: |` block (multi-line) instead of the trim'd one-line
- *      `description: ...(gstack)` form.
+ *      quoted `description: "...(gstack)"` form.
  *
  * The smoke test mutates the working tree mid-run. It restores the default
  * trim'd state in a finally block so a crash mid-test still leaves a clean
@@ -60,7 +60,7 @@ describe('--catalog-mode=full opt-out behavior (smoke)', () => {
   test('--catalog-mode=full produces multi-line description in frontmatter', () => {
     // Save the trim'd state so we can restore it.
     const trimmedShip = fs.readFileSync(SHIP_SKILL, 'utf-8');
-    expect(trimmedShip).toMatch(/^description: Ship workflow:[^\n]*\(gstack\)\n/m);
+    expect(trimmedShip).toMatch(/^description: "Ship workflow:[^\n]*\(gstack\)"\n/m);
 
     try {
       // Run with --catalog-mode=full. Mutates working tree.
@@ -100,7 +100,7 @@ describe('--catalog-mode=full opt-out behavior (smoke)', () => {
       }
       // Sanity-check the restored state matches what we saw at the start.
       const restoredShip = fs.readFileSync(SHIP_SKILL, 'utf-8');
-      expect(restoredShip).toMatch(/^description: Ship workflow:[^\n]*\(gstack\)\n/m);
+      expect(restoredShip).toMatch(/^description: "Ship workflow:[^\n]*\(gstack\)"\n/m);
     }
   }, 180_000);
 

--- a/test/catalog-trim.test.ts
+++ b/test/catalog-trim.test.ts
@@ -227,8 +227,8 @@ Original body content here.
     const result = applyCatalogTrim(minimalSkill, 'example');
     expect(result).not.toBeNull();
     const { content, parts } = result!;
-    // Frontmatter description is now ONE line ending with (gstack)
-    expect(content).toMatch(/^description: Example skill:[^\n]*\(gstack\)\n/m);
+    // Frontmatter description is now one YAML-safe quoted line ending with (gstack)
+    expect(content).toMatch(/^description: "Example skill:[^\n]*\(gstack\)"\n/m);
     // Body has the When to invoke section
     expect(content).toContain('## When to invoke this skill');
     expect(content).toContain('Use when asked to do an example task.');
@@ -257,7 +257,7 @@ Original body content here.
     expect(result).not.toBeNull();
     expect(result!.content).not.toMatch(/\(gstack\)preamble-tier/);
     expect(result!.content).not.toMatch(/\(gstack\)allowed-tools/);
-    expect(result!.content).toMatch(/\(gstack\)\n[a-z-]+:/);
+    expect(result!.content).toMatch(/\(gstack\)"\n[a-z-]+:/);
   });
 
   test('returns null on content without proper frontmatter', () => {

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -2,7 +2,7 @@
 name: ship
 preamble-tier: 4
 version: 1.0.0
-description: Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR. (gstack)
+description: "Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/unfreeze/SKILL.md
+++ b/unfreeze/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: unfreeze
 version: 0.1.0
-description: Clear the freeze boundary set by /freeze, allowing edits to all directories again. (gstack)
+description: "Clear the freeze boundary set by /freeze, allowing edits to all directories again. (gstack)"
 triggers:
   - unfreeze edits
   - unlock all directories


### PR DESCRIPTION
## Summary

This PR fixes Codex skill loading failures caused by generated `SKILL.md` frontmatter descriptions that become invalid YAML after catalog trimming.

When gstack is loaded by Codex, affected skills can be skipped with warnings like:

```text
Skipped loading 8 skill(s) due to invalid SKILL.md files
invalid YAML: mapping values are not allowed in this context
```

The root cause is that the generator converts long block-scalar descriptions into one-line inline YAML values, but some descriptions contain `: `. Without quoting, YAML can parse that colon as a mapping delimiter.

## Example

Before:

```yaml
description: Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR. (gstack)
```

After:

```yaml
description: "Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR. (gstack)"
```

## Changes

- Quote catalog-trimmed inline `description` values in `scripts/gen-skill-docs.ts` so Codex can parse generated skill frontmatter safely.
- Update catalog trim tests to expect YAML-safe quoted inline descriptions.
- Regenerate affected Claude host `SKILL.md` files.
- Update the `claude-ship-SKILL.md` golden fixture.

## Validation

- `bun run gen:skill-docs --host all --dry-run`
- YAML frontmatter parse check across generated `SKILL.md` files
- `git diff --check`
- `bun test`

Note: the existing `ship` token ceiling warning still appears during generation, but the command exits successfully and is unrelated to this Codex YAML loading fix.

## Contribution context

Thank you to the gstack team for building and maintaining this project. I have benefited a lot from using it.

Claude Code is still my primary agent environment, but because my team needs it, I am starting to use Codex as well. In my own projects, I am also beginning to support both Claude Code and Codex at the same time.

I would be happy to keep contributing compatibility fixes for using the gstack skill series from Codex in the future.
