### PR TITLE
fix(diff-scope): detect backend code in .mjs/.cjs/.mts/.cts files

### DIFF
--- a/bin/gstack-diff-scope
+++ b/bin/gstack-diff-scope
@@ -75,7 +75,7 @@ while IFS= read -r f; do
 
     # Backend: everything else that's code (excluding views/components already matched)
     *.rb|*.py|*.go|*.rs|*.java|*.php|*.ex|*.exs) BACKEND=true ;;
-    *.ts|*.js) BACKEND=true ;;  # Non-component TS/JS is backend
+    *.ts|*.mts|*.cts|*.js|*.mjs|*.cjs) BACKEND=true ;;  # Non-component TS/JS is backend (incl. ESM .mjs/.mts + CJS .cjs/.cts)
   esac
 done <<< "$FILES"
 

--- a/test/diff-scope.test.ts
+++ b/test/diff-scope.test.ts
@@ -84,6 +84,17 @@ describe('gstack-diff-scope', () => {
     expect(scope.SCOPE_TESTS).toBe('true');
   });
 
+  test('detects backend via ESM/CJS extensions (.mjs/.cjs/.mts/.cts)', () => {
+    // Pure-ESM Node projects ship backend code as .mjs/.cjs (and explicit-module
+    // TypeScript as .mts/.cts). These must register as backend so the review
+    // army's backend/security reviewers fire on such changes.
+    for (const f of ['server.mjs', 'helper.cjs', 'mod.mts', 'legacy.cts']) {
+      const dir = createRepo([f]);
+      const scope = runScope(dir);
+      expect(scope.SCOPE_BACKEND).toBe('true');
+    }
+  });
+
   // --- New scope signals (Review Army) ---
 
   test('detects migrations via db/migrate/', () => {


### PR DESCRIPTION
## Problem

`bin/gstack-diff-scope` feeds scope signals to the Review Army (`scripts/resolvers/review-army.ts`, `review.ts`) so it knows which specialist reviewers to launch. Backend detection only matched `*.ts` and `*.js`:

```sh
*.ts|*.js) BACKEND=true ;;
```

`.mjs` (ESM), `.cjs` (CommonJS), and `.mts`/`.cts` (explicit-module TypeScript) match neither glob — and no other category — so a change touching only those files yields **all-false** scope flags. Result: the backend and security reviewers never fire for pure-ESM Node projects.

## Root cause

The backend case never listed the module-system-explicit JS/TS extensions. `server.mjs` does not match `*.js` (the string must end in `.js`).

## Fix

Purely additive — extends the existing backend case. No file that was previously classified changes classification:

```sh
*.ts|*.mts|*.cts|*.js|*.mjs|*.cjs) BACKEND=true ;;
```

## Testing

```
$ bun test test/diff-scope.test.ts
 16 pass  0 fail
```

Added a regression test asserting `server.mjs` / `helper.cjs` / `mod.mts` / `legacy.cts` each set `SCOPE_BACKEND=true`. Verified before/after:

| file | before | after |
|------|--------|-------|
| `server.mjs` | `SCOPE_BACKEND=false` | `SCOPE_BACKEND=true` |
| `helper.cjs` | `false` | `true` |
| `mod.mts` | `false` | `true` |
| `legacy.cts` | `false` | `true` |
| `server.ts` / `server.js` | `true` | `true` (unchanged) |

Fixes #1810

🤖 Generated with [Claude Code](https://claude.com/claude-code)