### PR TITLE
v1.57.7.0 fix(ios-qa): sliding tunnel cache so device sessions survive past 30s

### DIFF
--- a/ios-qa/daemon/src/index.ts
+++ b/ios-qa/daemon/src/index.ts
@@ -64,9 +64,21 @@ export async function startDaemon(opts: DaemonOptions): Promise<RunningDaemon | 
   let tunnel: DeviceTunnel | null = null;
   let cachedTunnelAt = 0;
 
+  // Tunnel cache TTL — sliding idle-timeout. Every reuse refreshes the timer,
+  // so an active agent session never re-bootstraps. That matters because
+  // re-bootstrap is fragile: bootstrapTunnel reads the on-disk boot token,
+  // which StateServer DELETES at /auth/rotate (StateServer.swift), so a
+  // re-bootstrap against an already-rotated app fails with
+  // boot_token_unavailable until the app is cold-relaunched. Keeping a healthy
+  // tunnel alive avoids that trap. Default 5 min covers an agent's
+  // reason-then-act gaps; override via GSTACK_IOS_TUNNEL_CACHE_MS for long idles.
+  const tunnelCacheMs = Math.max(0, parseInt(process.env.GSTACK_IOS_TUNNEL_CACHE_MS ?? '300000', 10) || 300000);
+
   const getTunnel = async (): Promise<DeviceTunnel | null> => {
-    // Cache the tunnel for 30s; refresh on demand.
-    if (tunnel && Date.now() - cachedTunnelAt < 30_000) return tunnel;
+    if (tunnel && Date.now() - cachedTunnelAt < tunnelCacheMs) {
+      cachedTunnelAt = Date.now(); // sliding: refresh the idle timer on reuse
+      return tunnel;
+    }
     if (opts.tunnelProvider) {
       tunnel = await opts.tunnelProvider();
       cachedTunnelAt = Date.now();

--- a/ios-qa/daemon/test/daemon-integration.test.ts
+++ b/ios-qa/daemon/test/daemon-integration.test.ts
@@ -132,6 +132,36 @@ describe('daemon — loopback listener', () => {
     expect(lastReq?.headers['x-session-id']).toBe('sess-loopback-1');
   });
 
+  test('reuses the cached tunnel across requests (no re-bootstrap per call)', async () => {
+    // Regression guard: the tunnel cache is a sliding idle-timeout, so a burst
+    // of requests must bootstrap exactly once. A flat short TTL (or no cache)
+    // would re-bootstrap mid-session — fatal once the boot token is rotated.
+    let bootstraps = 0;
+    const countingTunnel: DeviceTunnel = {
+      udid: 'STUB-UDID',
+      ipv6Addr: '127.0.0.1',
+      port: stub.port,
+      bootTokenRotated: STATE_SERVER_TOKEN,
+    };
+    const pidPathCache = join(workDir, 'daemon-cache.pid');
+    const d = await startDaemon({
+      loopbackPort: daemon.loopbackPort + 7,
+      tailnetEnabled: false,
+      pidfilePath: pidPathCache,
+      tunnelProvider: async () => { bootstraps++; return countingTunnel; },
+    });
+    if ('error' in d) throw new Error(d.error);
+    try {
+      const base = `http://127.0.0.1:${d.loopbackPort}`;
+      await fetchWith('GET', `${base}/screenshot`);
+      await fetchWith('GET', `${base}/screenshot`);
+      await fetchWith('GET', `${base}/screenshot`);
+      expect(bootstraps).toBe(1);
+    } finally {
+      await d.close();
+    }
+  });
+
   test('returns 503 when no device tunnel is provided', async () => {
     // Force tunnel provider to return null by closing + restarting with null provider.
     await daemon.close();


### PR DESCRIPTION
## What

Make the iOS QA daemon's device-tunnel cache a **sliding idle-timeout** instead of a flat 30s window, with a configurable default.

## Why

`getTunnel()` in `ios-qa/daemon/src/index.ts` cached the CoreDevice tunnel for a flat **30s measured from bootstrap**, and never refreshed the timer on use. A vision-driven agent loop (`/ios-qa`) reads a screenshot, reasons, then taps — that round trip routinely exceeds 30s. When the cache expires the daemon re-bootstraps, but **re-bootstrap can't succeed against a still-running app**: `StateServer` deletes its on-disk boot token at `/auth/rotate` (`templates/StateServer.swift.template` → `removeItem(atPath: bootTokenPath)`), so `bootstrapTunnel` fails with `boot_token_unavailable` until the app is cold-relaunched.

Observed live: the bridge died roughly every 30 seconds mid-session and could only recover by killing + relaunching the app on the device.

## Fix

Refresh `cachedTunnelAt` on every cache hit (sliding idle-timeout), so an active session holds the same live tunnel and rotated bearer for as long as it keeps working. Default idle window raised to **5 min** (covers reason-then-act gaps) and made configurable via **`GSTACK_IOS_TUNNEL_CACHE_MS`**. No security change — the boot token still dies at rotate; this only avoids needless re-bootstrap of a healthy tunnel.

The default bump (30s → 5min) is the debatable knob; with the sliding behavior even a short default survives active use, but the reason-then-act *gap* between requests is what needs the longer window. Easy to dial back if you'd prefer.

## Test

Adds a regression test in `daemon-integration.test.ts` asserting a burst of requests bootstraps the tunnel exactly once. `bun test test/daemon-integration.test.ts` → 5 pass, 0 fail.

## Notes
- Heads-up (pre-existing, not touched here): `daemon-integration.test.ts` imports `afterEach` at the bottom of the file, and the `tailnet listener` describe block errors with `afterEach is not a function` under bun — reproduces on `main` verbatim, so that block's tests don't run. Worth a separate fix (move the import to the top).
- Fork PR: eval/E2E CI jobs won't get base-repo secrets, so they'll fail on empty-env auth. The daemon test + lint don't need secrets. Move base-side if you want full CI.
