### PR TITLE
Add Copilot host integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin/gstack-global-discover*
 .factory/
 .kiro/
 .opencode/
+.copilot/
 .slate/
 .cursor/
 .openclaw/

--- a/gstack-upgrade/SKILL.md
+++ b/gstack-upgrade/SKILL.md
@@ -95,9 +95,6 @@ elif [ -d "$HOME/.gstack/repos/gstack/.git" ]; then
 elif [ -d ".claude/skills/gstack/.git" ]; then
   INSTALL_TYPE="local-git"
   INSTALL_DIR=".claude/skills/gstack"
-elif [ -d ".agents/skills/gstack/.git" ]; then
-  INSTALL_TYPE="local-git"
-  INSTALL_DIR=".agents/skills/gstack"
 elif [ -d ".claude/skills/gstack" ]; then
   INSTALL_TYPE="vendored"
   INSTALL_DIR=".claude/skills/gstack"
@@ -160,7 +157,7 @@ if [ -n "$_ROOT" ] && [ -d "$_ROOT/.claude/skills/gstack" ]; then
     LOCAL_GSTACK="$_ROOT/.claude/skills/gstack"
   fi
 fi
-_TEAM_MODE=$(~/.claude/skills/gstack/bin/gstack-config get team_mode 2>/dev/null || echo "false")
+_TEAM_MODE=$($HOME/.claude/skills/gstack/bin/gstack-config get team_mode 2>/dev/null || echo "false")
 echo "LOCAL_GSTACK=$LOCAL_GSTACK"
 echo "TEAM_MODE=$_TEAM_MODE"
 ```

--- a/gstack-upgrade/SKILL.md.tmpl
+++ b/gstack-upgrade/SKILL.md.tmpl
@@ -39,7 +39,7 @@ _AUTO=""
 echo "AUTO_UPGRADE=$_AUTO"
 ```
 
-**If `AUTO_UPGRADE=true` or `AUTO_UPGRADE=1`:** Skip AskUserQuestion. Log "Auto-upgrading gstack v{old} → v{new}..." and proceed directly to Step 2. If `./setup` fails during auto-upgrade, restore from backup (`.bak` directory) and warn the user: "Auto-upgrade failed — restored previous version. Run `/gstack-upgrade` manually to retry."
+**If `AUTO_UPGRADE=true` or `AUTO_UPGRADE=1`:** Skip AskUserQuestion. Log "Auto-upgrading gstack v{old} → v{new}..." and proceed directly to Step 2. If `{{SETUP_COMMAND}}` fails during auto-upgrade, restore from backup (`.bak` directory) and warn the user: "Auto-upgrade failed — restored previous version. Run `/gstack-upgrade` manually to retry."
 
 **Otherwise**, use AskUserQuestion:
 - Question: "gstack **v{new}** is available (you're on v{old}). Upgrade now?"
