### PR TITLE
fix(make-pdf): render emoji instead of tofu (▯) in PDFs

### DIFF
--- a/make-pdf/src/print-css.ts
+++ b/make-pdf/src/print-css.ts
@@ -20,6 +20,11 @@
  *   - No <link>, no external CSS/fonts — everything inlined.
  *   - CJK fallback: Helvetica, Liberation Sans, Arial, Hiragino Kaku Gothic
  *     ProN, Noto Sans CJK JP, Microsoft YaHei, sans-serif.
+ *   - Emoji fallback: the body font stack ends in an emoji family
+ *     ("Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji") so
+ *     Chromium has a glyph source for emoji code points instead of
+ *     emitting .notdef tofu (▯). On Linux this requires an installed
+ *     emoji font — `setup` installs fonts-noto-color-emoji for that.
  */
 
 export interface PrintCssOptions {
@@ -84,7 +89,7 @@ function pageRules(size: string, margin: string, opts: PrintCssOptions): string 
     `  size: ${size};`,
     `  margin: ${margin};`,
     runningHeader
-      ? `  @top-center { content: "${runningHeader}"; font-family: Helvetica, "Liberation Sans", Arial, sans-serif; font-size: 9pt; color: #666; }`
+      ? `  @top-center { content: "${runningHeader}"; font-family: Helvetica, "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji"; font-size: 9pt; color: #666; }`
       : ``,
     showPageNumbers
       ? `  @bottom-center { content: counter(page) " of " counter(pages); font-family: Helvetica, "Liberation Sans", Arial, sans-serif; font-size: 9pt; color: #666; }`
@@ -107,7 +112,7 @@ function rootTypography(): string {
   return [
     `html { lang: en; }`,
     `body {`,
-    `  font-family: Helvetica, "Liberation Sans", Arial, "Hiragino Kaku Gothic ProN", "Noto Sans CJK JP", "Microsoft YaHei", sans-serif;`,
+    `  font-family: Helvetica, "Liberation Sans", Arial, "Hiragino Kaku Gothic ProN", "Noto Sans CJK JP", "Microsoft YaHei", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji";`,
     `  font-size: 11pt;`,
     `  line-height: 1.5;`,
     `  color: #111;`,

--- a/setup
+++ b/setup
@@ -433,6 +433,61 @@ if ! ensure_playwright_browser; then
   exit 1
 fi
 
+# 2b. Ensure an emoji font is installed (Linux only).
+#
+# Chromium renders emoji code points as .notdef "tofu" (▯) when no emoji
+# font is installed. macOS ships "Apple Color Emoji" and Windows ships
+# "Segoe UI Emoji", so they're fine out of the box. Most Linux distros and
+# containers ship NO emoji font, which is why make-pdf output shows tofu in
+# headers/tables that contain emoji. Install Noto Color Emoji to fix it.
+#
+# Best-effort: warn (don't fail) if we can't install — PDFs still generate,
+# they just fall back to tofu for emoji as before.
+ensure_emoji_font() {
+  # Already have an emoji font? (fontconfig knows about Noto Color Emoji)
+  if command -v fc-list >/dev/null 2>&1; then
+    if fc-list 2>/dev/null | grep -qiE 'noto color emoji|noto emoji|symbola|emojione|twemoji'; then
+      return 0
+    fi
+  fi
+
+  local sudo=""
+  if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+    sudo="sudo"
+  fi
+
+  if command -v apt-get >/dev/null 2>&1; then
+    echo "Installing emoji font (fonts-noto-color-emoji) so make-pdf emoji render..."
+    $sudo apt-get update -qq >/dev/null 2>&1 || true
+    $sudo apt-get install -y -qq fonts-noto-color-emoji >/dev/null 2>&1 || return 1
+  elif command -v dnf >/dev/null 2>&1; then
+    echo "Installing emoji font (google-noto-emoji-color-fonts)..."
+    $sudo dnf install -y google-noto-emoji-color-fonts >/dev/null 2>&1 || return 1
+  elif command -v pacman >/dev/null 2>&1; then
+    echo "Installing emoji font (noto-fonts-emoji)..."
+    $sudo pacman -Sy --noconfirm noto-fonts-emoji >/dev/null 2>&1 || return 1
+  elif command -v apk >/dev/null 2>&1; then
+    echo "Installing emoji font (font-noto-emoji)..."
+    $sudo apk add --no-cache font-noto-emoji >/dev/null 2>&1 || return 1
+  else
+    return 1
+  fi
+
+  # Refresh fontconfig cache so Chromium picks up the new font.
+  command -v fc-cache >/dev/null 2>&1 && fc-cache -f >/dev/null 2>&1 || true
+  return 0
+}
+
+if [ "$IS_WINDOWS" -eq 0 ] && [ "$(uname -s)" != "Darwin" ]; then
+  if ! ensure_emoji_font; then
+    echo "  Note: could not auto-install an emoji font. Emoji in make-pdf" >&2
+    echo "  output may render as boxes (▯). Install one manually, e.g.:" >&2
+    echo "    Debian/Ubuntu: sudo apt-get install fonts-noto-color-emoji" >&2
+    echo "    Fedora:        sudo dnf install google-noto-emoji-color-fonts" >&2
+    echo "    Arch:          sudo pacman -S noto-fonts-emoji" >&2
+  fi
+fi
+
 # 3. Ensure ~/.gstack global state directory exists
 mkdir -p "$HOME/.gstack/projects"
 


### PR DESCRIPTION
## Problem

`make-pdf` renders **emoji code points as tofu boxes (▯)** in output PDFs. Standard typographic and mathematical Unicode (em-dash `—`, multiplication `×`, arrow `→`, bullet `•`, ellipsis `…`, smart quotes `" "`) all render **correctly** — only emoji break.

This is very visible in practice: documents use emoji heavily in section headers and table status/signal columns, so the broken glyphs are all over the page.

### Evidence (verbatim from a broken PDF, `Creator: Chromium, Producer: Skia/PDF`)

Renders fine:
- `@izebel_eth — Identity Dossier` (em-dash)
- `GStack × GBrain Hackathon` (×)
- `network (izebel → cascaintern → tradinghoex)` (→)
- `quant • run by @tradinghoex` (•)

Renders broken (emoji → ▯):
- Header: `▯ BOT & COLLUSION EVIDENCE` (was 🚨)
- Table: `138.8x  ▯ Extreme bot`, `4.6x ▯ Suspicious`, `Low followers ▯ Ratio`

## Root cause

Classic missing emoji-font fallback in headless Chromium:
1. The print CSS `body` font stack (`Helvetica, "Liberation Sans", Arial, … sans-serif`) had **no emoji family**, so Chromium had nothing to fall back to for emoji code points.
2. Even with a fallback declared, **most Linux distros/containers ship no emoji font at all**, so Skia emits `.notdef` (tofu) for every emoji.

macOS ships *Apple Color Emoji* and Windows ships *Segoe UI Emoji*, so they're unaffected — this is a Linux/container bug.

## Fix

- **`make-pdf/src/print-css.ts`** — append `"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji"` to the body and running-header font stacks so Chromium has an emoji glyph source on every platform.
- **`setup`** — add `ensure_emoji_font()`: best-effort install of an emoji font on Linux (`fonts-noto-color-emoji` via apt, with dnf/pacman/apk fallbacks), then refresh the fontconfig cache. It **warns rather than fails** if it can't install, so setup never breaks on this.

## Behavior

- macOS / Windows: no change (emoji font already present).
- Linux: real emoji glyphs after `setup` instead of ▯.
- Non-emoji Unicode: unchanged (already worked).

## Testing

- `bash -n setup` passes.
- `ensure_emoji_font` short-circuits if `fc-list` already reports an emoji font, so it's idempotent and cheap on re-runs.

Reported by Garry — these PDFs "always have broken Unicode for special characters and emojis."