### PR TITLE
fix(setup): pin Playwright browser install to bundled version so headed browse connect works (#1829)

### DIFF
--- a/setup
+++ b/setup
@@ -250,17 +250,23 @@ if [ "$INSTALL_CODEX" -eq 1 ]; then
 fi
 
 ensure_playwright_browser() {
+  # Assert the *full* Chromium build exists before launching. chromium.launch()
+  # defaults to the headless shell (chromium_headless_shell), which can be
+  # present even when the full Chrome-for-Testing build that headed
+  # `browse connect` needs is missing — so a plain launch silently passes and
+  # masks a missing full build. chromium.executablePath() resolves the full
+  # build path regardless, so we stat it first. (#1829)
   if [ "$IS_WINDOWS" -eq 1 ]; then
     # On Windows, Bun can't launch Chromium due to broken pipe handling
     # (oven-sh/bun#4253). Use Node.js to verify Chromium works instead.
     (
       cd "$SOURCE_GSTACK_DIR"
-      node -e "const { chromium } = require('playwright'); (async () => { const b = await chromium.launch(); await b.close(); })()" 2>/dev/null
+      node -e "const { chromium } = require('playwright'); const fs = require('fs'); (async () => { if (!fs.existsSync(chromium.executablePath())) process.exit(1); const b = await chromium.launch(); await b.close(); })()" 2>/dev/null
     )
   else
     (
       cd "$SOURCE_GSTACK_DIR"
-      bun --eval 'import { chromium } from "playwright"; const browser = await chromium.launch(); await browser.close();'
+      bun --eval 'import { chromium } from "playwright"; import { existsSync } from "fs"; if (!existsSync(chromium.executablePath())) process.exit(1); const browser = await chromium.launch(); await browser.close();'
     ) >/dev/null 2>&1
   fi
 }
@@ -480,7 +486,18 @@ if ! ensure_playwright_browser; then
   echo "Installing Playwright Chromium..."
   (
     cd "$SOURCE_GSTACK_DIR"
-    bunx playwright install chromium
+    # The browse binary is compiled above against the lockfile-pinned Playwright.
+    # `bunx playwright install` resolves the *latest* Playwright at runtime, which
+    # downloads a different Chromium revision than the compiled binary expects, so
+    # headed `browse connect` fails with a missing full build even though setup
+    # "succeeds" and headless works. Pin the browser install to the same Playwright
+    # version bundled in node_modules so install and runtime can never drift. (#1829)
+    pw_version="$(bun --eval 'console.log(require("playwright/package.json").version)' 2>/dev/null)"
+    if [ -n "$pw_version" ]; then
+      bunx "playwright@$pw_version" install chromium
+    else
+      bunx playwright install chromium
+    fi
   )
 
   if [ "$IS_WINDOWS" -eq 1 ]; then

--- a/test/setup-playwright-pin.test.ts
+++ b/test/setup-playwright-pin.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from 'bun:test';
+import * as path from 'path';
+import * as fs from 'fs';
+
+// Regression guard for #1829: headed `browse connect` failed after a
+// "successful" ./setup because the browser-install step and the compiled
+// browse binary resolved different Playwright versions (hence different
+// Chromium revisions), and the post-install verify only exercised a headless
+// launch — which passes off the cached headless shell even when the full
+// Chrome-for-Testing build that headed mode needs is missing.
+//
+// These are static source assertions (no browser download) in the same spirit
+// as setup-windows-fallback.test.ts, so they stay fast and CI-portable.
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const SETUP_SRC = fs.readFileSync(path.join(ROOT, 'setup'), 'utf-8');
+
+function extractFn(name: string): string {
+  const start = SETUP_SRC.indexOf(`${name}() {`);
+  const end = SETUP_SRC.indexOf('\n}\n', start);
+  if (start < 0 || end < 0) throw new Error(`Could not locate ${name}() in setup`);
+  return SETUP_SRC.slice(start, end + 2);
+}
+
+describe('setup: Playwright browser install is pinned to the bundled version (#1829)', () => {
+  test('does not invoke unpinned `bunx playwright install` to download browsers', () => {
+    // The unpinned form resolves the *latest* Playwright at runtime, which can
+    // download a Chromium revision that differs from the one compiled into the
+    // browse binary. The fallback inside the version-pin guard is allowed, so
+    // we only forbid the unpinned call as a real (non-comment) browser-install
+    // command outside that guarded fallback.
+    const lines = SETUP_SRC.split('\n');
+    const offending = lines.filter((line) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('#')) return false;
+      // The guarded fallback lives directly under `if [ -n "$pw_version" ]`.
+      if (!/bunx\s+playwright\s+install\s+chromium/.test(line)) return false;
+      return true;
+    });
+    // Exactly one occurrence is permitted: the `else` fallback when the pinned
+    // version could not be resolved.
+    expect(offending.length).toBe(1);
+  });
+
+  test('installs the Playwright version bundled in node_modules', () => {
+    expect(SETUP_SRC).toContain('playwright/package.json');
+    expect(SETUP_SRC).toMatch(/bunx\s+"playwright@\$pw_version"\s+install\s+chromium/);
+  });
+});
+
+describe('setup: ensure_playwright_browser detects a missing full Chromium build (#1829)', () => {
+  const fn = extractFn('ensure_playwright_browser');
+
+  test('asserts chromium.executablePath() exists before treating the browser as ready', () => {
+    // Without this, the verify launches headless and passes off the cached
+    // headless shell, masking a missing full build that headed mode needs.
+    expect(fn).toContain('executablePath()');
+    // Both the Node (Windows) and Bun (Unix) branches must fail closed when the
+    // full build is absent.
+    expect(fn).toContain('fs.existsSync(chromium.executablePath())');
+    expect(fn).toContain('existsSync(chromium.executablePath())');
+    expect(fn).toContain('process.exit(1)');
+  });
+});


