### PR TITLE
fix(one-way-doors): treat 'rotate ... password' as a one-way door

### DIFF
--- a/scripts/one-way-doors.ts
+++ b/scripts/one-way-doors.ts
@@ -65,7 +65,7 @@ const DESTRUCTIVE_PATTERNS: RegExp[] = [
   // Credentials / auth — allow filler words ("the", "my") between verb and noun
   /\brevoke\s+[\w\s]*\b(api key|token|credential|access key|password)\b/i,
   /\breset\s+[\w\s]*\b(api key|token|password|credential)\b/i,
-  /\brotate\s+[\w\s]*\b(api key|token|secret|credential|access key)\b/i,
+  /\brotate\s+[\w\s]*\b(api key|token|secret|credential|access key|password)\b/i,
 
   // Scope / architecture forks (reversible with effort — still deserve confirmation)
   /\barchitectur(e|al)\s+(change|fork|shift|decision)\b/i,

--- a/test/plan-tune.test.ts
+++ b/test/plan-tune.test.ts
@@ -426,6 +426,19 @@ describe('one-way-doors classifier', () => {
     }
   });
 
+  test('rotate <credential> password is one-way (parity with revoke/reset)', () => {
+    const cases = [
+      'Rotate the database password?',
+      'rotate password for the service account',
+    ];
+    for (const summary of cases) {
+      const result = classifyQuestion({ summary });
+      expect(result.oneWay).toBe(true);
+      expect(result.reason).toBe('keyword');
+      expect(result.matched).toBeDefined();
+    }
+  });
+
   test('skill-category fallback fires for cso:approval and land-and-deploy:approval', () => {
     expect(isOneWayDoor({ skill: 'cso', category: 'approval' })).toBe(true);
     expect(isOneWayDoor({ skill: 'land-and-deploy', category: 'approval' })).toBe(true);


### PR DESCRIPTION
## Problem

`scripts/one-way-doors.ts` is the secondary keyword safety net for AskUserQuestion calls that fire without a registry id. Its three credential-rotation patterns are meant to be parallel (the inline comment says they "allow filler words between verb and noun"), but the `rotate` pattern omits `password`:

```ts
/\brevoke\s+[\w\s]*\b(api key|token|credential|access key|password)\b/i,  // has password
/\breset\s+[\w\s]*\b(api key|token|password|credential)\b/i,              // has password
/\brotate\s+[\w\s]*\b(api key|token|secret|credential|access key)\b/i,    // MISSING password
```

So `classifyQuestion`/`isOneWayDoor` classified "rotate the database password" as a reversible two-way door, while "revoke the password" and "reset the password" both correctly classified as one-way. The module header is explicit that this is the dangerous direction: "A false negative could mean auto-approving a destructive operation."

Reproduced on `main` (3bef43bc):

```
two-way   Rotate the database password?
two-way   rotate password for prod
ONE-WAY   Revoke the password
ONE-WAY   Reset the password
ONE-WAY   rotate the API key
```

## Root cause

A plain omission of `password` from the `rotate` noun alternation. "Rotate the password" is the most common phrasing of a credential-rotation op, more common than "rotate credential" (which the pattern already covers).

## Fix

Add `password` to the `rotate` alternation so the three credential verbs are at parity. One-line change, plus a regression test mirroring the existing `keyword fallback catches destructive summaries` test.

## Testing

- `bun test test/plan-tune.test.ts` — 48 pass / 0 fail.
- Verified the new test fails on `main` without the one-line fix (1 fail) and passes with it.
- Full `bun test` suite passes (exit 0).

Fixes #1839
