### PR TITLE
chore: harden secret handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,24 @@
-# Copy to .env and fill in values
-# bun auto-loads .env — no dotenv needed
+# Copy to .env and fill in values.
+# bun auto-loads .env — no dotenv needed.
+# NEVER commit .env. Use bin/gstack-secret-set to set values interactively.
 
-# Required for LLM-as-judge evals (bun run test:eval)
-ANTHROPIC_API_KEY=sk-ant-your-key-here
+# --- LLM / AI ---
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+GEMINI_API_KEY=
+GOOGLE_API_KEY=
+VOYAGE_API_KEY=
+
+# --- GitHub ---
+GITHUB_TOKEN=
+
+# --- Supabase (management operations only — not the public anon key) ---
+SUPABASE_ACCESS_TOKEN=
+SUPABASE_SERVICE_ROLE_KEY=
+DB_PASS=
+
+# --- Railway ---
+RAILWAY_TOKEN=
+
+# --- Communication ---
+SLACK_BOT_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,12 @@ extension/lib/xterm-addon-fit.js
 .env.local
 .env.*
 !.env.example
+env.private
+*.private
+secrets/*.env
+.oni-secrets/
+.gstack-secrets/
+tasks/runtime-secret-checks/
 supabase/.temp/
 
 # Throughput analysis — local-only, regenerate via scripts/garry-output-comparison.ts

--- a/bin/gstack-env-load
+++ b/bin/gstack-env-load
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# gstack-env-load — source gstack secrets into the current shell session
+#
+# Usage:  source bin/gstack-env-load
+# Note:   Must be sourced, not executed, to affect the calling shell.
+
+set -euo pipefail
+
+GSTACK_DIR="${GSTACK_DIR:-$HOME/gstack}"
+PRIVATE_ENV_GSTACK="$HOME/.config/gstack/env.private"
+PRIVATE_ENV_ONI="$HOME/.config/oni/env.private"
+ONI_SECRETS="$HOME/.config/oni/secrets.env"
+LOCAL_ENV="$GSTACK_DIR/.env"
+
+_loaded=0
+
+_load_file() {
+  local f="$1"
+  if [[ -f "$f" ]]; then
+    # shellcheck disable=SC1090
+    source "$f"
+    (( _loaded++ )) || true
+    echo "[gstack-env-load] loaded: $(basename "$f") — values not shown" >&2
+  fi
+}
+
+# Load in priority order: gstack-specific first, then ONI fallback, then local .env
+_load_file "$PRIVATE_ENV_GSTACK"
+_load_file "$PRIVATE_ENV_ONI"
+_load_file "$ONI_SECRETS"
+_load_file "$LOCAL_ENV"
+
+if [[ $_loaded -eq 0 ]]; then
+  echo "[gstack-env-load] warning: no env files found — set credentials with bin/gstack-secret-set" >&2
+fi
+
+unset _loaded
+unset -f _load_file

--- a/bin/gstack-secret-set
+++ b/bin/gstack-secret-set
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# gstack-secret-set — interactively set a secret in ~/.config/gstack/env.private
+#
+# Usage:  bin/gstack-secret-set VAR_NAME
+#
+# WARNING: Do NOT paste tokens into chat or AI sessions.
+#          Run this script in a clean terminal window only.
+
+set -euo pipefail
+
+PRIVATE_ENV="${HOME}/.config/gstack/env.private"
+
+usage() {
+  echo "Usage: gstack-secret-set VAR_NAME" >&2
+  echo "       Sets VAR_NAME in $PRIVATE_ENV (chmod 600)" >&2
+  echo "" >&2
+  echo "Known gstack credential names:" >&2
+  echo "  ANTHROPIC_API_KEY  OPENAI_API_KEY  GEMINI_API_KEY  GOOGLE_API_KEY" >&2
+  echo "  VOYAGE_API_KEY  GITHUB_TOKEN  RAILWAY_TOKEN  SLACK_BOT_TOKEN" >&2
+  echo "  SUPABASE_ACCESS_TOKEN  SUPABASE_SERVICE_ROLE_KEY  DB_PASS" >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+VAR_NAME="$1"
+
+# Validate var name is safe (uppercase alphanumeric + underscore)
+if ! [[ "$VAR_NAME" =~ ^[A-Z][A-Z0-9_]+$ ]]; then
+  echo "Error: VAR_NAME must be uppercase letters, digits, and underscores" >&2
+  exit 1
+fi
+
+echo ""
+echo "WARNING: Do NOT run this from a chat session or AI terminal." >&2
+echo "         Paste tokens only in a private terminal window." >&2
+echo ""
+
+# Prompt without echoing the value
+read -rsp "Enter value for $VAR_NAME (input hidden): " SECRET_VALUE
+echo "" >&2
+
+if [[ -z "$SECRET_VALUE" ]]; then
+  echo "Error: empty value — aborted" >&2
+  exit 1
+fi
+
+# Create config dir if needed, ensure private permissions
+mkdir -p "$(dirname "$PRIVATE_ENV")"
+touch "$PRIVATE_ENV"
+chmod 600 "$PRIVATE_ENV"
+
+# Replace existing line or append
+EXPORT_LINE="export ${VAR_NAME}='${SECRET_VALUE//\'/\'\\\'\'}'"
+
+if grep -qP "^export ${VAR_NAME}=" "$PRIVATE_ENV" 2>/dev/null || grep -qP "^${VAR_NAME}=" "$PRIVATE_ENV" 2>/dev/null; then
+  sed -i "s|^export ${VAR_NAME}=.*|${EXPORT_LINE}|;s|^${VAR_NAME}=.*|${EXPORT_LINE}|" "$PRIVATE_ENV"
+  echo "[gstack-secret-set] updated $VAR_NAME in $PRIVATE_ENV" >&2
+else
+  echo "$EXPORT_LINE" >> "$PRIVATE_ENV"
+  echo "[gstack-secret-set] appended $VAR_NAME to $PRIVATE_ENV" >&2
+fi
+
+# Clear value from this process
+unset SECRET_VALUE
+unset EXPORT_LINE
+
+echo "[gstack-secret-set] done — run: source bin/gstack-env-load" >&2

--- a/docs/secret-policy.md
+++ b/docs/secret-policy.md
@@ -1,0 +1,74 @@
+# gstack Secret Policy
+
+## Absolute rules
+
+1. **No secrets in git.** `.env` and all `*.env` files are gitignored and must never be committed.
+2. **No secrets printed to logs or AI chat.** Never `echo $ANTHROPIC_API_KEY` or similar in scripts, terminals, or AI sessions.
+3. **Private env files are chmod 600.** Only the owner may read them.
+4. **`.env.example` contains placeholder names only** — empty values, no real tokens, no partial tokens.
+5. **Secrets are loaded only through approved wrappers** — never inline in scripts.
+6. **Never paste tokens into a chat session or AI terminal.** Run `bin/gstack-secret-set` in a private terminal instead.
+
+## Secret storage
+
+Real secrets live only outside the repo:
+- `~/.env` (personal machine default — chmod 600)
+- `~/.config/gstack/env.private` (preferred — chmod 600)
+- `~/.config/oni/env.private` (ONI cross-system fallback — chmod 600)
+- GitHub Actions CI secrets (for CI/CD jobs only)
+
+Loading pattern (preferred — loads all sources in order):
+```bash
+source bin/gstack-env-load
+```
+
+To set a new credential interactively:
+```bash
+bin/gstack-secret-set VAR_NAME
+```
+
+## Leak scan requirement
+
+Before pushing any commit, run a redacted leak scan:
+```bash
+python3 - <<'PY'
+import re, subprocess, sys
+patterns = {
+    "openai_key": re.compile(r"sk-[A-Za-z0-9_\-]{20,}"),
+    "github_token": re.compile(r"(ghp|github_pat|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}"),
+    "slack_token": re.compile(r"xox[baprs]-[A-Za-z0-9\-]{20,}"),
+    "generic_secret": re.compile(r"(?i)(api[_-]?key|token|secret|password)\s*=\s*['\"]?[A-Za-z0-9_\-./+=]{16,}"),
+}
+files = subprocess.check_output(["git", "ls-files"], text=True).splitlines()
+hits = []; [hits.append((f, i, n)) for f in files for i, l in enumerate(open(f, errors="ignore").read().splitlines(), 1) if not any(x in l.lower() for x in ["example", "your_", "<", "changeme"]) for n, p in patterns.items() if p.search(l)]
+print("LEAK_SCAN_FAIL\n" + "\n".join(f"{f}:{i} {n}" for f, i, n in hits)) if hits else print("LEAK_SCAN_CLEAN")
+PY
+```
+
+## Adding new credentials
+
+1. Add the placeholder name (empty value) to `.env.example`
+2. Document the env var in this file under the variables table
+3. Run `bin/gstack-secret-set VAR_NAME` in a private terminal
+4. Verify: `[[ -n "$VAR_NAME" ]] && echo "set" || echo "missing"`
+
+## Rotating secrets
+
+Run `bin/gstack-secret-set VAR_NAME` in a private terminal. For GitHub Actions secrets, update via the GitHub UI. Do not rotate through AI sessions.
+
+## Variables tracked
+
+| Variable | Purpose | Source |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | Claude API / LLM-as-judge evals | `~/.config/gstack/env.private` |
+| `OPENAI_API_KEY` | OpenAI embeddings / evals | `~/.config/gstack/env.private` |
+| `GEMINI_API_KEY` / `GOOGLE_API_KEY` | Gemini model access | `~/.config/gstack/env.private` |
+| `VOYAGE_API_KEY` | Voyage code embeddings (gbrain) | `~/.config/gstack/env.private` |
+| `GITHUB_TOKEN` | GitHub API calls, CI auth | `~/.config/gstack/env.private` or CI secrets |
+| `SUPABASE_ACCESS_TOKEN` | Supabase management API (provision ops) | `~/.config/gstack/env.private` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role (server-side only) | `~/.config/gstack/env.private` |
+| `DB_PASS` | Supabase DB password (provision ops) | `~/.config/gstack/env.private` |
+| `RAILWAY_TOKEN` | Railway deployments | `~/.config/gstack/env.private` |
+| `SLACK_BOT_TOKEN` | Slack integrations | `~/.config/gstack/env.private` |
+
+**Note:** `GSTACK_SUPABASE_URL` and `GSTACK_SUPABASE_ANON_KEY` in `supabase/config.sh` are **public keys** — safe to commit per Supabase's RLS architecture (equivalent to a Firebase public config).


### PR DESCRIPTION
Adds safer secret/env handling without committing any token values.

Changes:
- expands .env.example placeholders
- adds gitignore coverage for private env/secret files
- adds docs/secret-policy.md
- adds bin/gstack-env-load
- adds bin/gstack-secret-set

Safety:
- changed-files leak scan passed
- no real secret values included
- no unrelated CLAUDE.md changes included