### PR TITLE
[codex] Fix Claude Code auth preflight for Codex host

### DIFF
--- a/claude/SKILL.md.tmpl
+++ b/claude/SKILL.md.tmpl
@@ -42,18 +42,10 @@ CLAUDE_BIN=$(command -v claude 2>/dev/null || echo "")
 If `NOT_FOUND`, stop and tell the user:
 "Claude CLI not found. Install Claude Code, then re-run this skill."
 
-Check auth:
-
-```bash
-if [ -f "$HOME/.claude/.credentials.json" ] || [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-  echo "AUTH_FOUND"
-else
-  echo "AUTH_MISSING"
-fi
-```
-
-If `AUTH_MISSING`, stop and tell the user:
-"No Claude authentication found. Run `claude` interactively to log in, or export `ANTHROPIC_API_KEY`, then re-run this skill."
+Do not preflight Claude authentication by checking credential files. Claude Code
+may store login state in OS keychain or another host-managed location that is not
+visible to this skill. Treat the first `claude -p` invocation as the auth check,
+then surface any login/auth failure from its JSON or stderr output.
 
 ---
 
@@ -117,10 +109,14 @@ except Exception as exc:
     print(f"CLAUDE_JSON_PARSE_ERROR: {exc}")
     sys.exit(0)
 
+result = obj.get("result") or obj.get("response") or ""
+result_lower = result.lower()
+
 if obj.get("is_error"):
     print("CLAUDE_ERROR: true")
+    if any(term in result_lower for term in ("auth", "login", "unauthorized", "not logged in")):
+        print("CLAUDE_AUTH_ERROR: true")
 
-result = obj.get("result") or obj.get("response") or ""
 if result:
     print(result)
 
@@ -137,7 +133,8 @@ if session_id:
 PY
 ```
 
-If stderr contains `auth`, `login`, or `unauthorized`, tell the user:
+If the parsed output contains `CLAUDE_AUTH_ERROR: true`, or stderr contains
+`auth`, `login`, `unauthorized`, or `not logged in`, tell the user:
 "Claude authentication failed. Run `claude` interactively to authenticate or export `ANTHROPIC_API_KEY`."
 
 ---
@@ -324,8 +321,7 @@ rm -f "$PROMPT_FILE" "$RESP_FILE" "$ERR_FILE"
 ## Error Handling
 
 - **Binary not found:** Stop with install instructions.
-- **Auth missing:** Stop with login/API key instructions.
-- **Auth failure from stderr:** Surface the stderr line and ask the user to re-authenticate.
+- **Auth failure from Claude output or stderr:** Surface the auth line and ask the user to re-authenticate.
 - **JSON parse failure:** Show raw stdout from `$RESP_FILE` and stderr from `$ERR_FILE`.
 - **Empty response:** Tell the user "Claude returned no response. Check stderr for errors."
 - **Resume failure:** Delete `.context/claude-session-id` and retry with a fresh session.

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1725,6 +1725,8 @@ describe('Codex generation (--host codex)', () => {
     expect(content).toContain('--allowedTools Read,Grep,Glob');
     expect(content).toContain('--disallowedTools Bash,Edit,Write');
     expect(content).toContain('is_error');
+    expect(content).toContain('CLAUDE_AUTH_ERROR');
+    expect(content).not.toContain('.credentials.json');
   });
 
   test('Codex review step stripped from Codex-host ship and review', () => {


### PR DESCRIPTION
## Summary

Fix the Codex-hosted `gstack-claude` skill so it does not reject a working Claude Code install just because `$HOME/.claude/.credentials.json` is absent.

With increased use of Codex, I have been experimenting heavily with the gstack setup and trying to smooth out the Codex <-> Claude Code handoff. This came from that dogfooding: `claude -p` works in the host environment even when `.credentials.json` is absent.

## Root Cause

The generated Codex skill preflighted Claude authentication by probing an implementation detail: `$HOME/.claude/.credentials.json` or `ANTHROPIC_API_KEY`. Modern Claude Code auth may be stored in OS Keychain or another host-managed location, so credential-file probing can false-negative before the skill ever invokes Claude.

## Fix

- Remove the `.credentials.json` authentication preflight.
- Treat the first `claude -p` invocation as the real auth check.
- Parse Claude JSON output so `is_error` still surfaces `CLAUDE_ERROR: true`, and auth/login failures also surface `CLAUDE_AUTH_ERROR: true`.
- Keep the generated Codex regression test from reintroducing `.credentials.json` probing.

## Safety Boundary

The safety boundary is unchanged:

- review/challenge modes still run tool-less Claude calls
- consult mode remains read-only with `Read,Grep,Glob`
- `Bash`, `Edit`, and `Write` remain disallowed

## Validation

- `claude -p "Reply with exactly OK." --output-format json --disable-slash-commands --tools ""` returned `result: "OK"` when run with host auth/keychain access.
- `bun test test/gen-skill-docs.test.ts -t "Codex output includes Claude outside-voice skill"`
- `bun run scripts/gen-skill-docs.ts --host codex --dry-run`
- `git diff --check`