### PR TITLE
[codex] Fix ship qa-only path for Codex host

### DIFF
--- a/hosts/codex.ts
+++ b/hosts/codex.ts
@@ -29,6 +29,7 @@ const codex: HostConfig = {
     { from: '.claude/skills/gstack', to: '.agents/skills/gstack' },
     { from: '.claude/skills/review', to: '.agents/skills/gstack/review' },
     { from: '.claude/skills', to: '.agents/skills' },
+    { from: '${CLAUDE_SKILL_DIR}/../qa-only/SKILL.md', to: '$GSTACK_ROOT/../gstack-qa-only/SKILL.md' },
   ],
 
   suppressedResolvers: [

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1737,6 +1737,12 @@ describe('Codex generation (--host codex)', () => {
     expect(reviewContent).not.toContain('CODEX_REVIEWS');
   });
 
+  test('Codex ship plan verification loads qa-only from gstack root', () => {
+    const shipContent = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-ship', 'SKILL.md'), 'utf-8');
+    expect(shipContent).toContain('$GSTACK_ROOT/../gstack-qa-only/SKILL.md');
+    expect(shipContent).not.toContain('${CLAUDE_SKILL_DIR}/../qa-only/SKILL.md');
+  });
+
   test('--host codex --dry-run freshness', () => {
     const result = Bun.spawnSync(['bun', 'run', 'scripts/gen-skill-docs.ts', '--host', 'codex', '--dry-run'], {
       cwd: ROOT,
@@ -1842,8 +1848,8 @@ describe('Codex generation (--host codex)', () => {
     }
   });
 
-  test('all four path rewrite rules produce correct output', () => {
-    // Test each of the 4 path rewrite rules individually
+  test('Codex path rewrite rules produce correct output', () => {
+    // Test host-configured path rewrite rules individually
     const content = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-review', 'SKILL.md'), 'utf-8');
 
     // Rule 1: ~/.claude/skills/gstack → $GSTACK_ROOT


### PR DESCRIPTION
## Summary

Fixes the generated Codex-host `/ship` skill so plan verification loads `/qa-only` from the Codex gstack skill layout.

## Related context

This is part of the same Codex-host compatibility cleanup series as the earlier Codex adaptation PR. The prior PR handled Codex-specific auth/preflight behavior; this PR addresses a separate generated-skill path issue in `/ship` plan verification.

## Root cause

`/ship` plan verification was still emitting the Claude-specific `${CLAUDE_SKILL_DIR}/../qa-only/SKILL.md` lookup. In Codex installs, generated skills are prefixed siblings like `gstack-qa-only`, and the runtime preamble exposes `$GSTACK_ROOT`, so the Claude-only path cannot resolve.

## What changed

- Add a Codex host path rewrite for `${CLAUDE_SKILL_DIR}/../qa-only/SKILL.md`.
- Keep Claude-host output unchanged.
- Add a Codex generation regression test for `gstack-ship`.

## CI note

The earlier draft head touched `scripts/resolvers/review.ts`, which caused review/design eval shards to run on a fork PR without API secrets and fail with `error_api`. The current head avoids that shared resolver touch; the rerun shows all E2E/LLM eval jobs passing, including the previously failing `e2e-design` and `e2e-review` shards.

The only remaining red job is `report`, which fails while posting the PR comment with `GraphQL: Resource not accessible by integration (addComment)`. That is the known fork PR comment-permission limitation rather than a test failure.

## Validation

- `bun test test/gen-skill-docs.test.ts` — 390 pass
- `bun test test/codex-hardening.test.ts` — 29 pass
- `bun run gen:skill-docs --host codex --dry-run` — all Codex skills FRESH
- `bun run eval:select --base origin/main` — E2E 0/165, LLM-judge 0/28 affected
- GitHub CI on `67af98f`: Skill Docs Freshness, Workflow Lint, Windows Free Tests, and all E2E/LLM eval shards pass
- `git diff --check`