@@ -83,24 +83,21 @@ Continue with the current skill.
 ### Step 2: Detect install type
 
 ```bash
-if [ -d "$HOME/.claude/skills/gstack/.git" ]; then
+if [ -d "{{HOST_GLOBAL_ROOT}}/.git" ]; then
   INSTALL_TYPE="global-git"
-  INSTALL_DIR="$HOME/.claude/skills/gstack"
+  INSTALL_DIR="{{HOST_GLOBAL_ROOT}}"
 elif [ -d "$HOME/.gstack/repos/gstack/.git" ]; then
   INSTALL_TYPE="global-git"
   INSTALL_DIR="$HOME/.gstack/repos/gstack"
-elif [ -d ".claude/skills/gstack/.git" ]; then
+elif [ -d "{{LOCAL_SKILL_ROOT}}/.git" ]; then
   INSTALL_TYPE="local-git"
-  INSTALL_DIR=".claude/skills/gstack"
-elif [ -d ".agents/skills/gstack/.git" ]; then
-  INSTALL_TYPE="local-git"
-  INSTALL_DIR=".agents/skills/gstack"
-elif [ -d ".claude/skills/gstack" ]; then
+  INSTALL_DIR="{{LOCAL_SKILL_ROOT}}"
+elif [ -d "{{LOCAL_SKILL_ROOT}}" ]; then
   INSTALL_TYPE="vendored"
-  INSTALL_DIR=".claude/skills/gstack"
-elif [ -d "$HOME/.claude/skills/gstack" ]; then
+  INSTALL_DIR="{{LOCAL_SKILL_ROOT}}"
+elif [ -d "{{HOST_GLOBAL_ROOT}}" ]; then
   INSTALL_TYPE="vendored-global"
-  INSTALL_DIR="$HOME/.claude/skills/gstack"
+  INSTALL_DIR="{{HOST_GLOBAL_ROOT}}"
 else
   echo "ERROR: gstack not found"
   exit 1
@@ -128,7 +125,7 @@ cd "$INSTALL_DIR"
 STASH_OUTPUT=$(git stash 2>&1)
 git fetch origin
 git reset --hard origin/main
-./setup
+{{SETUP_COMMAND}}
 ```
 If `$STASH_OUTPUT` contains "Saved working directory", warn the user: "Note: local changes were stashed. Run `git stash pop` in the skill directory to restore them."
 
@@ -139,7 +136,7 @@ TMP_DIR=$(mktemp -d)
 git clone --depth 1 https://github.com/garrytan/gstack.git "$TMP_DIR/gstack"
 mv "$INSTALL_DIR" "$INSTALL_DIR.bak"
 mv "$TMP_DIR/gstack" "$INSTALL_DIR"
-cd "$INSTALL_DIR" && ./setup
+cd "$INSTALL_DIR" && {{SETUP_COMMAND}}
 rm -rf "$INSTALL_DIR.bak" "$TMP_DIR"
 ```
 
@@ -150,14 +147,14 @@ Use the install directory from Step 2. Check if there's also a local vendored co
 ```bash
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 LOCAL_GSTACK=""
-if [ -n "$_ROOT" ] && [ -d "$_ROOT/.claude/skills/gstack" ]; then
-  _RESOLVED_LOCAL=$(cd "$_ROOT/.claude/skills/gstack" && pwd -P)
+if [ -n "$_ROOT" ] && [ -d "$_ROOT/{{LOCAL_SKILL_ROOT}}" ]; then
+  _RESOLVED_LOCAL=$(cd "$_ROOT/{{LOCAL_SKILL_ROOT}}" && pwd -P)
   _RESOLVED_PRIMARY=$(cd "$INSTALL_DIR" && pwd -P)
   if [ "$_RESOLVED_LOCAL" != "$_RESOLVED_PRIMARY" ]; then
-    LOCAL_GSTACK="$_ROOT/.claude/skills/gstack"
+    LOCAL_GSTACK="$_ROOT/{{LOCAL_SKILL_ROOT}}"
   fi
 fi
-_TEAM_MODE=$(~/.claude/skills/gstack/bin/gstack-config get team_mode 2>/dev/null || echo "false")
+_TEAM_MODE=$({{HOST_GLOBAL_ROOT}}/bin/gstack-config get team_mode 2>/dev/null || echo "false")
 echo "LOCAL_GSTACK=$LOCAL_GSTACK"
 echo "TEAM_MODE=$_TEAM_MODE"
 ```
@@ -166,9 +163,9 @@ echo "TEAM_MODE=$_TEAM_MODE"
 
 ```bash
 cd "$_ROOT"
