### PR TITLE
fix(extension): withhold auth token from content-script getPort callers

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -299,7 +299,13 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
 
   if (msg.type === 'getPort') {
-    sendResponse({ port: serverPort, connected: isConnected, token: authToken });
+    // Withhold the auth token from content-script callers (content scripts have
+    // sender.tab set), mirroring the getToken guard below. port/connected stay
+    // available to any extension context, but the localhost auth token is never
+    // handed to an injected page context — without this guard getPort leaks the
+    // exact token getToken is careful to protect.
+    const token = sender.tab ? null : authToken;
+    sendResponse({ port: serverPort, connected: isConnected, token });
     return true;
   }
 


### PR DESCRIPTION
## Summary

**Bug:** A content script can ask `extension/background.js` for the localhost auth token and get it.

**Root cause:** The `chrome.runtime.onMessage` listener has two paths that hand back the token. `getToken` already guards it (`if (sender.tab)` → `token: null`), so content scripts get nothing. `getPort`, a few lines above, returns `{ port, connected, token: authToken }` to every caller. The top-level `sender.id !== chrome.runtime.id` check only rejects *other* extensions, not this extension's own content scripts, so a content script that sends `getPort` receives the same token `getToken` deliberately withholds.

## Fix

Apply the same `sender.tab` guard to `getPort`, matching the adjacent `getToken` precedent in `extension/background.js`. `port` and `connected` stay available to any extension context; `token` is `null` for content-script callers.

## Test plan

- [x] 1 file changed, +7/-1.
- [x] Sidepanel and popup callers (no `sender.tab`) are unchanged; they still get the token.
- [x] Verified by inspection against the adjacent `getToken` guard. `extension/` has no automated test harness in the repo today, and `bun test` doesn't cover `extension/`, so Tier 1 stays green.

Happy to rebase, or to factor the shared `sender.tab` guard into a helper alongside `getToken` if you'd prefer that over duplicating the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
