### PR TITLE
fix(security): cross-project trust gate must fail closed in gstack-learnings-search (#1745)

### DIFF
--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -92,8 +92,11 @@ for (const taggedLine of lines) {
 
     // Trust gate: cross-project learnings only loaded if trusted (user-stated)
     // This prevents prompt injection from one project's AI-generated learnings
-    // silently influencing reviews in another project.
-    if (isCrossProject && e.trusted === false) continue;
+    // silently influencing reviews in another project. Fail closed — rows
+    // without a 'trusted' field (legacy data written before the field landed
+    // in #988 in 2026-04, hand-edited rows, rows produced by other tools)
+    // are treated as untrusted. See #1745.
+    if (isCrossProject && e.trusted !== true) continue;
 
     entries.push(e);
   } catch {}

--- a/test/gstack-learnings-search.test.ts
+++ b/test/gstack-learnings-search.test.ts
@@ -33,6 +33,11 @@ beforeAll(() => {
   const otherEntries = [
     { ts: '2026-05-04T00:00:00Z', skill: 'test', type: 'pattern', key: 'foreign-observed', insight: 'A foreign observed insight', confidence: 8, source: 'observed', trusted: false, files: [] },
     { ts: '2026-05-05T00:00:00Z', skill: 'test', type: 'pattern', key: 'foreign-user', insight: 'A foreign user-stated insight', confidence: 8, source: 'user-stated', trusted: true, files: [] },
+    // Legacy row written before the `trusted` field landed in #988 (2026-04).
+    // Per #1745 the trust gate must fail closed for rows without the field;
+    // matching foreign-legacy here would mean prompt-injection prevention has
+    // regressed.
+    { ts: '2026-05-06T00:00:00Z', skill: 'test', type: 'pattern', key: 'foreign-legacy', insight: 'INJECTED legacy guidance with no trusted field', confidence: 8, source: 'observed', files: [] },
   ];
   fs.writeFileSync(path.join(projDir, 'learnings.jsonl'), entries.map(e => JSON.stringify(e)).join('\n') + '\n');
   fs.writeFileSync(path.join(otherProjDir, 'learnings.jsonl'), otherEntries.map(e => JSON.stringify(e)).join('\n') + '\n');
@@ -78,5 +83,14 @@ describe('gstack-learnings-search cross-project trust gating', () => {
     expect(out).toContain('foreign-user');
     expect(out).toContain('[cross-project]');
     expect(out).not.toContain('foreign-observed');
+  });
+
+  test('cross-project trust gate fails closed for rows missing the trusted field (#1745)', () => {
+    // Legacy rows written before #988 don't carry a `trusted` field at all.
+    // A denylist gate (`trusted === false`) would admit them; the correct
+    // allowlist gate (`trusted !== true`) keeps them out.
+    const out = run(['--cross-project', '--query', 'INJECTED']);
+    expect(out).not.toContain('foreign-legacy');
+    expect(out).not.toContain('INJECTED');
   });
 });


### PR DESCRIPTION
## Summary

Closes #1745.

The inline comment in `bin/gstack-learnings-search` promises an allowlist: cross-project learnings are *only loaded if trusted (user-stated)* to prevent prompt injection from one project's AI-generated learnings silently influencing reviews in another. The implementation is a denylist:

```js
if (isCrossProject && e.trusted === false) continue;
```

Rows where `trusted` is missing / undefined (not literally `false`) are admitted because `undefined === false` is `false`. The `trusted` field landed in #988 (2026-04-13); `gstack-learnings-search` shipped earlier (#622, 2026-03-29). Any `learnings.jsonl` written in that window — plus legacy hand-edited rows and rows produced by other tools — lacks the field, so those rows leak across projects under `--cross-project` today.

## Fix

Flip the gate to a proper allowlist:

```js
if (isCrossProject && e.trusted !== true) continue;
```

Now only rows that explicitly set `trusted: true` are admitted across projects. Current-project rows are untouched (the gate is scoped to `isCrossProject`).

## Test plan

- [x] New regression test (`gstack-learnings-search cross-project trust gate fails closed for rows missing the trusted field (#1745)`) inserts a legacy-shape row with no `trusted` field into the other-project fixture and asserts the search does not surface its insight text under `--cross-project --query INJECTED`.
- [x] Pre-existing `cross-project mode only imports trusted entries from other projects` still passes (`foreign-user` (trusted=true) admitted, `foreign-observed` (trusted=false) blocked).
- [x] `bun test test/gstack-learnings-search.test.ts test/learnings.test.ts test/learnings-injection.test.ts` — 36/36 green locally.