### PR TITLE
fix(setup): add Claude runtime alias for renamed installs

### DIFF
--- a/setup
+++ b/setup
@@ -606,6 +606,44 @@ link_claude_root_skill_alias() {
   _print_windows_copy_note_once
 }
 
+# Claude skill bodies still reference ~/.claude/skills/gstack/ for runtime
+# assets. If the checkout is installed as ~/.claude/skills/<other-name>, keep a
+# runtime-only gstack alias so those paths resolve without rewriting generated
+# SKILL.md files or dirtying the checkout.
+ensure_claude_runtime_alias() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local install_name
+  local install_parent
+  local alias
+  local existing_real
+  local claude_skills_dir
+
+  claude_skills_dir="$HOME/.claude/skills"
+  [ "$skills_dir" = "$claude_skills_dir" ] || return 0
+
+  install_name="$(basename "$gstack_dir")"
+  [ "$install_name" = "gstack" ] && return 0
+
+  install_parent="$(dirname "$gstack_dir")"
+  [ "$install_parent" = "$skills_dir" ] || return 0
+
+  alias="$skills_dir/gstack"
+  if [ -d "$alias" ] && [ ! -L "$alias" ]; then
+    existing_real=$(cd "$alias" 2>/dev/null && pwd -P || echo "")
+    if [ -n "$existing_real" ] && [ "$existing_real" != "$gstack_dir" ]; then
+      log "  warning: $alias already exists as a separate install; not replacing it"
+      return 0
+    fi
+  fi
+
+  if [ -L "$alias" ] || [ ! -e "$alias" ]; then
+    _link_or_copy "$gstack_dir" "$alias"
+    log "  linked runtime alias: $alias -> $gstack_dir"
+    _print_windows_copy_note_once
+  fi
+}
+
 # ─── Helper: remove old unprefixed Claude skill entries ───────────────────────
 # Migration: when switching from flat names to gstack- prefixed names,
 # clean up stale symlinks or directories that point into the gstack directory.
@@ -982,6 +1020,7 @@ fi
 
 if [ "$INSTALL_CLAUDE" -eq 1 ]; then
   if [ "$SKILLS_BASENAME" = "skills" ]; then
+    ensure_claude_runtime_alias "$INSTALL_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
     # Clean up stale symlinks from the opposite prefix mode
     if [ "$SKILL_PREFIX" -eq 1 ]; then
       cleanup_old_claude_symlinks "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"

