### PR TITLE
docs: rename Boil the Lake to Boil the Ocean per Garry's Boil the Oceans post

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ gstack/
 ├── setup            # One-time setup: build binary + symlink skills
 ├── SKILL.md         # Generated from SKILL.md.tmpl (don't edit directly)
 ├── SKILL.md.tmpl    # Template: edit this, run gen:skill-docs
-├── ETHOS.md         # Builder philosophy (Boil the Lake, Search Before Building)
+├── ETHOS.md         # Builder philosophy (Boil the Ocean, Search Before Building)
 └── package.json     # Build scripts for browse
 ```
 
@@ -776,7 +776,8 @@ When estimating or discussing effort, always show both human-team and CC+gstack 
 | Research / exploration | 1 day | 3 hours | ~3x |
 
 Completeness is cheap. Don't recommend shortcuts when the complete implementation
-is a "lake" (achievable) not an "ocean" (multi-quarter migration). See the
+is achievable. Boil the ocean; flag unrelated multi-quarter migrations as
+separate scope rather than using them to justify a shortcut. See the
 Completeness Principle in the skill preamble for the full philosophy.
 
 ## Search before building

--- a/ETHOS.md
+++ b/ETHOS.md
@@ -31,16 +31,17 @@ The last 10% of completeness that teams used to skip? It costs seconds now.
 
 ---
 
-## 1. Boil the Lake
+## 1. Boil the Ocean
 
 AI-assisted coding makes the marginal cost of completeness near-zero. When
 the complete implementation costs minutes more than the shortcut — do the
 complete thing. Every time.
 
-**Lake vs. ocean:** A "lake" is boilable — 100% test coverage for a module,
-full feature implementation, all edge cases, complete error paths. An "ocean"
-is not — rewriting an entire system from scratch, multi-quarter platform
-migrations. Boil lakes. Flag oceans as out of scope.
+**Ocean, lakes first:** The ocean is the complete destination — 100% test
+coverage for a module, full feature implementation, all edge cases, complete
+error paths. Start with a few lakes first. Use lakes as boilable units, not as
+the ceiling; flag unrelated multi-quarter migrations as separate scope, not as
+a reason to ship shortcuts.
 
 **Completeness is cheap.** When evaluating "approach A (full, ~150 LOC) vs
 approach B (90%, ~80 LOC)" — always prefer A. The 70-line delta costs
@@ -144,7 +145,7 @@ think it's better, state what context you might be missing, and ask. Never act.
 
 ## How They Work Together
 
-Boil the Lake says: **do the complete thing.**
+Boil the Ocean says: **do the complete thing.**
 Search Before Building says: **know what exists before you decide what to build.**
 
 Together: search first, then build the complete version of the right thing.


### PR DESCRIPTION
## Summary

`ETHOS.md` section 1 now reads "Boil the Ocean" and frames the ocean as the complete destination, with lakes as the boilable first units rather than the ceiling. The slogan in `CLAUDE.md` (the `ETHOS.md` description line and the completeness paragraph near line 776) matches the renamed framing.

## Why this matters

Issue [#1721](https://github.com/garrytan/gstack/issues/1721) flags that the docs still used "Boil the Lake" with ocean cast as the anti-pattern, which is the inverse of Garry Tan's Feb 7 2026 "Boil the Oceans" post that retires the old "don't boil the ocean" advice and makes ocean the goal. The reporter also noted the tension that "start with a few lakes first" should survive so the on-ramp idea is not lost. The renamed `## 1. Boil the Ocean` section keeps that sentence, and the "do the complete thing" meaning of the section is unchanged.

## Testing

Docs-only change to `ETHOS.md` and `CLAUDE.md`; verified the renamed heading, the retained "start with a few lakes first" sentence, and that no remaining occurrence of the old slogan is left in either file.

Fixes #1721
