### PR TITLE
fix: add windowsHide to browse detached server spawn on Windows

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -285,6 +285,7 @@ function raiseHeadedWindowMacOS(): void {
     nodeSpawn('osascript', ['-e', 'tell application "Google Chrome for Testing" to activate'], {
       stdio: 'ignore',
       detached: true,
+      windowsHide: true,
     }).unref();
   } catch {
     // osascript missing or app not present — non-fatal
@@ -323,7 +324,7 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     const launcherCode =
       `const{spawn}=require('child_process');` +
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
-      `{detached:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
+      `{detached:true,windowsHide:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
       `${extraEnvStr})}).unref()`;
     Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'] });
   } else {
@@ -340,6 +341,7 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     // the Windows path's rationale — same root cause, different OS API.
     nodeSpawn('bun', ['run', SERVER_SCRIPT], {
       detached: true,
+      windowsHide: true,
       stdio: ['ignore', 'ignore', 'ignore'],
       env: { ...process.env, BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: parentPid, ...extraEnv },
     }).unref();

--- a/browse/test/cli-windows-hide.test.ts
+++ b/browse/test/cli-windows-hide.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..");
+const CLI = path.join(ROOT, "browse", "src", "cli.ts");
+
+function readCodeOnly(): string {
+  return fs.readFileSync(CLI, "utf-8")
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("//"))
+    .join("\n");
+}
+
+// #1835 tripwire. On Windows, detached child_process.spawn allocates a
+// console window unless windowsHide:true is set. These static checks fail CI
+// if any detached spawn path in cli.ts drops the Windows no-window flag.
+describe("#1835 detached browse spawns hide Windows consoles", () => {
+  test("Windows Node launcher spawn carries windowsHide:true", () => {
+    const src = readCodeOnly();
+    expect(src).toMatch(/spawn\(process\.execPath,[\s\S]{0,500}detached:\s*true[\s\S]{0,100}windowsHide:\s*true/);
+  });
+
+  test("non-Windows server nodeSpawn carries windowsHide:true", () => {
+    const src = readCodeOnly();
+    expect(src).toMatch(/nodeSpawn\('bun',[\s\S]{0,500}detached:\s*true[\s\S]{0,100}windowsHide:\s*true/);
+  });
+
+  test("every detached spawn site in cli.ts carries windowsHide:true", () => {
+    const src = readCodeOnly();
+    const detachedSpawns = src.match(/detached:\s*true/g)?.length ?? 0;
+    const windowsHideFlags = src.match(/windowsHide:\s*true/g)?.length ?? 0;
+    expect(detachedSpawns).toBeGreaterThan(0);
+    expect(windowsHideFlags).toBeGreaterThanOrEqual(detachedSpawns);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `windowsHide: true` to the detached server-launcher spawns in `browse/src/cli.ts` so starting the gstack browse server on Windows no longer flashes a black console window.

## Why this matters

Issue #1835 reports that on Windows, starting the browse server flashes two black console windows: the detached `bun.exe` server process and Playwright's `chrome-headless-shell.exe`. The detached launcher spawn near line 326 of `browse/src/cli.ts` sets `{detached:true,stdio:['ignore','ignore','ignore'],...}` but omits `windowsHide:true`, and `child_process.spawn({detached:true})` allocates a new console window on Windows unless `windowsHide:true` (Win32 `CREATE_NO_WINDOW`) is set; the headless-shell window is a secondary effect of the parent having a visible console. This adds `windowsHide:true` to the inlined launcher options object and to the sibling `child_process.spawn` detach call. `windowsHide` is a no-op on POSIX, so it is safe unconditionally.

## Testing

`browse/test/cli-windows-hide.test.ts` is a static-grep regression test in the repo's tripwire style: it asserts the launcher options string carries both `detached:true` and `windowsHide:true`, that the second detached `child_process.spawn` site also includes `windowsHide`, and fails if any future `detached:true` spawn site in `browse/src/cli.ts` drops it. Full suite runs in CI.

Fixes #1835
