### PR TITLE
fix(design/variants): surface real 240s timeout in AbortError message

### DIFF
--- a/design/src/variants.ts
+++ b/design/src/variants.ts
@@ -125,7 +125,7 @@ export async function generateVariant(
     } catch (err: any) {
       clearTimeout(timeout);
       if (err.name === "AbortError") {
-        return { path: outputPath, success: false, error: "Timeout (120s)" };
+        return { path: outputPath, success: false, error: "Timeout (240s)" };
       }
       lastError = err.message;
     }

--- a/design/test/variants-retry-after.test.ts
+++ b/design/test/variants-retry-after.test.ts
@@ -130,4 +130,56 @@ describe("generateVariant Retry-After handling", () => {
     const gap = calls[1].ts - calls[0].ts;
     expect(gap).toBeLessThan(500);
   });
+
+  test("AbortError surfaces the actual configured 240s timeout in the error message", async () => {
+    // Regression: `generateVariant`'s `setTimeout` aborts at 240_000 ms
+    // (240s) but the AbortError branch returned `"Timeout (120s)"`. A
+    // user staring at the failure has no way to know whether to bump
+    // the orchestrator timeout, retry, or drop the call — the message
+    // is off by 2x. Force the abort path and assert the surfaced
+    // string matches the real bound.
+    const fetchFn = (async (_input: any, init?: any): Promise<Response> => {
+      const signal = init?.signal as AbortSignal | undefined;
+      return await new Promise((_resolve, reject) => {
+        if (signal?.aborted) {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+          return;
+        }
+        signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    }) as typeof globalThis.fetch;
+
+    const originalSetTimeout = globalThis.setTimeout;
+    // Force the 240_000 ms timer to fire on the next event-loop tick
+    // so the test runs in milliseconds instead of 4 minutes. Only the
+    // 240_000 ms timer maps to fast; the leading exponential delays
+    // (2_000+ ms on retry) keep their real value via this branch
+    // because attempt 0 never sleeps.
+    const fastSetTimeout = ((handler: any, timeout?: number, ...rest: any[]): any => {
+      if (timeout === 240_000) {
+        return originalSetTimeout(handler, 0, ...rest);
+      }
+      return originalSetTimeout(handler, timeout as number, ...rest);
+    }) as typeof globalThis.setTimeout;
+    (globalThis as any).setTimeout = fastSetTimeout;
+
+    try {
+      const result = await generateVariant(
+        "fake-key", "prompt", outputPath, "1024x1024", "high", fetchFn,
+      );
+
+      expect(result.success).toBe(false);
+      // Critical: the message MUST report 240s (the real bound), not
+      // 120s (the pre-fix mismatched literal).
+      expect(result.error).toBe("Timeout (240s)");
+    } finally {
+      (globalThis as any).setTimeout = originalSetTimeout;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`generateVariant` in `design/src/variants.ts` arms its abort timer at `240_000` ms:

```ts
const timeout = setTimeout(() => controller.abort(), 240_000);
```

but the AbortError branch returns `"Timeout (120s)"` — half the actual bound:

```ts
} catch (err: any) {
  clearTimeout(timeout);
  if (err.name === "AbortError") {
    return { path: outputPath, success: false, error: "Timeout (120s)" };
  }
```

A user staring at `Timeout (120s)` has no way to know whether to bump the orchestrator timeout, retry, or drop the call — the surfaced number is off by 2x from the timer that fired. This is purely a stale string literal, but it's the only signal a caller gets when the OpenAI Responses API stalls.

No linked issue — caught while auditing `design/src/` after #1773 (the `gpt-image-2` regression).

## Fix

One-line literal correction in `variants.ts:128`: `"Timeout (120s)"` -> `"Timeout (240s)"`.

## Regression test

Adds a test to the existing `design/test/variants-retry-after.test.ts` that:

1. Stubs `fetch` to return a permanently-pending promise wired to the AbortSignal.
2. Monkey-patches `setTimeout` to fast-forward ONLY the `240_000` ms abort timer (delegating all other delays — including the retry-loop exponential backoff — to the real `setTimeout` so other behaviors aren't affected).
3. Awaits the resulting AbortError branch and asserts `result.error === "Timeout (240s)"`.

Without the fix this test fails with the pre-fix `"Timeout (120s)"` literal.

## Validation

```
$ bun test design/test/variants-retry-after.test.ts
 6 pass
 0 fail
 21 expect() calls
Ran 6 tests across 1 file. [8.05s]
```

(The existing 5 retry-after tests still pass; the new 6th test is the regression pin for the AbortError branch.)

## AI assistance disclosure

Patch was drafted with AI assistance. Diff hand-reviewed against `variants.ts:61` (the abort timer) and `variants.ts:128` (the error branch); test exercises the actual AbortError code path rather than asserting the literal directly so a future timeout change keeps the message and the timer in lockstep.