--- a/test/setup-claude-runtime-alias.test.ts
+++ b/test/setup-claude-runtime-alias.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect } from 'bun:test';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const SETUP = fs.readFileSync(path.join(ROOT, 'setup'), 'utf-8');
+
+function extractFunction(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`Could not locate ${name}() in setup`);
+  const end = src.indexOf('\n}\n', start);
+  if (end < 0) throw new Error(`Could not locate end of ${name}() in setup`);
+  return src.slice(start, end + 2);
+}
+
+describe('setup: Claude runtime alias for non-gstack install dirs', () => {
+  test('setup calls the runtime alias helper before linking Claude skills', () => {
+    const helperIdx = SETUP.indexOf('ensure_claude_runtime_alias "$INSTALL_GSTACK_DIR" "$INSTALL_SKILLS_DIR"');
+    const linkIdx = SETUP.indexOf('link_claude_skill_dirs "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"');
+
+    expect(helperIdx).toBeGreaterThan(-1);
+    expect(linkIdx).toBeGreaterThan(-1);
+    expect(helperIdx).toBeLessThan(linkIdx);
+  });
+
+  test.skipIf(process.platform === 'win32')('helper creates skills/gstack -> install dir when install basename is not gstack', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-runtime-alias-'));
+    try {
+      const skillsDir = path.join(tmp, '.claude', 'skills');
+      const installDir = path.join(skillsDir, 'gstack-dev');
+      fs.mkdirSync(installDir, { recursive: true });
+
+      const linkHelper = extractFunction(SETUP, '_link_or_copy');
+      const noteHelper = extractFunction(SETUP, '_print_windows_copy_note_once');
+      const aliasHelper = extractFunction(SETUP, 'ensure_claude_runtime_alias');
+      const script = `
+        set -e
+        HOME='${tmp}'
+        IS_WINDOWS=0
+        QUIET=0
+        _WINDOWS_COPY_NOTE_PRINTED=0
+        log() { echo "$@"; }
+        ${linkHelper}
+        ${noteHelper}
+        ${aliasHelper}
+        ensure_claude_runtime_alias '${installDir}' '${skillsDir}'
+      `;
+
+      const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8' });
+      expect(result.status).toBe(0);
+      const alias = path.join(skillsDir, 'gstack');
+      expect(fs.lstatSync(alias).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(alias)).toBe(installDir);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(process.platform === 'win32')('helper ignores non-Claude skills directories', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-runtime-alias-'));
+    try {
+      const skillsDir = path.join(tmp, 'skills');
+      const installDir = path.join(skillsDir, 'gstack-dev');
+      fs.mkdirSync(installDir, { recursive: true });
+
+      const linkHelper = extractFunction(SETUP, '_link_or_copy');
+      const noteHelper = extractFunction(SETUP, '_print_windows_copy_note_once');
+      const aliasHelper = extractFunction(SETUP, 'ensure_claude_runtime_alias');
+      const script = `
+        set -e
+        HOME='${tmp}'
+        IS_WINDOWS=0
+        QUIET=0
+        _WINDOWS_COPY_NOTE_PRINTED=0
+        log() { echo "$@"; }
+        ${linkHelper}
+        ${noteHelper}
+        ${aliasHelper}
+        ensure_claude_runtime_alias '${installDir}' '${skillsDir}'
+      `;
+
+      const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8' });
+      expect(result.status).toBe(0);
+      expect(fs.existsSync(path.join(skillsDir, 'gstack'))).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(process.platform === 'win32')('helper leaves canonical skills/gstack installs alone', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-runtime-alias-'));
+    try {
+      const skillsDir = path.join(tmp, '.claude', 'skills');
+      const installDir = path.join(skillsDir, 'gstack');
+      fs.mkdirSync(installDir, { recursive: true });
+
+      const linkHelper = extractFunction(SETUP, '_link_or_copy');
+      const noteHelper = extractFunction(SETUP, '_print_windows_copy_note_once');
+      const aliasHelper = extractFunction(SETUP, 'ensure_claude_runtime_alias');
+      const script = `
+        set -e
+        HOME='${tmp}'
+        IS_WINDOWS=0
+        QUIET=0
+        _WINDOWS_COPY_NOTE_PRINTED=0
+        log() { echo "$@"; }
+        ${linkHelper}
+        ${noteHelper}
+        ${aliasHelper}
+        ensure_claude_runtime_alias '${installDir}' '${skillsDir}'
+      `;
+
+      const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8' });
+      expect(result.status).toBe(0);
+      expect(fs.lstatSync(installDir).isDirectory()).toBe(true);
+      expect(fs.lstatSync(installDir).isSymbolicLink()).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1882.

Claude-host skill bodies still contain runtime references to `~/.claude/skills/gstack/...`. When the checkout is installed as `~/.claude/skills/<non-gstack>`, setup links slash-command wrappers but leaves those runtime paths unresolved.

This PR adds a narrow setup-time runtime alias:

- create `~/.claude/skills/gstack -> ~/.claude/skills/<install-name>` only for global Claude installs under `$HOME/.claude/skills`
- skip canonical `~/.claude/skills/gstack` installs
- skip non-Claude `skills/` directories to avoid scope creep
- refuse to replace an existing separate real `~/.claude/skills/gstack` install

No generated `SKILL.md` files are rewritten.

## Verification

- `bun test test/setup-claude-runtime-alias.test.ts test/setup-windows-fallback.test.ts test/setup-sections-linking.test.ts test/setup-conductor-worktree.test.ts`
  - 23 pass, 0 fail
- `bash -n setup`
- `git diff --check`
- Temp HOME smoke test:
  - installed from `$TMP_HOME/.claude/skills/gstack-dev`
  - verified `$TMP_HOME/.claude/skills/gstack -> $TMP_HOME/.claude/skills/gstack-dev`
  - verified `$TMP_HOME/.claude/skills/gstack/bin/gstack-config get skill_prefix` runs through the hardcoded runtime path

## Review

- Claude subagent review: approved, no blocking findings
- Codex autoreview first pass: requested a Claude-only scope guard
- Codex autoreview second pass after scope guard: APPROVE
- Post-open exact PR diff Codex review: APPROVE
  - Diff SHA-256: `086d3663f24146281aa563d8eb29019fc1b56c21d73ef2450c97833227d15475`

## CI / checks

GitHub currently reports no checks on the fork branch for this draft PR, so the exact-diff Codex review above was used as the fallback reviewer gate.

## Notes

A broader `bun run test:windows` run still has the pre-existing unrelated `browse/test/terminal-agent.test.ts` lazy-spawn failure. The touched files and this patch do not affect that path.