### PR TITLE
fix(gbrain): healthy thin-client misclassified as broken-config, suppressing brain blocks (#1792)

### DIFF
--- a/lib/gbrain-local-status.ts
+++ b/lib/gbrain-local-status.ts
@@ -244,6 +244,50 @@ function writeCache(status: LocalEngineStatus, key: CacheEntry["key"]): void {
 }
 
 /**
+ * Confirm a healthy thin-client brain via `gbrain doctor --json --fast`.
+ *
+ * Thin-client mode (remote MCP, no local DB) intentionally refuses the
+ * `gbrain sources list` probe — `sources` is a local-DB-only command. The probe
+ * therefore throws with a "not routable" stderr that matches neither the
+ * broken-db nor broken-config pattern, so freshClassify would mislabel a
+ * perfectly healthy thin-client as broken-config and suppress every brain block
+ * (#1792). Doctor is the mode-aware signal: it reports `mode` + `status` for
+ * thin-clients. We only call it on the not-routable failure path, so the cheap
+ * ~80ms sources-list probe still owns the healthy local-DB hot path.
+ *
+ * Returns true only when doctor confirms thin-client mode AND a healthy status
+ * (`ok`/`warnings`). Any parse failure or unhealthy status falls through to the
+ * caller's defensive classification — we never upgrade an unconfirmed brain.
+ */
+function isHealthyThinClient(env?: NodeJS.ProcessEnv): boolean {
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    const out = execFileSync("gbrain", ["doctor", "--json", "--fast"], {
+      encoding: "utf-8",
+      timeout: probeTimeoutMs(env),
+      stdio: ["ignore", "pipe", "ignore"],
+      env: buildGbrainEnv({ baseEnv: env ?? process.env }),
+      shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
+    });
+    parsed = JSON.parse(out);
+  } catch (err) {
+    // doctor exits 1 whenever health_score < 100 (normal on warnings), but
+    // still prints the JSON to stdout. Recover it before giving up. See #1415.
+    try {
+      const stdout = (err as { stdout?: Buffer | string })?.stdout ?? "";
+      const stdoutStr = typeof stdout === "string" ? stdout : stdout.toString("utf-8");
+      if (stdoutStr) parsed = JSON.parse(stdoutStr);
+    } catch {
+      return false;
+    }
+  }
+  if (!parsed) return false;
+  const mode = parsed.mode;
+  const status = parsed.status;
+  return mode === "thin-client" && (status === "ok" || status === "warnings");
+}
+
+/**
  * Probe via `gbrain sources list --json`. Classify the outcome.
  *
  * Pattern strings ("Cannot connect to database", "config.json") are deliberately
@@ -286,6 +330,12 @@ function freshClassify(env?: NodeJS.ProcessEnv): LocalEngineStatus {
 
     // ENOENT can happen if gbrain disappeared between resolveGbrainBin and now.
     if (e.code === "ENOENT") return "no-cli";
+
+    // Thin-client mode (remote MCP, no local DB) refuses `sources list` with a
+    // "not routable" error — `sources` is local-DB-only. This is NOT a broken
+    // brain: confirm health via the mode-aware doctor before classifying, so a
+    // healthy thin-client reports "ok" and keeps its brain blocks (#1792).
+    if (stderr.includes("not routable") && isHealthyThinClient(env)) return "ok";
 
     // Pattern match against gbrain's known error strings. Order matters:
     // "Cannot connect to database" is the more specific DB-unreachable signal.

--- a/test/gbrain-local-status.test.ts
+++ b/test/gbrain-local-status.test.ts
@@ -59,9 +59,18 @@ interface FakeEnv {
  * The classifier reads HOME via os.homedir() which reads process.env.HOME, so
  * we mutate process.env ambiently in each test (restored in afterEach).
  */
