### PR TITLE
fix(setup): add missing gen:skill-docs:user script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev:make-pdf": "bun run make-pdf/src/cli.ts",
     "dev:design": "bun run design/src/cli.ts",
     "gen:skill-docs": "bun run scripts/gen-skill-docs.ts",
+    "gen:skill-docs:user": "bun run scripts/gen-skill-docs.ts --respect-detection",
     "dev": "bun run browse/src/cli.ts",
     "server": "bun run browse/src/server.ts",
     "test": "bun test browse/test/ test/ make-pdf/test/ --ignore 'test/skill-e2e-*.test.ts' --ignore test/skill-llm-eval.test.ts --ignore test/skill-routing-e2e.test.ts --ignore test/codex-e2e.test.ts --ignore test/gemini-e2e.test.ts && (bun run slop:diff 2>/dev/null || true)",


### PR DESCRIPTION
## What

Adds the `gen:skill-docs:user` npm script that `setup` and `scripts/gen-skill-docs.ts` already expect but `package.json` never defined.

```json
"gen:skill-docs:user": "bun run scripts/gen-skill-docs.ts --respect-detection",
```

## Why

On machines where gbrain is installed, `./setup` regenerates the Claude-host SKILL.md files with un-suppressed brain-aware blocks by calling `bun run gen:skill-docs:user --host claude` (setup:1297). That script was missing, so the step failed with:

```
error: Script not found "gen:skill-docs:user"
```

The failure was non-fatal (setup continued and reported "ready"), but the brain-aware blocks were silently skipped — gbrain-equipped machines never got the regenerated planning skills with gbrain context blocks.

`scripts/gen-skill-docs.ts:40-41` documents the intended mapping: `gen:skill-docs:user` == `gen:skill-docs --respect-detection`. This PR just wires it up.

## Verification

```
$ bun run gen:skill-docs:user --host claude
... TOTAL 64237 lines ~802764 tokens
EXIT=0
```

Surfaced while upgrading a global install from v1.52.0.0 → v1.54.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)