### PR TITLE
feat(browse): add GSTACK_HEADED_NOGPU opt-in for headed mode on virtual displays (Xvnc/Xvfb)

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -442,6 +442,17 @@ export class BrowserManager {
       // Sites like Google and NYTimes check this to block automation browsers.
       '--disable-blink-features=AutomationControlled',
     ];
+    // Headless virtual displays (Xvnc/Xvfb on EC2) have no real GPU; Playwright's
+    // bundled Chromium crashes (SIGTRAP) during GPU process init. Disabling the
+    // GPU process keeps headed mode alive on VNC. Opt-in via GSTACK_HEADED_NOGPU.
+    if (process.env.GSTACK_HEADED_NOGPU === '1') {
+      launchArgs.push(
+        '--disable-gpu',
+        '--disable-gpu-compositing',
+        '--disable-software-rasterizer',
+        '--disable-dev-shm-usage',
+      );
+    }
     if (extensionPath) {
       // Skip --load-extension when running against a custom Chromium build
       // that already bakes the extension in as a component extension


### PR DESCRIPTION
## Problem

On headless Linux servers using virtual displays (Xvnc, Xvfb), Playwright's bundled Chromium crashes with SIGTRAP during GPU process initialization when headed mode is requested. This makes `/browse --headed` completely non-functional on remote Linux dev boxes.

Root cause: virtual display drivers (Xvnc, Xvfb) have no real GPU. Chromium's GPU process init path raises SIGTRAP when it can't initialize hardware acceleration, crashing the browser before the page loads.

## Solution

Add an opt-in env var `GSTACK_HEADED_NOGPU=1` that appends GPU-disabling Chromium flags at launch:

- `--disable-gpu`
- `--disable-gpu-compositing`
- `--disable-software-rasterizer`
- `--disable-dev-shm-usage`

This bypasses the GPU process entirely, keeping headed mode alive on VNC-backed virtual displays.

## Usage

```bash
GSTACK_HEADED_NOGPU=1 browse --headed https://example.com
```

Or export it for a session:

```bash
export GSTACK_HEADED_NOGPU=1
browse --headed ...
```

## Safety

- **Opt-in only** — users on real displays (macOS, physical Linux desktop) are unaffected; they never set this flag
- **No behavioral change** when the env var is unset (default)
- Tested on Amazon Linux 2023 aarch64 with Xvnc :2 using system Brave 148 as the Chromium path

## Context

This came up while using gstack `/browse --headed` on an EC2 dev box with a VNC display for interactive browser automation. The fix unblocks headed mode for the growing number of users running Claude Code on remote Linux servers.