### PR TITLE
Restructure setup phases to improve failure handling and fix bugs

### DIFF
--- a/setup
+++ b/setup
@@ -374,162 +374,35 @@ cleanup_copied_bun() {
 prepare_bun_for_windows_compile
 trap cleanup_copied_bun EXIT
 
-# 1. Build browse binary if needed (smart rebuild: stale sources, package.json, lock)
-NEEDS_BUILD=0
-if [ ! -x "$BROWSE_BIN" ]; then
-  NEEDS_BUILD=1
-elif [ -n "$(find "$SOURCE_GSTACK_DIR/browse/src" -type f -newer "$BROWSE_BIN" -print -quit 2>/dev/null)" ]; then
-  NEEDS_BUILD=1
-elif [ "$SOURCE_GSTACK_DIR/package.json" -nt "$BROWSE_BIN" ]; then
-  NEEDS_BUILD=1
-elif [ -f "$SOURCE_GSTACK_DIR/bun.lock" ] && [ "$SOURCE_GSTACK_DIR/bun.lock" -nt "$BROWSE_BIN" ]; then
-  NEEDS_BUILD=1
-fi
+# ────────────────────────────────────────────────────────────────────────────
+# PHASE A — Trivial operations (always succeed first)
+# ────────────────────────────────────────────────────────────────────────────
 
-if [ "$NEEDS_BUILD" -eq 1 ]; then
-  log "Building browse binary..."
-  (
-    cd "$SOURCE_GSTACK_DIR"
-    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
-    bun_cmd run build
-  )
-  # Safety net: write .version if build script didn't (e.g., git not available during build)
-  if [ ! -f "$SOURCE_GSTACK_DIR/browse/dist/.version" ]; then
-    git -C "$SOURCE_GSTACK_DIR" rev-parse HEAD > "$SOURCE_GSTACK_DIR/browse/dist/.version" 2>/dev/null || true
-  fi
-
-  # macOS Apple Silicon: ad-hoc codesign compiled binaries.
-  # Bun's --compile can produce a corrupt or linker-only code signature that
-  # macOS kills with SIGKILL (exit 137). The two-step remove+re-sign is
-  # required because a naive `codesign -s - -f` fails when the existing
-  # signature block is corrupt. This is idempotent and costs <1s.
-  # See: https://github.com/garrytan/gstack/issues/997
-  if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
-    for _bin in browse/dist/browse browse/dist/find-browse design/dist/design make-pdf/dist/pdf bin/gstack-global-discover; do
-      _bin_path="$SOURCE_GSTACK_DIR/$_bin"
-      [ -f "$_bin_path" ] && [ -x "$_bin_path" ] || continue
-      codesign --remove-signature "$_bin_path" 2>/dev/null || true
-      if ! codesign -s - -f "$_bin_path" 2>/dev/null; then
-        log "warning: codesign failed for $_bin (binary may not run on Apple Silicon)"
-      fi
-    done
-  fi
-
-  # macOS: install coreutils for `gtimeout` (Codex hang protection in /codex + /autoplan).
-  # macOS ships BSD `timeout`-less; Homebrew's coreutils installs GNU timeout as
-  # `gtimeout` to avoid shadowing BSD utilities. The /codex and /autoplan skills
-  # fall back to unwrapped codex invocations when neither is available — this
-  # auto-install upgrades them to hang-protected where possible.
-  # Skip entirely with GSTACK_SKIP_COREUTILS=1 (CI, managed machines, offline envs).
-  if [ "$(uname -s)" = "Darwin" ] && [ "${GSTACK_SKIP_COREUTILS:-0}" != "1" ]; then
-    if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
-      if command -v brew >/dev/null 2>&1; then
-        log "Installing coreutils for Codex hang protection (set GSTACK_SKIP_COREUTILS=1 to skip)..."
-        brew install coreutils >/dev/null 2>&1 || log "warning: brew install coreutils failed; /codex will run without hang protection"
-      else
-        log "warning: Homebrew not found. /codex will run without hang protection. Install coreutils manually or set GSTACK_SKIP_COREUTILS=1."
-      fi
-    fi
-  fi
-fi
-
-if [ ! -x "$BROWSE_BIN" ]; then
-  echo "gstack setup failed: browse binary missing at $BROWSE_BIN" >&2
-  exit 1
-fi
-
-# 1b. Generate .agents/ Codex skill docs — always regenerate to prevent stale descriptions.
-# .agents/ is no longer committed — generated at setup time from .tmpl templates.
-# bun run build already does this, but we need it when NEEDS_BUILD=0 (binary is fresh).
-# Always regenerate: generation is fast (<2s) and mtime-based staleness checks are fragile
-# (miss stale files when timestamps match after clone/checkout/upgrade).
-AGENTS_DIR="$SOURCE_GSTACK_DIR/.agents/skills"
-NEEDS_AGENTS_GEN=1
-
-if [ "$NEEDS_AGENTS_GEN" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
-  log "Generating .agents/ skill docs..."
-  (
-    cd "$SOURCE_GSTACK_DIR"
-    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
-    bun_cmd run gen:skill-docs --host codex
-  )
-fi
-
-# 1c. Generate .factory/ Factory Droid skill docs
-if [ "$INSTALL_FACTORY" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
-  log "Generating .factory/ skill docs..."
-  (
-    cd "$SOURCE_GSTACK_DIR"
-    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
-    bun_cmd run gen:skill-docs --host factory
-  )
-fi
-
-# 1d. Generate .opencode/ OpenCode skill docs
-if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
-  log "Generating .opencode/ skill docs..."
-  (
-    cd "$SOURCE_GSTACK_DIR"
-    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
-    bun_cmd run gen:skill-docs --host opencode
-  )
-fi
-
-# 2. Ensure Playwright's Chromium is available
-if ! ensure_playwright_browser; then
-  echo "Installing Playwright Chromium..."
-  (
-    cd "$SOURCE_GSTACK_DIR"
-    bunx playwright install chromium
-  )
-
-  if [ "$IS_WINDOWS" -eq 1 ]; then
-    # On Windows, Node.js launches Chromium (not Bun — see oven-sh/bun#4253).
-    # Ensure playwright is importable by Node from the gstack directory.
-    if ! command -v node >/dev/null 2>&1; then
-      echo "gstack setup failed: Node.js is required on Windows (Bun cannot launch Chromium due to a pipe bug)" >&2
-      echo "  Install Node.js: https://nodejs.org/" >&2
-      exit 1
-    fi
-    echo "Windows detected — verifying Node.js can load Playwright..."
-    (
-      cd "$SOURCE_GSTACK_DIR"
-      # Bun's node_modules already has playwright; verify Node can require it
-      node -e "require('playwright')" 2>/dev/null || npm install --no-save playwright
-      # @ngrok/ngrok is externalized in server-node.mjs and resolved at runtime.
-      # Verify the platform-specific native binary is installed so /pair-agent
-      # tunnels don't fail later with a cryptic module-not-found error.
-      node -e "require('@ngrok/ngrok')" 2>/dev/null || npm install --no-save @ngrok/ngrok
-    )
-  fi
-fi
-
-if ! ensure_playwright_browser; then
-  if [ "$IS_WINDOWS" -eq 1 ]; then
-    echo "gstack setup failed: Playwright Chromium could not be launched via Node.js" >&2
-    echo "  This is a known issue with Bun on Windows (oven-sh/bun#4253)." >&2
-    echo "  Ensure Node.js is installed and 'node -e \"require('playwright')\"' works." >&2
-  else
-    echo "gstack setup failed: Playwright Chromium could not be launched" >&2
-  fi
-  exit 1
-fi
-
-# 2b. Ensure a color-emoji font is installed so make-pdf emoji render (Linux).
-#     Best-effort: warn instead of failing if it can't install.
-if ! ensure_emoji_font; then
-  echo "  Note: could not auto-install a color-emoji font. Emoji in make-pdf" >&2
-  echo "  output may render as boxes (▯). Install one manually, e.g.:" >&2
-  echo "    Debian/Ubuntu: sudo apt-get install fonts-noto-color-emoji" >&2
-  echo "    Fedora:        sudo dnf install google-noto-color-emoji-fonts" >&2
-  echo "    Arch:          sudo pacman -S noto-fonts-emoji" >&2
-  echo "    Alpine:        sudo apk add font-noto-emoji" >&2
-else
-  refresh_browse_daemon_for_fonts
-fi
-
-# 3. Ensure ~/.gstack global state directory exists
+# A1. Ensure ~/.gstack global state directory exists
 mkdir -p "$HOME/.gstack/projects"
+
+# A2. First-time welcome + legacy /tmp cleanup
+if [ ! -f "$HOME/.gstack/.welcome-seen" ]; then
+  log "  Welcome! Run /gstack-upgrade anytime to stay current."
+  touch "$HOME/.gstack/.welcome-seen"
+fi
+rm -f /tmp/gstack-latest-version
+
+# A3. GBrain detection (file scan; writes gbrain-detection.json).
+# Regen on detection hit happens later in B6, once bun is ready and skill
+# docs are generated. See the B6 block for the regen + warn behavior.
+DETECT_BIN="$SOURCE_GSTACK_DIR/bin/gstack-gbrain-detect"
+GBRAIN_STATE_DIR="${GSTACK_HOME:-$HOME/.gstack}"
+DETECTION_FILE="$GBRAIN_STATE_DIR/gbrain-detection.json"
+mkdir -p "$GBRAIN_STATE_DIR"
+if [ -x "$DETECT_BIN" ]; then
+  if "$DETECT_BIN" > "$DETECTION_FILE.tmp" 2>/dev/null; then
+    mv "$DETECTION_FILE.tmp" "$DETECTION_FILE"
+  else
+    rm -f "$DETECTION_FILE.tmp"
+    log "  warning: gstack-gbrain-detect failed — brain-aware blocks will stay suppressed"
+  fi
+fi
 
 # ─── Helper: link Claude skill subdirectories into a skills parent directory ──
 # Creates real directories (not symlinks) at the top level with a SKILL.md symlink
@@ -711,7 +584,7 @@ link_codex_skill_dirs() {
 
   if [ ! -d "$agents_dir" ]; then
     echo "  Generating .agents/ skill docs..."
-    ( cd "$gstack_dir" && bun run gen:skill-docs --host codex )
+    ( cd "$gstack_dir" && bun_cmd run gen:skill-docs --host codex )
   fi
 
   if [ ! -d "$agents_dir" ]; then
@@ -916,7 +789,7 @@ link_factory_skill_dirs() {
 
   if [ ! -d "$factory_dir" ]; then
     echo "  Generating .factory/ skill docs..."
-    ( cd "$gstack_dir" && bun run gen:skill-docs --host factory )
+    ( cd "$gstack_dir" && bun_cmd run gen:skill-docs --host factory )
   fi
 
   if [ ! -d "$factory_dir" ]; then
@@ -948,7 +821,7 @@ link_opencode_skill_dirs() {
 
   if [ ! -d "$opencode_dir" ]; then
     echo "  Generating .opencode/ skill docs..."
-    ( cd "$gstack_dir" && bun run gen:skill-docs --host opencode )
+    ( cd "$gstack_dir" && bun_cmd run gen:skill-docs --host opencode )
   fi
 
   if [ ! -d "$opencode_dir" ]; then
@@ -972,7 +845,96 @@ link_opencode_skill_dirs() {
   fi
 }
 
-# 4. Install for Claude (default)
+# ────────────────────────────────────────────────────────────────────────────
+# PHASE B — Local compute & filesystem (low fail)
+# ────────────────────────────────────────────────────────────────────────────
+
+# B1. Build browse binary if needed (smart rebuild: stale sources, package.json, lock)
+NEEDS_BUILD=0
+if [ ! -x "$BROWSE_BIN" ]; then
+  NEEDS_BUILD=1
+elif [ -n "$(find "$SOURCE_GSTACK_DIR/browse/src" -type f -newer "$BROWSE_BIN" -print -quit 2>/dev/null)" ]; then
+  NEEDS_BUILD=1
+elif [ "$SOURCE_GSTACK_DIR/package.json" -nt "$BROWSE_BIN" ]; then
+  NEEDS_BUILD=1
+elif [ -f "$SOURCE_GSTACK_DIR/bun.lock" ] && [ "$SOURCE_GSTACK_DIR/bun.lock" -nt "$BROWSE_BIN" ]; then
+  NEEDS_BUILD=1
+fi
+
+if [ "$NEEDS_BUILD" -eq 1 ]; then
+  log "Building browse binary..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
+    bun_cmd run build
+  )
+  # Safety net: write .version if build script didn't (e.g., git not available during build)
+  if [ ! -f "$SOURCE_GSTACK_DIR/browse/dist/.version" ]; then
+    git -C "$SOURCE_GSTACK_DIR" rev-parse HEAD > "$SOURCE_GSTACK_DIR/browse/dist/.version" 2>/dev/null || true
+  fi
+
+  # macOS Apple Silicon: ad-hoc codesign compiled binaries.
+  # Bun's --compile can produce a corrupt or linker-only code signature that
+  # macOS kills with SIGKILL (exit 137). The two-step remove+re-sign is
+  # required because a naive `codesign -s - -f` fails when the existing
+  # signature block is corrupt. This is idempotent and costs <1s.
+  # See: https://github.com/garrytan/gstack/issues/997
+  if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+    for _bin in browse/dist/browse browse/dist/find-browse design/dist/design make-pdf/dist/pdf bin/gstack-global-discover; do
+      _bin_path="$SOURCE_GSTACK_DIR/$_bin"
+      [ -f "$_bin_path" ] && [ -x "$_bin_path" ] || continue
+      codesign --remove-signature "$_bin_path" 2>/dev/null || true
+      if ! codesign -s - -f "$_bin_path" 2>/dev/null; then
+        log "warning: codesign failed for $_bin (binary may not run on Apple Silicon)"
+      fi
+    done
+  fi
+
+fi
+
+if [ ! -x "$BROWSE_BIN" ]; then
+  echo "gstack setup failed: browse binary missing at $BROWSE_BIN" >&2
+  exit 1
+fi
+
+# B2a. Generate .agents/ Codex skill docs — always regenerate to prevent stale descriptions.
+# .agents/ is no longer committed — generated at setup time from .tmpl templates.
+# bun run build already does this, but we need it when NEEDS_BUILD=0 (binary is fresh).
+# Always regenerate: generation is fast (<2s) and mtime-based staleness checks are fragile
+# (miss stale files when timestamps match after clone/checkout/upgrade).
+AGENTS_DIR="$SOURCE_GSTACK_DIR/.agents/skills"
+NEEDS_AGENTS_GEN=1
+
+if [ "$NEEDS_AGENTS_GEN" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .agents/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
+    bun_cmd run gen:skill-docs --host codex
+  )
+fi
+
+# B2b. Generate .factory/ Factory Droid skill docs
+if [ "$INSTALL_FACTORY" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .factory/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
+    bun_cmd run gen:skill-docs --host factory
+  )
+fi
+
+# B2c. Generate .opencode/ OpenCode skill docs
+if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .opencode/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
+    bun_cmd run gen:skill-docs --host opencode
+  )
+fi
+
+# B3a. Install for Claude (default)
 SKILLS_BASENAME="$(basename "$INSTALL_SKILLS_DIR")"
 SKILLS_PARENT_BASENAME="$(basename "$(dirname "$INSTALL_SKILLS_DIR")")"
 CODEX_REPO_LOCAL=0
@@ -1082,7 +1044,7 @@ if [ "$INSTALL_CLAUDE" -eq 1 ]; then
   fi
 fi
 
-# 5. Install for Codex
+# B3b. Install for Codex
 if [ "$INSTALL_CODEX" -eq 1 ]; then
   if [ "$CODEX_REPO_LOCAL" -eq 1 ]; then
     CODEX_SKILLS="$INSTALL_SKILLS_DIR"
@@ -1103,7 +1065,7 @@ if [ "$INSTALL_CODEX" -eq 1 ]; then
   log "  codex skills: $CODEX_SKILLS"
 fi
 
-# 6. Install for Kiro CLI (copy from .agents/skills, rewrite paths)
+# B3c. Install for Kiro CLI (copy from .agents/skills, rewrite paths)
 if [ "$INSTALL_KIRO" -eq 1 ]; then
   KIRO_SKILLS="$HOME/.kiro/skills"
   AGENTS_DIR="$SOURCE_GSTACK_DIR/.agents/skills"
@@ -1173,7 +1135,7 @@ if [ "$INSTALL_KIRO" -eq 1 ]; then
   fi
 fi
 
-# 6b. Install for Factory Droid
+# B3d. Install for Factory Droid
 if [ "$INSTALL_FACTORY" -eq 1 ]; then
   mkdir -p "$FACTORY_SKILLS"
   create_factory_runtime_root "$SOURCE_GSTACK_DIR" "$FACTORY_GSTACK"
@@ -1183,7 +1145,7 @@ if [ "$INSTALL_FACTORY" -eq 1 ]; then
   echo "  factory skills: $FACTORY_SKILLS"
 fi
 
-# 6c. Install for OpenCode
+# B3e. Install for OpenCode
 if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   mkdir -p "$OPENCODE_SKILLS"
   create_opencode_runtime_root "$SOURCE_GSTACK_DIR" "$OPENCODE_GSTACK"
@@ -1193,14 +1155,14 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   echo "  opencode skills: $OPENCODE_SKILLS"
 fi
 
-# 7. Create .agents/ sidecar symlinks for the real Codex skill target.
+# B4. Create .agents/ sidecar symlinks for the real Codex skill target.
 # The root Codex skill ends up pointing at $SOURCE_GSTACK_DIR/.agents/skills/gstack,
 # so the runtime assets must live there for both global and repo-local installs.
 if [ "$INSTALL_CODEX" -eq 1 ]; then
   create_agents_sidecar "$SOURCE_GSTACK_DIR"
 fi
 
-# 8. Run pending version migrations
+# B5. Run pending version migrations
 # Migrations handle state fixes that ./setup alone can't cover (stale config,
 # orphaned files, directory structure changes). Each migration is idempotent.
 MIGRATIONS_DIR="$SOURCE_GSTACK_DIR/gstack-upgrade/migrations"
@@ -1227,14 +1189,27 @@ if [ "$CURRENT_VERSION" != "unknown" ]; then
   echo "$CURRENT_VERSION" > "$HOME/.gstack/.last-setup-version"
 fi
 
-# 9. First-time welcome + legacy cleanup
-if [ ! -f "$HOME/.gstack/.welcome-seen" ]; then
-  log "  Welcome! Run /gstack-upgrade anytime to stay current."
-  touch "$HOME/.gstack/.welcome-seen"
+# B6. GBrain regen if detected (see A3 for the detection write).
+# Users who install gbrain after running ./setup should re-run setup OR call
+# `gstack-config gbrain-refresh` + `bun run gen:skill-docs:user`.
+if [ -f "$DETECTION_FILE" ]; then
+  if grep -q '"gbrain_local_status": "ok"' "$DETECTION_FILE" 2>/dev/null; then
+    log "gbrain detected — regenerating Claude SKILL.md with brain-aware blocks (~250 token overhead per planning skill)..."
+    (
+      cd "$SOURCE_GSTACK_DIR"
+      bun_cmd run gen:skill-docs:user --host claude
+    ) || log "  warning: gen:skill-docs:user failed — run 'bun run gen:skill-docs:user' manually if you want brain-aware blocks"
+  else
+    log "gbrain not detected — brain-aware blocks suppressed in planning-skill SKILL.md files (zero token overhead)."
+    log "  To enable: install gbrain via /setup-gbrain, then re-run ./setup or 'gstack-config gbrain-refresh'."
+  fi
 fi
-rm -f /tmp/gstack-latest-version
 
-# 10. Team mode: register/unregister SessionStart hook
+# ────────────────────────────────────────────────────────────────────────────
+# PHASE C — Settings.json mutation (medium fail, fully reversible)
+# ────────────────────────────────────────────────────────────────────────────
+
+# C1. Team mode: register/unregister SessionStart hook
 SETTINGS_HOOK="$SOURCE_GSTACK_DIR/bin/gstack-settings-hook"
 HOOK_CMD="$SOURCE_GSTACK_DIR/bin/gstack-session-update"
 
@@ -1268,45 +1243,7 @@ if [ "$NO_TEAM_MODE" -eq 1 ]; then
   log "Team mode disabled: auto-update hook removed."
 fi
 
-# ─── GBrain detection + conditional SKILL.md regen ──────────────────────
-#
-# Detect whether gbrain is installed and persist the result to
-# ~/.gstack/gbrain-detection.json so gen-skill-docs can decide whether to
-# render GBRAIN_CONTEXT_LOAD and GBRAIN_SAVE_RESULTS blocks. If detected,
-# regenerate the Claude-host SKILL.md files with the un-suppressed
-# (compressed) brain-aware blocks via `bun run gen:skill-docs:user`.
-#
-# If gbrain is not detected, the canonical no-gbrain SKILL.md files
-# (which were just generated above by `gen:skill-docs --host claude` if
-# applicable, or which are checked in) stay as-is. Zero token overhead
-# for non-gbrain users.
-#
-# Users who install gbrain after running ./setup should re-run setup OR
-# call `gstack-config gbrain-refresh` + `bun run gen:skill-docs:user`.
-DETECT_BIN="$SOURCE_GSTACK_DIR/bin/gstack-gbrain-detect"
-GBRAIN_STATE_DIR="${GSTACK_HOME:-$HOME/.gstack}"
-DETECTION_FILE="$GBRAIN_STATE_DIR/gbrain-detection.json"
-mkdir -p "$GBRAIN_STATE_DIR"
-if [ -x "$DETECT_BIN" ]; then
-  if "$DETECT_BIN" > "$DETECTION_FILE.tmp" 2>/dev/null; then
-    mv "$DETECTION_FILE.tmp" "$DETECTION_FILE"
-    if grep -q '"gbrain_local_status": "ok"' "$DETECTION_FILE" 2>/dev/null; then
-      log "gbrain detected — regenerating Claude SKILL.md with brain-aware blocks (~250 token overhead per planning skill)..."
-      (
-        cd "$SOURCE_GSTACK_DIR"
-        bun_cmd run gen:skill-docs:user --host claude 2>&1 | tail -3
-      ) || log "  warning: gen:skill-docs:user failed — run 'bun run gen:skill-docs:user' manually if you want brain-aware blocks"
-    else
-      log "gbrain not detected — brain-aware blocks suppressed in planning-skill SKILL.md files (zero token overhead)."
-      log "  To enable: install gbrain via /setup-gbrain, then re-run ./setup or 'gstack-config gbrain-refresh'."
-    fi
-  else
-    rm -f "$DETECTION_FILE.tmp"
-    log "  warning: gstack-gbrain-detect failed — brain-aware blocks will stay suppressed"
-  fi
-fi
-
-# 11. Plan-tune cathedral hook install (T8).
+# C2. Plan-tune cathedral hook install (T8).
 #
 # Registers PostToolUse (deterministic AUQ capture) + PreToolUse (preference
 # enforcement) hooks in ~/.claude/settings.json so /plan-tune actually does
@@ -1448,7 +1385,89 @@ if [ "$NO_TEAM_MODE" -ne 1 ] \
   fi
 fi
 
+# C3. Tear down plan-tune hooks on --no-team.
 # Also tear down plan-tune hooks on --no-team (matches the existing pattern).
 if [ "$NO_TEAM_MODE" -eq 1 ] && [ -x "$SETTINGS_HOOK" ]; then
   "$SETTINGS_HOOK" remove-source --source plan-tune-cathedral 2>/dev/null || true
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# PHASE D — External network / sudo / package managers (highest fail)
+# Each step is best-effort: failure leaves the install usable but with reduced
+# browser / PDF features. Skills, hooks, and migrations are already in place
+# from earlier phases, so re-running ./setup retries only this phase.
+# ────────────────────────────────────────────────────────────────────────────
+
+# D1. macOS: install coreutils for `gtimeout` (Codex hang protection in /codex + /autoplan).
+# macOS ships BSD `timeout`-less; Homebrew's coreutils installs GNU timeout as
+# `gtimeout` to avoid shadowing BSD utilities. The /codex and /autoplan skills
+# fall back to unwrapped codex invocations when neither is available — this
+# auto-install upgrades them to hang-protected where possible.
+# Skip entirely with GSTACK_SKIP_COREUTILS=1 (CI, managed machines, offline envs).
+if [ "$(uname -s)" = "Darwin" ] && [ "${GSTACK_SKIP_COREUTILS:-0}" != "1" ]; then
+  if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
+    if command -v brew >/dev/null 2>&1; then
+      log "Installing coreutils for Codex hang protection (set GSTACK_SKIP_COREUTILS=1 to skip)..."
+      brew install coreutils >/dev/null 2>&1 || log "warning: brew install coreutils failed; /codex will run without hang protection"
+    else
+      log "warning: Homebrew not found. /codex will run without hang protection. Install coreutils manually or set GSTACK_SKIP_COREUTILS=1."
+    fi
+  fi
+fi
+
+# D2. Ensure a color-emoji font is installed so make-pdf emoji render (Linux).
+#     Best-effort: warn instead of failing if it can't install.
+if ! ensure_emoji_font; then
+  echo "  Note: could not auto-install a color-emoji font. Emoji in make-pdf" >&2
+  echo "  output may render as boxes (▯). Install one manually, e.g.:" >&2
+  echo "    Debian/Ubuntu: sudo apt-get install fonts-noto-color-emoji" >&2
+  echo "    Fedora:        sudo dnf install google-noto-color-emoji-fonts" >&2
+  echo "    Arch:          sudo pacman -S noto-fonts-emoji" >&2
+  echo "    Alpine:        sudo apk add font-noto-emoji" >&2
+else
+  refresh_browse_daemon_for_fonts
+fi
+
+# D3. Ensure Playwright's Chromium is available (best-effort: warn on failure).
+# When Chromium download or launch fails, browser-driven features (/qa,
+# /design-review, make-pdf, sidebar, /pair-agent) are unavailable. All other
+# gstack functionality (skill registration, hooks, migrations) is already
+# installed by earlier phases. Re-running ./setup retries this step.
+_PW_FAIL_REASON=""
+
+if ! ensure_playwright_browser; then
+  echo "Installing Playwright Chromium..."
+  if ! ( cd "$SOURCE_GSTACK_DIR" && bunx playwright install chromium ); then
+    _PW_FAIL_REASON="chromium-install"
+  fi
+
+  if [ -z "$_PW_FAIL_REASON" ] && [ "$IS_WINDOWS" -eq 1 ]; then
+    # On Windows, Node.js launches Chromium (not Bun — see oven-sh/bun#4253).
+    # Ensure playwright is importable by Node from the gstack directory.
+    if ! command -v node >/dev/null 2>&1; then
+      _PW_FAIL_REASON="windows-no-node"
+    else
+      echo "Windows detected — verifying Node.js can load Playwright..."
+      if ! ( cd "$SOURCE_GSTACK_DIR" && \
+             { node -e "require('playwright')" 2>/dev/null || npm install --no-save playwright; } && \
+             { node -e "require('@ngrok/ngrok')" 2>/dev/null || npm install --no-save @ngrok/ngrok; } ); then
+        _PW_FAIL_REASON="windows-node-modules"
+      fi
+    fi
+  fi
+fi
+
+if [ -z "$_PW_FAIL_REASON" ] && ! ensure_playwright_browser; then
+  _PW_FAIL_REASON="post-install-launch"
+fi
+
+if [ -n "$_PW_FAIL_REASON" ]; then
+  log ""
+  log "  warning: Playwright Chromium is unavailable ($_PW_FAIL_REASON)."
+  log "    Browser features (/qa, /design-review, make-pdf, sidebar, /pair-agent) are unavailable."
+  if [ "$IS_WINDOWS" -eq 1 ]; then
+    log "    Known Bun-on-Windows issue (oven-sh/bun#4253). Ensure Node.js is installed,"
+    log "    then verify: node -e \"require('playwright')\""
+  fi
+  log "    Re-run ./setup to retry. Skills, hooks, and migrations are already installed."
 fi

--- a/setup
+++ b/setup
@@ -399,7 +399,7 @@ if [ -x "$DETECT_BIN" ]; then
   if "$DETECT_BIN" > "$DETECTION_FILE.tmp" 2>/dev/null; then
     mv "$DETECTION_FILE.tmp" "$DETECTION_FILE"
   else
-    rm -f "$DETECTION_FILE.tmp"
+    rm -f "$DETECTION_FILE.tmp" "$DETECTION_FILE"
     log "  warning: gstack-gbrain-detect failed — brain-aware blocks will stay suppressed"
   fi
 fi
@@ -1386,7 +1386,6 @@ if [ "$NO_TEAM_MODE" -ne 1 ] \
 fi
 
 # C3. Tear down plan-tune hooks on --no-team.
-# Also tear down plan-tune hooks on --no-team (matches the existing pattern).
 if [ "$NO_TEAM_MODE" -eq 1 ] && [ -x "$SETTINGS_HOOK" ]; then
   "$SETTINGS_HOOK" remove-source --source plan-tune-cathedral 2>/dev/null || true
 fi

--- a/test/setup-gbrain-detection.test.ts
+++ b/test/setup-gbrain-detection.test.ts
@@ -1,0 +1,12 @@
+import { describe, test, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const SETUP_SRC = fs.readFileSync(path.join(ROOT, 'setup'), 'utf-8');
+
+describe('setup: gbrain detection failure handling', () => {
+  test('failed detection clears both temp and persisted detection files', () => {
+    expect(SETUP_SRC).toContain('rm -f "$DETECTION_FILE.tmp" "$DETECTION_FILE"');
+  });
+});


### PR DESCRIPTION
## Summary

- **Restructures `setup` into four phases** ordered by failure probability, so a bad network day or missing `sudo` never leaves users with zero skills installed
- **Makes Playwright/Chromium failures non-fatal** — was `exit 1`, now a named warning with `$_PW_FAIL_REASON`; skills, hooks, and migrations are already in place before Phase D runs
- **Fixes two bugs** found in code review

## Phase structure

| Phase | What runs | Fail risk |
|-------|-----------|-----------|
| A | Filesystem ops: `~/.gstack/`, welcome message, GBrain detection | Always succeeds |
| B | Local compute: binary build, skill linking, migrations, GBrain regen | Low |
| C | `settings.json` mutation: team/plan-tune hooks | Medium, fully reversible |
| D | Network/sudo/package managers: coreutils, emoji font, Playwright | Highest — **warn not exit** |

Previously, a Playwright install failure (network issue, bad mirror, missing sudo) would `exit 1` mid-run, leaving skills unregistered. Now Phase D is best-effort; re-running `./setup` retries only that phase.

## Bug fixes

- **Windows non-ASCII bun path** (lines 587, 792, 824): `link_codex_skill_dirs`, `link_factory_skill_dirs`, and `link_opencode_skill_dirs` were calling `bun run` directly instead of `bun_cmd`, bypassing the Windows non-ASCII path workaround. Silent failures masked by subsequent directory-existence checks.
- **GBrain regen exit code masked** (line 1200): `bun_cmd run gen:skill-docs:user ... | tail -3` caused `tail`'s exit 0 to swallow bun's failure, so the `|| log "warning..."` clause never fired. Removed the pipe.

## Test plan

- [x] Run `./setup` on a clean install — confirm skills link, hooks install, and Playwright failure (if any) prints a warning instead of aborting
- [x] Run `./setup --host codex` on Windows with non-ASCII username — confirm Codex skill docs generate
- [x] Run `./setup` with GBrain installed — confirm warning fires if `gen:skill-docs:user` fails