### PR TITLE
fix(gbrain): strip .git when the remote URL has a trailing slash

### DIFF
--- a/lib/gstack-memory-helpers.ts
+++ b/lib/gstack-memory-helpers.ts
@@ -106,10 +106,12 @@ export function canonicalizeRemote(url: string | null | undefined): string {
     // strip user@ prefix on URL-style remotes
     s = s.replace(/^[^@\/]+@/, "");
   }
+  // strip trailing slash(es) first, so a URL written with a trailing slash
+  // still matches the `.git$` suffix below (e.g. ".../repo.git/" must
+  // canonicalize to ".../repo", not ".../repo.git").
+  s = s.replace(/\/+$/, "");
   // strip trailing .git
   s = s.replace(/\.git$/i, "");
-  // strip trailing slash
-  s = s.replace(/\/+$/, "");
   // collapse multiple slashes (after path normalization)
   s = s.replace(/\/{2,}/g, "/");
   return s.toLowerCase();

--- a/test/gstack-memory-helpers.test.ts
+++ b/test/gstack-memory-helpers.test.ts
@@ -67,6 +67,21 @@ describe("canonicalizeRemote", () => {
   it("collapses redundant slashes", () => {
     expect(canonicalizeRemote("https://github.com//foo//bar")).toBe("github.com/foo/bar");
   });
+
+  it("strips .git even when the URL has a trailing slash", () => {
+    // A remote configured with both a .git suffix and a trailing slash must
+    // canonicalize to the same key as one without — otherwise the same repo
+    // gets two dedup/source-id keys across machines.
+    expect(canonicalizeRemote("https://github.com/garrytan/gstack.git/")).toBe("github.com/garrytan/gstack");
+    expect(canonicalizeRemote("git@github.com:garrytan/gstack.git/")).toBe("github.com/garrytan/gstack");
+    expect(canonicalizeRemote("https://github.com/foo/bar.git///")).toBe("github.com/foo/bar");
+  });
+
+  it("produces the same key with or without a trailing slash", () => {
+    expect(canonicalizeRemote("https://github.com/garrytan/gstack.git/")).toBe(
+      canonicalizeRemote("https://github.com/garrytan/gstack.git")
+    );
+  });
 });
 
 // ── secretScanFile ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`canonicalizeRemote()` (`lib/gstack-memory-helpers.ts`) is the canonical `host/org/repo` dedup key — no scheme, no trailing `.git`. When a configured `origin` URL ends with a **trailing slash** (e.g. `git remote add origin https://github.com/garrytan/gstack.git/`, which is valid and clones fine) the `.git` suffix was **not** stripped:

```
canonicalizeRemote('https://github.com/garrytan/gstack.git/')
  => 'github.com/garrytan/gstack.git'   // expected 'github.com/garrytan/gstack'
```

## Root cause

`.git` was stripped before trailing slashes, and the `.git$` regex is anchored on end-of-string:

```ts
s = s.replace(/\.git$/i, "");   // string ends in "/", so this no-ops
s = s.replace(/\/+$/, "");      // slash removed → "...gstack.git" left behind
```

This key feeds gbrain code source-ids (`deriveCodeSourceId` / `deriveLegacyCodeSourceId` in `bin/gstack-gbrain-sync.ts`, and `bin/gstack-memory-ingest.ts`), which join the last two path segments. So the same repo produced **different source-ids across machines** depending on whether `origin` carried a trailing slash (`gstack-code-garrytan-gstack-<hash>` vs `gstack-code-garrytan-gstack-git-<hash>` after id sanitization) — splitting federated cross-source search, the exact thing the canonical key exists to prevent.

## Fix

Strip trailing slash(es) **first**, then the `.git` suffix (a reorder of the two existing steps). No behavior change for any input that previously canonicalized correctly.

## Testing

`bun test test/gstack-memory-helpers.test.ts` — 27 pass (was 25; +2 new cases).

Added regression tests for the `.git/` combination, proven to fail on `main` before the fix:

```
✗ strips .git even when the URL has a trailing slash
    Expected: "github.com/garrytan/gstack"
    Received: "github.com/garrytan/gstack.git"
✗ produces the same key with or without a trailing slash
```

Also ran the downstream consumer suite `bun test test/gstack-gbrain-sync.test.ts` — 37 pass, 0 fail.

Fixes #1895