+type GbrainBehavior =
+  | "ok"
+  | "broken-db"
+  | "broken-config"
+  | "throws"
+  | "slow"
+  | "thin-client-ok"
+  | "thin-client-unhealthy";
+
 function makeEnv(opts: {
   withGbrain?: boolean;
-  gbrainBehavior?: "ok" | "broken-db" | "broken-config" | "throws" | "slow";
+  gbrainBehavior?: GbrainBehavior;
   withConfig?: boolean;
 }): FakeEnv {
   const tmp = mkdtempSync(join(tmpdir(), "gbrain-local-status-test-"));
@@ -101,9 +110,7 @@ function makeEnv(opts: {
   };
 }
 
-function makeFakeGbrainScript(
-  behavior: "ok" | "broken-db" | "broken-config" | "throws" | "slow",
-): string {
+function makeFakeGbrainScript(behavior: GbrainBehavior): string {
   // "slow": healthy engine on a cold pooler connection (#1964) — sleeps past
   // the (test-lowered) probe timeout, then would answer fine.
   if (behavior === "slow") {
@@ -120,6 +127,8 @@ fi
 exit 0
 `;
   }
+  const isThinClient =
+    behavior === "thin-client-ok" || behavior === "thin-client-unhealthy";
   const stderrLine =
     behavior === "broken-db"
       ? 'echo "Cannot connect to database: . Fix: Check your connection URL in ~/.gbrain/config.json" >&2'
@@ -127,13 +136,27 @@ exit 0
         ? 'echo "Error: malformed config.json at ~/.gbrain/config.json" >&2'
         : behavior === "throws"
           ? 'echo "unexpected gbrain failure" >&2'
-          : "";
+          : isThinClient
+            ? 'echo "\\`gbrain sources\\` is not routable. sources commands manage local DB + config rows. Per-subcommand thin-client routing lands in v0.31.x." >&2'
+            : "";
   const exitCode = behavior === "ok" ? 0 : 1;
+  // Thin-client doctor: mode-aware health signal the classifier falls back to
+  // when `sources list` is refused. doctor exits 1 when health_score < 100 but
+  // still prints JSON to stdout (matches real gbrain + #1415 recovery path).
+  const doctorStatus = behavior === "thin-client-unhealthy" ? "error" : "ok";
+  const doctorExit = behavior === "thin-client-unhealthy" ? "1" : "0";
+  const doctorBlock = isThinClient
+    ? `if [ "$1 $2 $3" = "doctor --json --fast" ]; then
+  echo '{"mode":"thin-client","status":"${doctorStatus}"}'
+  exit ${doctorExit}
+fi`
+    : "";
   return `#!/bin/sh
 if [ "$1" = "--version" ]; then
-  echo "gbrain 0.33.1.0"
+  echo "gbrain 0.41.28.0"
   exit 0
 fi
+${doctorBlock}
 if [ "$1 $2" = "sources list" ]; then
   if [ ${exitCode} -eq 0 ]; then
     echo '{"sources":[]}'
@@ -229,6 +252,30 @@ describe("lib/gbrain-local-status — status classification", () => {
     env = makeEnv({ withGbrain: true, gbrainBehavior: "ok", withConfig: true });
     restoreEnv = applyEnv(env);
     expect(localEngineStatus({ noCache: true })).toBe("ok");
+  });
+
+  it("returns 'ok' for a healthy thin-client whose 'sources list' is not routable (#1792)", () => {
+    // Thin-client refuses the local-DB-only sources probe; doctor confirms
+    // mode=thin-client + status=ok. Must NOT be mislabeled broken-config.
+    env = makeEnv({
+      withGbrain: true,
+      gbrainBehavior: "thin-client-ok",
+      withConfig: true,
+    });
+    restoreEnv = applyEnv(env);
+    expect(localEngineStatus({ noCache: true })).toBe("ok");
+  });
+
+  it("stays defensive (broken-config) when a not-routable brain is unhealthy per doctor (#1792)", () => {
+    // "not routable" alone must not upgrade an unconfirmed brain: doctor reports
+    // status=error, so we fall through to the defensive default.
+    env = makeEnv({
+      withGbrain: true,
+      gbrainBehavior: "thin-client-unhealthy",
+      withConfig: true,
+    });
+    restoreEnv = applyEnv(env);
+    expect(localEngineStatus({ noCache: true })).toBe("broken-config");
   });
 
   it("returns 'timeout' (not broken-config) when the probe exceeds the deadline (#1964)", () => {


### PR DESCRIPTION
## Problem

Brain-aware planning (v1.52) advertises support for any thin-client MCP brain, but a healthy thin-client never gets brain blocks.

`freshClassify()` in `lib/gbrain-local-status.ts` classifies the engine by probing with `gbrain sources list --json` — a **local-DB-only** command. In thin-client mode (remote MCP, no local DB) gbrain refuses it:

```
$ gbrain sources list --json
`gbrain sources` is not routable. sources commands manage local DB + config rows.
Per-subcommand thin-client routing lands in v0.31.x. ...   (exit 1)
```

That stderr matches neither the `broken-db` ("Cannot connect to database") nor the `broken-config` ("config.json") pattern, so the catch falls through to the defensive `broken-config` default. `gen-skill-docs --respect-detection` then un-suppresses brain blocks only when status is `ok`, so a healthy thin-client (doctor reports `mode: thin-client`, `status: ok`) silently loses brain-aware planning across every planning SKILL.md.

## Root cause

In `freshClassify()` the 5-state classifier has no healthy-thin-client path and never checks the brain mode — once the on-PATH + config-exists checks pass (both true for a thin-client), the only signal is the local-DB probe, which thin-clients reject by design.

## Fix

On the **not-routable failure path only**, confirm health via the mode-aware `gbrain doctor --json --fast` (the same doctor call already used in `bin/gstack-gbrain-detect` and `lib/gstack-memory-helpers.ts`) and return `ok` when doctor reports `mode: "thin-client"` with `ok`/`warnings` status.

Design notes:
- **No added latency on the hot path.** The cheap ~80ms `sources list` probe still owns the healthy local-DB case; doctor is only consulted when the probe is *refused*, so local-DB brains are unaffected.
- **No enum change.** A healthy thin-client correctly maps to the existing `ok` state.
- **Stays defensive.** A doctor parse failure or any non-healthy status falls through to the existing classification — an unconfirmed brain is never upgraded. The `not routable` string is also required, so genuine broken-db/broken-config errors are untouched.
- doctor exits 1 when `health_score < 100` (normal under warnings) but still prints JSON to stdout; the helper recovers stdout from the error object, matching the established pattern (#1415).

## Tests

`test/gbrain-local-status.test.ts` (gate-tier, fully mocked — fake `gbrain` on PATH, no real CLI/DB):
- healthy thin-client: `sources list` not-routable + `doctor` reports `thin-client`/`ok` → classifies **`ok`** (was `broken-config`).
- not-routable but `doctor` reports an unhealthy status → stays **`broken-config`** (defensive default preserved).

```
bun test test/gbrain-local-status.test.ts
# 14 pass, 0 fail
```

Adjacent gbrain suites (`gbrain-detect-shape`, `gbrain-detection-override`, `gstack-gbrain-detect-mcp-mode`, `gbrain-sync-skip`) remain green. Pre-existing `gstack-gbrain-detect` subprocess failures reproduce unchanged on `origin/main` and are unrelated to this change.

Fixes #1792

🤖 Generated with [Claude Code](https://claude.com/claude-code)