### PR TITLE
fix(gen-skill-docs): quote frontmatter descriptions containing colons

### DIFF
--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -2,7 +2,7 @@
 name: design-consultation
 preamble-tier: 3
 version: 1.0.0
-description: Design consultation: understands your product, researches the landscape, proposes a complete design system (aesthetic, typography, color, layout, spacing, motion), and generates font+color preview... (gstack)
+description: "Design consultation: understands your product, researches the landscape, proposes a complete design system (aesthetic, typography, color, layout, spacing, motion), and generates font+color preview... (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -2,7 +2,7 @@
 name: design-html
 preamble-tier: 2
 version: 1.0.0
-description: Design finalization: generates production-quality Pretext-native HTML/CSS. (gstack)
+description: "Design finalization: generates production-quality Pretext-native HTML/CSS. (gstack)"
 triggers:
   - build the design
   - code the mockup

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -2,7 +2,7 @@
 name: design-review
 preamble-tier: 4
 version: 2.0.0
-description: Designer's eye QA: finds visual inconsistency, spacing issues, hierarchy problems, AI slop patterns, and slow interactions — then fixes them. (gstack)
+description: "Designer's eye QA: finds visual inconsistency, spacing issues, hierarchy problems, AI slop patterns, and slow interactions — then fixes them. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -2,7 +2,7 @@
 name: design-shotgun
 preamble-tier: 2
 version: 1.0.0
-description: Design shotgun: generate multiple AI design variants, open a comparison board, collect structured feedback, and iterate. (gstack)
+description: "Design shotgun: generate multiple AI design variants, open a comparison board, collect structured feedback, and iterate. (gstack)"
 triggers:
   - explore design variants
   - show me design options

--- a/guard/SKILL.md
+++ b/guard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: guard
 version: 0.1.0
-description: Full safety mode: destructive command warnings + directory-scoped edits. (gstack)
+description: "Full safety mode: destructive command warnings + directory-scoped edits. (gstack)"
 triggers:
   - full safety mode
   - guard against mistakes

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -2,7 +2,7 @@
 name: plan-tune
 preamble-tier: 2
 version: 1.0.0
-description: Self-tuning question sensitivity + developer psychographic for gstack (v1: observational). (gstack)
+description: "Self-tuning question sensitivity + developer psychographic for gstack (v1: observational). (gstack)"
 triggers:
   - tune questions
   - stop asking me that

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -323,6 +323,20 @@ export function buildWhenToInvokeSection(parts: CatalogParts): string {
  * Returns the rewritten content plus the parts (used for proactive-suggestions
  * JSON aggregation at the end of the run).
  */
+/**
+ * Render a string as a single-line YAML scalar for frontmatter. A plain scalar
+ * is invalid YAML when it contains ": " / a trailing ":" (read as a mapping
+ * separator) or starts with an indicator character, so quote those cases with a
+ * double-quoted scalar (escaping backslash and double-quote). Descriptions
+ * commonly contain colons (e.g. "Set up gbrain: install the CLI"), which made
+ * strict loaders (Codex/OpenAI skill loading) reject the generated SKILL.md.
+ */
+export function toYamlPlainOrQuoted(value: string): string {
+  const needsQuoting = /:(\s|$)/.test(value) || /^[!&*?|>@`"'#%,\[\]{}\- ]/.test(value);
+  if (!needsQuoting) return value;
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 export function applyCatalogTrim(content: string, skillName: string): { content: string; parts: CatalogParts } | null {
   // Locate description block in frontmatter
   if (!content.startsWith('---\n')) return null;
@@ -355,7 +369,7 @@ export function applyCatalogTrim(content: string, skillName: string): { content:
   // Replace description in frontmatter — keep trailing newline so the next
   // YAML field doesn't collide on the same line as the description value.
   const newDesc = buildTrimmedDescription(parts);
-  const newFrontmatter = frontmatter.replace(descMatch[0], `description: ${newDesc}\n`);
+  const newFrontmatter = frontmatter.replace(descMatch[0], `description: ${toYamlPlainOrQuoted(newDesc)}\n`);
   let newContent = '---\n' + newFrontmatter + content.slice(fmEnd);
 
   // Insert body section after frontmatter (after the closing ---\n and any

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -2,7 +2,7 @@
 name: setup-gbrain
 preamble-tier: 2
 version: 1.0.0
-description: Set up gbrain for this coding agent: install the CLI, initialize a local PGLite or Supabase brain, register MCP, capture per-remote trust policy. (gstack)
+description: "Set up gbrain for this coding agent: install the CLI, initialize a local PGLite or Supabase brain, register MCP, capture per-remote trust policy. (gstack)"
 triggers:
   - setup gbrain
   - install gbrain

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -2,7 +2,7 @@
 name: ship
 preamble-tier: 4
 version: 1.0.0
-description: Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR. (gstack)
+description: "Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR. (gstack)"
 allowed-tools:
   - Bash
   - Read


### PR DESCRIPTION
## Description

Closes #1778.

`applyCatalogTrim` in `scripts/gen-skill-docs.ts` rewrites the trimmed catalog description back into SKILL.md frontmatter as a **plain** YAML scalar:

```yaml
description: Set up gbrain for this coding agent: install the CLI, ... (gstack)
```

When the description contains `": "` (or a trailing colon), a strict YAML parser reads the second colon as a mapping separator and rejects the document:

```
invalid YAML: mapping values are not allowed in this context
```

Codex/OpenAI skill loading uses a strict parser, so every affected skill was silently skipped.

## Change

- Add `toYamlPlainOrQuoted(value)`: returns the value unchanged when it is a valid plain scalar, otherwise emits a double-quoted scalar (escaping `\` and `"`). Quoting triggers only on `: ` / trailing colon / leading YAML indicator chars, so existing colon-free descriptions are byte-for-byte unchanged.
- Use it at the trim rewrite site.
- Regenerated SKILL.md for the 8 skills whose descriptions contain colons (design-consultation, design-html, design-review, design-shotgun, guard, plan-tune, setup-gbrain, ship).

## Testing

- `bun test test/gen-skill-docs.test.ts` — 389 pass (incl. per-host `--dry-run` freshness across all hosts).
- `bun test test/skill-validation.test.ts` — 329 pass.
- Regenerated docs are fresh (`gen:skill-docs` for claude/codex/factory and the remaining hosts produces no further diff).