### PR TITLE
fix(learnings): fail closed when cross-project learning lacks trusted field

### DIFF
--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -90,10 +90,13 @@ for (const taggedLine of lines) {
     const isCrossProject = sourceTag === 'cross';
     e._crossProject = isCrossProject;
 
-    // Trust gate: cross-project learnings only loaded if trusted (user-stated)
-    // This prevents prompt injection from one project's AI-generated learnings
-    // silently influencing reviews in another project.
-    if (isCrossProject && e.trusted === false) continue;
+    // Trust gate: cross-project learnings only loaded if explicitly trusted
+    // (user-stated). This prevents prompt injection from one project's
+    // AI-generated learnings silently influencing reviews in another project.
+    // Fail closed: rows missing the trusted field (legacy entries written
+    // before the field existed, hand-edited rows, or rows from other tools)
+    // are treated as untrusted rather than admitted by default.
+    if (isCrossProject && e.trusted !== true) continue;
 
     entries.push(e);
   } catch {}

--- a/test/gstack-learnings-search.test.ts
+++ b/test/gstack-learnings-search.test.ts
@@ -33,6 +33,9 @@ beforeAll(() => {
   const otherEntries = [
     { ts: '2026-05-04T00:00:00Z', skill: 'test', type: 'pattern', key: 'foreign-observed', insight: 'A foreign observed insight', confidence: 8, source: 'observed', trusted: false, files: [] },
     { ts: '2026-05-05T00:00:00Z', skill: 'test', type: 'pattern', key: 'foreign-user', insight: 'A foreign user-stated insight', confidence: 8, source: 'user-stated', trusted: true, files: [] },
+    // Legacy / hand-written / third-party row written before the trusted field
+    // existed: no `trusted` key at all. Must NOT be admitted cross-project.
+    { ts: '2026-05-06T00:00:00Z', skill: 'test', type: 'pattern', key: 'foreign-legacy', insight: 'A foreign legacy insight', confidence: 8, source: 'observed', files: [] },
   ];
   fs.writeFileSync(path.join(projDir, 'learnings.jsonl'), entries.map(e => JSON.stringify(e)).join('\n') + '\n');
   fs.writeFileSync(path.join(otherProjDir, 'learnings.jsonl'), otherEntries.map(e => JSON.stringify(e)).join('\n') + '\n');
@@ -78,5 +81,12 @@ describe('gstack-learnings-search cross-project trust gating', () => {
     expect(out).toContain('foreign-user');
     expect(out).toContain('[cross-project]');
     expect(out).not.toContain('foreign-observed');
+  });
+
+  test('cross-project mode rejects foreign rows missing the trusted field (fail closed)', () => {
+    const out = run(['--cross-project', '--query', 'foreign']);
+    // Legacy/hand-written rows with no `trusted` field must be treated as
+    // untrusted, not admitted by default — otherwise the trust gate fails open.
+    expect(out).not.toContain('foreign-legacy');
   });
 });


### PR DESCRIPTION
Fixes #1745

## Summary
- treat a cross-project learnings row as untrusted unless `trusted === true`
- add a regression test for a foreign row written with no `trusted` field

## Root cause
`gstack-learnings-search --cross-project` documents an allowlist ("cross-project learnings only loaded if trusted (user-stated)") to keep one project's AI-generated learnings from influencing reviews in another. The gate was a denylist:

```js
if (isCrossProject && e.trusted === false) continue;
```

`undefined === false` is `false`, so any cross-project row missing the `trusted` field was admitted. The field was introduced in security wave 3 (#988, 2026-04-13); `gstack-learnings-search` shipped earlier (#622). Rows written before the field existed — plus hand-edited rows and rows from other tools — have no `trusted` key and leak across projects today.

## Fix
Switch the gate to an allowlist (`e.trusted !== true`). Current-format rows are unaffected: `user-stated` rows carry `trusted: true` and still load; everything else carries `trusted: false` and is still excluded. Only rows missing the field change behavior, and they now fail closed.

## Testing
- `bun test test/gstack-learnings-search.test.ts` (6 pass; the new test fails on the pre-fix binary, confirming it guards the regression)
- `bun test test/learnings.test.ts test/learnings-injection.test.ts` (30 pass)
- direct repro on a clean GSTACK_HOME: a foreign `observed` row with no `trusted` field is no longer admitted; a foreign `user-stated`/`trusted: true` row still is
- `git diff --check` clean; `git merge-tree` clean against `origin/main`