### PR TITLE
fix(redact): detect modern OpenAI keys (sk-proj-/sk-svcacct-/sk-admin- with -/_ body)

### DIFF
--- a/lib/redact-patterns.ts
+++ b/lib/redact-patterns.ts
@@ -233,8 +233,14 @@ export const PATTERNS: RedactPattern[] = [
     id: "openai.key",
     tier: "HIGH",
     category: "secret",
-    description: "OpenAI API key (incl. sk-proj-)",
-    regex: /\b(sk-(?:proj-)?[A-Za-z0-9]{32,})\b/,
+    description: "OpenAI API key (legacy sk- + project/service/admin keys)",
+    // Two forms. Legacy keys are bare `sk-` + a contiguous alphanumeric run.
+    // Modern keys carry a `sk-proj-` / `sk-svcacct-` / `sk-admin-` prefix and a
+    // base64url-style body that includes `-` and `_` (the same charset the
+    // sibling `anthropic.key` already allows). The body charset is widened only
+    // on the prefixed form so the bare `sk-` path keeps its narrow alnum match
+    // and does not start matching kebab/snake identifiers that begin with `sk-`.
+    regex: /\b(sk-(?:proj|svcacct|admin)-[A-Za-z0-9_\-]{32,}|sk-[A-Za-z0-9]{32,})\b/,
   },
   {
     id: "sendgrid.key",

--- a/test/redact-engine.test.ts
+++ b/test/redact-engine.test.ts
@@ -57,6 +57,20 @@ describe("HIGH credential patterns", () => {
     expect(ids(`random ${tok} here`)).not.toContain("twilio.auth_token");
   });
 
+  test("openai.key flags modern prefixed keys whose body carries -/_ separators", () => {
+    // Regression: the legacy regex required a contiguous [A-Za-z0-9] run right
+    // after the prefix, so real `sk-proj-`/`sk-svcacct-`/`sk-admin-` keys (whose
+    // base64url body contains `-` and `_`) slipped through with NO finding — a
+    // HIGH credential failing OPEN past the redaction gate.
+    expect(ids("OPENAI_API_KEY=sk-proj-Ab12_Cd34-Ef56Gh78Ij90Kl12Mn34Op56Qr78St90Uv")).toContain("openai.key");
+    expect(ids("sk-svcacct-abc_def-ghijklmnopqrstuvwxyz0123456789ABCDEF")).toContain("openai.key");
+    expect(ids("sk-admin-AAA_bbb-CCCdddEEEfffGGGhhhIIIjjjKKKlllMMMnnn")).toContain("openai.key");
+    // Legacy bare `sk-` + contiguous alnum still flagged.
+    expect(ids("sk-" + "B".repeat(48))).toContain("openai.key");
+    // FP guard: a short `sk-` kebab identifier is not a key.
+    expect(ids("ran the sk-mydata step")).not.toContain("openai.key");
+  });
+
   test("db.url_with_password flags real password, skips placeholder/env-var", () => {
     expect(ids("postgres://user:s3cretP@ss@db.example.com/app")).toContain("db.url_with_password");
     expect(ids("postgres://user:${DB_PASSWORD}@host/app")).not.toContain("db.url_with_password");


### PR DESCRIPTION
## Problem

`lib/redact-patterns.ts` `openai.key` is **HIGH** tier (block), but it only matches a contiguous alphanumeric body:

```ts
regex: /\b(sk-(?:proj-)?[A-Za-z0-9]{32,})\b/,
```

Modern OpenAI keys aren't pure-alphanumeric. Project / service-account / admin keys (`sk-proj-`, `sk-svcacct-`, `sk-admin-`) use a base64url-style body containing `-` and `_` — the same charset gitleaks / trufflehog / GitHub secret scanning use for OpenAI. `[A-Za-z0-9]{32,}` stops at the first separator, never reaches 32 chars, and the scan returns **no finding at all**: a genuinely-secret HIGH credential fails **open** through the redaction gate behind `/spec`, `/ship`, `/cso`, and `/document-*`.

The sibling `anthropic.key` in the same file already permits separators (`sk-ant-[A-Za-z0-9_\-]{20,}`); `openai.key` is the inconsistent one.

## Repro on `main` (c43c850c)

`lib/redact-engine` `scan()` of realistic prefixed keys:

```
MISSED   sk-proj-Ab12_Cd34-Ef56Gh78Ij90Kl12Mn34Op56Qr78St90Uv   -> findings: NONE
MISSED   sk-svcacct-abc_def-ghijklmnopqrstuvwxyz0123456789ABCDEF -> findings: NONE
DETECTED sk-proj-aaaa…(40 contiguous — the only shape the suite covered)
```

`test/redact-engine.test.ts` only exercised `"sk-proj-" + "a".repeat(40)`, so the gap was untested.

## Root cause

The body character class excludes `-`/`_`, which real modern keys contain.

## Fix

Widen the body charset to `[A-Za-z0-9_\-]` **only** on the prefixed form, and keep the bare `sk-` legacy path narrow (alnum) so it doesn't start matching kebab/snake identifiers that begin with `sk-`:

```ts
regex: /\b(sk-(?:proj|svcacct|admin)-[A-Za-z0-9_\-]{32,}|sk-[A-Za-z0-9]{32,})\b/,
```

Single bounded quantifier per alternative — linear-time, passes `redact-pattern-lint`. No tier/visibility/engine changes.

## Testing

- New regression test asserts the three prefixed separator forms now flag `openai.key`, the legacy bare `sk-` form still flags, and a short `sk-` kebab identifier does **not** (FP guard).
- `bun test test/redact-engine.test.ts test/redact-pattern-lint.test.ts test/redact-engine-autoredact.test.ts` → 101 pass, 0 fail.
- `bun test test/redact-doc-resolver.test.ts test/redact-prepush-hook.test.ts test/gstack-redact-cli.test.ts` → 30 pass, 0 fail (description change is doc-safe).

Fixes #1868

🤖 Generated with [Claude Code](https://claude.com/claude-code)