### PR TITLE
fix: validate redact max bytes

### DIFF
--- a/bin/gstack-redact
+++ b/bin/gstack-redact
@@ -161,12 +161,20 @@ function readLines(path: string | undefined): string[] | undefined {
 function buildOpts(): ScanOptions {
   const vis = (arg("--repo-visibility") as RepoVisibility) || "unknown";
   const maxBytes = arg("--max-bytes");
+  const parsedMaxBytes = maxBytes ? Number(maxBytes) : undefined;
+  if (
+    maxBytes &&
+    (!Number.isInteger(parsedMaxBytes) || parsedMaxBytes <= 0)
+  ) {
+    process.stderr.write("gstack-redact: --max-bytes must be a positive integer\n");
+    process.exit(1);
+  }
   return {
     repoVisibility: ["public", "private", "unknown"].includes(vis) ? vis : "unknown",
     allowlist: readLines(arg("--allowlist")),
     selfEmail: arg("--self-email"),
     repoPublicEmails: readLines(arg("--repo-public-emails")),
-    ...(maxBytes ? { maxBytes: parseInt(maxBytes, 10) } : {}),
+    ...(parsedMaxBytes ? { maxBytes: parsedMaxBytes } : {}),
   };
 }
 

--- a/lib/redact-engine.ts
+++ b/lib/redact-engine.ts
@@ -253,7 +253,10 @@ function emailAllowed(email: string, opts: ScanOptions): boolean {
 
 export function scan(input: string, opts: ScanOptions = {}): ScanResult {
   const repoVisibility: RepoVisibility = opts.repoVisibility ?? "unknown";
-  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  const maxBytes =
+    Number.isFinite(opts.maxBytes) && opts.maxBytes > 0
+      ? opts.maxBytes
+      : DEFAULT_MAX_BYTES;
 
   // Fail CLOSED on oversize input. Check byte length BEFORE heavy work.
   const byteLen = Buffer.byteLength(input, "utf8");

--- a/test/gstack-redact-cli.test.ts
+++ b/test/gstack-redact-cli.test.ts
@@ -94,4 +94,16 @@ describe("gstack-redact oversize fails closed", () => {
     expect(code).toBe(3);
     expect(stdout).toContain("too large");
   });
+
+  test("malformed --max-bytes exits with usage error", () => {
+    const { code, stderr } = run(["--max-bytes", "notanumber"], "safe text");
+    expect(code).toBe(1);
+    expect(stderr).toContain("--max-bytes must be a positive integer");
+  });
+
+  test("negative --max-bytes exits with usage error", () => {
+    const { code, stderr } = run(["--max-bytes", "-5"], "safe text");
+    expect(code).toBe(1);
+    expect(stderr).toContain("--max-bytes must be a positive integer");
+  });
 });

--- a/test/redact-engine.test.ts
+++ b/test/redact-engine.test.ts
@@ -239,6 +239,17 @@ describe("oversize fails CLOSED", () => {
     expect(r.findings[0].id).toBe("engine.input_too_large");
     expect(exitCodeFor(r)).toBe(3);
   });
+
+  test("invalid byte caps fall back to the default fail-closed cap", () => {
+    const big = "a".repeat(2 * 1024 * 1024);
+
+    for (const maxBytes of [NaN, -1, 0]) {
+      const r = scan(big, { maxBytes });
+      expect(r.oversize).toBe(true);
+      expect(r.findings[0].id).toBe("engine.input_too_large");
+      expect(exitCodeFor(r)).toBe(3);
+    }
+  });
 });
 
 describe("validators", () => {


### PR DESCRIPTION
## Summary
- reject malformed or non-positive gstack-redact --max-bytes values with a usage error
- keep the redaction engine fail-closed by falling back to the default cap for invalid maxBytes values
- add CLI and engine regression tests for invalid caps

Fixes #1824

## Testing
- bun test test/redact-engine.test.ts test/gstack-redact-cli.test.ts