-git rm -r --cached .claude/skills/gstack/ 2>/dev/null || true
-if ! grep -qF '.claude/skills/gstack/' .gitignore 2>/dev/null; then
-  echo '.claude/skills/gstack/' >> .gitignore
+git rm -r --cached {{LOCAL_SKILL_ROOT}}/ 2>/dev/null || true
+if ! grep -qF '{{LOCAL_SKILL_ROOT}}/' .gitignore 2>/dev/null; then
+  echo '{{LOCAL_SKILL_ROOT}}/' >> .gitignore
 fi
 rm -rf "$LOCAL_GSTACK"
 ```
@@ -179,12 +176,12 @@ Tell user: "Removed vendored copy at `$LOCAL_GSTACK` (team mode active — globa
 mv "$LOCAL_GSTACK" "$LOCAL_GSTACK.bak"
 cp -Rf "$INSTALL_DIR" "$LOCAL_GSTACK"
 rm -rf "$LOCAL_GSTACK/.git"
-cd "$LOCAL_GSTACK" && ./setup
+cd "$LOCAL_GSTACK" && {{SETUP_COMMAND}}
 rm -rf "$LOCAL_GSTACK.bak"
 ```
 Tell user: "Also updated vendored copy at `$LOCAL_GSTACK` — commit `.claude/skills/gstack/` when you're ready."
 
