### PR TITLE
Fix iOS QA first-run SwiftPM manifest blockers

### DIFF
--- a/ios-qa/scripts/gen-accessors-tool/Package.swift
+++ b/ios-qa/scripts/gen-accessors-tool/Package.swift
@@ -31,10 +31,5 @@ let package = Package(
             ],
             path: "Sources/GenAccessors"
         ),
-        .testTarget(
-            name: "GenAccessorsTests",
-            dependencies: ["GenAccessors"],
-            path: "Tests/GenAccessorsTests"
-        ),
     ]
 )

--- a/ios-qa/templates/Package.swift.template
+++ b/ios-qa/templates/Package.swift.template
@@ -1,3 +1,4 @@
+// swift-tools-version:5.9
 // AUTO-GENERATED from gstack/ios-qa/templates/Package.swift.template
 //
 // Drop-in SPM package definition for the DebugBridge stack. Three targets:
@@ -18,7 +19,6 @@
 // CI invariant: `swift build -c release` + `nm -j build/Release/<binary>
 // | grep -q DebugBridge && exit 1`.
 
-// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
@@ -57,11 +57,6 @@ let package = Package(
             swiftSettings: [
                 .define("DEBUG", .when(configuration: .debug)),
             ]
-        ),
-        .testTarget(
-            name: "DebugBridgeCoreTests",
-            dependencies: ["DebugBridgeCore"],
-            path: "Tests/DebugBridgeCoreTests"
         ),
     ]
 )

--- a/test/skill-e2e-ios-swift-build.test.ts
+++ b/test/skill-e2e-ios-swift-build.test.ts
@@ -25,6 +25,7 @@ import { join } from 'path';
 const ROOT = join(import.meta.dir, '..');
 const FIXTURE_PATH = join(ROOT, 'test/fixtures/ios-qa/FixtureApp');
 const TEMPLATES_PATH = join(ROOT, 'ios-qa/templates');
+const GEN_ACCESSORS_PACKAGE = join(ROOT, 'ios-qa/scripts/gen-accessors-tool/Package.swift');
 
 // Parity: canonical Obj-C touch templates must match the fixture's working
 // copy. The fixture is the only place the .m / .h are exercised end-to-end
@@ -58,6 +59,19 @@ describe('template ↔ fixture parity', () => {
     // DebugBridgeUI must depend on the other two; that's how the consuming
     // app gets the transitive set with one dependency entry.
     expect(tmpl).toMatch(/name:\s*"DebugBridgeUI"[\s\S]*?dependencies:\s*\["DebugBridgeCore",\s*"DebugBridgeTouch"\]/);
+  });
+
+  test('generated Swift packages only reference shipped test directories', () => {
+    const genAccessorsPackage = readFileSync(GEN_ACCESSORS_PACKAGE, 'utf-8');
+    const debugBridgePackage = readFileSync(join(TEMPLATES_PATH, 'Package.swift.template'), 'utf-8');
+
+    expect(genAccessorsPackage).not.toContain('Tests/GenAccessorsTests');
+    expect(debugBridgePackage).not.toContain('Tests/DebugBridgeCoreTests');
+  });
+
+  test('Package.swift.template keeps swift-tools-version on the first line', () => {
+    const tmpl = readFileSync(join(TEMPLATES_PATH, 'Package.swift.template'), 'utf-8');
+    expect(tmpl.split(/\r?\n/, 1)[0]).toBe('// swift-tools-version:5.9');
   });
 });
 


### PR DESCRIPTION
## Summary

This fixes the P0 SwiftPM manifest blockers from issue #1735:

- Remove the `GenAccessorsTests` test target from `ios-qa/scripts/gen-accessors-tool/Package.swift` because the shipped skill does not include `Tests/GenAccessorsTests`.
- Move `// swift-tools-version:5.9` to line 1 of `ios-qa/templates/Package.swift.template` so SwiftPM accepts the rendered DebugBridge package manifest.
- Remove the `DebugBridgeCoreTests` test target from `ios-qa/templates/Package.swift.template` because the codegen output does not create `Tests/DebugBridgeCoreTests`.
- Add regression coverage for both invariants.

This intentionally only addresses the P0 first-run blockers from #1735 (#3, #5, #6). The remaining issues in that report should stay open for follow-up PRs.

## Root Cause

SwiftPM validates every declared target path before building a selected target, so missing test target directories break first-run setup even when the user is only trying to build the production tool/package. The rendered DebugBridge package also failed manifest parsing because SwiftPM requires the tools-version directive to be the first line of `Package.swift`.

## Validation

- `bun test test/skill-e2e-ios-swift-build.test.ts -t "template"`
- `swift package describe --package-path ios-qa/scripts/gen-accessors-tool --type json`
- Rendered `ios-qa/templates/Package.swift.template` into a temporary DebugBridge package with dummy source directories and verified `swift package describe --type json` returns `tools_version: "5.9"` and the three DebugBridge targets/products.
- `git diff --check`