### PR TITLE
fix(browse): apply --no-sandbox to headed launch sites (root/container)

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -342,17 +342,9 @@ export class BrowserManager {
     // BROWSE_EXTENSIONS_DIR points to an unpacked Chrome extension directory.
     // Extensions only work in headed mode, so we use an off-screen window.
     const extensionsDir = process.env.BROWSE_EXTENSIONS_DIR;
-    const { STEALTH_LAUNCH_ARGS } = await import('./stealth');
-    const launchArgs: string[] = [...STEALTH_LAUNCH_ARGS];
+    const { STEALTH_LAUNCH_ARGS, sandboxDisableArgs } = await import('./stealth');
+    const launchArgs: string[] = [...STEALTH_LAUNCH_ARGS, ...sandboxDisableArgs()];
     let useHeadless = true;
-
-    // Docker/CI/root: Chromium sandbox requires unprivileged user namespaces which
-    // are typically disabled in containers and are never available for the root
-    // user on Linux. Detect all three cases and add --no-sandbox automatically.
-    const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
-    if (process.env.CI || process.env.CONTAINER || isRoot) {
-      launchArgs.push('--no-sandbox');
-    }
 
     if (extensionsDir) {
       // Skip --load-extension when running against a custom Chromium build that
@@ -435,12 +427,16 @@ export class BrowserManager {
     this.nextTabId = 1;
 
     // Find the gstack extension directory for auto-loading
+    const { sandboxDisableArgs } = await import('./stealth');
     const extensionPath = this.findExtensionPath();
     const launchArgs = [
       '--hide-crash-restore-bubble',
       // Anti-bot-detection: remove the navigator.webdriver flag that Playwright sets.
       // Sites like Google and NYTimes check this to block automation browsers.
       '--disable-blink-features=AutomationControlled',
+      // Docker/CI/root: disable the Chromium sandbox when unavailable, otherwise
+      // headed mode aborts at launch as root even though headless succeeds.
+      ...sandboxDisableArgs(),
     ];
     if (extensionPath) {
       // Skip --load-extension when running against a custom Chromium build
@@ -1555,8 +1551,9 @@ export class BrowserManager {
     try {
       const fs = require('fs');
       const path = require('path');
+      const { sandboxDisableArgs } = await import('./stealth');
       const extensionPath = this.findExtensionPath();
-      const launchArgs = ['--hide-crash-restore-bubble'];
+      const launchArgs = ['--hide-crash-restore-bubble', ...sandboxDisableArgs()];
       if (extensionPath) {
         launchArgs.push(`--disable-extensions-except=${extensionPath}`);
         launchArgs.push(`--load-extension=${extensionPath}`);

--- a/browse/src/stealth.ts
+++ b/browse/src/stealth.ts
@@ -194,6 +194,28 @@ export const STEALTH_LAUNCH_ARGS = [
   '--disable-blink-features=AutomationControlled',
 ];
 
+/**
+ * Chromium's setuid sandbox requires unprivileged user namespaces, which are
+ * typically disabled in containers (Docker/CI) and are NEVER available for the
+ * root user on Linux. In those cases Chromium aborts at launch with
+ * "Chromium sandboxing failed!" / the process closes immediately. Detect all
+ * three cases and disable the sandbox so launches succeed.
+ *
+ * Returns `['--no-sandbox']` when sandboxing is known to be unavailable,
+ * otherwise an empty array. Spread this into a chromium launch's `args`.
+ *
+ * This must be applied to EVERY launch site — headless `launch()`, headed
+ * `launchHeaded()`, and the extension-reload handoff — otherwise headed mode
+ * crashes as root even though headless works.
+ */
+export function sandboxDisableArgs(): string[] {
+  const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+  if (process.env.CI || process.env.CONTAINER || isRoot) {
+    return ['--no-sandbox'];
+  }
+  return [];
+}
+
 /** Test-only helper: report whether extended mode is currently active. */
 export function isExtendedStealthEnabled(): boolean {
   return extendedModeEnabled();

--- a/browse/test/sandbox-disable-args.test.ts
+++ b/browse/test/sandbox-disable-args.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { sandboxDisableArgs } from '../src/stealth';
+
+// Snapshot + restore the env vars the helper reads, so tests don't leak state.
+const ORIG = {
+  CI: process.env.CI,
+  CONTAINER: process.env.CONTAINER,
+};
+
+function clearEnv() {
+  delete process.env.CI;
+  delete process.env.CONTAINER;
+}
+
+afterEach(() => {
+  // restore
+  if (ORIG.CI === undefined) delete process.env.CI; else process.env.CI = ORIG.CI;
+  if (ORIG.CONTAINER === undefined) delete process.env.CONTAINER; else process.env.CONTAINER = ORIG.CONTAINER;
+});
+
+describe('sandboxDisableArgs', () => {
+  test('returns --no-sandbox when CONTAINER is set', () => {
+    clearEnv();
+    process.env.CONTAINER = '1';
+    expect(sandboxDisableArgs()).toContain('--no-sandbox');
+  });
+
+  test('returns --no-sandbox when CI is set', () => {
+    clearEnv();
+    process.env.CI = 'true';
+    expect(sandboxDisableArgs()).toContain('--no-sandbox');
+  });
+
+  test('returns --no-sandbox when running as root (uid 0)', () => {
+    clearEnv();
+    const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+    // Only assert the root branch when the test process is actually root
+    // (true in the CI/container image). On a normal dev box uid!=0, so we
+    // assert the negative branch instead.
+    if (isRoot) {
+      expect(sandboxDisableArgs()).toContain('--no-sandbox');
+    } else {
+      expect(sandboxDisableArgs()).toEqual([]);
+    }
+  });
+
+  test('returns [] when not container/CI and not root', () => {
+    clearEnv();
+    const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+    if (!isRoot) {
+      expect(sandboxDisableArgs()).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The `browse` daemon's **headless** launch path disables the Chromium sandbox automatically when it can't be used (CI, container, or running as root). The **headed** paths do not. So when the daemon runs headed as root inside a container — e.g. driving a virtual X display (`Xvfb`) for screenshots/automation — Chromium aborts immediately at launch:

```
[browse] Server failed to start:
[browse] Failed to start: persistentContext: Target page, context or browser has been closed
Browser logs:
  - [pid=...][err] Chromium sandboxing failed!
  - <process did exit: exitCode=1>
```

Headless mode works in the exact same environment; only headed mode crashes. That asymmetry makes headed-on-Xvfb effectively unusable in containers without manually patching the binary.

## Root Cause

`browser-manager.ts` had the sandbox-disable detection inline in `launch()` (the headless path):

```ts
const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
if (process.env.CI || process.env.CONTAINER || isRoot) {
  launchArgs.push('--no-sandbox');
}
```

But `launchHeaded()` and the extension-reload handoff built their own `launchArgs` arrays and never added `--no-sandbox`. Three launch sites, only one of them sandbox-aware.

## Solution

Extract the detection into a single shared helper `sandboxDisableArgs()` in `stealth.ts` (which already centralizes launch args), and apply it at **all three** launch sites:

```ts
// stealth.ts
export function sandboxDisableArgs(): string[] {
  const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
  if (process.env.CI || process.env.CONTAINER || isRoot) {
    return ['--no-sandbox'];
  }
  return [];
}
```

| Launch site | Before | After |
|---|---|---|
| `launch()` (headless) | inline `--no-sandbox` block | `...sandboxDisableArgs()` |
| `launchHeaded()` | no sandbox handling ❌ | `...sandboxDisableArgs()` ✅ |
| extension-reload handoff | no sandbox handling ❌ | `...sandboxDisableArgs()` ✅ |

This also de-duplicates the inline block `launch()` previously carried. Behavior is unchanged on dev machines (non-root, no CI/CONTAINER env): the helper returns `[]`, so the sandbox stays enabled.

## Testing

- New unit test `browse/test/sandbox-disable-args.test.ts` covers all branches (CONTAINER set, CI set, root uid, and the negative case). `bun test` → 4 pass / 0 fail.
- `tsc --noEmit` clean.
- Verified end-to-end: with this change, headed Chromium launches successfully against `Xvfb :99` as root in a container (`DISPLAY=:99 CONTAINER=1`), and element screenshots render correctly. Without it, the same launch crashes with "Chromium sandboxing failed!".

## Notes

`--no-sandbox` is only added when the sandbox is genuinely unavailable (container/CI/root). A local daemon driving user-specified URLs has marginal sandbox benefit in those environments, and this matches the policy `launch()` already applied for the headless path.