-If `./setup` fails, restore from backup and warn the user:
+If `{{SETUP_COMMAND}}` fails, restore from backup and warn the user:
 ```bash
 rm -rf "$LOCAL_GSTACK"
 mv "$LOCAL_GSTACK.bak" "$LOCAL_GSTACK"

--- a/hosts/copilot.ts
+++ b/hosts/copilot.ts
@@ -1,0 +1,22 @@
+import type { HostConfig } from '../scripts/host-config';
+import opencode from './opencode';
+
+const copilot: HostConfig = {
+  ...opencode,
+  name: 'copilot',
+  displayName: 'GitHub Copilot CLI',
+  cliCommand: 'gh',
+  cliAliases: [],
+
+  globalRoot: '.copilot/skills/gstack',
+  localSkillRoot: '.copilot/skills/gstack',
+  hostSubdir: '.copilot',
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.copilot/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.copilot/skills/gstack' },
+    { from: '.claude/skills', to: '.copilot/skills' },
+  ],
+};
+
+export default copilot;

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -11,6 +11,7 @@ import codex from './codex';
 import factory from './factory';
 import kiro from './kiro';
 import opencode from './opencode';
+import copilot from './copilot';
 import slate from './slate';
 import cursor from './cursor';
 import openclaw from './openclaw';
@@ -18,7 +19,7 @@ import hermes from './hermes';
 import gbrain from './gbrain';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, copilot, slate, cursor, openclaw, hermes, gbrain];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, copilot, slate, cursor, openclaw, hermes, gbrain };

--- a/scripts/resolvers/index.ts
+++ b/scripts/resolvers/index.ts
@@ -15,6 +15,7 @@
  */
 
 import type { TemplateContext, ResolverFn, ResolverValue } from './types';
+import { getHostConfig } from '../../hosts/index';
 
 // Domain modules
 import { generatePreamble } from './preamble';
@@ -88,6 +89,9 @@ export const RESOLVERS: Record<string, ResolverValue> = {
   MODEL_OVERLAY: generateModelOverlay,
   TASTE_PROFILE: generateTasteProfile,
   BIN_DIR: (ctx) => ctx.paths.binDir,
+  HOST_GLOBAL_ROOT: (ctx) => `$HOME/${getHostConfig(ctx.host).globalRoot}`,
+  LOCAL_SKILL_ROOT: (ctx) => ctx.paths.localSkillRoot,
+  SETUP_COMMAND: (ctx) => ctx.host === 'claude' ? './setup' : `./setup --host ${ctx.host}`,
   GBRAIN_CONTEXT_LOAD: generateGBrainContextLoad,
   GBRAIN_SAVE_RESULTS: generateGBrainSaveResults,
   BRAIN_PREFLIGHT: generateBrainPreflight,

--- a/setup
+++ b/setup
@@ -24,6 +24,8 @@ FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
 OPENCODE_SKILLS="$HOME/.config/opencode/skills"
 OPENCODE_GSTACK="$OPENCODE_SKILLS/gstack"
+COPILOT_SKILLS="$HOME/.copilot/skills"
+COPILOT_GSTACK="$COPILOT_SKILLS/gstack"
 
 IS_WINDOWS=0
 case "$(uname -s)" in
@@ -85,7 +87,7 @@ NO_TEAM_MODE=0
 PLAN_TUNE_HOOKS_MODE=""   # "" = resolve from env/config/prompt; "yes"/"no" = explicit
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, copilot, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -101,7 +103,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|opencode|auto) ;;
+  claude|codex|kiro|factory|opencode|copilot|auto) ;;
   openclaw)
     echo ""
     echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
@@ -136,7 +138,7 @@ case "$HOST" in
     echo "GBrain setup and brain skills ship from the GBrain repo."
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, copilot, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -200,14 +202,16 @@ INSTALL_CODEX=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
 INSTALL_OPENCODE=0
+INSTALL_COPILOT=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
   command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
+  command -v gh >/dev/null 2>&1 && [ -d "$HOME/.copilot" ] && INSTALL_COPILOT=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ] && [ "$INSTALL_COPILOT" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
@@ -220,6 +224,8 @@ elif [ "$HOST" = "factory" ]; then
   INSTALL_FACTORY=1
 elif [ "$HOST" = "opencode" ]; then
   INSTALL_OPENCODE=1
+elif [ "$HOST" = "copilot" ]; then
+  INSTALL_COPILOT=1
 fi
 
 migrate_direct_codex_install() {
@@ -472,6 +478,16 @@ if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
     cd "$SOURCE_GSTACK_DIR"
     bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
     bun_cmd run gen:skill-docs --host opencode
+  )
+fi
+
+# 1e. Generate .copilot/ GitHub Copilot CLI skill docs
+if [ "$INSTALL_COPILOT" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .copilot/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
+    bun_cmd run gen:skill-docs --host copilot
   )
 fi
 
@@ -908,6 +924,59 @@ create_opencode_runtime_root() {
   fi
 }
 
+create_copilot_runtime_root() {
+  local gstack_dir="$1"
+  local copilot_gstack="$2"
+  local copilot_dir="$gstack_dir/.copilot/skills"
+
+  if [ -L "$copilot_gstack" ]; then
+    rm -f "$copilot_gstack"
+  elif [ -d "$copilot_gstack" ] && [ "$copilot_gstack" != "$gstack_dir" ]; then
+    rm -rf "$copilot_gstack"
+  fi
+
+  mkdir -p "$copilot_gstack" "$copilot_gstack/browse" "$copilot_gstack/design" "$copilot_gstack/gstack-upgrade" "$copilot_gstack/review" "$copilot_gstack/qa" "$copilot_gstack/plan-devex-review"
+
+  if [ -f "$copilot_dir/gstack/SKILL.md" ]; then
+    _link_or_copy "$copilot_dir/gstack/SKILL.md" "$copilot_gstack/SKILL.md"
+  fi
+  if [ -d "$gstack_dir/bin" ]; then
+    _link_or_copy "$gstack_dir/bin" "$copilot_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    _link_or_copy "$gstack_dir/browse/dist" "$copilot_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    _link_or_copy "$gstack_dir/browse/bin" "$copilot_gstack/browse/bin"
+  fi
+  if [ -d "$gstack_dir/design/dist" ]; then
+    _link_or_copy "$gstack_dir/design/dist" "$copilot_gstack/design/dist"
+  fi
+  if [ -f "$copilot_dir/gstack-upgrade/SKILL.md" ]; then
+    _link_or_copy "$copilot_dir/gstack-upgrade/SKILL.md" "$copilot_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      _link_or_copy "$gstack_dir/review/$f" "$copilot_gstack/review/$f"
+    fi
+  done
+  if [ -d "$gstack_dir/review/specialists" ]; then
+    _link_or_copy "$gstack_dir/review/specialists" "$copilot_gstack/review/specialists"
+  fi
+  if [ -d "$gstack_dir/qa/templates" ]; then
+    _link_or_copy "$gstack_dir/qa/templates" "$copilot_gstack/qa/templates"
+  fi
+  if [ -d "$gstack_dir/qa/references" ]; then
+    _link_or_copy "$gstack_dir/qa/references" "$copilot_gstack/qa/references"
+  fi
+  if [ -f "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" ]; then
+    _link_or_copy "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" "$copilot_gstack/plan-devex-review/dx-hall-of-fame.md"
+  fi
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    _link_or_copy "$gstack_dir/ETHOS.md" "$copilot_gstack/ETHOS.md"
+  fi
+}
+
 link_factory_skill_dirs() {
   local gstack_dir="$1"
   local skills_dir="$2"
@@ -957,6 +1026,38 @@ link_opencode_skill_dirs() {
   fi
 
   for skill_dir in "$opencode_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        _link_or_copy "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+link_copilot_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local copilot_dir="$gstack_dir/.copilot/skills"
+  local linked=()
+
+  if [ ! -d "$copilot_dir" ]; then
+    echo "  Generating .copilot/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host copilot )
+  fi
+
+  if [ ! -d "$copilot_dir" ]; then
+    echo "  warning: .copilot/skills/ generation failed — run 'bun run gen:skill-docs --host copilot' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$copilot_dir"/gstack*/; do
     if [ -f "$skill_dir/SKILL.md" ]; then
       skill_name="$(basename "$skill_dir")"
       [ "$skill_name" = "gstack" ] && continue
@@ -1191,6 +1292,16 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   echo "gstack ready (opencode)."
   echo "  browse: $BROWSE_BIN"
   echo "  opencode skills: $OPENCODE_SKILLS"
+fi
+
+# 6d. Install for GitHub Copilot CLI
+if [ "$INSTALL_COPILOT" -eq 1 ]; then
+  mkdir -p "$COPILOT_SKILLS"
+  create_copilot_runtime_root "$SOURCE_GSTACK_DIR" "$COPILOT_GSTACK"
+  link_copilot_skill_dirs "$SOURCE_GSTACK_DIR" "$COPILOT_SKILLS"
+  echo "gstack ready (copilot)."
+  echo "  browse: $BROWSE_BIN"
+  echo "  copilot skills: $COPILOT_SKILLS"
 fi
 
 # 7. Create .agents/ sidecar symlinks for the real Codex skill target.

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2343,9 +2343,9 @@ describe('setup script validation', () => {
     expect(claudeSection).toContain('link_claude_root_skill_alias "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"');
   });
 
-  test('setup supports --host auto|claude|codex|kiro|opencode', () => {
+  test('setup supports --host auto|claude|codex|kiro|opencode|copilot', () => {
     expect(setupContent).toContain('--host');
-    expect(setupContent).toContain('claude|codex|kiro|factory|opencode|auto');
+    expect(setupContent).toContain('claude|codex|kiro|factory|opencode|copilot|auto');
   });
 
   test('auto mode detects claude, codex, kiro, and opencode binaries', () => {
@@ -2353,6 +2353,7 @@ describe('setup script validation', () => {
     expect(setupContent).toContain('command -v codex');
     expect(setupContent).toContain('command -v kiro-cli');
     expect(setupContent).toContain('command -v opencode');
+    expect(setupContent).toContain('command -v gh');
   });
 
   // T1: Sidecar skip guard — prevents .agents/skills/gstack from being linked as a skill
@@ -2392,6 +2393,46 @@ describe('setup script validation', () => {
     expect(setupContent).toContain('qa/templates');
     expect(setupContent).toContain('qa/references');
     expect(setupContent).toContain('dx-hall-of-fame.md');
+  });
+
+  test('setup supports --host copilot with install section and Copilot skill path vars', () => {
+    expect(setupContent).toContain('INSTALL_COPILOT=');
+    expect(setupContent).toContain('COPILOT_SKILLS="$HOME/.copilot/skills"');
+    expect(setupContent).toContain('COPILOT_GSTACK="$COPILOT_SKILLS/gstack"');
+    expect(setupContent).toContain('bun_cmd run gen:skill-docs --host copilot');
+  });
+
+  test('setup installs Copilot skills into an opencode-shaped nested runtime root', () => {
+    expect(setupContent).toContain('create_copilot_runtime_root');
+    expect(setupContent).toContain('.copilot/skills');
+    expect(setupContent).toContain('review/specialists');
+    expect(setupContent).toContain('qa/templates');
+    expect(setupContent).toContain('qa/references');
+    expect(setupContent).toContain('dx-hall-of-fame.md');
+  });
+
+  test('generated Copilot preambles use Copilot roots and not opencode/codex roots', () => {
+    const copilotSkillDir = path.join(ROOT, '.copilot', 'skills', 'gstack-ship');
+    if (!fs.existsSync(copilotSkillDir)) return; // skip if .copilot/ not generated
+    const content = fs.readFileSync(path.join(copilotSkillDir, 'SKILL.md'), 'utf-8');
+    expect(content).toContain('GSTACK_ROOT="$HOME/.copilot/skills/gstack"');
+    expect(content).toContain('[ -n "$_ROOT" ] && [ -d "$_ROOT/.copilot/skills/gstack" ]');
+    expect(content).toContain('$GSTACK_BIN/');
+    expect(content).not.toContain('.opencode/skills');
+    expect(content).not.toContain('.agents/skills/gstack');
+    expect(content).not.toContain('$HOME/.config/opencode/skills/gstack');
+    expect(content).not.toContain('$HOME/.codex/skills/gstack');
+  });
+
+  test('generated Copilot upgrade skill refreshes the Copilot host after pull/reset', () => {
+    const upgradePath = path.join(ROOT, '.copilot', 'skills', 'gstack-upgrade', 'SKILL.md');
+    if (!fs.existsSync(upgradePath)) return; // skip if .copilot/ not generated
+    const content = fs.readFileSync(upgradePath, 'utf-8');
+    expect(content).toContain('./setup --host copilot');
+    expect(content).toContain('INSTALL_DIR="$HOME/.copilot/skills/gstack"');
+    expect(content).toContain('INSTALL_DIR=".copilot/skills/gstack"');
+    expect(content).not.toContain('.agents/skills/gstack');
+    expect(content).not.toContain('cd "$INSTALL_DIR"\nSTASH_OUTPUT=$(git stash 2>&1)\ngit fetch origin\ngit reset --hard origin/main\n./setup\n');
   });
 
   test('create_agents_sidecar links runtime assets', () => {
@@ -3033,7 +3074,7 @@ describe('plan-mode-info resolver (handshake-replacement)', () => {
     // Non-Claude hosts render to hostSubdirs (.agents/, .openclaw/, etc). The
     // plan-mode-info resolver has no host-scoping — all hosts get the new
     // section, none get the old handshake. Scan all candidate host dirs.
-    const hostDirs = ['.agents', '.openclaw', '.opencode', '.factory', '.hermes', '.kiro', '.cursor', '.slate'];
+    const hostDirs = ['.agents', '.openclaw', '.opencode', '.copilot', '.factory', '.hermes', '.kiro', '.cursor', '.slate'];
     let checked = 0;
     for (const host of hostDirs) {
       const skillsRoot = path.join(ROOT, host, 'skills');

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -19,6 +19,7 @@ import {
   factory,
   kiro,
   opencode,
+  copilot,
   slate,
   cursor,
   openclaw,
@@ -30,8 +31,8 @@ const ROOT = path.resolve(import.meta.dir, '..');
 // ─── hosts/index.ts ─────────────────────────────────────────
 
 describe('hosts/index.ts', () => {
-  test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+  test('ALL_HOST_CONFIGS has 11 hosts', () => {
+    expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {
@@ -50,6 +51,7 @@ describe('hosts/index.ts', () => {
     expect(factory.name).toBe('factory');
     expect(kiro.name).toBe('kiro');
     expect(opencode.name).toBe('opencode');
+    expect(copilot.name).toBe('copilot');
     expect(slate.name).toBe('slate');
     expect(cursor.name).toBe('cursor');
     expect(openclaw.name).toBe('openclaw');
@@ -257,6 +259,17 @@ describe('HOST_PATHS derivation from configs', () => {
     expect(HOST_PATHS.codex.designDir).toBe('$GSTACK_DESIGN');
   });
 
+  test('Copilot uses opencode-style env var paths with Copilot roots', () => {
+    expect(copilot.usesEnvVars).toBe(true);
+    expect(copilot.globalRoot).toBe('.copilot/skills/gstack');
+    expect(copilot.localSkillRoot).toBe('.copilot/skills/gstack');
+    expect(copilot.hostSubdir).toBe('.copilot');
+    expect(HOST_PATHS.copilot.skillRoot).toBe('$GSTACK_ROOT');
+    expect(HOST_PATHS.copilot.binDir).toBe('$GSTACK_BIN');
+    expect(HOST_PATHS.copilot.browseDir).toBe('$GSTACK_BROWSE');
+    expect(HOST_PATHS.copilot.designDir).toBe('$GSTACK_DESIGN');
+  });
+
   test('every host with usesEnvVars=true gets env var paths', () => {
     for (const config of ALL_HOST_CONFIGS) {
       if (config.usesEnvVars) {
@@ -369,16 +382,41 @@ describe('host-config-export.ts CLI', () => {
     expect(lines).toContain('plan-devex-review/dx-hall-of-fame.md');
   });
 
+  test('copilot symlinks match opencode runtime assets', () => {
+    const { stdout, exitCode } = run('symlinks', 'copilot');
+    expect(exitCode).toBe(0);
+    const lines = stdout.split('\n');
+    expect(lines).toEqual(expect.arrayContaining([
+      'bin',
+      'browse/dist',
+      'browse/bin',
+      'design/dist',
+      'gstack-upgrade',
+      'ETHOS.md',
+      'review/checklist.md',
+      'review/design-checklist.md',
+      'review/greptile-triage.md',
+      'review/TODOS-format.md',
+      'review/specialists',
+      'qa/templates',
+      'qa/references',
+      'plan-devex-review/dx-hall-of-fame.md',
+    ]));
+  });
+
   test('symlinks with missing host exits 1', () => {
     const { exitCode } = run('symlinks');
     expect(exitCode).toBe(1);
   });
 
-  test('detect finds claude (since we are running in claude)', () => {
+  test('detect prints installed host names from PATH', () => {
     const { stdout, exitCode } = run('detect');
     expect(exitCode).toBe(0);
-    // claude binary should be on PATH in this environment
-    expect(stdout).toContain('claude');
+    const names = stdout.split('\n').filter(Boolean);
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(ALL_HOST_NAMES).toContain(name);
+    }
   });
 
   test('unknown command exits 1', () => {


### PR DESCRIPTION
## Summary
- add a first-class `copilot` host config derived from the opencode host shape
- install Copilot skills into `~/.copilot/skills` with a real `gstack` runtime root
- make `/gstack-upgrade` use host-derived roots and run `./setup --host <host>` for external hosts
- ignore generated `.copilot/` output like other generated host dirs

## Tests
- `bun test test/host-config.test.ts test/gen-skill-docs.test.ts`
- `bun run gen:skill-docs --host all --dry-run`
- `./setup --host copilot --quiet --no-plan-tune-hooks`