### PR TITLE
fix: quote SKILL.md description values containing colons

### DIFF
--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -2,7 +2,7 @@
 name: design-consultation
 preamble-tier: 3
 version: 1.0.0
-description: Design consultation: understands your product, researches the landscape, proposes a complete design system (aesthetic, typography, color, layout, spacing, motion), and generates font+color preview... (gstack)
+description: "Design consultation: understands your product, researches the landscape, proposes a complete design system (aesthetic, typography, color, layout, spacing, motion), and generates font+color preview... (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -2,7 +2,7 @@
 name: design-html
 preamble-tier: 2
 version: 1.0.0
-description: Design finalization: generates production-quality Pretext-native HTML/CSS. (gstack)
+description: "Design finalization: generates production-quality Pretext-native HTML/CSS. (gstack)"
 triggers:
   - build the design
   - code the mockup

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -2,7 +2,7 @@
 name: design-review
 preamble-tier: 4
 version: 2.0.0
-description: Designer's eye QA: finds visual inconsistency, spacing issues, hierarchy problems, AI slop patterns, and slow interactions — then fixes them. (gstack)
+description: "Designer's eye QA: finds visual inconsistency, spacing issues, hierarchy problems, AI slop patterns, and slow interactions — then fixes them. (gstack)"
 allowed-tools:
   - Bash
   - Read

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -2,7 +2,7 @@
 name: design-shotgun
 preamble-tier: 2
 version: 1.0.0
-description: Design shotgun: generate multiple AI design variants, open a comparison board, collect structured feedback, and iterate. (gstack)
+description: "Design shotgun: generate multiple AI design variants, open a comparison board, collect structured feedback, and iterate. (gstack)"
 triggers:
   - explore design variants
   - show me design options

--- a/guard/SKILL.md
+++ b/guard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: guard
 version: 0.1.0
-description: Full safety mode: destructive command warnings + directory-scoped edits. (gstack)
+description: "Full safety mode: destructive command warnings + directory-scoped edits. (gstack)"
 triggers:
   - full safety mode
   - guard against mistakes

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -2,7 +2,7 @@
 name: plan-tune
 preamble-tier: 2
 version: 1.0.0
-description: Self-tuning question sensitivity + developer psychographic for gstack (v1: observational). (gstack)
+description: "Self-tuning question sensitivity + developer psychographic for gstack (v1: observational). (gstack)"
 triggers:
   - tune questions
   - stop asking me that

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -2,7 +2,7 @@
 name: setup-gbrain
 preamble-tier: 2
 version: 1.0.0
-description: Set up gbrain for this coding agent: install the CLI, initialize a local PGLite or Supabase brain, register MCP, capture per-remote trust policy. (gstack)
+description: "Set up gbrain for this coding agent: install the CLI, initialize a local PGLite or Supabase brain, register MCP, capture per-remote trust policy. (gstack)"
 triggers:
   - setup gbrain
   - install gbrain

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -2,7 +2,7 @@
 name: ship
 preamble-tier: 4
 version: 1.0.0
-description: Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR. (gstack)
+description: "Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR. (gstack)"
 allowed-tools:
   - Bash
   - Read


### PR DESCRIPTION
## Problem

8 SKILL.md files have `description` frontmatter values containing `: ` (colon + space), which strict YAML parsers interpret as a new mapping key — causing this error:

```
invalid YAML: mapping values are not allowed in this context
```

Affected skills: `design-html`, `design-consultation`, `design-review`, `design-shotgun`, `guard`, `plan-tune`, `setup-gbrain`, `ship`

This breaks any tool that uses a strict YAML parser to load SKILL.md files (confirmed with OpenAI Codex CLI, which uses js-yaml in strict mode).

## Fix

Wrap the affected `description` values in double quotes so the colon is unambiguously part of the string value, not a mapping indicator.

**Before:**
```yaml
description: Design finalization: generates production-quality Pretext-native HTML/CSS. (gstack)
```

**After:**
```yaml
description: "Design finalization: generates production-quality Pretext-native HTML/CSS. (gstack)"
```

## Test

```python
import yaml
# parses cleanly with PyYAML, js-yaml, and other strict parsers
yaml.safe_load('description: "Design finalization: generates foo"')
```