### PR TITLE
feat(plan-eng-review): flag optimistic-UI on a server-gated action as a code-quality check

### DIFF
--- a/plan-eng-review/sections/review-sections.md
+++ b/plan-eng-review/sections/review-sections.md
@@ -126,6 +126,7 @@ Evaluate:
 * Code organization and module structure.
 * DRY violations—be aggressive here.
 * Error handling patterns and missing edge cases (call these out explicitly).
+* Server-gated or actuated actions with optimistic UI—does the client await and surface the real result, or assume success? A swallowed rejection (auth/permission/validation) renders as false success; verify the effect landed, not the toast.
 * Technical debt hotspots.
 * Areas that are over-engineered or under-engineered relative to my preferences.
 * Existing ASCII diagrams in touched files — are they still accurate after this change?

--- a/plan-eng-review/sections/review-sections.md.tmpl
+++ b/plan-eng-review/sections/review-sections.md.tmpl
@@ -28,6 +28,7 @@ Evaluate:
 * Code organization and module structure.
 * DRY violations—be aggressive here.
 * Error handling patterns and missing edge cases (call these out explicitly).
+* Server-gated or actuated actions with optimistic UI—does the client await and surface the real result, or assume success? A swallowed rejection (auth/permission/validation) renders as false success; verify the effect landed, not the toast.
 * Technical debt hotspots.
 * Areas that are over-engineered or under-engineered relative to my preferences.
 * Existing ASCII diagrams in touched files — are they still accurate after this change?


### PR DESCRIPTION
**What** — One bullet added to eng-review's *Code quality review* checklist: for an action whose real effect is gated/actuated server-side (auth, permission, validation), check that the client **awaits and surfaces the real result** instead of optimistically assuming success.

**Why** — Hit this on a live bug: an approval action was wired to the user who clicked it, but only an admin could grant it. The UI optimistically marked it done and showed a success toast while the server returned 403 — green check, nothing granted, no admin ever notified. eng-review slid past it because it fails *closed* (dodges the security lens) and *looks* like success (dodges the failure-mode lens). The catalog already has general "silent failure / swallowed error" framing in the adversarial `/ship` pass, but not this specific, common client↔server variant.

**Change** — One bullet. Edited the source template (`plan-eng-review/sections/review-sections.md.tmpl`) and regenerated the committed section doc via `bun run gen:skill-docs` so `.md` and `.tmpl` stay in sync. No version bump — left to your release flow. Template/section/validation tests pass locally: `template-context-parity`, `section-manifest-consistency`, `skill-validation`, `skill-size-budget`, `parity-sectioned` (389 pass).