### PR TITLE
fix(ship): absolute bin path for gstack-next-version in landing-report/land-and-deploy/review

### DIFF
--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -1159,7 +1159,7 @@ BASE_VERSION=$(git show origin/$BASE_BRANCH:VERSION 2>/dev/null | tr -d '\r\n[:s
 # We don't need the exact original level — we just need "a level" that passes to the util.
 # If the minor digit advanced, call it minor; patch digit, patch; etc. If base > branch, skip (not ours to land).
 # For simplicity: use "patch" as a conservative default; util handles collision-past regardless of input level.
-QUEUE_JSON=$(bun run bin/gstack-next-version \
+QUEUE_JSON=$(bun run ~/.claude/skills/gstack/bin/gstack-next-version \
   --base "$BASE_BRANCH" \
   --bump patch \
   --current-version "$BASE_VERSION" 2>/dev/null || echo '{"offline":true}')

--- a/land-and-deploy/SKILL.md.tmpl
+++ b/land-and-deploy/SKILL.md.tmpl
@@ -341,7 +341,7 @@ BASE_VERSION=$(git show origin/$BASE_BRANCH:VERSION 2>/dev/null | tr -d '\r\n[:s
 # We don't need the exact original level — we just need "a level" that passes to the util.
 # If the minor digit advanced, call it minor; patch digit, patch; etc. If base > branch, skip (not ours to land).
 # For simplicity: use "patch" as a conservative default; util handles collision-past regardless of input level.
-QUEUE_JSON=$(bun run bin/gstack-next-version \
+QUEUE_JSON=$(bun run ~/.claude/skills/gstack/bin/gstack-next-version \
   --base "$BASE_BRANCH" \
   --bump patch \
   --current-version "$BASE_VERSION" 2>/dev/null || echo '{"offline":true}')

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -781,7 +781,7 @@ they'd claim for micro/patch/minor/major. Cheap (same gh call cached by bun).
 
 ```bash
 for LEVEL in micro patch minor major; do
-  bun run bin/gstack-next-version \
+  bun run ~/.claude/skills/gstack/bin/gstack-next-version \
     --base "$BASE_BRANCH" \
     --bump "$LEVEL" \
     --current-version "$BASE_VERSION" \

--- a/landing-report/SKILL.md.tmpl
+++ b/landing-report/SKILL.md.tmpl
@@ -67,7 +67,7 @@ they'd claim for micro/patch/minor/major. Cheap (same gh call cached by bun).
 
 ```bash
 for LEVEL in micro patch minor major; do
-  bun run bin/gstack-next-version \
+  bun run ~/.claude/skills/gstack/bin/gstack-next-version \
     --base "$BASE_BRANCH" \
     --bump "$LEVEL" \
     --current-version "$BASE_VERSION" \

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -1074,7 +1074,7 @@ Check whether this PR's claimed VERSION still points at a free slot in the queue
 BRANCH_VERSION=$(git show HEAD:VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "")
 BASE_BRANCH=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo main)
 BASE_VERSION=$(git show origin/$BASE_BRANCH:VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "")
-QUEUE_JSON=$(bun run bin/gstack-next-version \
+QUEUE_JSON=$(bun run ~/.claude/skills/gstack/bin/gstack-next-version \
   --base "$BASE_BRANCH" \
   --bump patch \
   --current-version "$BASE_VERSION" 2>/dev/null || echo '{"offline":true}')

--- a/review/SKILL.md.tmpl
+++ b/review/SKILL.md.tmpl
@@ -89,7 +89,7 @@ Check whether this PR's claimed VERSION still points at a free slot in the queue
 BRANCH_VERSION=$(git show HEAD:VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "")
 BASE_BRANCH=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo main)
 BASE_VERSION=$(git show origin/$BASE_BRANCH:VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "")
-QUEUE_JSON=$(bun run bin/gstack-next-version \
+QUEUE_JSON=$(bun run ~/.claude/skills/gstack/bin/gstack-next-version \
   --base "$BASE_BRANCH" \
   --bump patch \
   --current-version "$BASE_VERSION" 2>/dev/null || echo '{"offline":true}')


### PR DESCRIPTION
## Problem

`/ship` (now fixed), `/landing-report`, `/land-and-deploy`, and `/review` invoke the queue-aware version allocator as a **bare relative path**:

```bash
QUEUE_JSON=$(bun run bin/gstack-next-version ... 2>/dev/null || echo '{"offline":true}')
```

When the *installed* skills run from a user's project repo, `bin/gstack-next-version` doesn't resolve (the util lives at the gstack install root, `~/.claude/skills/gstack/bin/`). So `bun` errors, the `|| echo '{"offline":true}'` fallback fires, and the skill silently degrades:

> ⚠ workspace-aware ship offline — using local bump only

This drops queue-collision awareness on every run — version collisions then surface late (e.g. at the CI version-gate or `/land-and-deploy` drift gate) instead of at ship time. It looks like an auth/network failure but isn't.

`ship/SKILL.md(.tmpl)` was already corrected to use the absolute `~/.claude/skills/gstack/bin/gstack-next-version` (matching every other gstack bin call in these files). This applies the same fix to the three skills that were missed.

## Fix

Prefix the invocation with `~/.claude/skills/gstack/bin/` in the `.tmpl` sources for `landing-report`, `land-and-deploy`, and `review`, then regenerate.

- Non-Claude host variants already rendered `$GSTACK_ROOT/bin/...` correctly via the per-host substitution and are unaffected (no diff).
- CI references (`.github/workflows/version-gate.yml`, `.gitlab-ci.yml`) are intentionally left bare — they run from the gstack repo root where `bin/` exists.

## Verification

Ran the exact `bun run ~/.claude/skills/gstack/bin/gstack-next-version --base <base> --bump <level> --current-version <v>` from a real downstream repo: returns full JSON with `"offline": false` and correct collision handling (`"reason": "bumped past claimed X.Y.Z.W"`), where the bare path previously fell through to `{"offline":true}`.

Edited `.tmpl` + `bun run gen:skill-docs --host all`; the only diffs are the three template path swaps, their regenerated canonical Claude `SKILL.md`, and `llms.txt`.