### PR TITLE
ci: update GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,5 +4,5 @@ jobs:
   actionlint:
     runs-on: ubicloud-standard-8
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.1
       - uses: rhysd/actionlint@v1.7.11

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -20,18 +20,18 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.1
 
       # Copy lockfile + package.json into Docker build context
       - run: cp package.json bun.lock .github/docker/
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7.2.0
         with:
           context: .github/docker
           file: .github/docker/Dockerfile.ci

--- a/.github/workflows/skill-docs.yml
+++ b/.github/workflows/skill-docs.yml
@@ -4,7 +4,7 @@ jobs:
   check-freshness:
     runs-on: ubicloud-standard-8
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.1
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - name: Check Claude host freshness


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` from `v4` → `v5.0.1` in all three workflows (`actionlint.yml`, `ci-image.yml`, `skill-docs.yml`)
- Bump `docker/login-action` from `v3` → `v4.2.0` in `ci-image.yml`
- Bump `docker/build-push-action` from `v6` → `v7.2.0` in `ci-image.yml`

## Why

GitHub Actions is deprecating Node.js 20 runners (deadline June 16, 2026). The old action versions (`checkout@v4`, `login-action@v3`, `build-push-action@v6`) use `node20`; the new versions use `node24`. This removes the deprecation annotations visible in runs [27183519090](https://github.com/garrytan/gstack/actions/runs/27183519090), [27183519096](https://github.com/garrytan/gstack/actions/runs/27183519096), and [27183519105](https://github.com/garrytan/gstack/actions/runs/27183519105).

## Test plan

- [ ] CI runs on this PR should show no Node.js 20 deprecation warnings
- [ ] `actionlint` job passes
- [ ] `skill-docs` freshness check passes
- [ ] `ci-image` build is unaffected (no functional changes, only action runner versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)