### PR TITLE
fix(taste): rejected preferences must carry rejection-strength confidence

### DIFF
--- a/bin/gstack-taste-update
+++ b/bin/gstack-taste-update
@@ -196,9 +196,14 @@ function bumpPref(list: Preference[], value: string, opposite: Preference[], act
     entry.rejected_count += 1;
   }
   entry.last_seen = now;
-  // Laplace-smoothed confidence
+  // Laplace-smoothed confidence in THIS bucket's signal: an approved entry's
+  // confidence reflects how strongly it's approved, a rejected entry's how
+  // strongly it's rejected. Using approved_count for both buckets pinned every
+  // rejected entry to 0 (rejected entries never gain approvals), which made the
+  // `show` ranking meaningless and the taste-drift warning unreachable.
   const total = entry.approved_count + entry.rejected_count;
-  entry.confidence = entry.approved_count / (total + 1);
+  const ownCount = action === 'approved' ? entry.approved_count : entry.rejected_count;
+  entry.confidence = ownCount / (total + 1);
   // Flag conflict if the opposite bucket has a strong entry for this value
   const opp = opposite.find(p => p.value.toLowerCase() === value.toLowerCase());
   if (opp && opp.approved_count + opp.rejected_count >= 3 && opp.confidence >= 0.6) {

--- a/test/taste-engine.test.ts
+++ b/test/taste-engine.test.ts
@@ -141,6 +141,35 @@ describe('taste-engine: Laplace-smoothed confidence', () => {
     expect(rejected.rejected_count).toBe(1);
     expect(rejected.approved_count).toBe(0);
   });
+
+  test('repeated rejections raise rejected confidence toward 1', () => {
+    for (let i = 0; i < 5; i++) {
+      run(['rejected', `variant-${i}`, '--reason', 'fonts: Comic Sans']);
+    }
+    const p = readProfile();
+    const pref = p.dimensions.fonts.rejected[0];
+    expect(pref.rejected_count).toBe(5);
+    // Confidence reflects this bucket's signal: 5 / (5 + 0 + 1) = 0.833.
+    // Pre-fix this was approved_count/(total+1) = 0/6 = 0 for every rejected entry.
+    expect(pref.confidence).toBeCloseTo(5 / 6, 5);
+  });
+
+  test('show ranks rejections by strength, not insertion order', () => {
+    run(['rejected', 'weak', '--reason', 'colors: beige']);
+    for (let i = 0; i < 4; i++) {
+      run(['rejected', `strong-${i}`, '--reason', 'colors: crimson']);
+    }
+    const r = run(['show']);
+    expect(r.status).toBe(0);
+    // The strongly-rejected value must rank above the weakly-rejected one even
+    // though it was inserted second. Pre-fix both keys were 0, so the sort was a
+    // no-op and "beige" (inserted first) won.
+    const crimsonIdx = r.stdout.indexOf('crimson');
+    const beigeIdx = r.stdout.indexOf('beige');
+    expect(crimsonIdx).toBeGreaterThanOrEqual(0);
+    expect(beigeIdx).toBeGreaterThanOrEqual(0);
+    expect(crimsonIdx).toBeLessThan(beigeIdx);
+  });
 });
 
 describe('taste-engine: decay math', () => {
@@ -308,6 +337,19 @@ describe('taste-engine: taste drift conflict detection', () => {
     const r = run(['approved', 'v1', '--reason', 'fonts: Inter']);
     expect(r.status).toBe(0);
     expect(r.stderr).not.toContain('taste drift');
+  });
+
+  test('drift warning fires from real CLI rejections (no seeding)', () => {
+    // Build the opposite signal through the real CLI: 4 rejections take confidence
+    // to 4/5 = 0.8, above the 0.6 drift threshold. Pre-fix every rejected entry was
+    // pinned to confidence 0, so this branch was unreachable without hand-seeding.
+    for (let i = 0; i < 4; i++) {
+      run(['rejected', `variant-${i}`, '--reason', 'fonts: Comic Sans']);
+    }
+    const r = run(['approved', 'v-approve', '--reason', 'fonts: Comic Sans']);
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain('taste drift');
+    expect(r.stderr).toContain('Comic Sans');
   });
 });
 


### PR DESCRIPTION
## Repro / observed problem

In `bin/gstack-taste-update`, every preference in a `rejected` bucket is permanently stored with `confidence: 0`, regardless of how many times the value is rejected. On upstream main (19770ea8):

```
$ gstack-taste-update rejected v1 --reason "colors: crimson"   # x3
$ gstack-taste-update rejected vx --reason "colors: beige"     # x1
$ gstack-taste-update show
[colors]
  rejected:
    crimson — conf 0.00 (+0/-3)
    beige — conf 0.00 (+0/-1)
```

## Root cause

`bumpPref()` computed confidence as approval rate for **both** buckets:

```ts
const total = entry.approved_count + entry.rejected_count;
entry.confidence = entry.approved_count / (total + 1);
```

The approved and rejected lists are disjoint, so a rejected-bucket entry only ever gets `rejected_count` incremented — `approved_count` stays 0 and `confidence` is always `0`. That broke three things:

1. `show` prints `conf 0.00` for every rejection.
2. `show` ranks rejections by `confidence * rejected_count` = `0` for all, so the top-3 is insertion order, not the strongest rejections.
3. The taste-drift warning (`opp.confidence >= 0.6`) is unreachable through real CLI use. The existing test only passed it by hand-seeding `confidence: 0.8` via `writeProfile`, with a comment admitting the natural value is `0/5`.

## Fix

Compute confidence from this bucket's own count:

```ts
const total = entry.approved_count + entry.rejected_count;
const ownCount = action === 'approved' ? entry.approved_count : entry.rejected_count;
entry.confidence = ownCount / (total + 1);
```

Approved-bucket confidence is unchanged (there `total === approved_count`, so `approved_count/(total+1)` is identical). Rejected entries now reflect rejection strength, so `crimson` (3 rejections) → 0.75 and `beige` (1) → 0.50, the ranking orders by strength, and the drift warning fires after enough real rejections.

## Testing

`bun test test/taste-engine.test.ts` — 22 pass (19 existing + 3 new). Added:

- `repeated rejections raise rejected confidence toward 1` (5 rejections → 5/6)
- `show ranks rejections by strength, not insertion order`
- `drift warning fires from real CLI rejections (no seeding)`

All three **fail on main** and pass with this change. Verified `git diff --check` clean and `git merge-tree --write-tree HEAD origin/main` merges cleanly.

Fixes #1776