### PR DESCRIPTION
Fixes #1829

## Problem

On a clean install/upgrade, headed `browse connect` fails with a missing full Chromium build:

```
Executable doesn't exist at .../ms-playwright/chromium-1208/.../Google Chrome for Testing
    at async launchHeaded (browse/src/browser-manager.ts)
```

even though `./setup` reported success and **headless** browse works fine.

## Root cause (two issues in `setup`)

1. **Install/runtime version drift.** The browse binary is compiled (setup ~line 390) against the lockfile-pinned Playwright (`playwright@1.58.2` → Chromium revision **1208**). But the browser-install step ran `bunx playwright install chromium`, which resolves the **latest** Playwright at runtime (currently `1.60.0` → revision **1223**) and downloads a different full build than the binary expects. The cache ends up with `chromium-1223` (wrong) and `chromium_headless_shell-1208` but **not** `chromium-1208` (full) — so headed launch fails.
2. **Headless-only verify masks it.** `ensure_playwright_browser()` only ran a default `chromium.launch()` (headless), which passes off the cached `chromium_headless_shell` even when the full Chrome-for-Testing build is absent. So setup reports success.

## Fix

- Install browsers with the Playwright version **bundled in `node_modules`** (read from `playwright/package.json`) instead of `bunx`-latest, so the installed Chromium revision always matches the compiled binary and the two can never drift. Falls back to the old behavior only if the version can't be resolved.
- Harden `ensure_playwright_browser()` to assert `chromium.executablePath()` exists before treating the browser as ready (both the Node/Windows and Bun/Unix branches), so a missing **full** build fails setup instead of being silently masked by the cached headless shell.

This matches the maintainer-suggested direction in the issue (pin the install to the bundled version; make verify catch a missing full build).

## Testing

- `bun test test/setup-playwright-pin.test.ts` — new static-source regression test (no browser download), 3 pass.
- `bun test test/setup-windows-fallback.test.ts test/setup-emoji-font.test.ts` — existing setup tests still green (20 pass).
- `bash -n setup` — syntax OK.
- Verified locally that the bundled version resolves to `1.58.2` and `chromium.executablePath()` returns the `chromium-1208` full-build path the issue reports as missing.

## Relationship to other open Playwright PRs (not duplicates)

- **#1761** / **#1703** (bump to `^1.60.0` for the Node 24.16+ yauzl hang) and **#1565** (bump + runtime `executablePath` pin in `browser-manager.ts` for Flutter headless rendering) target different symptoms and code paths. A version bump only *incidentally* realigns revisions while npm's "latest" happens to equal the pinned range; the moment a newer Playwright ships, `bunx`-latest drifts again. This PR fixes the **drift mechanism** in the install/verify path and is complementary to those changes.