### PR TITLE
fix(preamble): self-heal GSTACK_ROOT when host globalRoot is absent

### DIFF
--- a/scripts/resolvers/preamble/generate-preamble-bash.ts
+++ b/scripts/resolvers/preamble/generate-preamble-bash.ts
@@ -7,6 +7,7 @@ export function generatePreambleBash(ctx: TemplateContext): string {
     ? `_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 GSTACK_ROOT="$HOME/${hostConfig.globalRoot}"
 [ -n "$_ROOT" ] && [ -d "$_ROOT/${ctx.paths.localSkillRoot}" ] && GSTACK_ROOT="$_ROOT/${ctx.paths.localSkillRoot}"
+[ ! -x "$GSTACK_ROOT/bin/gstack-update-check" ] && [ -x "\${GSTACK_HOME:-$HOME/.local/share/gstack}/bin/gstack-update-check" ] && GSTACK_ROOT="\${GSTACK_HOME:-$HOME/.local/share/gstack}"
 GSTACK_BIN="$GSTACK_ROOT/bin"
 GSTACK_BROWSE="$GSTACK_ROOT/browse/dist"
 GSTACK_DESIGN="$GSTACK_ROOT/design/dist"

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -16,6 +16,7 @@ description: |
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 GSTACK_ROOT="$HOME/.codex/skills/gstack"
 [ -n "$_ROOT" ] && [ -d "$_ROOT/.agents/skills/gstack" ] && GSTACK_ROOT="$_ROOT/.agents/skills/gstack"
+[ ! -x "$GSTACK_ROOT/bin/gstack-update-check" ] && [ -x "${GSTACK_HOME:-$HOME/.local/share/gstack}/bin/gstack-update-check" ] && GSTACK_ROOT="${GSTACK_HOME:-$HOME/.local/share/gstack}"
 GSTACK_BIN="$GSTACK_ROOT/bin"
 GSTACK_BROWSE="$GSTACK_ROOT/browse/dist"
 GSTACK_DESIGN="$GSTACK_ROOT/design/dist"

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -18,6 +18,7 @@ disable-model-invocation: true
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 GSTACK_ROOT="$HOME/.factory/skills/gstack"
 [ -n "$_ROOT" ] && [ -d "$_ROOT/.factory/skills/gstack" ] && GSTACK_ROOT="$_ROOT/.factory/skills/gstack"
+[ ! -x "$GSTACK_ROOT/bin/gstack-update-check" ] && [ -x "${GSTACK_HOME:-$HOME/.local/share/gstack}/bin/gstack-update-check" ] && GSTACK_ROOT="${GSTACK_HOME:-$HOME/.local/share/gstack}"
 GSTACK_BIN="$GSTACK_ROOT/bin"
 GSTACK_BROWSE="$GSTACK_ROOT/browse/dist"
 GSTACK_DESIGN="$GSTACK_ROOT/design/dist"


### PR DESCRIPTION
## Problem

The env-var preamble emitted by `scripts/resolvers/preamble/generate-preamble-bash.ts` (for `usesEnvVars` hosts — codex, factory, etc.) resolves the runtime root as:

```bash
GSTACK_ROOT="$HOME/<host.globalRoot>"   # e.g. ~/.codex/skills/gstack
[ -n "$_ROOT" ] && [ -d "$_ROOT/<localSkillRoot>" ] && GSTACK_ROOT="$_ROOT/<localSkillRoot>"
```

That assumes gstack is installed at `$HOME/<host.globalRoot>`. On a shared install where gstack lives at `~/.local/share/gstack` and is symlinked **per-skill** into the host's skills dir (so a full `~/.codex/skills/gstack` install dir never exists), the global path doesn't resolve. `$GSTACK_BIN/gstack-update-check` then silently no-ops (`|| true`), and the preamble bootstrap can't locate gstack's binaries.

## Fix

One additive line: if the resolved `GSTACK_ROOT` has no executable `bin/gstack-update-check` but the canonical `${GSTACK_HOME:-$HOME/.local/share/gstack}` does, fall back to it.

```bash
[ ! -x "$GSTACK_ROOT/bin/gstack-update-check" ] && [ -x "${GSTACK_HOME:-$HOME/.local/share/gstack}/bin/gstack-update-check" ] && GSTACK_ROOT="${GSTACK_HOME:-$HOME/.local/share/gstack}"
```

- **Standard installs are unaffected** — their host path has the binary, so the fallback never triggers.
- `globalRoot` is **unchanged**, so the `host-config` test pinning `.codex/skills/gstack` stays green.
- Only shared / relocated layouts self-heal.

## Tests

- `bun test test/gen-skill-docs.test.ts test/host-config.test.ts test/skill-validation.test.ts` → **792 pass / 0 fail**.
- Refreshed the codex + factory ship golden baselines (`test/fixtures/golden/{codex,factory}-ship-SKILL.md`); the diff is exactly the one added line.

> Note: this is a fork PR, so secret-gated eval/E2E CI jobs will run without secrets — the change is preamble-only and covered by the free tier above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
