### PR TITLE
feat(hosts): add Pi as a supported host (closes #1288)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bin/gstack-global-discover*
 .slate/
 .cursor/
 .openclaw/
+.pi/
 .hermes/
 .gbrain/
 .gbrain-source

--- a/README.md
+++ b/README.md
@@ -120,10 +120,28 @@ Or target a specific agent with `./setup --host <name>`:
 | Slate | `--host slate` | `~/.slate/skills/gstack-*/` |
 | Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |
 | Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |
+| Pi | `--host pi` | `~/.pi/agent/skills/gstack-*/` |
 | GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |
 
 **Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).
 It's one TypeScript config file, zero code changes.
+
+### Pi
+
+[Pi](https://pi.dev) implements the [Agent Skills standard](https://agentskills.io/specification)
+end-to-end, so every gstack skill works out of the box once the skills directory
+is configured. Install gstack into pi's global agent skills path:
+
+```bash
+git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack
+cd ~/gstack && ./setup --host pi
+```
+
+Skills land at `~/.pi/agent/skills/gstack-*/`. For project-local skills (trusted
+project), pi also discovers `.pi/skills/`. Pi loads skill descriptions at startup
+and lazy-loads the full `SKILL.md` on demand, matching Claude Code's behavior.
+
+Invoke a skill with `/skill:<name>` (e.g. `/skill:review`, `/skill:ship`).
 
 ## See it work
 

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,10 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import pi from './pi';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, pi];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, pi };

--- a/hosts/pi.ts
+++ b/hosts/pi.ts
@@ -1,0 +1,60 @@
+import type { HostConfig } from '../scripts/host-config';
+
+const pi: HostConfig = {
+  name: 'pi',
+  displayName: 'Pi',
+  cliCommand: 'pi',
+  cliAliases: [],
+
+  globalRoot: '.pi/agent/skills/gstack',
+  localSkillRoot: '.pi/skills/gstack',
+  hostSubdir: '.pi',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: 1024,
+  },
+
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.pi/agent/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.pi/skills/gstack' },
+    { from: '.claude/skills', to: '.pi/skills' },
+  ],
+  toolRewrites: {
+    'use the Bash tool': 'use the bash tool',
+    'use the Write tool': 'use the write tool',
+    'use the Read tool': 'use the read tool',
+    'use the Edit tool': 'use the edit tool',
+    'use the Grep tool': 'use the grep tool',
+    'use the Glob tool': 'use the find tool',
+    'use the Agent tool': 'use the agent tool',
+    'the Bash tool': 'the bash tool',
+    'the Read tool': 'the read tool',
+    'the Write tool': 'the write tool',
+    'the Edit tool': 'the edit tool',
+  },
+  suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
+
+  runtimeRoot: {
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'design/dist', 'gstack-upgrade', 'ETHOS.md', 'review/specialists', 'qa/templates', 'qa/references', 'plan-devex-review/dx-hall-of-fame.md'],
+    globalFiles: {
+      'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  learningsMode: 'basic',
+};
+
+export default pi;


### PR DESCRIPTION
Closes #1288

## Summary

Adds **Pi** (https://pi.dev) as a 9th supported gstack host.

Pi implements the [Agent Skills standard](https://agentskills.io/specification) end-to-end, so every existing gstack skill works as-is. The integration is a single declarative config — no generator, setup, or tooling changes.

### What this PR adds

- **`hosts/pi.ts`** — minimal HostConfig mirroring the opencode pattern:
  - `globalRoot: .pi/agent/skills/gstack`
  - `localSkillRoot: .pi/skills/gstack`
  - `frontmatter`: allowlist (`name` + `description`), `descriptionLimit: 1024` (pi enforces the 1024-char cap per spec)
  - `pathRewrites`: 3 standard `.claude/skills` → `.pi/skills` rewrites
  - `toolRewrites`: Claude tool names → pi's lowercase-verb native tool names (`read`, `write`, `edit`, `bash`, `grep`, `find`, `agent`)
  - `install`: `symlink-generated` strategy, `prefixable: false`
- **`hosts/index.ts`** — register `pi` in `ALL_HOST_CONFIGS` and re-exports
- **`.gitignore`** — skip `.pi/` (generated skill docs)
- **`README.md`** — add Pi row to the host table and a dedicated `### Pi` install section

### How Pi users would install

```bash
git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack
cd ~/gstack && ./setup --host pi
```

Skills land at `~/.pi/agent/skills/gstack-*/`, then `/skill:review`, `/skill:ship`, etc. work in pi.

### Verification

| Check | Result |
|---|---|
| `bun run gen:skill-docs --host pi` | 54 skills generated, 0 errors |
| `grep -r '.claude/skills' .pi/skills/` | 0 matches (no path leakage) |
| `grep -r 'use the Bash tool' .pi/skills/` | 0 matches (tool rewrites applied) |
| `bun run scripts/host-config-export.ts validate` | All 11 configs valid (10 existing + pi) |
| `bun test test/host-config.test.ts test/gen-skill-docs.test.ts` | 69/69 passed |
| `bun run skill:check` | Pi detected, 0 missing skills |
| `bun run gen:skill-docs --host all` | Idempotent — total stable at 63576 lines |

### Notes for reviewers

- Pi's `~/.pi/agent/skills/` is its primary global skills dir per the [Pi skills docs](https://pi.dev/docs/latest/skills). Pi also discovers `~/.agents/skills/` and `.pi/skills/` (project-local, after trust).
- The `codex` skill is excluded via `skipSkills: ['codex']` — same as every other non-Claude host.
- No `coAuthorTrailer` set: pi is model-agnostic (Anthropic, OpenAI, local models), so there is no single author identity to attribute.
- The `hostSubdir` `.pi/` does not collide with pi's daemon socket file (`.pi.sock`, a sibling at repo root) — different paths.