### PR TITLE
fix(openclaw): quiet native skill triggers

### DIFF
--- a/openclaw/skills/gstack-openclaw-ceo-review/SKILL.md
+++ b/openclaw/skills/gstack-openclaw-ceo-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gstack-openclaw-ceo-review
-description: Use when asked to review a plan, challenge a proposal, run a CEO review, poke holes in an approach, think bigger about scope, or decide whether to expand or reduce the plan.
+description: "OpenClaw-native method clone. Manual — invoke only when the user explicitly names gstack-openclaw-ceo-review."
 ---
 
 # CEO Plan Review

--- a/openclaw/skills/gstack-openclaw-investigate/SKILL.md
+++ b/openclaw/skills/gstack-openclaw-investigate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gstack-openclaw-investigate
-description: Use when asked to debug, fix a bug, investigate an error, or do root cause analysis, and when users report errors, stack traces, unexpected behavior, or say something stopped working.
+description: "OpenClaw-native method clone. Manual — invoke only when the user explicitly names gstack-openclaw-investigate."
 ---
 
 # Systematic Debugging

--- a/openclaw/skills/gstack-openclaw-office-hours/SKILL.md
+++ b/openclaw/skills/gstack-openclaw-office-hours/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gstack-openclaw-office-hours
-description: Use when asked to brainstorm, evaluate whether an idea is worth building, run office hours, or think through a new product idea or design direction before any code is written.
+description: "OpenClaw-native method clone. Manual — invoke only when the user explicitly names gstack-openclaw-office-hours."
 ---
 
 # YC Office Hours

--- a/openclaw/skills/gstack-openclaw-retro/SKILL.md
+++ b/openclaw/skills/gstack-openclaw-retro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gstack-openclaw-retro
-description: "Weekly engineering retrospective. Analyzes commit history, work patterns, and code quality metrics with persistent history and trend tracking. Team-aware with per-person contributions, praise, and growth areas. Use when asked for weekly retro, what shipped this week, or engineering retrospective."
+description: "OpenClaw-native method clone. Manual — invoke only when the user explicitly names gstack-openclaw-retro."
 ---
 
 # Weekly Engineering Retrospective


### PR DESCRIPTION
## Summary
- make OpenClaw native skill descriptions manual/exact-name only
- prevent ambient Codex/Claude skill routing from auto-triggering nested OpenClaw clones

## Test
- bun test skills/gstack/test/openclaw-native-skills.test.ts