### PR TITLE
fix(config): preserve spaces in config values

### DIFF
--- a/bin/gstack-config
+++ b/bin/gstack-config
@@ -248,6 +248,16 @@ resolve_user_slug() {
   printf '%s' "$_slug"
 }
 
+read_config_value() {
+  local key="$1"
+  if [ ! -f "$CONFIG_FILE" ]; then
+    return 0
+  fi
+  grep -E "^${key}:" "$CONFIG_FILE" 2>/dev/null \
+    | tail -1 \
+    | sed -E "s/^${key}:[[:space:]]*//; s/[[:space:]]+$//"
+}
+
 case "${1:-}" in
   get)
     KEY="${2:?Usage: gstack-config get <key>}"
@@ -257,8 +267,7 @@ case "${1:-}" in
       echo "Error: key must contain only alphanumeric characters, underscores, and an optional @<hex-hash> suffix" >&2
       exit 1
     fi
-    # Use literal match for keys containing @ (sha hashes), regex otherwise
-    VALUE=$(grep -F "${KEY}:" "$CONFIG_FILE" 2>/dev/null | grep -E "^${KEY%@*}(@[a-f0-9]+)?:" | grep -F "${KEY}:" | tail -1 | awk '{print $2}' | tr -d '[:space:]' || true)
+    VALUE=$(read_config_value "$KEY" || true)
     if [ -z "$VALUE" ]; then
       VALUE=$(lookup_default "$KEY")
     fi
@@ -307,14 +316,15 @@ case "${1:-}" in
     if [ ! -f "$CONFIG_FILE" ]; then
       printf '%s' "$CONFIG_HEADER" > "$CONFIG_FILE"
     fi
-    # Escape sed special chars in value and drop embedded newlines
-    ESC_VALUE="$(printf '%s' "$VALUE" | head -1 | sed 's/[&/\]/\\&/g')"
+    # Drop embedded newlines, then escape sed replacement metacharacters.
+    SAFE_VALUE="$(printf '%s' "$VALUE" | head -1)"
+    ESC_VALUE="$(printf '%s' "$SAFE_VALUE" | sed 's/[&/\]/\\&/g')"
     if grep -qE "^${KEY}:" "$CONFIG_FILE" 2>/dev/null; then
       # Portable in-place edit (BSD sed uses -i '', GNU sed uses -i without arg)
       _tmpfile="$(mktemp "${CONFIG_FILE}.XXXXXX")"
       sed "/^${KEY}:/s/.*/${KEY}: ${ESC_VALUE}/" "$CONFIG_FILE" > "$_tmpfile" && mv "$_tmpfile" "$CONFIG_FILE"
     else
-      echo "${KEY}: ${VALUE}" >> "$CONFIG_FILE"
+      echo "${KEY}: ${SAFE_VALUE}" >> "$CONFIG_FILE"
     fi
     # Auto-relink skills when prefix setting changes (skip during setup to avoid recursive call)
     if [ "$KEY" = "skill_prefix" ] && [ -z "${GSTACK_SETUP_RUNNING:-}" ]; then
@@ -332,7 +342,7 @@ case "${1:-}" in
                skill_prefix checkpoint_mode checkpoint_push explain_level \
                codex_reviews gstack_contributor skip_eng_review workspace_root \
                artifacts_sync_mode artifacts_sync_mode_prompted plan_tune_hooks; do
-      VALUE=$(grep -E "^${KEY}:" "$CONFIG_FILE" 2>/dev/null | tail -1 | awk '{print $2}' | tr -d '[:space:]' || true)
+      VALUE=$(read_config_value "$KEY" || true)
       SOURCE="default"
       if [ -n "$VALUE" ]; then
         SOURCE="set"

--- a/test/explain-level-config.test.ts
+++ b/test/explain-level-config.test.ts
@@ -88,3 +88,20 @@ describe('gstack-config explain_level', () => {
     expect(run('get', 'explain_level').stdout).toBe('default');
   });
 });
+
+describe('gstack-config values with spaces', () => {
+  test('workspace_root preserves internal spaces on set/get/list', () => {
+    const value = path.join(os.tmpdir(), 'Conductor Workspaces');
+    expect(run('set', 'workspace_root', value).status).toBe(0);
+
+    expect(run('get', 'workspace_root').stdout).toBe(value);
+
+    const listed = run('list');
+    expect(listed.status).toBe(0);
+    expect(
+      listed.stdout
+        .split('\n')
+        .some((line) => line.includes('workspace_root:') && line.includes(value) && line.includes('(set)')),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve everything after `key:` when `gstack-config get` reads config values, instead of taking only the second whitespace-delimited field
- Reuse the same reader for `gstack-config list` active values
- Add a regression test for `workspace_root` values containing spaces

Fixes #1782

## Root cause
`gstack-config get` used `awk '{print $2}'`, which silently truncated values like `workspace_root: /tmp/Conductor Workspaces` to `/tmp/Conductor`. `gstack-next-version` consumes `workspace_root` for sibling worktree scanning, so configured roots with spaces were ignored.

## Tests
- `bun test test/explain-level-config.test.ts test/docs-config-keys.test.ts`
- `bun test test/gstack-next-version.test.ts test/brain-sync.test.ts test/explain-level-config.test.ts`
- `bash -n bin/gstack-config`
- `git diff --check`
- Direct repro: `gstack-config set workspace_root "/tmp/Conductor Workspaces"` then `get workspace_root` returns the full path

## Collision checks
Searched open and closed issues/PRs for `workspace_root space`, `gstack-config config.yaml space`, and open PRs touching `gstack-config`. No existing issue or canonical PR covered this truncation bug.
