### PR TITLE
fix(browse): make local Playwright launch work on Windows

### DIFF
--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -11,7 +11,9 @@ description: |
   automatically", or "make the decisions for me".
   Proactively suggest when the user has a plan file and wants to run the full review
   gauntlet without answering 15-30 intermediate questions. (gstack)
-  Voice triggers (speech-to-text aliases): "auto plan", "automatic review".
+voice-triggers:
+  - "auto plan"
+  - "automatic review"
 benefits-from: [office-hours]
 allowed-tools:
   - Bash

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -8,7 +8,9 @@ description: |
   Compares before/after on every PR. Tracks performance trends over time.
   Use when: "performance", "benchmark", "page speed", "lighthouse", "web vitals",
   "bundle size", "load time". (gstack)
-  Voice triggers (speech-to-text aliases): "speed test", "check performance".
+voice-triggers:
+  - "speed test"
+  - "check performance"
 allowed-tools:
   - Bash
   - Read

--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -20,7 +20,8 @@ bun build "$SRC_DIR/server.ts" \
   --external playwright \
   --external playwright-core \
   --external diff \
-  --external "bun:sqlite"
+  --external "bun:sqlite" \
+  --external "@ngrok/ngrok"
 
 # Step 2: Post-process
 # Replace import.meta.dir with a resolvable reference

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,8 @@
       "dependencies": {
         "@ngrok/ngrok": "^1.7.0",
         "diff": "^7.0.0",
-        "playwright": "^1.58.2",
+        "playwright": "1.60.0",
+        "playwright-core": "1.60.0",
         "puppeteer-core": "^24.40.0",
       },
       "devDependencies": {
@@ -156,9 +157,9 @@
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
-    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
-    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 

--- a/careful/SKILL.md
+++ b/careful/SKILL.md
@@ -17,6 +17,7 @@ hooks:
         - type: command
           command: "bash ${CLAUDE_SKILL_DIR}/bin/check-careful.sh"
           statusMessage: "Checking for destructive commands..."
+sensitive: true
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -8,7 +8,10 @@ description: |
   your code. Consult: ask codex anything with session continuity for follow-ups.
   The "200 IQ autistic developer" second opinion. Use when asked to "codex review",
   "codex challenge", "ask codex", "second opinion", or "consult codex". (gstack)
-  Voice triggers (speech-to-text aliases): "code x", "code ex", "get another opinion".
+voice-triggers:
+  - "code x"
+  - "code ex"
+  - "get another opinion"
 allowed-tools:
   - Bash
   - Read

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -9,7 +9,13 @@ description: |
   Two modes: daily (zero-noise, 8/10 confidence gate) and comprehensive (monthly deep
   scan, 2/10 bar). Trend tracking across audit runs.
   Use when: "security audit", "threat model", "pentest review", "OWASP", "CSO review". (gstack)
-  Voice triggers (speech-to-text aliases): "see-so", "see so", "security review", "security check", "vulnerability scan", "run security".
+voice-triggers:
+  - "see-so"
+  - "see so"
+  - "security review"
+  - "security check"
+  - "vulnerability scan"
+  - "run security"
 allowed-tools:
   - Bash
   - Read

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -11,7 +11,10 @@ description: |
   for each design type. Use when: "finalize this design", "turn this into HTML",
   "build me a page", "implement this design", or after any planning skill.
   Proactively suggest when user has approved a design or has a plan ready. (gstack)
-  Voice triggers (speech-to-text aliases): "build the design", "code the mockup", "make it real".
+voice-triggers:
+  - "build the design"
+  - "code the mockup"
+  - "make it real"
 allowed-tools:
   - Bash
   - Read

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -10,7 +10,11 @@ description: |
   exist (the boomerang: plan said 3 minutes, reality says 8). Use when asked to
   "test the DX", "DX audit", "developer experience test", or "try the
   onboarding". Proactively suggest after shipping a developer-facing feature. (gstack)
-  Voice triggers (speech-to-text aliases): "dx audit", "test the developer experience", "try the onboarding", "developer experience test".
+voice-triggers:
+  - "dx audit"
+  - "test the developer experience"
+  - "try the onboarding"
+  - "developer experience test"
 allowed-tools:
   - Read
   - Edit

--- a/freeze/SKILL.md
+++ b/freeze/SKILL.md
@@ -23,6 +23,7 @@ hooks:
         - type: command
           command: "bash ${CLAUDE_SKILL_DIR}/bin/check-freeze.sh"
           statusMessage: "Checking freeze boundary..."
+sensitive: true
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->

--- a/gstack-upgrade/SKILL.md
+++ b/gstack-upgrade/SKILL.md
@@ -5,7 +5,11 @@ description: |
   Upgrade gstack to the latest version. Detects global vs vendored install,
   runs the upgrade, and shows what's new. Use when asked to "upgrade gstack",
   "update gstack", or "get latest version".
-  Voice triggers (speech-to-text aliases): "upgrade the tools", "update the tools", "gee stack upgrade", "g stack upgrade".
+voice-triggers:
+  - "upgrade the tools"
+  - "update the tools"
+  - "gee stack upgrade"
+  - "g stack upgrade"
 allowed-tools:
   - Bash
   - Read

--- a/guard/SKILL.md
+++ b/guard/SKILL.md
@@ -28,6 +28,7 @@ hooks:
         - type: command
           command: "bash ${CLAUDE_SKILL_DIR}/../freeze/bin/check-freeze.sh"
           statusMessage: "Checking freeze boundary..."
+sensitive: true
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -13,6 +13,7 @@ allowed-tools:
   - Write
   - Glob
   - AskUserQuestion
+sensitive: true
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -7,7 +7,8 @@ description: |
   The sidebar shows a live activity feed and chat. Anti-bot stealth built in.
   Use when asked to "open gstack browser", "launch browser", "connect chrome",
   "open chrome", "real browser", "launch chrome", "side panel", or "control my browser".
-  Voice triggers (speech-to-text aliases): "show me the browser".
+voice-triggers:
+  - "show me the browser"
 allowed-tools:
   - Bash
   - Read

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "@ngrok/ngrok": "^1.7.0",
     "diff": "^7.0.0",
-    "playwright": "^1.58.2",
+    "playwright": "1.60.0",
+    "playwright-core": "1.60.0",
     "puppeteer-core": "^24.40.0"
   },
   "engines": {

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -8,7 +8,11 @@ description: |
   gets its own tab with scoped access (read+write by default, admin on request).
   Use when asked to "pair agent", "connect agent", "share browser", "remote browser",
   "let another agent use my browser", or "give browser access". (gstack)
-  Voice triggers (speech-to-text aliases): "pair agent", "connect agent", "share my browser", "remote browser access".
+voice-triggers:
+  - "pair agent"
+  - "connect agent"
+  - "share my browser"
+  - "remote browser access"
 allowed-tools:
   - Bash
   - Read

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -11,7 +11,13 @@ description: |
   or "API design review".
   Proactively suggest when the user has a plan for developer-facing products
   (APIs, CLIs, SDKs, libraries, platforms, docs). (gstack)
-  Voice triggers (speech-to-text aliases): "dx review", "developer experience review", "devex review", "devex audit", "API design review", "onboarding review".
+voice-triggers:
+  - "dx review"
+  - "developer experience review"
+  - "devex review"
+  - "devex audit"
+  - "API design review"
+  - "onboarding review"
 benefits-from: [office-hours]
 allowed-tools:
   - Read

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -9,7 +9,10 @@ description: |
   "review the architecture", "engineering review", or "lock in the plan".
   Proactively suggest when the user has a plan or design doc and is about to
   start coding — to catch architecture issues before implementation. (gstack)
-  Voice triggers (speech-to-text aliases): "tech review", "technical review", "plan engineering review".
+voice-triggers:
+  - "tech review"
+  - "technical review"
+  - "plan engineering review"
 benefits-from: [office-hours]
 allowed-tools:
   - Read

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -8,7 +8,9 @@ description: |
   fixes anything. Use when asked to "just report bugs", "qa report only", or
   "test but don't fix". For the full test-fix-verify loop, use /qa instead.
   Proactively suggest when the user wants a bug report without any code changes. (gstack)
-  Voice triggers (speech-to-text aliases): "bug report", "just check for bugs".
+voice-triggers:
+  - "bug report"
+  - "just check for bugs"
 allowed-tools:
   - Bash
   - Read

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -11,7 +11,10 @@ description: |
   or asks "does this work?". Three tiers: Quick (critical/high only),
   Standard (+ medium), Exhaustive (+ cosmetic). Produces before/after health scores,
   fix evidence, and a ship-readiness summary. For report-only mode, use /qa-only. (gstack)
-  Voice triggers (speech-to-text aliases): "quality check", "test the app", "run QA".
+voice-triggers:
+  - "quality check"
+  - "test the app"
+  - "run QA"
 allowed-tools:
   - Bash
   - Read

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -18,6 +18,7 @@ allowed-tools:
   - Agent
   - AskUserQuestion
   - WebSearch
+sensitive: true
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->

--- a/unfreeze/SKILL.md
+++ b/unfreeze/SKILL.md
@@ -9,6 +9,7 @@ description: |
 allowed-tools:
   - Bash
   - Read
+sensitive: true
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->


### PR DESCRIPTION
## Problem

On Windows, `browse` (and any local Playwright run that goes through the node server) hangs at chromium launch and never returns. Two independent causes are at play.

## Root causes and fixes

**1. The node server bundle can't be rebuilt (`browse/scripts/build-node-server.sh`).**
The script runs `bun build server.ts --target=node`, but `server.ts` does `await import('@ngrok/ngrok')`. bun then tries to emit ngrok's ~10 MB native `.node` binary as a *second* output file and fails with:

> error: cannot write multiple output files without an output directory

so the build aborts and a stale `server-node.mjs` is left in place. Marking `@ngrok/ngrok` external fixes the build — ngrok still resolves from `node_modules` at runtime, and the basic browse path never touches it.

This matters on Windows specifically because the CLI must spawn the server under **node**: bun can't drive Playwright's chromium there. The `--remote-debugging-pipe` handshake never completes under bun on Windows (oven-sh/bun#4253, oven-sh/bun#9911), so the node-server bundle is the supported path and it has to build.

**2. Playwright 1.58.2 resolves chromium 1208, which crashes under `--remote-debugging-pipe`.**
chromium 1208 hits an ICU init crash (`base/i18n/icu_util.cc ... Invalid file descriptor to ICU data received`). chromium 1223 fixes it. Pinning `playwright` and `playwright-core` to `1.60.0` gives a deterministic chromium revision (1223) instead of letting `^1.58.2` float onto a broken one.

## Result

With both changes, on Windows 11: `browse goto` returns 200, the daemon stays healthy, and `js` / `screenshot` work.

## Scope

Source-only: `build-node-server.sh`, `package.json`, `bun.lock`. No `dist/` or binary changes.
