### PR TITLE
Fix AskUserQuestion hook pass-through

### DIFF
--- a/docs/spikes/claude-code-hook-mutation.md
+++ b/docs/spikes/claude-code-hook-mutation.md
@@ -51,7 +51,8 @@ Optional in subagent context: `agent_id`, `agent_type`.
 - `"deny"` — block (feedback to Claude, NOT a synthetic answer per Codex
   correction in D-prefixed decisions)
 - `"ask"` — escalate to user
-- `"defer"` — let permission flow continue
+- No output — let permission flow continue
+- `"defer"` — pause a non-interactive SDK/tool caller so it can resume later
 
 **`updatedInput` semantics:** shallow merge of fields present in the returned
 object onto the original `tool_input`. Only valid with
@@ -88,7 +89,7 @@ required for our hook to fire there.
   accepting.
 
 **`permissionDecision` precedence (when multiple hooks decide):**
-`deny > ask > allow > defer` — most restrictive wins.
+Claude Code treats `defer` as an explicit pause/resume decision, not as the normal pass-through path. Hooks that do not need to decide should exit 0 with no output.
 
 ## Implementation hookSpecificOutput examples
 
@@ -107,11 +108,12 @@ required for our hook to fire there.
 ```
 
 **Pass-through (no preference, or one-way safety override):**
+Exit 0 with no stdout. If the hook has context to add, omit `permissionDecision`:
 ```json
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "defer"
+    "additionalContext": "optional context for Claude"
   }
 }
 ```

--- a/hosts/claude/hooks/question-preference-hook.ts
+++ b/hosts/claude/hooks/question-preference-hook.ts
@@ -12,11 +12,11 @@
  *   2. Look up door_type from scripts/question-registry.ts (default two-way).
  *   3. Read preferences with precedence: project-local > global (D8).
  *   4. Apply:
- *        never-ask + one-way → defer (safety override; one-way always asks).
+ *        never-ask + one-way → no decision (safety override; one-way always asks).
  *        never-ask + two-way + marker → deny with auto-decided recommendation
  *          in reason. Mark tool_use_id so PostToolUse logs as 'auto-decided'.
  *        ask-only-for-one-way + two-way + marker → same as never-ask.
- *        always-ask, or no preference → defer.
+ *        always-ask, or no preference → no decision.
  *
  * Why deny+reason instead of allow+updatedInput:
  *   AskUserQuestion's `updatedInput` shape for "pre-resolve this question"
@@ -31,7 +31,7 @@
  *   - First: (recommended) label suffix on an option.
  *   - Fall back: "Recommendation: X" prose match against option labels.
  *   - Refuse to auto-decide if ambiguous (multiple labels OR no parseable
- *     recommendation): defer instead of silent-wrong.
+ *     recommendation): no decision instead of silent-wrong.
  *
  * Always exits 0. Hook errors land in ~/.gstack/hook-errors.log.
  * See docs/spikes/claude-code-hook-mutation.md for the protocol contract.
@@ -91,13 +91,17 @@ function readStdin(): Promise<string> {
   });
 }
 
-function defer(additionalContext?: string): void {
-  const out: Record<string, unknown> = {
-    hookEventName: 'PreToolUse',
-    permissionDecision: 'defer',
-  };
-  if (additionalContext) out.additionalContext = additionalContext;
-  process.stdout.write(JSON.stringify({ hookSpecificOutput: out }));
+function passThrough(additionalContext?: string): void {
+  if (additionalContext) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext,
+        },
+      }),
+    );
+  }
   process.exit(0);
 }
 
@@ -346,7 +350,7 @@ function logAutoDecided(
 async function main(): Promise<void> {
   const raw = await readStdin();
   if (!raw.trim()) {
-    defer();
+    passThrough();
     return;
   }
   let stdin: HookStdin;
@@ -354,7 +358,7 @@ async function main(): Promise<void> {
     stdin = JSON.parse(raw);
   } catch (e) {
     logHookError(`stdin parse failed: ${(e as Error).message}`);
-    defer();
+    passThrough();
     return;
   }
 
@@ -363,26 +367,26 @@ async function main(): Promise<void> {
     toolName !== 'AskUserQuestion' &&
     !toolName.match(/^mcp__.+__AskUserQuestion$/)
   ) {
-    defer();
+    passThrough();
     return;
   }
 
   const questions = stdin.tool_input?.questions || [];
   if (questions.length === 0) {
-    defer();
+    passThrough();
     return;
   }
 
   // For multi-question AUQ, enforcement is all-or-nothing per call:
   // we deny only if ALL questions have marker + never-ask + safe door type.
-  // Mixed cases pass through (defer) so the user still gets to answer.
+  // Mixed cases pass through so the user still gets to answer.
   const registry = loadRegistry();
   const slug = slugFromCwd(stdin.cwd);
   const memoryNuggets = loadMemoryNuggets(stdin.session_id);
 
   // Compute Layer 8 memory context inline: any nuggets matching the
   // signal_keys of the questions in this AUQ get surfaced as additionalContext.
-  // This applies whether we defer OR deny — gives the agent + user the
+  // This applies whether we pass through OR deny — gives the agent + user the
   // relevant prior context either way.
   const contextNuggets: string[] = [];
   for (const q of questions) {
@@ -405,13 +409,13 @@ async function main(): Promise<void> {
     const qText = q.question || '';
     const marker = qText.match(MARKER_RE);
     if (!marker) {
-      defer(memoryContext);
+      passThrough(memoryContext);
       return;
     }
     const questionId = marker[1];
     const pref = lookupPreference(slug, questionId);
     if (!pref.preference || pref.preference === 'always-ask') {
-      defer(memoryContext);
+      passThrough(memoryContext);
       return;
     }
 
@@ -419,7 +423,7 @@ async function main(): Promise<void> {
     const doorType = entry?.door_type || 'two-way';
     if (doorType === 'one-way') {
       // Safety override — even never-ask doesn't bypass one-way doors.
-      defer(memoryContext);
+      passThrough(memoryContext);
       return;
     }
 
@@ -427,7 +431,7 @@ async function main(): Promise<void> {
     const { recommended, ambiguous } = extractRecommended(qText, opts);
     if (!recommended || ambiguous) {
       // Refuse-on-ambiguous per D2 — fail safe, ask normally.
-      defer(memoryContext);
+      passThrough(memoryContext);
       return;
     }
     autoDecisions.push({ id: questionId, recommended });
@@ -455,5 +459,5 @@ async function main(): Promise<void> {
 
 main().catch((e) => {
   logHookError(`main crash: ${(e as Error).message}`);
-  defer();
+  passThrough();
 });

--- a/test/memory-cache-injection.test.ts
+++ b/test/memory-cache-injection.test.ts
@@ -64,7 +64,7 @@ function runHook(stdin: object): { stdout: string; stderr: string; status: numbe
 // ----------------------------------------------------------------------
 
 describe('memory injection', () => {
-  test('injects matching nugget into additionalContext on defer', () => {
+  test('injects matching nugget into additionalContext while passing through', () => {
     writeMemory([
       {
         nugget: 'User prefers verbose explanations with tradeoffs',
@@ -86,7 +86,7 @@ describe('memory injection', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toContain('verbose explanations');
   });
 
@@ -110,7 +110,8 @@ describe('memory injection', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toBeUndefined();
   });
 
@@ -214,7 +215,8 @@ describe('per-session memory cache', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toBeUndefined();
   });
 });

--- a/test/question-preference-hook.test.ts
+++ b/test/question-preference-hook.test.ts
@@ -3,15 +3,15 @@
  *
  * Covers:
  *   - never-ask + marker + two-way + clean recommendation → deny+reason
- *   - never-ask + no marker → defer (D18 marker gate)
- *   - never-ask + one-way → defer (safety override)
- *   - never-ask + ambiguous recommendation → defer (D2 refuse-on-ambiguous)
- *   - always-ask → defer
- *   - no preference → defer
+ *   - never-ask + no marker → no decision (D18 marker gate)
+ *   - never-ask + one-way → no decision (safety override)
+ *   - never-ask + ambiguous recommendation → no decision (D2 refuse-on-ambiguous)
+ *   - always-ask → no decision
+ *   - no preference → no decision
  *   - project preference wins over global (D8 precedence)
  *   - global preference applies when no project preference set
  *   - mcp__*__AskUserQuestion matcher accepted
- *   - empty stdin → defer (crash safety)
+ *   - empty stdin → no decision (crash safety)
  *   - auto-decided event logged via gstack-question-log (PostToolUse won't fire)
  *   - auto-decided marker written to ~/.gstack/sessions/<id>/.auto-decided-<tool_use_id>
  */
@@ -101,12 +101,17 @@ function autoDecidedEvents(): Array<Record<string, unknown>> {
     .filter((e) => e.source === 'auto-decided');
 }
 
+function expectNoDecision(r: { stdout: string; parsed: any }): void {
+  expect(r.stdout).toBe('');
+  expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
+}
+
 // ----------------------------------------------------------------------
-// Defer paths
+// Pass-through paths
 // ----------------------------------------------------------------------
 
-describe('defers (no enforcement)', () => {
-  test('no preference set → defer', () => {
+describe('passes through (no enforcement)', () => {
+  test('no preference set → no decision', () => {
     const r = runHook({
       session_id: 's1',
       tool_name: 'AskUserQuestion',
@@ -118,10 +123,10 @@ describe('defers (no enforcement)', () => {
       },
     });
     expect(r.status).toBe(0);
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 
-  test('marker missing → defer (D18)', () => {
+  test('marker missing → no decision (D18)', () => {
     writeProjectPref('test-q', 'never-ask');
     const r = runHook({
       session_id: 's2',
@@ -133,10 +138,10 @@ describe('defers (no enforcement)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 
-  test('always-ask preference → defer', () => {
+  test('always-ask preference → no decision', () => {
     writeProjectPref('test-q', 'always-ask');
     const r = runHook({
       session_id: 's3',
@@ -148,10 +153,10 @@ describe('defers (no enforcement)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 
-  test('empty stdin → defer (crash safety)', () => {
+  test('empty stdin → no decision (crash safety)', () => {
     const env: Record<string, string> = {};
     for (const [k, v] of Object.entries(process.env)) {
       if (v !== undefined) env[k] = v;
@@ -159,14 +164,13 @@ describe('defers (no enforcement)', () => {
     env.GSTACK_STATE_ROOT = stateRoot;
     const res = spawnSync(HOOK, [], { env, input: '', encoding: 'utf-8' });
     expect(res.status).toBe(0);
-    const parsed = JSON.parse(res.stdout || '{}');
-    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(res.stdout).toBe('');
   });
 
-  test('non-AUQ tool_name → defer (defensive)', () => {
+  test('non-AUQ tool_name → no decision (defensive)', () => {
     writeProjectPref('test-q', 'never-ask');
     const r = runHook({ session_id: 's4', tool_name: 'Bash', tool_use_id: 'tu-4', tool_input: {} });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 });
 
@@ -196,7 +200,7 @@ describe('enforces never-ask preferences', () => {
     expect(r.parsed?.hookSpecificOutput?.permissionDecisionReason).toContain('Fix now');
   });
 
-  test('one-way door → defer even with never-ask (safety override)', () => {
+  test('one-way door → no decision even with never-ask (safety override)', () => {
     writeProjectPref('ship-test-failure-triage', 'never-ask');
     const r = runHook({
       session_id: 's6',
@@ -211,10 +215,10 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 
-  test('ambiguous recommendation (two labels) → defer (D2 refuse-on-ambiguous)', () => {
+  test('ambiguous recommendation (two labels) → no decision (D2 refuse-on-ambiguous)', () => {
     writeProjectPref('ship-pre-landing-review-fix', 'never-ask');
     const r = runHook({
       session_id: 's7',
@@ -229,10 +233,10 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 
-  test('no recommendation marker AND no prose match → defer', () => {
+  test('no recommendation marker AND no prose match → no decision', () => {
     writeProjectPref('ship-pre-landing-review-fix', 'never-ask');
     const r = runHook({
       session_id: 's8',
@@ -247,7 +251,7 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 });
 
@@ -293,7 +297,7 @@ describe('precedence: project wins over global (D8)', () => {
     expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('deny');
   });
 
-  test('project always-ask + global never-ask → defer (project wins)', () => {
+  test('project always-ask + global never-ask → no decision (project wins)', () => {
     writeProjectPref('ship-pre-landing-review-fix', 'always-ask');
     writeGlobalPref('ship-pre-landing-review-fix', 'never-ask');
     const r = runHook({
@@ -309,7 +313,7 @@ describe('precedence: project wins over global (D8)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 });
 

--- a/test/skill-e2e-plan-tune-cathedral.test.ts
+++ b/test/skill-e2e-plan-tune-cathedral.test.ts
@@ -263,7 +263,7 @@ describeIfSelected('PlanTune cathedral E2E: annotation', ['plan-tune-annotation'
     cleanupFixture(fixture.workDir);
   });
 
-  testConcurrentIfSelected('PreToolUse hook surfaces memory nugget on defer', async () => {
+  testConcurrentIfSelected('PreToolUse hook surfaces memory nugget while passing through', async () => {
     const hookPath = path.join(
       fixture.workDir,
       'hosts',
@@ -296,7 +296,7 @@ describeIfSelected('PlanTune cathedral E2E: annotation', ['plan-tune-annotation'
     });
     expect(res.status).toBe(0);
     const parsed = JSON.parse(res.stdout || '{}');
-    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(parsed.hookSpecificOutput?.additionalContext).toContain('verbose explanations');
   });
 });


### PR DESCRIPTION
## Summary

- stop returning `permissionDecision: "defer"` for normal AskUserQuestion pass-through paths
- keep auto-decision `deny` behavior unchanged
- preserve memory `additionalContext` by emitting context without a permission decision

## Why

Claude Code treats `permissionDecision: "defer"` as an explicit SDK pause/resume flow, not as "no opinion". In SDK hosts such as Conductor, Gstack's no-op defer response caused `mcp__conductor__AskUserQuestion` to be emitted but not dispatched to the MCP handler.

The correct pass-through behavior is exit 0 with no stdout. When Gstack has context to inject, it can emit `additionalContext` without a `permissionDecision`.

## Test plan

- `bun test test/question-preference-hook.test.ts test/memory-cache-injection.test.ts test/auq-error-fallback-hook.test.ts test/gstack-settings-hook-schema-aware.test.ts`
- SDK repro from the original Conductor workspace against this PR checkout: exact Gstack hooks invoked the AUQ MCP handler in `none`, `pre`, `post`, and `both` hook modes; orphaned AUQs: 0.