### PR TITLE
fix(bun-polyfill): Windows cookie picker silently fails — Bun.spawn polyfill is missing proc.exited (and three related bugs)

### DIFF
--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -99,11 +99,32 @@ globalThis.Bun = {
     // (~16-64 KB) back-pressures the child until it blocks in write() and
     // `exit` never fires. Eager draining keeps the pipes flowing regardless
     // of read order; replay below is via fresh Web ReadableStreams.
+    //
+    // Cap the buffer so a runaway child can't OOM the server. 16 MB is
+    // generous: DPAPI outputs are tiny, tasklist is <1 KB, and the
+    // browser-skill consumer has its own 1 MB readCapped. Once the cap is
+    // reached we keep draining the pipe (so the child never blocks) but
+    // discard further bytes. Override via GSTACK_SPAWN_MAX_BUFFER (bytes).
+    const MAX_BUFFER = Math.max(
+      0,
+      parseInt(process.env.GSTACK_SPAWN_MAX_BUFFER || '', 10) || 16 * 1024 * 1024,
+    );
     const drain = (stream) => {
-      if (!stream) return { done: Promise.resolve(), chunks: [] };
-      const chunks = [];
+      if (!stream) return { done: Promise.resolve(), chunks: [], truncated: false };
+      const state = { chunks: [], bytes: 0, truncated: false };
       const done = new Promise((resolve) => {
-        stream.on('data', (chunk) => chunks.push(chunk));
+        stream.on('data', (chunk) => {
+          if (state.bytes >= MAX_BUFFER) { state.truncated = true; return; }
+          if (state.bytes + chunk.length <= MAX_BUFFER) {
+            state.chunks.push(chunk);
+            state.bytes += chunk.length;
+          } else {
+            const remaining = MAX_BUFFER - state.bytes;
+            state.chunks.push(chunk.subarray(0, remaining));
+            state.bytes = MAX_BUFFER;
+            state.truncated = true;
+          }
+        });
         // Any terminal event resolves: 'end' on normal close, 'error' on a
         // stream-level error, 'close' as the belt-and-suspenders for spawn
         // failures where Node fires 'close' but neither 'end' nor 'error'.
@@ -111,7 +132,7 @@ globalThis.Bun = {
         stream.once('error', resolve);
         stream.once('close', resolve);
       });
-      return { done, chunks };
+      return { done, chunks: state.chunks };
     };
     const stdoutDrain = drain(proc.stdout);
     const stderrDrain = drain(proc.stderr);

--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -12,7 +12,6 @@
 
 const http = require('http');
 const { spawnSync, spawn } = require('child_process');
-const { Readable } = require('stream');
 
 globalThis.Bun = {
   serve(options) {
@@ -94,34 +93,70 @@ globalThis.Bun = {
       cwd: options.cwd,
     });
 
+    // Drain stdout/stderr eagerly into in-memory buffers. Bun's spawn buffers
+    // these for the consumer; Node's Readables are pull-based, so if the caller
+    // awaits `proc.exited` before reading, anything past the OS pipe buffer
+    // (~16-64 KB) back-pressures the child until it blocks in write() and
+    // `exit` never fires. Eager draining keeps the pipes flowing regardless
+    // of read order; replay below is via fresh Web ReadableStreams.
+    const drain = (stream) => {
+      if (!stream) return { done: Promise.resolve(), chunks: [] };
+      const chunks = [];
+      const done = new Promise((resolve) => {
+        stream.on('data', (chunk) => chunks.push(chunk));
+        stream.once('end', resolve);
+        stream.once('error', resolve);   // exit event carries the real status
+      });
+      return { done, chunks };
+    };
+    const stdoutDrain = drain(proc.stdout);
+    const stderrDrain = drain(proc.stderr);
+
     // Bun's spawn exposes `proc.exited` as a Promise resolving to the exit
     // code; several call sites — DPAPI decryption, isBrowserRunning,
     // browser-skill-commands — `await proc.exited` directly or via
     // Promise.race with a timeout. Without this, those awaits resolve to
     // `undefined` immediately and the operation looks like a silent failure.
+    // Resolve only after both pipes have finished draining so consumers that
+    // read stdout AFTER awaiting exit see the full output, not a partial buffer.
     const exited = new Promise((resolveExited) => {
+      let exitStatus;
       proc.once('exit', (code, signal) => {
         // Match Bun: exit code on normal exit; 128 + signal number on signal;
         // 0 if neither was reported.
-        if (code !== null) resolveExited(code);
-        else if (signal) resolveExited(128 + (require('os').constants.signals[signal] || 0));
-        else resolveExited(0);
+        if (code !== null) exitStatus = code;
+        else if (signal) exitStatus = 128 + (require('os').constants.signals[signal] || 0);
+        else exitStatus = 0;
       });
-      proc.once('error', () => resolveExited(1));
+      proc.once('error', () => {
+        if (exitStatus === undefined) exitStatus = 1;
+      });
+      Promise.all([
+        new Promise((r) => proc.once('exit', r)),
+        stdoutDrain.done,
+        stderrDrain.done,
+      ]).then(() => resolveExited(exitStatus !== undefined ? exitStatus : 0));
     });
 
-    // Bun gives consumers a Web ReadableStream so `new Response(proc.stdout)`
-    // works regardless of read order. With Node's Readable, the stream auto-
-    // drains once the child exits, so `await proc.exited` followed by
-    // `new Response(proc.stdout).text()` throws "body disturbed or locked".
-    // Readable.toWeb hands the consumer a fresh ReadableStream that buffers
-    // until it's read. Falls back to the raw Node stream on Node < 18.
-    const toWeb = (s) => (s && typeof Readable.toWeb === 'function' ? Readable.toWeb(s) : s);
+    // Replay buffered output as a fresh Web ReadableStream. `start()` awaits
+    // the drain before enqueueing so `new Response(proc.stdout).text()` yields
+    // the complete output regardless of whether the consumer reads before or
+    // after awaiting `proc.exited`. Stream is single-shot (locked after one
+    // read), matching Bun's behavior.
+    const replay = (d) => new ReadableStream({
+      async start(controller) {
+        await d.done;
+        for (const chunk of d.chunks) {
+          controller.enqueue(chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk));
+        }
+        controller.close();
+      },
+    });
 
     return {
       pid: proc.pid,
-      stdout: toWeb(proc.stdout),
-      stderr: toWeb(proc.stderr),
+      stdout: replay(stdoutDrain),
+      stderr: replay(stderrDrain),
       stdin: proc.stdin,
       exited,
       unref() { proc.unref(); },

--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -104,8 +104,12 @@ globalThis.Bun = {
       const chunks = [];
       const done = new Promise((resolve) => {
         stream.on('data', (chunk) => chunks.push(chunk));
+        // Any terminal event resolves: 'end' on normal close, 'error' on a
+        // stream-level error, 'close' as the belt-and-suspenders for spawn
+        // failures where Node fires 'close' but neither 'end' nor 'error'.
         stream.once('end', resolve);
-        stream.once('error', resolve);   // exit event carries the real status
+        stream.once('error', resolve);
+        stream.once('close', resolve);
       });
       return { done, chunks };
     };
@@ -131,11 +135,17 @@ globalThis.Bun = {
       proc.once('error', () => {
         if (exitStatus === undefined) exitStatus = 1;
       });
-      Promise.all([
-        new Promise((r) => proc.once('exit', r)),
-        stdoutDrain.done,
-        stderrDrain.done,
-      ]).then(() => resolveExited(exitStatus !== undefined ? exitStatus : 0));
+      // Wait for either 'exit' (normal child lifecycle) or 'error' (spawn
+      // failure — Node fires error without exit when the binary is missing).
+      // Either path resolves the lifecycle promise; without listening to both
+      // a spawn error hangs `await proc.exited` until the consumer's own
+      // timeout fires.
+      const lifecycle = new Promise((r) => {
+        proc.once('exit', r);
+        proc.once('error', r);
+      });
+      Promise.all([lifecycle, stdoutDrain.done, stderrDrain.done])
+        .then(() => resolveExited(exitStatus !== undefined ? exitStatus : 0));
     });
 
     // Replay buffered output as a fresh Web ReadableStream. `start()` awaits

--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -12,6 +12,7 @@
 
 const http = require('http');
 const { spawnSync, spawn } = require('child_process');
+const { Readable } = require('stream');
 
 globalThis.Bun = {
   serve(options) {
@@ -93,11 +94,36 @@ globalThis.Bun = {
       cwd: options.cwd,
     });
 
+    // Bun's spawn exposes `proc.exited` as a Promise resolving to the exit
+    // code; several call sites — DPAPI decryption, isBrowserRunning,
+    // browser-skill-commands — `await proc.exited` directly or via
+    // Promise.race with a timeout. Without this, those awaits resolve to
+    // `undefined` immediately and the operation looks like a silent failure.
+    const exited = new Promise((resolveExited) => {
+      proc.once('exit', (code, signal) => {
+        // Match Bun: exit code on normal exit; 128 + signal number on signal;
+        // 0 if neither was reported.
+        if (code !== null) resolveExited(code);
+        else if (signal) resolveExited(128 + (require('os').constants.signals[signal] || 0));
+        else resolveExited(0);
+      });
+      proc.once('error', () => resolveExited(1));
+    });
+
+    // Bun gives consumers a Web ReadableStream so `new Response(proc.stdout)`
+    // works regardless of read order. With Node's Readable, the stream auto-
+    // drains once the child exits, so `await proc.exited` followed by
+    // `new Response(proc.stdout).text()` throws "body disturbed or locked".
+    // Readable.toWeb hands the consumer a fresh ReadableStream that buffers
+    // until it's read. Falls back to the raw Node stream on Node < 18.
+    const toWeb = (s) => (s && typeof Readable.toWeb === 'function' ? Readable.toWeb(s) : s);
+
     return {
       pid: proc.pid,
-      stdout: proc.stdout,
-      stderr: proc.stderr,
+      stdout: toWeb(proc.stdout),
+      stderr: toWeb(proc.stderr),
       stdin: proc.stdin,
+      exited,
       unref() { proc.unref(); },
       kill(signal) { proc.kill(signal); },
     };

--- a/browse/test/bun-polyfill.test.ts
+++ b/browse/test/bun-polyfill.test.ts
@@ -97,6 +97,30 @@ describe('bun-polyfill', () => {
     expect(result.stdout.toString().trim()).toBe('ready:0');
   });
 
+  // Spawn-failure case: Node emits 'error' but not 'exit' when the binary
+  // is missing, so listening only for 'exit' hangs `await proc.exited`
+  // forever. The lifecycle promise must resolve on either event.
+  test('Bun.spawn proc.exited resolves on spawn failure (missing binary)', async () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      require('${polyfillPath}');
+      (async () => {
+        const p = Bun.spawn(['this-binary-does-not-exist-zzz-' + Date.now()], {
+          stdio: ['ignore', 'pipe', 'pipe']
+        });
+        const code = await Promise.race([
+          p.exited,
+          new Promise((_, r) => setTimeout(() => r(new Error('timeout')), 3000))
+        ]).catch(() => 'TIMEOUT');
+        console.log('exit:' + code);
+      })();
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    // Anything other than 'TIMEOUT' (and ideally a non-zero number) means the
+    // lifecycle promise resolved on the spawn error.
+    const out = result.stdout.toString().trim();
+    expect(out).not.toBe('exit:TIMEOUT');
+    expect(out).toMatch(/^exit:\d+$/);
+  });
+
   // Regression for the pipe-blocking case: if the child writes more than the
   // OS pipe buffer (~16-64 KB) and the polyfill doesn't drain eagerly, the
   // child blocks in write() and `exit` never fires. 1 MB is well past every

--- a/browse/test/bun-polyfill.test.ts
+++ b/browse/test/bun-polyfill.test.ts
@@ -1,8 +1,11 @@
 import { describe, test, expect, afterAll } from 'bun:test';
 import * as path from 'path';
 
-// Load the polyfill into a fresh object (don't clobber globalThis.Bun)
-const polyfillPath = path.resolve(import.meta.dir, '../src/bun-polyfill.cjs');
+// Load the polyfill into a fresh object (don't clobber globalThis.Bun).
+// Forward-slash on Windows so the path interpolates cleanly into the
+// `require('${polyfillPath}')` template literals below — raw backslashes
+// would be interpreted as JS escape sequences in the spawned Node script.
+const polyfillPath = path.resolve(import.meta.dir, '../src/bun-polyfill.cjs').replace(/\\/g, '/');
 
 describe('bun-polyfill', () => {
   // We test the polyfill by requiring it in a subprocess under Node.js
@@ -46,6 +49,52 @@ describe('bun-polyfill', () => {
     expect(lines[0]).toBe('HAS_PID');
     expect(lines[1]).toBe('HAS_KILL');
     expect(lines[2]).toBe('HAS_UNREF');
+  });
+
+  // Bun.spawn parity: `proc.exited` is a Promise resolving to the exit code.
+  // The DPAPI helper and isBrowserRunning both `await proc.exited`; without
+  // it the awaits resolve immediately to `undefined` and the caller reads
+  // stdout before the child has produced it — surfacing as a silent failure.
+  test('Bun.spawn exposes proc.exited that resolves to the exit code', async () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      require('${polyfillPath}');
+      (async () => {
+        const p = Bun.spawn(['node', '-e', 'process.exit(0)'], { stdio: ['ignore', 'ignore', 'ignore'] });
+        console.log(typeof p.exited === 'object' && typeof p.exited.then === 'function' ? 'IS_PROMISE' : 'NOT_PROMISE');
+        console.log('exit:' + await p.exited);
+      })();
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    const lines = result.stdout.toString().trim().split('\n');
+    expect(lines[0]).toBe('IS_PROMISE');
+    expect(lines[1]).toBe('exit:0');
+  });
+
+  test('Bun.spawn proc.exited reflects non-zero exit codes', async () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      require('${polyfillPath}');
+      (async () => {
+        const p = Bun.spawn(['node', '-e', 'process.exit(3)'], { stdio: ['ignore', 'ignore', 'ignore'] });
+        console.log('exit:' + await p.exited);
+      })();
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    expect(result.stdout.toString().trim()).toBe('exit:3');
+  });
+
+  test('Bun.spawn proc.exited resolves before reading stdout (no race)', async () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      require('${polyfillPath}');
+      (async () => {
+        // Real-world pattern: write to stdout, then exit. Awaiting proc.exited
+        // before reading must guarantee the bytes are flushed.
+        const p = Bun.spawn(['node', '-e', 'process.stdout.write("ready"); process.exit(0)'], {
+          stdio: ['ignore', 'pipe', 'ignore']
+        });
+        const code = await p.exited;
+        const out = await new Response(p.stdout).text();
+        console.log(out + ':' + code);
+      })();
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    expect(result.stdout.toString().trim()).toBe('ready:0');
   });
 
   test('Bun.serve creates an HTTP server that responds', async () => {

--- a/browse/test/bun-polyfill.test.ts
+++ b/browse/test/bun-polyfill.test.ts
@@ -97,6 +97,31 @@ describe('bun-polyfill', () => {
     expect(result.stdout.toString().trim()).toBe('ready:0');
   });
 
+  // Regression for the pipe-blocking case: if the child writes more than the
+  // OS pipe buffer (~16-64 KB) and the polyfill doesn't drain eagerly, the
+  // child blocks in write() and `exit` never fires. 1 MB is well past every
+  // OS pipe buffer size. Pre-fix this test hangs forever; post-fix it returns
+  // in <500ms. Bun's default per-test timeout is 5s — generous here.
+  test('Bun.spawn drains large stdout so proc.exited still resolves', async () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      require('${polyfillPath}');
+      (async () => {
+        const ONE_MB = 1024 * 1024;
+        const p = Bun.spawn(
+          ['node', '-e', 'process.stdout.write("x".repeat(' + ONE_MB + ')); process.exit(0)'],
+          { stdio: ['ignore', 'pipe', 'ignore'] }
+        );
+        const code = await Promise.race([
+          p.exited,
+          new Promise((_, r) => setTimeout(() => r(new Error('timeout')), 10000))
+        ]).catch(e => 'TIMEOUT');
+        const out = await new Response(p.stdout).text();
+        console.log(out.length + ':' + code);
+      })().catch((e) => { console.log('THREW:' + e.message); });
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    expect(result.stdout.toString().trim()).toBe('1048576:0');
+  }, 15000);
+
   test('Bun.serve creates an HTTP server that responds', async () => {
     const result = Bun.spawnSync(['node', '-e', `
       require('${polyfillPath}');

--- a/browse/test/bun-polyfill.test.ts
+++ b/browse/test/bun-polyfill.test.ts
@@ -121,6 +121,32 @@ describe('bun-polyfill', () => {
     expect(out).toMatch(/^exit:\d+$/);
   });
 
+  // GSTACK_SPAWN_MAX_BUFFER caps the drain so a runaway child can't OOM the
+  // server. Past the cap, the pipe keeps flowing (child doesn't block) but
+  // further bytes are dropped. Set a small cap, write more than that, assert
+  // the captured stdout equals the cap and the child exits cleanly.
+  test('Bun.spawn caps buffered output at GSTACK_SPAWN_MAX_BUFFER', async () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      process.env.GSTACK_SPAWN_MAX_BUFFER = '${1024}';
+      require('${polyfillPath}');
+      (async () => {
+        // Child writes 10 KB; cap is 1 KB; drained output should be exactly 1 KB
+        // and exit should still resolve cleanly (child not back-pressured to death).
+        const p = Bun.spawn(
+          ['node', '-e', 'process.stdout.write("y".repeat(10 * 1024)); process.exit(0)'],
+          { stdio: ['ignore', 'pipe', 'ignore'] }
+        );
+        const code = await Promise.race([
+          p.exited,
+          new Promise((_, r) => setTimeout(() => r(new Error('timeout')), 3000))
+        ]).catch(() => 'TIMEOUT');
+        const out = await new Response(p.stdout).text();
+        console.log(out.length + ':' + code);
+      })();
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    expect(result.stdout.toString().trim()).toBe('1024:0');
+  });
+
   // Regression for the pipe-blocking case: if the child writes more than the
   // OS pipe buffer (~16-64 KB) and the polyfill doesn't drain eagerly, the
   // child blocks in write() and `exit` never fires. 1 MB is well past every


### PR DESCRIPTION
## TL;DR

On Windows the Node-fallback `Bun.spawn` polyfill was incomplete in four small but compounding ways. The most visible symptom: cookie picker reports `DPAPI decryption failed:` with empty stderr because the PowerShell child never actually gets to run before the caller reads its (still-empty) output.

This PR fills in the gaps — `proc.exited`, eager pipe draining, lifecycle resolves on spawn failure, configurable memory cap. Two files, +130 / -18. Driven through `/codex review`: three iterations caught real bugs in my own first pass; all four commits stay on the branch so the review trail is auditable.

## What broke, in plain English

`browse/src/bun-polyfill.cjs` provides `globalThis.Bun` for the Node-based browse server. (Bun can't drive Playwright's Chromium on Windows, so the server falls back to Node + this shim — see `oven-sh/bun#4253`.) The polyfill claims to give "Bun API equivalents", but `Bun.spawn` skipped four important behaviors:

| # | What's missing | Where it bites |
|---|---|---|
| 1 | `proc.exited` is not a Promise at all | Eight call sites `await proc.exited` directly. Under the polyfill that resolves to `undefined` immediately; caller reads stdout before the child has produced anything. |
| 2 | `stdout`/`stderr` are Node Readables, not Web ReadableStreams | `new Response(proc.stdout).text()` only works in a narrow read order; large output back-pressures the child until it deadlocks on `write()`. |
| 3 | Lifecycle only listens for `'exit'` | Spawn failure (binary missing) fires `'error'` instead — `await proc.exited` then hangs until the consumer's own timeout fires. |
| 4 | Unbounded buffering | Once you eagerly drain to fix #2, you've defeated the consumer's `readCapped`. A runaway child can OOM the server. |

The eight `await proc.exited` call sites are: `cookie-import-browser.ts` lines 545, 581, 649, 783 (DPAPI helper + `isBrowserRunning`), `browser-skill-commands.ts` 194 and 282, `cli.ts:1247`, `terminal-agent.ts:483`.

Most visible to users: the cookie picker's DPAPI helper at `cookie-import-browser.ts:545`. `await Promise.race([proc.exited, timeout])` short-circuits because `exited` is `undefined`, the PowerShell `[ProtectedData]::Unprotect` script never gets called, stdout/stderr are empty when read, and the helper throws `DPAPI decryption failed: ` with nothing after the colon. That's the umbrella symptom in #764.

## The fix

`browse/src/bun-polyfill.cjs`:

- **Add `proc.exited`** — a Promise resolving to the exit code: `code` on normal exit, `128 + signum` on signal, `1` on spawn error.
- **Eagerly drain stdout/stderr** into in-memory chunk arrays via `'data'` events so the OS pipe buffer never fills and the child never blocks on `write()`.
- **Cap the drain at 16 MB by default** (`GSTACK_SPAWN_MAX_BUFFER` env override). Generous for every real call site (DPAPI ~32 B, tasklist <1 KB, codex review ~100 KB) and small enough to bound worst-case memory. Past the cap the pipe keeps flowing but further bytes are dropped, so the child never blocks.
- **Replay drained output** as fresh Web `ReadableStream`s. `start()` awaits the drain before enqueueing so consumers see complete output whether they read before or after awaiting `exited`.
- **Resolve `proc.exited` on `exit` OR `error`** so spawn failures don't hang.

`browse/test/bun-polyfill.test.ts` — six new regression tests covering each scenario. Also a one-line Windows-path-escape fix: the existing `require('${polyfillPath}')` interpolation silently broke on Windows because raw backslashes got JS-escaped in the template literal. Forward-slash normalizing the path fixes it and lets these tests actually run on the windows-free-tests matrix.

## Evidence

Before, on Windows:

```js
require('./browse/src/bun-polyfill.cjs');
const p = Bun.spawn(['node', '-e', 'process.exit(7)'], { stdio: ['ignore','ignore','ignore'] });
console.log('typeof exited:', typeof p.exited);   // undefined
console.log('await:', await p.exited);            // undefined
```

After: `typeof exited: object`, `await: 7`.

DPAPI-equivalent flow (the exact shape of `cookie-import-browser.ts:545`):

```js
const p = Bun.spawn(
  ['node', '-e', 'process.stdout.write("plaintext"); process.exit(0)'],
  { stdio: ['ignore', 'pipe', 'pipe'] }
);
const code = await Promise.race([p.exited, new Promise((_, r) => setTimeout(() => r(new Error('timeout')), 5000))]);
const stdout = await new Response(p.stdout).text();
console.log({ code, stdout });
```

| Branch | `code` | `stdout` | Caller sees |
|---|---|---|---|
| `main` | `undefined` | `''` | `DPAPI decryption failed: ` (empty stderr) |
| this PR | `0` | `'plaintext'` | DPAPI helper returns the decrypted value |

## How this PR was reviewed

Driven through gstack's own `/codex review` adversarial gate. Codex caught three follow-on bugs in my initial pass; each became its own commit:

| Pass | Codex finding | Severity | Fix commit |
|---|---|---|---|
| 1 | `Readable.toWeb()` is pull-based; large output (>16 KB) back-pressures the child to a deadlock. | **P1** | `1d77c85` — eager-drain + replay |
| 2 | Lifecycle only listens for `'exit'`; spawn failure (`'error'`) hangs `await proc.exited`. | P2 | `899b3be` — listen for both events |
| 3 | Unbounded buffering defeats the consumer's `readCapped` at the call site. | P2 | `33143ad` — `GSTACK_SPAWN_MAX_BUFFER` cap |
| 4 | **PASS** — no remaining issues. | — | — |

All four commits kept on the branch (no force-squash) so the review-driven evolution is visible. If preferred for landing, I'll squash on request.

## Tests

- `bun test browse/test/bun-polyfill.test.ts` — 10 pass / 0 fail (6 new + 4 pre-existing)
- `bun test browse/test/cookie-import-browser.test.ts` — 22 pass / 0 fail
- Full `bun test` — passes; the lone `batch.test.ts (unnamed)` `beforeEach`-timeout flake is on `main` and unrelated.

## Notes

- Related to **#764** (Windows cookie import). This PR is the unblocker for the v10/v11 DPAPI path that the picker depends on.
- Related to **#392** (Windows DPAPI + v20 fallback, open + conflicting since March). This PR is strictly scoped to the polyfill so it can land independently of that broader effort.
- The v20 App-Bound Encryption fallback path (`importCookiesViaCdp` at `cookie-import-browser.ts:818`) has two more bugs I discovered but didn't include here: `isBrowserRunning` false-positive against Playwright's bundled `chrome.exe`, and an "all-or-nothing" CDP fallback trigger that never fires on partial v20 failures. Happy to file those as follow-up PRs after this lands so each one stays small and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)