### PR TITLE
fix(office-hours): persist sessions through to the unified profile (P0) + robustness/test wave

### DIFF
--- a/bin/gstack-developer-profile
+++ b/bin/gstack-developer-profile
@@ -17,6 +17,10 @@
 #   --check-mismatch    detect meaningful gaps between declared and observed.
 #   --migrate           migrate builder-profile.jsonl → developer-profile.json.
 #                       Idempotent; archives the source file on success.
+#   --append-session    read a session entry as JSON on stdin and append it to
+#                       sessions[] (write-through to developer-profile.json).
+#   --append-resources  read {resources_shown,[topics]} as JSON on stdin and merge
+#                       into resources_shown WITHOUT counting as a session.
 #
 # Profile file: ~/.gstack/developer-profile.json (unified schema — see
 # docs/designs/PLAN_TUNING_V0.md). Event file: ~/.gstack/projects/{SLUG}/
@@ -25,7 +29,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
+# State root resolution mirrors bin/gstack-paths precedence so the profile the
+# skill WRITES (--append-session/--append-resources) and the one it READS are the
+# same file under a plugin install (CLAUDE_PLUGIN_DATA) or a GSTACK_HOME override.
+GSTACK_HOME="${GSTACK_HOME:-${CLAUDE_PLUGIN_DATA:-$HOME/.gstack}}"
 PROFILE_FILE="$GSTACK_HOME/developer-profile.json"
 LEGACY_FILE="$GSTACK_HOME/builder-profile.jsonl"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null || true)"
@@ -44,58 +51,29 @@ do_migrate() {
   fi
 
   if [ -f "$PROFILE_FILE" ]; then
-    # Already migrated — no-op (idempotent).
+    # Already migrated — no-op (idempotent). Orphaned appends are healed by
+    # reconcile_legacy() on the next read rather than re-migrated here.
     echo "MIGRATE: already migrated (developer-profile.json exists)"
     return 0
   fi
 
-  # Run migration in a temp file, then atomic rename.
+  # Run migration in a temp file, then atomic rename. Aggregation + resource-row
+  # filtering + malformed-line accounting live in scripts/profile-store.ts.
+  mkdir -p "$GSTACK_HOME"
   local TMPOUT
   TMPOUT=$(mktemp "$GSTACK_HOME/developer-profile.json.XXXXXX.tmp")
   trap 'rm -f "$TMPOUT"' EXIT
 
-  cat "$LEGACY_FILE" | bun -e "
-    const lines = (await Bun.stdin.text()).trim().split('\n').filter(Boolean);
-    const sessions = [];
-    const signalsAcc = {};
-    const resources = new Set();
-    const topics = new Set();
-    for (const line of lines) {
-      try {
-        const e = JSON.parse(line);
-        sessions.push(e);
-        for (const s of (e.signals || [])) {
-          signalsAcc[s] = (signalsAcc[s] || 0) + 1;
-        }
-        for (const r of (e.resources_shown || [])) resources.add(r);
-        for (const t of (e.topics || [])) topics.add(t);
-      } catch {}
-    }
-    const profile = {
-      identity: {},
-      declared: {},
-      inferred: {
-        values: {
-          scope_appetite: 0.5,
-          risk_tolerance: 0.5,
-          detail_preference: 0.5,
-          autonomy: 0.5,
-          architecture_care: 0.5,
-        },
-        sample_size: 0,
-        diversity: { skills_covered: 0, question_ids_covered: 0, days_span: 0 },
-      },
-      gap: {},
-      overrides: {},
-      sessions,
-      signals_accumulated: signalsAcc,
-      resources_shown: Array.from(resources),
-      topics: Array.from(topics),
-      migrated_at: new Date().toISOString(),
-      schema_version: 1,
-    };
-    console.log(JSON.stringify(profile, null, 2));
-  " > "$TMPOUT"
+  ( cd "$ROOT_DIR" && LEGACY_PATH="$LEGACY_FILE" OUT_PATH="$TMPOUT" bun -e "
+    import('./scripts/profile-store.ts').then((m) => {
+      const fs = require('fs');
+      const raw = fs.existsSync(process.env.LEGACY_PATH) ? fs.readFileSync(process.env.LEGACY_PATH, 'utf-8') : '';
+      const lines = raw.trim() ? raw.trim().split('\n') : [];
+      const { profile, dropped } = m.migrateLegacy(lines);
+      fs.writeFileSync(process.env.OUT_PATH, JSON.stringify(profile, null, 2));
+      if (dropped > 0) console.error('MIGRATE: WARNING dropped ' + dropped + ' malformed line(s) from builder-profile.jsonl');
+    }).catch((e) => { console.error('MIGRATE: ' + e.message); process.exit(1); });
+  " )
 
   # Atomic rename.
   mv "$TMPOUT" "$PROFILE_FILE"
@@ -116,12 +94,47 @@ do_migrate() {
 }
 
 # -----------------------------------------------------------------------
+# Reconcile: fold orphaned legacy appends back into the unified profile.
+# An older buggy /office-hours kept appending to builder-profile.jsonl AFTER
+# migration, where the read path never saw them. This heals those installs:
+# fold any not-yet-present legacy sessions, then archive the file. Idempotent.
+# -----------------------------------------------------------------------
+reconcile_legacy() {
+  [ -f "$PROFILE_FILE" ] || return 0
+  [ -f "$LEGACY_FILE" ] || return 0
+  local TMPOUT
+  TMPOUT=$(mktemp "$GSTACK_HOME/developer-profile.json.XXXXXX.tmp")
+  if ( cd "$ROOT_DIR" && PROFILE_PATH="$PROFILE_FILE" LEGACY_PATH="$LEGACY_FILE" OUT_PATH="$TMPOUT" bun -e "
+    import('./scripts/profile-store.ts').then((m) => {
+      const fs = require('fs');
+      const profile = JSON.parse(fs.readFileSync(process.env.PROFILE_PATH, 'utf-8'));
+      const raw = fs.readFileSync(process.env.LEGACY_PATH, 'utf-8');
+      const lines = raw.trim() ? raw.trim().split('\n') : [];
+      const { profile: out, dropped } = m.foldLegacy(profile, lines);
+      fs.writeFileSync(process.env.OUT_PATH, JSON.stringify(out, null, 2));
+      if (dropped > 0) console.error('RECONCILE: WARNING dropped ' + dropped + ' malformed line(s) from builder-profile.jsonl');
+    }).catch((e) => { console.error('RECONCILE: ' + e.message); process.exit(1); });
+  " ); then
+    mv "$TMPOUT" "$PROFILE_FILE"
+    local TS
+    TS="$(date +%Y-%m-%d-%H%M%S)"
+    mv "$LEGACY_FILE" "$LEGACY_FILE.reconciled-$TS"
+  else
+    rm -f "$TMPOUT"
+  fi
+}
+
+# -----------------------------------------------------------------------
 # Load-or-migrate helper: ensure developer-profile.json exists.
 # Auto-migrates from builder-profile.jsonl if present.
 # Returns path to profile file via stdout. Creates a minimal stub if nothing exists.
 # -----------------------------------------------------------------------
 ensure_profile() {
   if [ -f "$PROFILE_FILE" ]; then
+    # Heal orphaned legacy appends from an older buggy /office-hours (one-time).
+    if [ -f "$LEGACY_FILE" ]; then
+      reconcile_legacy
+    fi
     return 0
   fi
   if [ -f "$LEGACY_FILE" ]; then
@@ -149,6 +162,8 @@ ensure_profile() {
   "overrides": {},
   "sessions": [],
   "signals_accumulated": {},
+  "resources_shown": [],
+  "topics": [],
   "schema_version": 1
 }
 EOF
@@ -161,7 +176,9 @@ do_read() {
   ensure_profile
   cat "$PROFILE_FILE" | bun -e "
     const p = JSON.parse(await Bun.stdin.text());
-    const sessions = p.sessions || [];
+    // Resource-tracking rows (mode:'resources') are not sessions — exclude them
+    // from every session-derived value so tier/journey don't double-count.
+    const sessions = (p.sessions || []).filter(e => e.mode !== 'resources');
     const count = sessions.length;
     let tier = 'introduction';
     if (count >= 8) tier = 'inner_circle';
@@ -174,10 +191,12 @@ do_read() {
       ? prev.project_slug !== last.project_slug
       : false;
 
+    // Human-facing design title: explicit title, else doc basename, else blank.
+    const designOf = (e) => e.design_title
+      ? e.design_title
+      : (e.design_doc ? String(e.design_doc).split('/').pop() : '');
     const designs = sessions.map(e => e.design_doc || '').filter(Boolean);
-    const designTitles = sessions
-      .map(e => (e.design_doc ? (e.project_slug || 'unknown') : ''))
-      .filter(Boolean);
+    const designTitles = sessions.filter(e => e.design_doc || e.design_title).map(designOf);
 
     const signalCounts = p.signals_accumulated || {};
     let totalSignals = 0;
@@ -194,7 +213,7 @@ do_read() {
     console.log('TIER: ' + tier);
     console.log('LAST_PROJECT: ' + (last.project_slug || ''));
     console.log('LAST_ASSIGNMENT: ' + (last.assignment || ''));
-    console.log('LAST_DESIGN_TITLE: ' + (last.design_doc || ''));
+    console.log('LAST_DESIGN_TITLE: ' + designOf(last));
     console.log('DESIGN_COUNT: ' + designs.length);
     console.log('DESIGN_TITLES: ' + JSON.stringify(designTitles));
     console.log('ACCUMULATED_SIGNALS: ' + signalStr);
@@ -429,6 +448,70 @@ do_vibe() {
 }
 
 # -----------------------------------------------------------------------
+# Append a session entry (read JSON object from stdin). Write-through to the
+# unified profile so the read path sees it. JSON encoding happens here, so the
+# caller never assembles JSON in the shell (no quote/newline corruption).
+# -----------------------------------------------------------------------
+do_append_session() {
+  local INPUT
+  INPUT="$(cat)"
+  ensure_profile
+  local TMPOUT
+  TMPOUT=$(mktemp "$GSTACK_HOME/developer-profile.json.XXXXXX.tmp")
+  if ( cd "$ROOT_DIR" && PROFILE_PATH="$PROFILE_FILE" OUT_PATH="$TMPOUT" APPEND_JSON="$INPUT" bun -e "
+    import('./scripts/profile-store.ts').then((m) => {
+      const fs = require('fs');
+      let entry;
+      try { entry = JSON.parse(process.env.APPEND_JSON); }
+      catch (e) { console.error('append-session: invalid JSON — ' + e.message); process.exit(2); }
+      const profile = JSON.parse(fs.readFileSync(process.env.PROFILE_PATH, 'utf-8'));
+      const out = m.appendSession(profile, entry);
+      fs.writeFileSync(process.env.OUT_PATH, JSON.stringify(out, null, 2));
+      console.log('APPEND: ok — ' + m.realSessions(out).length + ' session(s)');
+    }).catch((e) => { console.error('append-session: ' + e.message); process.exit(1); });
+  " ); then
+    mv "$TMPOUT" "$PROFILE_FILE"
+    SCRIPT_DIR_E="$(cd "$(dirname "$0")" && pwd)"
+    "$SCRIPT_DIR_E/gstack-brain-enqueue" "developer-profile.json" 2>/dev/null &
+  else
+    local rc=$?
+    rm -f "$TMPOUT"
+    return "$rc"
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Append a resources-shown record (read JSON {resources_shown,[topics]} from
+# stdin). Merges into the profile's resources_shown/topics WITHOUT adding a
+# session row, so founder-resource dedup works without inflating SESSION_COUNT.
+# -----------------------------------------------------------------------
+do_append_resources() {
+  local INPUT
+  INPUT="$(cat)"
+  ensure_profile
+  local TMPOUT
+  TMPOUT=$(mktemp "$GSTACK_HOME/developer-profile.json.XXXXXX.tmp")
+  if ( cd "$ROOT_DIR" && PROFILE_PATH="$PROFILE_FILE" OUT_PATH="$TMPOUT" APPEND_JSON="$INPUT" bun -e "
+    import('./scripts/profile-store.ts').then((m) => {
+      const fs = require('fs');
+      let entry;
+      try { entry = JSON.parse(process.env.APPEND_JSON); }
+      catch (e) { console.error('append-resources: invalid JSON — ' + e.message); process.exit(2); }
+      const profile = JSON.parse(fs.readFileSync(process.env.PROFILE_PATH, 'utf-8'));
+      const out = m.mergeResources(profile, entry);
+      fs.writeFileSync(process.env.OUT_PATH, JSON.stringify(out, null, 2));
+      console.log('APPEND: ok — ' + (out.resources_shown || []).length + ' resource(s) tracked');
+    }).catch((e) => { console.error('append-resources: ' + e.message); process.exit(1); });
+  " ); then
+    mv "$TMPOUT" "$PROFILE_FILE"
+  else
+    local rc=$?
+    rm -f "$TMPOUT"
+    return "$rc"
+  fi
+}
+
+# -----------------------------------------------------------------------
 # Dispatch
 # -----------------------------------------------------------------------
 case "$CMD" in
@@ -441,6 +524,8 @@ case "$CMD" in
   --vibe) do_vibe ;;
   --check-mismatch) do_check_mismatch ;;
   --migrate) do_migrate ;;
+  --append-session) do_append_session ;;
+  --append-resources) do_append_resources ;;
   --help|-h) sed -n '1,/^set -euo/p' "$0" | sed 's|^# \?||' ;;
   *)
     echo "gstack-developer-profile: unknown subcommand '$CMD'" >&2

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -34,14 +34,13 @@ gbrain:
     - id: prior-sessions
       kind: list
       filter:
-        type: ceo-plan
         tags_contains: "repo:{repo_slug}"
       sort: updated_at_desc
       limit: 5
       render_as: "## Prior office-hours sessions in this repo"
     - id: builder-profile
       kind: filesystem
-      glob: "~/.gstack/builder-profile.jsonl"
+      glob: "~/.gstack/developer-profile.json"
       tail: 1
       render_as: "## Your builder profile snapshot"
     - id: design-doc-history
@@ -835,12 +834,29 @@ eval "$(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)"
 1. Read `CLAUDE.md`, `TODOS.md` (if they exist).
 2. Run `git log --oneline -30` and `git diff origin/main --stat 2>/dev/null` to understand recent context.
 3. Use Grep/Glob to map the codebase areas most relevant to the user's request.
-4. **List existing design docs for this project:**
+4. **List existing design docs for this project — and offer to resume one:**
    ```bash
    setopt +o nomatch 2>/dev/null || true  # zsh compat
    ls -t ~/.gstack/projects/$SLUG/*-design-*.md 2>/dev/null
    ```
-   If design docs exist, list them: "Prior designs for this project: [titles + dates]"
+   If design docs exist, list them ("Prior designs for this project: [titles + dates]") and,
+   via AskUserQuestion, offer to pick up where they left off:
+
+   > You've designed in this repo before. Continue one, or start fresh?
+   > - **Resume "{most recent title}"** — pick up the latest design
+   > - **Build on a specific prior design** — choose from the list
+   > - **Start a new idea** — fresh session
+
+   - **Resume / Build on:** read the chosen doc, infer its mode from the `Mode:` field
+     (so you can skip the goal question in step 5), and recap it back in 3-4 lines — its
+     **Recommended Approach**, any **Open Questions**, and **The Assignment** — framed as
+     "Last time you decided…". Then SKIP the Phase 2 diagnostic and go straight to Phase 3
+     (Premise Challenge) against the existing premises, so the session builds on prior
+     thinking instead of re-interrogating it. The Phase 5 doc gets a `Supersedes:` link to
+     the resumed one.
+   - **Start a new idea:** proceed normally.
+
+   If no prior design docs exist, proceed.
 
 ## Prior Learnings
 
@@ -897,10 +913,11 @@ smarter on their codebase over time.
    - Startup, intrapreneurship → **Startup mode** (Phase 2A)
    - Hackathon, open source, research, learning, having fun → **Builder mode** (Phase 2B)
 
-6. **Assess product stage** (only for startup/intrapreneurship modes):
+6. **Assess product stage** (only for startup/intrapreneurship modes). This selects the smart-routing question set below:
    - Pre-product (idea stage, no users yet)
    - Has users (people using it, not yet paying)
    - Has paying customers
+   - Pure engineering/infra (internal tooling or infrastructure with no external "customer" — routes to a reduced question set)
 
 Output: "Here's what I understand about this project and the area you want to change: ..."
 
@@ -1063,7 +1080,7 @@ The pressure is in the stacking — don't collapse it into a single ask. The spe
 
 **Escape hatch:** If the user expresses impatience ("just do it," "skip the questions"):
 - Say: "I hear you. But the hard questions are the value — skipping them is like skipping the exam and going straight to the prescription. Let me ask two more, then we'll move."
-- Consult the smart routing table for the founder's product stage. Ask the 2 most critical remaining questions from that stage's list, then proceed to Phase 3.
+- Consult the smart routing table for the founder's product stage. Ask the 2 highest-priority questions from that stage's list that you have NOT already asked, then proceed to Phase 3.
 - If the user pushes back a second time, respect it — proceed to Phase 3 immediately. Don't ask a third time.
 - If only 1 question remains, ask it. If 0 remain, proceed directly.
 - Only allow a FULL skip (no additional questions) if the user provides a fully formed plan with real evidence — existing users, revenue numbers, specific customer names. Even then, still run Phase 3 (Premise Challenge) and Phase 4 (Alternatives).
@@ -1110,7 +1127,7 @@ Ask these **ONE AT A TIME** via AskUserQuestion. The goal is to brainstorm and s
 
 **STOP** after each question. Wait for the response before asking the next.
 
-**Escape hatch:** If the user says "just do it," expresses impatience, or provides a fully formed plan → fast-track to Phase 4 (Alternatives Generation). If user provides a fully formed plan, skip Phase 2 entirely but still run Phase 3 and Phase 4.
+**Escape hatch:** If the user says "just do it," expresses impatience, or provides a fully formed plan → stop asking Phase 2B questions and move on, but STILL run Phase 3 (Premise Challenge) before Phase 4 (Alternatives Generation) — never skip the premise check. If the user provides a fully formed plan, skip Phase 2 entirely (Phase 2.5 / 2.75 self-gate on having questioned, so they fall away naturally); Phase 3 and Phase 4 always run.
 
 **If the vibe shifts mid-session** — the user starts in builder mode but says "actually I think this could be a real company" or mentions customers, revenue, fundraising — upgrade to Startup mode naturally. Say something like: "Okay, now we're talking — let me ask you some harder questions." Then switch to the Phase 2A questions.
 
@@ -1515,34 +1532,46 @@ Track which of these signals appeared during the session:
 
 Count the signals. You'll use this count in Phase 6 to determine which tier of closing message to use.
 
-### Builder Profile Append
+### Session Persistence
 
-After counting signals, append a session entry to the builder profile. This is the single
+After counting signals, persist this session to the developer profile — the single
 source of truth for all closing state (tier, resource dedup, journey tracking).
+**Write it through the profile binary**, which appends to the same `developer-profile.json`
+the closing reads from. (Do NOT hand-append raw JSONL to a file — that older path is no
+longer read, and shell-assembled JSON corrupts on quoted / apostrophe / newline text.)
+
+Emit one JSON **object** on stdin via a quoted heredoc. Substitute the real values; if
+`assignment` or a topic contains a double-quote, escape it as `\"` (it's JSON). You do
+NOT need to provide `date` — it is stamped automatically.
 
 ```bash
-eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
-mkdir -p "$GSTACK_STATE_ROOT"
+~/.claude/skills/gstack/bin/gstack-developer-profile --append-session <<'OHSESSION'
+{
+  "mode": "MODE",
+  "project_slug": "SLUG",
+  "signal_count": N,
+  "signals": SIGNALS_ARRAY,
+  "design_doc": "DOC_PATH",
+  "design_title": "DESIGN_TITLE",
+  "assignment": "ASSIGNMENT_TEXT",
+  "topics": TOPICS_ARRAY
+}
+OHSESSION
 ```
 
-Append one JSON line with these fields (substitute actual values from this session):
-- `date`: current ISO 8601 timestamp
+Field notes (substitute actual values from this session):
 - `mode`: "startup" or "builder" (from Phase 1 mode selection)
 - `project_slug`: the SLUG value from the preamble
 - `signal_count`: number of signals counted above
 - `signals`: array of signal names observed (e.g., `["named_users", "pushback", "taste"]`)
 - `design_doc`: path to the design doc that will be written in Phase 5 (construct it now)
+- `design_title`: the design's human title (its `# Design: {title}` heading) — used in the closing's design-trajectory line
 - `assignment`: the assignment you will give in the design doc's "The Assignment" section
-- `resources_shown`: empty array `[]` for now (populated after resource selection in Phase 6)
 - `topics`: array of 2-3 topic keywords that describe what this session was about
 
-```bash
-eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
-echo '{"date":"TIMESTAMP","mode":"MODE","project_slug":"SLUG","signal_count":N,"signals":SIGNALS_ARRAY,"design_doc":"DOC_PATH","assignment":"ASSIGNMENT_TEXT","resources_shown":[],"topics":TOPICS_ARRAY}' >> "$GSTACK_STATE_ROOT/builder-profile.jsonl"
-```
-
-This entry is append-only. The `resources_shown` field will be updated via a second append
-after resource selection in Phase 6 Beat 3.5.
+The command prints `APPEND: ok` on success. If it reports invalid JSON, fix the escaping
+and re-run — the session is never silently dropped. Resources shown are recorded
+separately in Phase 6 Beat 3.5.
 
 ---
 
@@ -1675,7 +1704,8 @@ Supersedes: {prior filename — omit this line if first design on this branch}
 
 ## Distribution Plan
 {how users get the deliverable — binary download, package manager, container image, web service, etc.}
-{CI/CD pipeline for building and publishing — or "existing deployment pipeline covers this"}
+{CI/CD pipeline for building and publishing — GitHub Actions, manual release, auto-deploy on merge?}
+{omit this section if the deliverable is a web service with existing deployment pipeline}
 
 ## Next Steps
 {concrete build tasks — what to implement first, second, third}
@@ -1768,8 +1798,14 @@ over time.
 ### Step 1: Read Builder Profile
 
 ```bash
-PROFILE=$(~/.claude/skills/gstack/bin/gstack-builder-profile 2>/dev/null) || PROFILE="SESSION_COUNT: 0
+# A new user legitimately reads SESSION_COUNT: 0 / TIER: introduction (no error).
+# The fallback only triggers on a genuine exec failure — surface it rather than
+# silently greeting a returning user as a first-timer.
+PROFILE=$(~/.claude/skills/gstack/bin/gstack-developer-profile --read) || {
+  echo "office-hours: profile read failed — defaulting to introduction tier (see error above)." >&2
+  PROFILE="SESSION_COUNT: 0
 TIER: introduction"
+}
 SESSION_TIER=$(echo "$PROFILE" | grep "^TIER:" | awk '{print $2}')
 SESSION_COUNT=$(echo "$PROFILE" | grep "^SESSION_COUNT:" | awk '{print $2}')
 ```
@@ -1817,7 +1853,7 @@ Use the founder signal count from Phase 4.5 to select the right sub-tier.
 > GStack thinks you are among the top people who could do this.
 
 Then use AskUserQuestion: "Would you consider applying to Y Combinator?"
-- If yes: run `open https://ycombinator.com/apply?ref=gstack` and say: "Bring this design doc to your YC interview. It's better than most pitch decks."
+- If yes: run `~/.claude/skills/gstack/bin/gstack-open-url https://ycombinator.com/apply?ref=gstack` and say: "Bring this design doc to your YC interview. It's better than most pitch decks."
 - If no: respond warmly: "Totally fair. The design doc is yours either way, and the offer stands if you ever change your mind." No pressure, no guilt, no re-ask.
 
 - **Middle tier** (1-2 signals, or builder whose project solves a real problem):
@@ -1897,7 +1933,7 @@ with a narrative arc (not a data table). The arc tells the STORY of their journe
 second person, referencing specific things they said across sessions. Then open it:
 ```bash
 eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
-open "$GSTACK_STATE_ROOT/builder-journey.md"
+~/.claude/skills/gstack/bin/gstack-open-url "$GSTACK_STATE_ROOT/builder-journey.md"
 ```
 
 Then proceed to Founder Resources below.
@@ -1924,8 +1960,9 @@ Share 2-3 resources from the pool below. For repeat users, resources compound by
 to accumulated session context, not just this session's category.
 
 **Dedup check:** Read `RESOURCES_SHOWN` from the builder profile output above.
-If `RESOURCES_SHOWN_COUNT` is 34 or more, skip this section entirely (all resources exhausted).
-Otherwise, avoid selecting any URL that appears in the RESOURCES_SHOWN list.
+If `RESOURCES_SHOWN_COUNT` is greater than or equal to the number of resources in the pool
+below (count them at runtime — currently 34), skip this section entirely (all resources
+exhausted). Otherwise, avoid selecting any URL that appears in the RESOURCES_SHOWN list.
 
 **Selection rules:**
 - Pick 2-3 resources. Mix categories — never 3 of the same type.
@@ -1948,12 +1985,12 @@ Otherwise, avoid selecting any URL that appears in the RESOURCES_SHOWN list.
 > {1-2 sentence blurb — direct, specific, encouraging. Match Garry's voice: tell them WHY this one matters for THEIR situation.}
 > {url}
 
-**Resource Pool:**
+**Resource Pool** (34 entries — if you add or remove one, update the dedup-gate count above; `test/office-hours-structure.test.ts` enforces they match):
 
 GARRY TAN VIDEOS:
 1. "My $200 million startup mistake: Peter Thiel asked and I said no" (5 min) — The single best "why you should take the leap" video. Peter Thiel writes him a check at dinner, he says no because he might get promoted to Level 60. That 1% stake would be worth $350-500M today. https://www.youtube.com/watch?v=dtnG0ELjvcM
 2. "Unconventional Advice for Founders" (48 min, Stanford) — The magnum opus. Covers everything a pre-launch founder needs: get therapy before your psychology kills your company, good ideas look like bad ideas, the Katamari Damacy metaphor for growth. No filler. https://www.youtube.com/watch?v=Y4yMc99fpfY
-3. "The New Way To Build A Startup" (8 min) — The 2026 playbook. Introduces the "20x company" — tiny teams beating incumbents through AI automation. Three real case studies. If you're starting something now and aren't thinking this way, you're already behind. https://www.youtube.com/watch?v=rWUWfj_PqmM
+3. "The New Way To Build A Startup" (8 min) — The new-era playbook. Introduces the "20x company" — tiny teams beating incumbents through AI automation. Three real case studies. If you're starting something now and aren't thinking this way, you're already behind. https://www.youtube.com/watch?v=rWUWfj_PqmM
 4. "How To Build The Future: Sam Altman" (30 min) — Sam talks about what it takes to go from an idea to something real — picking what's important, finding your tribe, and why conviction matters more than credentials. https://www.youtube.com/watch?v=xXCBz_8hM9w
 5. "What Founders Can Do To Improve Their Design Game" (15 min) — Garry was a designer before he was an investor. Taste and craft are the real competitive advantage, not MBA skills or fundraising tricks. https://www.youtube.com/watch?v=ksGNfd-wQY4
 
@@ -1967,7 +2004,7 @@ LIGHTCONE PODCAST:
 10. "Billion-Dollar Unpopular Startup Ideas" (25 min) — Uber, Coinbase, DoorDash — they all sounded terrible at first. The best opportunities are the ones most people dismiss. Liberating if your idea feels "weird." https://www.youtube.com/watch?v=Hm-ZIiwiN1o
 11. "Vertical AI Agents Could Be 10X Bigger Than SaaS" (40 min) — The most-watched Lightcone episode. If you're building in AI, this is the landscape map — where the biggest opportunities are and why vertical agents win. https://www.youtube.com/watch?v=ASABxNenD_U
 12. "The Truth About Building AI Startups Today" (35 min) — Cuts through the hype. What's actually working, what's not, and where the real defensibility comes from in AI startups right now. https://www.youtube.com/watch?v=TwDJhUJL-5o
-13. "Startup Ideas You Can Now Build With AI" (30 min) — Concrete, actionable ideas for things that weren't possible 12 months ago. If you're looking for what to build, start here. https://www.youtube.com/watch?v=K4s6Cgicw_A
+13. "Startup Ideas You Can Now Build With AI" (30 min) — Concrete, actionable ideas for things that just became possible. If you're looking for what to build, start here. https://www.youtube.com/watch?v=K4s6Cgicw_A
 14. "Vibe Coding Is The Future" (30 min) — Building software just changed forever. If you can describe what you want, you can build it. The barrier to being a technical founder has never been lower. https://www.youtube.com/watch?v=IACHfKmZMr8
 15. "How To Get AI Startup Ideas" (30 min) — Not theoretical. Walks through specific AI startup ideas that are working right now and explains why the window is open. https://www.youtube.com/watch?v=TANaRNMbYgk
 16. "10 People + AI = Billion Dollar Company?" (25 min) — The thesis behind the 20x company. Small teams with AI leverage are outperforming 100-person incumbents. If you're a solo builder or small team, this is your permission slip to think big. https://www.youtube.com/watch?v=CKvo_kQbakU
@@ -1996,17 +2033,19 @@ PAUL GRAHAM ESSAYS:
 
 **After presenting resources — log to builder profile and offer to open:**
 
-1. Log the selected resource URLs to the builder profile (single source of truth).
-Append a resource-tracking entry:
+1. Record the shown resource URLs in the profile (single source of truth for dedup).
+This merges into `resources_shown` WITHOUT counting as a session:
 ```bash
-eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
-echo '{"date":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","mode":"resources","project_slug":"'"${SLUG:-unknown}"'","signal_count":0,"signals":[],"design_doc":"","assignment":"","resources_shown":["URL1","URL2","URL3"],"topics":[]}' >> "$GSTACK_STATE_ROOT/builder-profile.jsonl"
+~/.claude/skills/gstack/bin/gstack-developer-profile --append-resources <<'OHRES'
+{ "resources_shown": ["URL1", "URL2", "URL3"] }
+OHRES
 ```
 
-2. Log the selection to analytics:
+2. Log the selection to analytics (best-effort; same state root as the profile):
 ```bash
-mkdir -p ~/.gstack/analytics
-echo '{"skill":"office-hours","event":"resources_shown","count":NUM_RESOURCES,"categories":"CAT1,CAT2","ts":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+mkdir -p "$GSTACK_STATE_ROOT/analytics"
+echo '{"skill":"office-hours","event":"resources_shown","count":NUM_RESOURCES,"categories":"CAT1,CAT2","ts":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' >> "$GSTACK_STATE_ROOT/analytics/skill-usage.jsonl" 2>/dev/null || true
 ```
 
 3. Use AskUserQuestion to offer opening the resources:
@@ -2020,8 +2059,8 @@ Options:
 - D) [Title of resource 3, if 3 were shown] — open just this one
 - E) Skip — I'll find them later
 
-If A: run `open URL1 && open URL2 && open URL3` (opens each in default browser).
-If B/C/D: run `open` on the selected URL only.
+If A: run `for u in URL1 URL2 URL3; do ~/.claude/skills/gstack/bin/gstack-open-url "$u"; done` (opens each in the default browser, cross-platform; independent so one failure doesn't skip the rest).
+If B/C/D: run `~/.claude/skills/gstack/bin/gstack-open-url URL` on the selected URL only.
 If E: proceed to next-skill recommendations.
 
 ### Next-skill recommendations

--- a/office-hours/SKILL.md.tmpl
+++ b/office-hours/SKILL.md.tmpl
@@ -34,14 +34,13 @@ gbrain:
     - id: prior-sessions
       kind: list
       filter:
-        type: ceo-plan
         tags_contains: "repo:{repo_slug}"
       sort: updated_at_desc
       limit: 5
       render_as: "## Prior office-hours sessions in this repo"
     - id: builder-profile
       kind: filesystem
-      glob: "~/.gstack/builder-profile.jsonl"
+      glob: "~/.gstack/developer-profile.json"
       tail: 1
       render_as: "## Your builder profile snapshot"
     - id: design-doc-history
@@ -82,12 +81,29 @@ Understand the project and the area the user wants to change.
 1. Read `CLAUDE.md`, `TODOS.md` (if they exist).
 2. Run `git log --oneline -30` and `git diff origin/main --stat 2>/dev/null` to understand recent context.
 3. Use Grep/Glob to map the codebase areas most relevant to the user's request.
-4. **List existing design docs for this project:**
+4. **List existing design docs for this project — and offer to resume one:**
    ```bash
    setopt +o nomatch 2>/dev/null || true  # zsh compat
    ls -t ~/.gstack/projects/$SLUG/*-design-*.md 2>/dev/null
    ```
-   If design docs exist, list them: "Prior designs for this project: [titles + dates]"
+   If design docs exist, list them ("Prior designs for this project: [titles + dates]") and,
+   via AskUserQuestion, offer to pick up where they left off:
+
+   > You've designed in this repo before. Continue one, or start fresh?
+   > - **Resume "{most recent title}"** — pick up the latest design
+   > - **Build on a specific prior design** — choose from the list
+   > - **Start a new idea** — fresh session
+
+   - **Resume / Build on:** read the chosen doc, infer its mode from the `Mode:` field
+     (so you can skip the goal question in step 5), and recap it back in 3-4 lines — its
+     **Recommended Approach**, any **Open Questions**, and **The Assignment** — framed as
+     "Last time you decided…". Then SKIP the Phase 2 diagnostic and go straight to Phase 3
+     (Premise Challenge) against the existing premises, so the session builds on prior
+     thinking instead of re-interrogating it. The Phase 5 doc gets a `Supersedes:` link to
+     the resumed one.
+   - **Start a new idea:** proceed normally.
+
+   If no prior design docs exist, proceed.
 
 {{LEARNINGS_SEARCH}}
 
@@ -108,10 +124,11 @@ Understand the project and the area the user wants to change.
    - Startup, intrapreneurship → **Startup mode** (Phase 2A)
    - Hackathon, open source, research, learning, having fun → **Builder mode** (Phase 2B)
 
-6. **Assess product stage** (only for startup/intrapreneurship modes):
+6. **Assess product stage** (only for startup/intrapreneurship modes). This selects the smart-routing question set below:
    - Pre-product (idea stage, no users yet)
    - Has users (people using it, not yet paying)
    - Has paying customers
+   - Pure engineering/infra (internal tooling or infrastructure with no external "customer" — routes to a reduced question set)
 
 Output: "Here's what I understand about this project and the area you want to change: ..."
 
@@ -274,7 +291,7 @@ The pressure is in the stacking — don't collapse it into a single ask. The spe
 
 **Escape hatch:** If the user expresses impatience ("just do it," "skip the questions"):
 - Say: "I hear you. But the hard questions are the value — skipping them is like skipping the exam and going straight to the prescription. Let me ask two more, then we'll move."
-- Consult the smart routing table for the founder's product stage. Ask the 2 most critical remaining questions from that stage's list, then proceed to Phase 3.
+- Consult the smart routing table for the founder's product stage. Ask the 2 highest-priority questions from that stage's list that you have NOT already asked, then proceed to Phase 3.
 - If the user pushes back a second time, respect it — proceed to Phase 3 immediately. Don't ask a third time.
 - If only 1 question remains, ask it. If 0 remain, proceed directly.
 - Only allow a FULL skip (no additional questions) if the user provides a fully formed plan with real evidence — existing users, revenue numbers, specific customer names. Even then, still run Phase 3 (Premise Challenge) and Phase 4 (Alternatives).
@@ -321,7 +338,7 @@ Ask these **ONE AT A TIME** via AskUserQuestion. The goal is to brainstorm and s
 
 **STOP** after each question. Wait for the response before asking the next.
 
-**Escape hatch:** If the user says "just do it," expresses impatience, or provides a fully formed plan → fast-track to Phase 4 (Alternatives Generation). If user provides a fully formed plan, skip Phase 2 entirely but still run Phase 3 and Phase 4.
+**Escape hatch:** If the user says "just do it," expresses impatience, or provides a fully formed plan → stop asking Phase 2B questions and move on, but STILL run Phase 3 (Premise Challenge) before Phase 4 (Alternatives Generation) — never skip the premise check. If the user provides a fully formed plan, skip Phase 2 entirely (Phase 2.5 / 2.75 self-gate on having questioned, so they fall away naturally); Phase 3 and Phase 4 always run.
 
 **If the vibe shifts mid-session** — the user starts in builder mode but says "actually I think this could be a real company" or mentions customers, revenue, fundraising — upgrade to Startup mode naturally. Say something like: "Okay, now we're talking — let me ask you some harder questions." Then switch to the Phase 2A questions.
 
@@ -468,34 +485,46 @@ Track which of these signals appeared during the session:
 
 Count the signals. You'll use this count in Phase 6 to determine which tier of closing message to use.
 
-### Builder Profile Append
+### Session Persistence
 
-After counting signals, append a session entry to the builder profile. This is the single
+After counting signals, persist this session to the developer profile — the single
 source of truth for all closing state (tier, resource dedup, journey tracking).
+**Write it through the profile binary**, which appends to the same `developer-profile.json`
+the closing reads from. (Do NOT hand-append raw JSONL to a file — that older path is no
+longer read, and shell-assembled JSON corrupts on quoted / apostrophe / newline text.)
+
+Emit one JSON **object** on stdin via a quoted heredoc. Substitute the real values; if
+`assignment` or a topic contains a double-quote, escape it as `\"` (it's JSON). You do
+NOT need to provide `date` — it is stamped automatically.
 
 ```bash
-eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
-mkdir -p "$GSTACK_STATE_ROOT"
+~/.claude/skills/gstack/bin/gstack-developer-profile --append-session <<'OHSESSION'
+{
+  "mode": "MODE",
+  "project_slug": "SLUG",
+  "signal_count": N,
+  "signals": SIGNALS_ARRAY,
+  "design_doc": "DOC_PATH",
+  "design_title": "DESIGN_TITLE",
+  "assignment": "ASSIGNMENT_TEXT",
+  "topics": TOPICS_ARRAY
+}
+OHSESSION
 ```
 
-Append one JSON line with these fields (substitute actual values from this session):
-- `date`: current ISO 8601 timestamp
+Field notes (substitute actual values from this session):
 - `mode`: "startup" or "builder" (from Phase 1 mode selection)
 - `project_slug`: the SLUG value from the preamble
 - `signal_count`: number of signals counted above
 - `signals`: array of signal names observed (e.g., `["named_users", "pushback", "taste"]`)
 - `design_doc`: path to the design doc that will be written in Phase 5 (construct it now)
+- `design_title`: the design's human title (its `# Design: {title}` heading) — used in the closing's design-trajectory line
 - `assignment`: the assignment you will give in the design doc's "The Assignment" section
-- `resources_shown`: empty array `[]` for now (populated after resource selection in Phase 6)
 - `topics`: array of 2-3 topic keywords that describe what this session was about
 
-```bash
-eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
-echo '{"date":"TIMESTAMP","mode":"MODE","project_slug":"SLUG","signal_count":N,"signals":SIGNALS_ARRAY,"design_doc":"DOC_PATH","assignment":"ASSIGNMENT_TEXT","resources_shown":[],"topics":TOPICS_ARRAY}' >> "$GSTACK_STATE_ROOT/builder-profile.jsonl"
-```
-
-This entry is append-only. The `resources_shown` field will be updated via a second append
-after resource selection in Phase 6 Beat 3.5.
+The command prints `APPEND: ok` on success. If it reports invalid JSON, fix the escaping
+and re-run — the session is never silently dropped. Resources shown are recorded
+separately in Phase 6 Beat 3.5.
 
 ---
 
@@ -628,7 +657,8 @@ Supersedes: {prior filename — omit this line if first design on this branch}
 
 ## Distribution Plan
 {how users get the deliverable — binary download, package manager, container image, web service, etc.}
-{CI/CD pipeline for building and publishing — or "existing deployment pipeline covers this"}
+{CI/CD pipeline for building and publishing — GitHub Actions, manual release, auto-deploy on merge?}
+{omit this section if the deliverable is a web service with existing deployment pipeline}
 
 ## Next Steps
 {concrete build tasks — what to implement first, second, third}
@@ -661,8 +691,14 @@ over time.
 ### Step 1: Read Builder Profile
 
 ```bash
-PROFILE=$(~/.claude/skills/gstack/bin/gstack-builder-profile 2>/dev/null) || PROFILE="SESSION_COUNT: 0
+# A new user legitimately reads SESSION_COUNT: 0 / TIER: introduction (no error).
+# The fallback only triggers on a genuine exec failure — surface it rather than
+# silently greeting a returning user as a first-timer.
+PROFILE=$(~/.claude/skills/gstack/bin/gstack-developer-profile --read) || {
+  echo "office-hours: profile read failed — defaulting to introduction tier (see error above)." >&2
+  PROFILE="SESSION_COUNT: 0
 TIER: introduction"
+}
 SESSION_TIER=$(echo "$PROFILE" | grep "^TIER:" | awk '{print $2}')
 SESSION_COUNT=$(echo "$PROFILE" | grep "^SESSION_COUNT:" | awk '{print $2}')
 ```
@@ -710,7 +746,7 @@ Use the founder signal count from Phase 4.5 to select the right sub-tier.
 > GStack thinks you are among the top people who could do this.
 
 Then use AskUserQuestion: "Would you consider applying to Y Combinator?"
-- If yes: run `open https://ycombinator.com/apply?ref=gstack` and say: "Bring this design doc to your YC interview. It's better than most pitch decks."
+- If yes: run `~/.claude/skills/gstack/bin/gstack-open-url https://ycombinator.com/apply?ref=gstack` and say: "Bring this design doc to your YC interview. It's better than most pitch decks."
 - If no: respond warmly: "Totally fair. The design doc is yours either way, and the offer stands if you ever change your mind." No pressure, no guilt, no re-ask.
 
 - **Middle tier** (1-2 signals, or builder whose project solves a real problem):
@@ -790,7 +826,7 @@ with a narrative arc (not a data table). The arc tells the STORY of their journe
 second person, referencing specific things they said across sessions. Then open it:
 ```bash
 eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
-open "$GSTACK_STATE_ROOT/builder-journey.md"
+~/.claude/skills/gstack/bin/gstack-open-url "$GSTACK_STATE_ROOT/builder-journey.md"
 ```
 
 Then proceed to Founder Resources below.
@@ -817,8 +853,9 @@ Share 2-3 resources from the pool below. For repeat users, resources compound by
 to accumulated session context, not just this session's category.
 
 **Dedup check:** Read `RESOURCES_SHOWN` from the builder profile output above.
-If `RESOURCES_SHOWN_COUNT` is 34 or more, skip this section entirely (all resources exhausted).
-Otherwise, avoid selecting any URL that appears in the RESOURCES_SHOWN list.
+If `RESOURCES_SHOWN_COUNT` is greater than or equal to the number of resources in the pool
+below (count them at runtime — currently 34), skip this section entirely (all resources
+exhausted). Otherwise, avoid selecting any URL that appears in the RESOURCES_SHOWN list.
 
 **Selection rules:**
 - Pick 2-3 resources. Mix categories — never 3 of the same type.
@@ -841,12 +878,12 @@ Otherwise, avoid selecting any URL that appears in the RESOURCES_SHOWN list.
 > {1-2 sentence blurb — direct, specific, encouraging. Match Garry's voice: tell them WHY this one matters for THEIR situation.}
 > {url}
 
-**Resource Pool:**
+**Resource Pool** (34 entries — if you add or remove one, update the dedup-gate count above; `test/office-hours-structure.test.ts` enforces they match):
 
 GARRY TAN VIDEOS:
 1. "My $200 million startup mistake: Peter Thiel asked and I said no" (5 min) — The single best "why you should take the leap" video. Peter Thiel writes him a check at dinner, he says no because he might get promoted to Level 60. That 1% stake would be worth $350-500M today. https://www.youtube.com/watch?v=dtnG0ELjvcM
 2. "Unconventional Advice for Founders" (48 min, Stanford) — The magnum opus. Covers everything a pre-launch founder needs: get therapy before your psychology kills your company, good ideas look like bad ideas, the Katamari Damacy metaphor for growth. No filler. https://www.youtube.com/watch?v=Y4yMc99fpfY
-3. "The New Way To Build A Startup" (8 min) — The 2026 playbook. Introduces the "20x company" — tiny teams beating incumbents through AI automation. Three real case studies. If you're starting something now and aren't thinking this way, you're already behind. https://www.youtube.com/watch?v=rWUWfj_PqmM
+3. "The New Way To Build A Startup" (8 min) — The new-era playbook. Introduces the "20x company" — tiny teams beating incumbents through AI automation. Three real case studies. If you're starting something now and aren't thinking this way, you're already behind. https://www.youtube.com/watch?v=rWUWfj_PqmM
 4. "How To Build The Future: Sam Altman" (30 min) — Sam talks about what it takes to go from an idea to something real — picking what's important, finding your tribe, and why conviction matters more than credentials. https://www.youtube.com/watch?v=xXCBz_8hM9w
 5. "What Founders Can Do To Improve Their Design Game" (15 min) — Garry was a designer before he was an investor. Taste and craft are the real competitive advantage, not MBA skills or fundraising tricks. https://www.youtube.com/watch?v=ksGNfd-wQY4
 
@@ -860,7 +897,7 @@ LIGHTCONE PODCAST:
 10. "Billion-Dollar Unpopular Startup Ideas" (25 min) — Uber, Coinbase, DoorDash — they all sounded terrible at first. The best opportunities are the ones most people dismiss. Liberating if your idea feels "weird." https://www.youtube.com/watch?v=Hm-ZIiwiN1o
 11. "Vertical AI Agents Could Be 10X Bigger Than SaaS" (40 min) — The most-watched Lightcone episode. If you're building in AI, this is the landscape map — where the biggest opportunities are and why vertical agents win. https://www.youtube.com/watch?v=ASABxNenD_U
 12. "The Truth About Building AI Startups Today" (35 min) — Cuts through the hype. What's actually working, what's not, and where the real defensibility comes from in AI startups right now. https://www.youtube.com/watch?v=TwDJhUJL-5o
-13. "Startup Ideas You Can Now Build With AI" (30 min) — Concrete, actionable ideas for things that weren't possible 12 months ago. If you're looking for what to build, start here. https://www.youtube.com/watch?v=K4s6Cgicw_A
+13. "Startup Ideas You Can Now Build With AI" (30 min) — Concrete, actionable ideas for things that just became possible. If you're looking for what to build, start here. https://www.youtube.com/watch?v=K4s6Cgicw_A
 14. "Vibe Coding Is The Future" (30 min) — Building software just changed forever. If you can describe what you want, you can build it. The barrier to being a technical founder has never been lower. https://www.youtube.com/watch?v=IACHfKmZMr8
 15. "How To Get AI Startup Ideas" (30 min) — Not theoretical. Walks through specific AI startup ideas that are working right now and explains why the window is open. https://www.youtube.com/watch?v=TANaRNMbYgk
 16. "10 People + AI = Billion Dollar Company?" (25 min) — The thesis behind the 20x company. Small teams with AI leverage are outperforming 100-person incumbents. If you're a solo builder or small team, this is your permission slip to think big. https://www.youtube.com/watch?v=CKvo_kQbakU
@@ -889,17 +926,19 @@ PAUL GRAHAM ESSAYS:
 
 **After presenting resources — log to builder profile and offer to open:**
 
-1. Log the selected resource URLs to the builder profile (single source of truth).
-Append a resource-tracking entry:
+1. Record the shown resource URLs in the profile (single source of truth for dedup).
+This merges into `resources_shown` WITHOUT counting as a session:
 ```bash
-eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
-echo '{"date":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","mode":"resources","project_slug":"'"${SLUG:-unknown}"'","signal_count":0,"signals":[],"design_doc":"","assignment":"","resources_shown":["URL1","URL2","URL3"],"topics":[]}' >> "$GSTACK_STATE_ROOT/builder-profile.jsonl"
+~/.claude/skills/gstack/bin/gstack-developer-profile --append-resources <<'OHRES'
+{ "resources_shown": ["URL1", "URL2", "URL3"] }
+OHRES
 ```
 
-2. Log the selection to analytics:
+2. Log the selection to analytics (best-effort; same state root as the profile):
 ```bash
-mkdir -p ~/.gstack/analytics
-echo '{"skill":"office-hours","event":"resources_shown","count":NUM_RESOURCES,"categories":"CAT1,CAT2","ts":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+mkdir -p "$GSTACK_STATE_ROOT/analytics"
+echo '{"skill":"office-hours","event":"resources_shown","count":NUM_RESOURCES,"categories":"CAT1,CAT2","ts":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' >> "$GSTACK_STATE_ROOT/analytics/skill-usage.jsonl" 2>/dev/null || true
 ```
 
 3. Use AskUserQuestion to offer opening the resources:
@@ -913,8 +952,8 @@ Options:
 - D) [Title of resource 3, if 3 were shown] — open just this one
 - E) Skip — I'll find them later
 
-If A: run `open URL1 && open URL2 && open URL3` (opens each in default browser).
-If B/C/D: run `open` on the selected URL only.
+If A: run `for u in URL1 URL2 URL3; do ~/.claude/skills/gstack/bin/gstack-open-url "$u"; done` (opens each in the default browser, cross-platform; independent so one failure doesn't skip the rest).
+If B/C/D: run `~/.claude/skills/gstack/bin/gstack-open-url URL` on the selected URL only.
 If E: proceed to next-skill recommendations.
 
 ### Next-skill recommendations

--- a/scripts/profile-store.ts
+++ b/scripts/profile-store.ts
@@ -1,0 +1,185 @@
+/**
+ * scripts/profile-store.ts — pure helpers for the unified developer profile
+ * store (~/.gstack/developer-profile.json).
+ *
+ * Consumed by bin/gstack-developer-profile (migrate / reconcile / append-session
+ * / append-resources) and unit-tested in test/profile-store.test.ts.
+ *
+ * Design note: /office-hours persists session state by calling
+ * `gstack-developer-profile --append-session` / `--append-resources`, which write
+ * THROUGH to the same developer-profile.json the read path consumes. The old skill
+ * appended raw JSONL to builder-profile.jsonl, which the read path migrated away
+ * and never re-read — freezing every returning user's state at session 1. These
+ * helpers keep one source of truth and recover orphaned legacy appends.
+ */
+
+export interface Session {
+  date?: string;
+  mode?: string;
+  project_slug?: string;
+  signal_count?: number;
+  signals?: string[];
+  design_doc?: string;
+  design_title?: string;
+  assignment?: string;
+  resources_shown?: string[];
+  topics?: string[];
+  [k: string]: unknown;
+}
+
+export interface Profile {
+  sessions: Session[];
+  signals_accumulated: Record<string, number>;
+  resources_shown: string[];
+  topics: string[];
+  [k: string]: unknown;
+}
+
+/** A "resources" row records which founder resources were shown; it is NOT a
+ *  session and must never count toward SESSION_COUNT / TIER. */
+export const isResourcesRow = (e: Session): boolean => !!e && e.mode === 'resources';
+
+export function emptyProfile(): Profile {
+  return {
+    identity: {},
+    declared: {},
+    inferred: {
+      values: {
+        scope_appetite: 0.5,
+        risk_tolerance: 0.5,
+        detail_preference: 0.5,
+        autonomy: 0.5,
+        architecture_care: 0.5,
+      },
+      sample_size: 0,
+      diversity: { skills_covered: 0, question_ids_covered: 0, days_span: 0 },
+    },
+    gap: {},
+    overrides: {},
+    sessions: [],
+    signals_accumulated: {},
+    resources_shown: [],
+    topics: [],
+    schema_version: 1,
+  };
+}
+
+function uniq(arr: unknown[]): string[] {
+  return Array.from(new Set(arr.filter((x): x is string => typeof x === 'string' && x.length > 0)));
+}
+
+/** Recompute derived aggregates from sessions[], preserving (never shrinking)
+ *  top-level resources_shown / topics that came from --append-resources. */
+export function recompute(profile: Profile): Profile {
+  const signals: Record<string, number> = {};
+  const resources: string[] = [...(profile.resources_shown || [])];
+  const topics: string[] = [...(profile.topics || [])];
+  for (const e of profile.sessions || []) {
+    for (const s of e.signals || []) signals[s] = (signals[s] || 0) + 1;
+    for (const r of e.resources_shown || []) resources.push(r);
+    for (const t of e.topics || []) topics.push(t);
+  }
+  profile.signals_accumulated = signals;
+  profile.resources_shown = uniq(resources);
+  profile.topics = uniq(topics);
+  return profile;
+}
+
+export function appendSession(profile: Profile, entry: Session): Profile {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    throw new Error('append-session: entry must be a JSON object');
+  }
+  if (!entry.date) entry.date = new Date().toISOString();
+  profile.sessions = profile.sessions || [];
+  profile.sessions.push(entry);
+  return recompute(profile);
+}
+
+export function mergeResources(
+  profile: Profile,
+  entry: { resources_shown?: string[]; topics?: string[] },
+): Profile {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    throw new Error('append-resources: entry must be a JSON object');
+  }
+  profile.resources_shown = uniq([...(profile.resources_shown || []), ...(entry.resources_shown || [])]);
+  profile.topics = uniq([...(profile.topics || []), ...(entry.topics || [])]);
+  return profile;
+}
+
+/** Stable identity for dedup when reconciling orphaned legacy lines. */
+function sig(e: Session): string {
+  return JSON.stringify([e.date || '', e.mode || '', e.project_slug || '', e.assignment || '', e.design_doc || '']);
+}
+
+/** Parse legacy jsonl lines into sessions + merged resources/topics.
+ *  `dropped` counts unparseable lines so callers can warn instead of silently losing data. */
+export function parseLegacy(lines: string[]): {
+  sessions: Session[];
+  resources: string[];
+  topics: string[];
+  dropped: number;
+} {
+  const sessions: Session[] = [];
+  const resources: string[] = [];
+  const topics: string[] = [];
+  let dropped = 0;
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let e: Session;
+    try {
+      e = JSON.parse(line);
+    } catch {
+      dropped++;
+      continue;
+    }
+    for (const r of e.resources_shown || []) resources.push(r);
+    for (const t of e.topics || []) topics.push(t);
+    if (!isResourcesRow(e)) sessions.push(e);
+  }
+  return { sessions, resources, topics, dropped };
+}
+
+/** Build a fresh profile from legacy jsonl lines (used by --migrate). */
+export function migrateLegacy(lines: string[]): { profile: Profile; dropped: number } {
+  const { sessions, resources, topics, dropped } = parseLegacy(lines);
+  const profile = emptyProfile();
+  profile.sessions = sessions;
+  profile.resources_shown = resources;
+  profile.topics = topics;
+  return { profile: recompute(profile), dropped };
+}
+
+/** Fold orphaned legacy lines into an existing profile (used by reconcile),
+ *  skipping sessions already present (dedup by signature). */
+export function foldLegacy(
+  profile: Profile,
+  lines: string[],
+): { profile: Profile; dropped: number; added: number } {
+  const { sessions, resources, topics, dropped } = parseLegacy(lines);
+  profile.sessions = profile.sessions || [];
+  const seen = new Set(profile.sessions.map(sig));
+  let added = 0;
+  for (const e of sessions) {
+    const k = sig(e);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    profile.sessions.push(e);
+    added++;
+  }
+  profile.resources_shown = uniq([...(profile.resources_shown || []), ...resources]);
+  profile.topics = uniq([...(profile.topics || []), ...topics]);
+  return { profile: recompute(profile), dropped, added };
+}
+
+/** Sessions that count toward tier/journey (excludes resource-tracking rows). */
+export function realSessions(profile: Profile): Session[] {
+  return (profile.sessions || []).filter((e) => !isResourcesRow(e));
+}
+
+/** Human-facing design title: explicit title, else doc basename, else slug. */
+export function designTitle(e: Session): string {
+  if (e.design_title) return String(e.design_title);
+  if (e.design_doc) return String(e.design_doc).split('/').pop() || '';
+  return e.project_slug ? String(e.project_slug) : '';
+}

--- a/scripts/resolvers/gbrain.ts
+++ b/scripts/resolvers/gbrain.ts
@@ -38,7 +38,7 @@ Any non-zero exit code from gbrain commands should be treated as a transient fai
 
 export function generateGBrainSaveResults(ctx: TemplateContext): string {
   const skillSaveMap: Record<string, string> = {
-    'office-hours': 'Save the design document as a brain page:\n```bash\ngbrain put_page --title "Office Hours: <project name>" --tags "design-doc,<project-slug>" <<\'EOF\'\n<design doc content in markdown>\nEOF\n```',
+    'office-hours': 'Save the design document as a brain page (the `repo:<project-slug>` tag is what the prior-sessions context query matches on next time):\n```bash\ngbrain put_page --title "Office Hours: <project name>" --tags "design-doc,repo:<project-slug>" <<\'EOF\'\n<design doc content in markdown>\nEOF\n```',
     'investigate': 'Save the root cause analysis as a brain page:\n```bash\ngbrain put_page --title "Investigation: <issue summary>" --tags "investigation,<affected-files>" <<\'EOF\'\n<investigation findings in markdown>\nEOF\n```',
     'plan-ceo-review': 'Save the CEO plan as a brain page:\n```bash\ngbrain put_page --title "CEO Plan: <feature name>" --tags "ceo-plan,<feature-slug>" <<\'EOF\'\n<scope decisions and vision in markdown>\nEOF\n```',
     'retro': 'Save the retrospective as a brain page:\n```bash\ngbrain put_page --title "Retro: <date range>" --tags "retro,<date>" <<\'EOF\'\n<retro output in markdown>\nEOF\n```',

--- a/test/builder-profile.test.ts
+++ b/test/builder-profile.test.ts
@@ -40,6 +40,7 @@ function makeEntry(overrides: Partial<{
   signal_count: number;
   signals: string[];
   design_doc: string;
+  design_title: string;
   assignment: string;
   resources_shown: string[];
   topics: string[];
@@ -51,6 +52,7 @@ function makeEntry(overrides: Partial<{
     signal_count: 0,
     signals: [],
     design_doc: '',
+    design_title: '',
     assignment: '',
     resources_shown: [],
     topics: [],
@@ -292,13 +294,23 @@ describe('gstack-builder-profile', () => {
       expect(r['LAST_PROJECT']).toBe('new-app');
     });
 
-    test('returns last design doc', () => {
+    test('returns last design title (basename fallback when no explicit title)', () => {
       writeProfile([
         makeEntry({ design_doc: 'path/to/design-1.md' }),
         makeEntry({ design_doc: 'path/to/design-2.md', date: '2026-04-02T00:00:00Z' }),
       ]);
       const r = runProfile();
-      expect(r['LAST_DESIGN_TITLE']).toBe('path/to/design-2.md');
+      // LAST_DESIGN_TITLE surfaces a human title, not a raw filesystem path.
+      expect(r['LAST_DESIGN_TITLE']).toBe('design-2.md');
+    });
+
+    test('prefers an explicit design_title over the doc path', () => {
+      writeProfile([
+        makeEntry({ design_doc: 'path/to/d1.md', design_title: 'First Idea' }),
+        makeEntry({ design_doc: 'path/to/d2.md', design_title: 'Second Idea', date: '2026-04-02T00:00:00Z' }),
+      ]);
+      const r = runProfile();
+      expect(r['LAST_DESIGN_TITLE']).toBe('Second Idea');
     });
   });
 

--- a/test/office-hours-links.test.ts
+++ b/test/office-hours-links.test.ts
@@ -1,0 +1,60 @@
+/**
+ * office-hours founder-resource link-check (OPT-IN, network).
+ *
+ * The closing hands users 34 hand-picked YouTube videos / PG essays. Dead
+ * YouTube IDs still render a valid-looking "Video unavailable" page, so link rot
+ * is silent. This test catches it — but only when LINKCHECK=1, so the normal
+ * `bun run test` suite stays deterministic and offline. Wire it to a weekly CI
+ * cron rather than the per-commit suite.
+ *
+ *   LINKCHECK=1 bun test test/office-hours-links.test.ts
+ */
+
+import { describe, test, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const SKILL = path.join(ROOT, 'office-hours', 'SKILL.md');
+const ENABLED = process.env.LINKCHECK === '1';
+
+function poolUrls(): string[] {
+  const content = fs.readFileSync(SKILL, 'utf-8');
+  const start = content.indexOf('**Resource Pool**');
+  const end = content.indexOf('**After presenting resources', start);
+  const slice = content.slice(start, end);
+  return Array.from(new Set(content.length && start > -1 ? (slice.match(/https?:\/\/[^\s)]+/g) || []) : []));
+}
+
+async function isLive(url: string): Promise<boolean> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), 12_000);
+  try {
+    // YouTube: a removed/private video returns 404 from oembed (watch pages 200 even when dead).
+    if (/youtube\.com\/watch|youtu\.be\//.test(url)) {
+      const oembed = `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`;
+      const r = await fetch(oembed, { signal: ac.signal, headers: { 'user-agent': 'gstack-linkcheck' } });
+      return r.status === 200;
+    }
+    let r = await fetch(url, { method: 'HEAD', signal: ac.signal, redirect: 'follow', headers: { 'user-agent': 'gstack-linkcheck' } });
+    if (r.status === 405 || r.status === 403) {
+      r = await fetch(url, { method: 'GET', signal: ac.signal, redirect: 'follow', headers: { 'user-agent': 'gstack-linkcheck' } });
+    }
+    return r.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+(ENABLED ? describe : describe.skip)('office-hours resource links (LINKCHECK=1)', () => {
+  test('every founder-resource URL is reachable', async () => {
+    const urls = poolUrls();
+    expect(urls.length).toBeGreaterThan(0);
+    const results = await Promise.all(urls.map(async (u) => ({ u, live: await isLive(u) })));
+    const dead = results.filter((r) => !r.live).map((r) => r.u);
+    if (dead.length) console.error('DEAD LINKS:\n' + dead.join('\n'));
+    expect(dead).toEqual([]);
+  }, 120_000);
+});

--- a/test/office-hours-profile.test.ts
+++ b/test/office-hours-profile.test.ts
@@ -1,0 +1,263 @@
+/**
+ * bin/gstack-developer-profile — write-through persistence for /office-hours.
+ *
+ * Regression guard for the profile data-loss bug: /office-hours used to APPEND
+ * session state to builder-profile.jsonl while the read path migrated to
+ * developer-profile.json and never re-read the legacy file — so every session
+ * after the first was silently dropped, freezing tier / dedup / journey.
+ *
+ * These tests mirror the REAL skill lifecycle (write → read[migrate] → write →
+ * read) which the existing suites never exercised (each test there starts from a
+ * fresh tmpdir and reads exactly once).
+ *
+ * Covers:
+ * - --append-session: writes through to the unified profile the read path uses
+ * - --append-resources: merges shown resources WITHOUT counting as a session
+ * - JSON-safe round-trip of free-form assignment text (quotes / newlines)
+ * - mode:"resources" rows never inflate SESSION_COUNT / TIER
+ * - design_title surfaced (not project slug / raw path)
+ * - state root honors CLAUDE_PLUGIN_DATA (plugin install) like gstack-paths
+ * - reconcile: orphaned legacy appends are healed on read
+ * - malformed migration lines are reported, not silently dropped
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { spawnSync } from 'child_process';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const BIN_DEV = path.join(ROOT, 'bin', 'gstack-developer-profile');
+
+let tmpHome: string;
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-ohp-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+function runDev(
+  args: string[],
+  opts: { input?: string; env?: Record<string, string | undefined> } = {},
+): { stdout: string; stderr: string; status: number } {
+  const env = opts.env ?? { ...process.env, GSTACK_HOME: tmpHome };
+  const res = spawnSync(BIN_DEV, args, {
+    env,
+    input: opts.input,
+    encoding: 'utf-8',
+    cwd: ROOT,
+  });
+  return { stdout: res.stdout ?? '', stderr: res.stderr ?? '', status: res.status ?? -1 };
+}
+
+/** Parse the legacy KEY: VALUE --read output into a map. */
+function read(env?: Record<string, string | undefined>): Record<string, string> {
+  const r = runDev(['--read'], env ? { env } : {});
+  const out: Record<string, string> = {};
+  for (const line of r.stdout.split('\n')) {
+    const i = line.indexOf(':');
+    if (i > 0) out[line.slice(0, i).trim()] = line.slice(i + 1).trim();
+  }
+  return out;
+}
+
+function session(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    mode: 'builder',
+    project_slug: 'app',
+    signal_count: 0,
+    signals: [],
+    design_doc: '',
+    design_title: '',
+    assignment: '',
+    topics: [],
+    ...overrides,
+  });
+}
+
+function writeLegacy(sessions: Array<Record<string, unknown>>) {
+  fs.writeFileSync(
+    path.join(tmpHome, 'builder-profile.jsonl'),
+    sessions.map((s) => JSON.stringify(s)).join('\n') + '\n',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The core regression: writes must reach the store reads come from.
+// ---------------------------------------------------------------------------
+
+describe('office-hours profile write-through', () => {
+  test('append-session after a migration is reflected on the next read (P0)', () => {
+    // Session 1 the legacy way, then a read that migrates+archives the jsonl.
+    writeLegacy([{ mode: 'builder', project_slug: 'app', assignment: 'watch users', signals: [] }]);
+    expect(read()['SESSION_COUNT']).toBe('1');
+
+    // Session 2 via the new write path.
+    const r = runDev(['--append-session'], { input: session({ assignment: 'talk to 5 users', project_slug: 'app' }) });
+    expect(r.status).toBe(0);
+
+    const after = read();
+    expect(after['SESSION_COUNT']).toBe('2');
+    expect(after['LAST_ASSIGNMENT']).toBe('talk to 5 users');
+    expect(after['TIER']).toBe('welcome_back');
+  });
+
+  test('append-session works for a brand-new user with no prior profile', () => {
+    const r = runDev(['--append-session'], { input: session({ assignment: 'first' }) });
+    expect(r.status).toBe(0);
+    expect(read()['SESSION_COUNT']).toBe('1');
+  });
+
+  test('tier advances across many appended sessions', () => {
+    for (let i = 0; i < 4; i++) {
+      const r = runDev(['--append-session'], { input: session({ assignment: `a${i}` }) });
+      expect(r.status).toBe(0);
+    }
+    const after = read();
+    expect(after['SESSION_COUNT']).toBe('4');
+    expect(after['TIER']).toBe('regular');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resources are merged, never counted as a session (P1-1).
+// ---------------------------------------------------------------------------
+
+describe('append-resources', () => {
+  test('merges shown resources without inflating the session count', () => {
+    runDev(['--append-session'], { input: session({ assignment: 'do the thing' }) });
+    const r = runDev(['--append-resources'], {
+      input: JSON.stringify({ resources_shown: ['https://a.example', 'https://b.example'] }),
+    });
+    expect(r.status).toBe(0);
+
+    const after = read();
+    expect(after['SESSION_COUNT']).toBe('1');
+    expect(after['TIER']).toBe('welcome_back');
+    expect(after['LAST_ASSIGNMENT']).toBe('do the thing'); // not an empty resources row
+    expect(after['RESOURCES_SHOWN_COUNT']).toBe('2');
+  });
+
+  test('resource merges are deduplicated across calls', () => {
+    runDev(['--append-session'], { input: session() });
+    runDev(['--append-resources'], { input: JSON.stringify({ resources_shown: ['https://x.example'] }) });
+    runDev(['--append-resources'], { input: JSON.stringify({ resources_shown: ['https://x.example', 'https://y.example'] }) });
+    expect(read()['RESOURCES_SHOWN_COUNT']).toBe('2');
+  });
+
+  test('legacy mode:"resources" rows do not count as sessions on migrate (P1-1)', () => {
+    writeLegacy([
+      { mode: 'builder', project_slug: 'app', assignment: 'real session', signals: [], resources_shown: [] },
+      { mode: 'resources', project_slug: 'app', assignment: '', signals: [], resources_shown: ['https://r.example'] },
+    ]);
+    const after = read();
+    expect(after['SESSION_COUNT']).toBe('1');
+    expect(after['LAST_ASSIGNMENT']).toBe('real session');
+    expect(after['RESOURCES_SHOWN_COUNT']).toBe('1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON safety: free-form assignment text must survive verbatim (P0-2).
+// ---------------------------------------------------------------------------
+
+describe('JSON-safe round-trip', () => {
+  test('assignment with quotes, apostrophe and newline round-trips verbatim', () => {
+    const assignment = 'Ask three customers "would you pay?"\nThen email Sarah — don\'t wait.';
+    const r = runDev(['--append-session'], { input: session({ assignment }) });
+    expect(r.status).toBe(0);
+
+    const profile = JSON.parse(fs.readFileSync(path.join(tmpHome, 'developer-profile.json'), 'utf-8'));
+    expect(profile.sessions.at(-1).assignment).toBe(assignment);
+  });
+
+  test('invalid JSON input fails loudly instead of silently dropping', () => {
+    const r = runDev(['--append-session'], { input: '{not valid json' });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr.toLowerCase()).toMatch(/json|invalid|parse/);
+    // And it must not have created a corrupt/garbage profile entry.
+    const file = path.join(tmpHome, 'developer-profile.json');
+    if (fs.existsSync(file)) {
+      const p = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      expect((p.sessions || []).length).toBe(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Design titles, not slugs / paths (P2-6).
+// ---------------------------------------------------------------------------
+
+describe('design titles', () => {
+  test('DESIGN_TITLES and LAST_DESIGN_TITLE use the human title', () => {
+    runDev(['--append-session'], { input: session({ design_doc: '/p/a.md', design_title: 'Realtime Inbox' }) });
+    runDev(['--append-session'], { input: session({ design_doc: '/p/b.md', design_title: 'Inbox Zero Agent' }) });
+    const after = read();
+    expect(JSON.parse(after['DESIGN_TITLES'])).toEqual(['Realtime Inbox', 'Inbox Zero Agent']);
+    expect(after['LAST_DESIGN_TITLE']).toBe('Inbox Zero Agent');
+  });
+
+  test('falls back to the doc basename when no design_title is present', () => {
+    runDev(['--append-session'], { input: session({ design_doc: '/p/user-main-design-x.md' }) });
+    expect(read()['LAST_DESIGN_TITLE']).toBe('user-main-design-x.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State root honors CLAUDE_PLUGIN_DATA, matching gstack-paths (P1-5).
+// ---------------------------------------------------------------------------
+
+describe('state root resolution', () => {
+  test('writes and reads under CLAUDE_PLUGIN_DATA when GSTACK_HOME is unset', () => {
+    const env = { ...process.env, GSTACK_HOME: undefined, CLAUDE_PLUGIN_DATA: tmpHome } as Record<string, string | undefined>;
+    const w = runDev(['--append-session'], { input: session({ assignment: 'plugin path' }), env });
+    expect(w.status).toBe(0);
+    expect(fs.existsSync(path.join(tmpHome, 'developer-profile.json'))).toBe(true);
+    expect(read(env)['SESSION_COUNT']).toBe('1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reconcile: orphaned legacy appends (from the buggy version) are healed (P0 heal).
+// ---------------------------------------------------------------------------
+
+describe('legacy reconcile', () => {
+  test('orphaned builder-profile.jsonl appended after migration is folded back in', () => {
+    writeLegacy([{ mode: 'builder', project_slug: 'app', assignment: 's1', signals: [] }]);
+    expect(read()['SESSION_COUNT']).toBe('1'); // migrates + archives
+
+    // Simulate the buggy version re-creating the legacy file with an orphaned session.
+    writeLegacy([{ mode: 'builder', project_slug: 'app', assignment: 's2', signals: [] }]);
+    const after = read(); // should reconcile
+    expect(after['SESSION_COUNT']).toBe('2');
+    expect(after['LAST_ASSIGNMENT']).toBe('s2');
+    // Legacy file should be archived again, not left to double-fold next time.
+    expect(fs.existsSync(path.join(tmpHome, 'builder-profile.jsonl'))).toBe(false);
+    expect(read()['SESSION_COUNT']).toBe('2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loud failures, not silent drops (P1-2).
+// ---------------------------------------------------------------------------
+
+describe('malformed migration lines', () => {
+  test('warns to stderr and does not silently undercount', () => {
+    fs.writeFileSync(
+      path.join(tmpHome, 'builder-profile.jsonl'),
+      [
+        JSON.stringify({ mode: 'builder', project_slug: 'app', assignment: 'good1', signals: [] }),
+        '{ broken json',
+        JSON.stringify({ mode: 'builder', project_slug: 'app', assignment: 'good2', signals: [] }),
+      ].join('\n') + '\n',
+    );
+    const r = runDev(['--migrate']);
+    expect(r.status).toBe(0);
+    expect(r.stderr.toLowerCase()).toMatch(/dropped|malformed|skipped/);
+    expect(read()['SESSION_COUNT']).toBe('2');
+  });
+});

--- a/test/office-hours-structure.test.ts
+++ b/test/office-hours-structure.test.ts
@@ -1,0 +1,139 @@
+/**
+ * office-hours/SKILL.md structural guards (deterministic, free — no LLM).
+ *
+ * These lock down load-bearing invariants that were previously enforced only by
+ * paid evals or not at all: the resource-pool/dedup-gate coupling, required
+ * design-doc sections, the privacy gate, the Phase-4 STOP gate, mode-switch and
+ * escape-hatch rules, smart-routing question integrity, cross-platform opening,
+ * and the profile write-through contract (no regression to raw JSONL appends).
+ *
+ * Reads the GENERATED SKILL.md (what actually ships); run `bun run gen:skill-docs`
+ * if this drifts.
+ */
+
+import { describe, test, expect, beforeAll } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const SKILL = path.join(ROOT, 'office-hours', 'SKILL.md');
+
+let content = '';
+beforeAll(() => {
+  content = fs.readFileSync(SKILL, 'utf-8');
+});
+
+describe('resource pool integrity', () => {
+  function poolUrls(): string[] {
+    const start = content.indexOf('**Resource Pool**');
+    const end = content.indexOf('**After presenting resources', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const slice = content.slice(start, end);
+    return (slice.match(/https?:\/\/[^\s)]+/g) || []);
+  }
+
+  test('pool has no duplicate URLs', () => {
+    const urls = poolUrls();
+    expect(urls.length).toBeGreaterThan(0);
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  test('dedup-gate threshold and header count both equal the pool size', () => {
+    const urls = poolUrls();
+    const gate = content.match(/currently (\d+)\)/);
+    const header = content.match(/\*\*Resource Pool\*\*\s*\((\d+) entries/);
+    expect(gate).not.toBeNull();
+    expect(header).not.toBeNull();
+    expect(Number(gate![1])).toBe(urls.length);
+    expect(Number(header![1])).toBe(urls.length);
+  });
+});
+
+describe('profile write-through contract (P0 regression guard)', () => {
+  test('uses the append subcommands, not raw JSONL appends', () => {
+    expect(content).toContain('--append-session');
+    expect(content).toContain('--append-resources');
+  });
+
+  test('never appends raw JSON to builder-profile.jsonl (the data-loss path)', () => {
+    expect(content).not.toMatch(/>>\s*"?\$?\{?GSTACK_STATE_ROOT[^\n]*builder-profile\.jsonl/);
+    expect(content).not.toContain('builder-profile.jsonl');
+  });
+});
+
+describe('required design-doc sections', () => {
+  for (const section of ['## Distribution Plan', '## The Assignment', '## Success Criteria', '## Problem Statement', '## Recommended Approach']) {
+    test(`present: ${section}`, () => {
+      expect(content).toContain(section);
+    });
+  }
+
+  test('both design-doc templates carry a Distribution Plan', () => {
+    const count = (content.match(/## Distribution Plan/g) || []).length;
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('privacy gate', () => {
+  test('generalized-terms instruction and the gate prompt survive', () => {
+    expect(content).toContain('generalized category terms');
+    expect(content).toContain('OK to proceed?');
+    expect(content.toLowerCase()).toContain("never the user");
+  });
+});
+
+describe('Phase 4 STOP gate', () => {
+  test('section anchors and the stop sentence are intact', () => {
+    expect(content).toContain('## Phase 4: Alternatives Generation');
+    expect(content).toContain('## Phase 4.5');
+    expect(content).toContain('Do NOT proceed to Phase 4.5');
+  });
+});
+
+describe('mode-switch and escape-hatch rules', () => {
+  test('vibe-shift upgrade survives', () => {
+    expect(content).toContain('upgrade to Startup mode');
+  });
+  test("anti-nagging 'don't ask a third time' rule survives", () => {
+    expect(content).toContain("Don't ask a third time");
+  });
+  test('builder escape hatch still runs Premise Challenge (does not skip to Phase 4)', () => {
+    // Guard against reverting to "fast-track to Phase 4" which skipped Phase 3.
+    expect(content).not.toContain('fast-track to Phase 4 (Alternatives Generation)');
+  });
+});
+
+describe('smart-routing question integrity', () => {
+  test('every Qn referenced in the routing table has a definition, and stages are wired', () => {
+    const start = content.indexOf('Smart routing based on product stage');
+    const firstQ = content.indexOf('#### Q1:', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(firstQ).toBeGreaterThan(start);
+    const region = content.slice(start, firstQ);
+    const nums = new Set([...region.matchAll(/\bQ(\d)\b/g)].map((m) => m[1]));
+    expect(nums.size).toBeGreaterThan(0);
+    for (const n of nums) {
+      expect(content).toContain(`#### Q${n}:`);
+    }
+    for (const stage of ['Pre-product', 'Has users', 'Has paying customers', 'Pure engineering/infra']) {
+      expect(region).toContain(stage);
+    }
+  });
+
+  test('every routing stage is a selectable Phase 1 product-stage option', () => {
+    const stageStart = content.indexOf('Assess product stage');
+    const stageRegion = content.slice(stageStart, stageStart + 600);
+    for (const stage of ['Pre-product', 'Has users', 'Has paying customers', 'Pure engineering/infra']) {
+      expect(stageRegion).toContain(stage);
+    }
+  });
+});
+
+describe('cross-platform opening', () => {
+  test('uses gstack-open-url and never &&-chains bare open', () => {
+    expect(content).toContain('gstack-open-url');
+    expect(content).not.toMatch(/&&\s*open\s+URL/);
+    expect(content).not.toMatch(/\bopen\s+"\$GSTACK_STATE_ROOT\/builder-journey\.md"/);
+  });
+});

--- a/test/profile-store.test.ts
+++ b/test/profile-store.test.ts
@@ -1,0 +1,121 @@
+/**
+ * scripts/profile-store.ts — pure-function unit tests (no subprocess, no fs).
+ * Fast guard for the merge/aggregate/reconcile logic behind /office-hours
+ * profile persistence.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+  emptyProfile,
+  recompute,
+  appendSession,
+  mergeResources,
+  migrateLegacy,
+  foldLegacy,
+  realSessions,
+  designTitle,
+  isResourcesRow,
+} from '../scripts/profile-store';
+
+describe('appendSession', () => {
+  test('adds a session and stamps a date when missing', () => {
+    const p = appendSession(emptyProfile(), { mode: 'builder', assignment: 'x' });
+    expect(p.sessions.length).toBe(1);
+    expect(typeof p.sessions[0].date).toBe('string');
+    expect(p.sessions[0].date!.length).toBeGreaterThan(0);
+  });
+
+  test('preserves a provided date verbatim', () => {
+    const p = appendSession(emptyProfile(), { date: '2026-01-02T03:04:05Z', mode: 'builder' });
+    expect(p.sessions[0].date).toBe('2026-01-02T03:04:05Z');
+  });
+
+  test('tallies signals across appended sessions', () => {
+    let p = emptyProfile();
+    p = appendSession(p, { signals: ['taste', 'agency'] });
+    p = appendSession(p, { signals: ['taste'] });
+    expect(p.signals_accumulated.taste).toBe(2);
+    expect(p.signals_accumulated.agency).toBe(1);
+  });
+
+  test('rejects non-object entries', () => {
+    expect(() => appendSession(emptyProfile(), 'nope' as unknown as Record<string, unknown>)).toThrow();
+    expect(() => appendSession(emptyProfile(), [1, 2] as unknown as Record<string, unknown>)).toThrow();
+  });
+});
+
+describe('mergeResources', () => {
+  test('unions resources and dedups', () => {
+    let p = emptyProfile();
+    p = mergeResources(p, { resources_shown: ['a', 'b'] });
+    p = mergeResources(p, { resources_shown: ['b', 'c'] });
+    expect(p.resources_shown.sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  test('does not add a session', () => {
+    const p = mergeResources(emptyProfile(), { resources_shown: ['a'] });
+    expect(p.sessions.length).toBe(0);
+  });
+
+  test('recompute preserves merged resources (never shrinks)', () => {
+    let p = mergeResources(emptyProfile(), { resources_shown: ['kept'] });
+    p = appendSession(p, { mode: 'builder', resources_shown: ['from-session'] });
+    expect(p.resources_shown.sort()).toEqual(['from-session', 'kept']);
+  });
+});
+
+describe('migrateLegacy', () => {
+  test('counts dropped malformed lines instead of silently losing them', () => {
+    const { profile, dropped } = migrateLegacy([
+      JSON.stringify({ mode: 'builder', signals: ['taste'] }),
+      '{ broken',
+      JSON.stringify({ mode: 'startup', signals: ['pushback'] }),
+    ]);
+    expect(dropped).toBe(1);
+    expect(profile.sessions.length).toBe(2);
+    expect(profile.signals_accumulated.taste).toBe(1);
+  });
+
+  test('resource rows do not become sessions but their resources merge', () => {
+    const { profile } = migrateLegacy([
+      JSON.stringify({ mode: 'builder', assignment: 'real' }),
+      JSON.stringify({ mode: 'resources', resources_shown: ['https://r'] }),
+    ]);
+    expect(profile.sessions.length).toBe(1);
+    expect(profile.resources_shown).toEqual(['https://r']);
+  });
+});
+
+describe('foldLegacy', () => {
+  test('adds only sessions not already present (dedup by signature)', () => {
+    let p = appendSession(emptyProfile(), { date: 'd1', mode: 'builder', project_slug: 'app', assignment: 's1' });
+    const before = p.sessions.length;
+    const { profile, added } = foldLegacy(p, [
+      JSON.stringify({ date: 'd1', mode: 'builder', project_slug: 'app', assignment: 's1' }), // dup
+      JSON.stringify({ date: 'd2', mode: 'builder', project_slug: 'app', assignment: 's2' }), // new
+    ]);
+    expect(added).toBe(1);
+    expect(profile.sessions.length).toBe(before + 1);
+    expect(profile.sessions.at(-1)!.assignment).toBe('s2');
+  });
+});
+
+describe('helpers', () => {
+  test('realSessions excludes resource rows', () => {
+    const p = emptyProfile();
+    p.sessions = [{ mode: 'builder' }, { mode: 'resources' }, { mode: 'startup' }];
+    expect(realSessions(p).length).toBe(2);
+  });
+
+  test('isResourcesRow', () => {
+    expect(isResourcesRow({ mode: 'resources' })).toBe(true);
+    expect(isResourcesRow({ mode: 'builder' })).toBe(false);
+  });
+
+  test('designTitle prefers title, then basename, then slug', () => {
+    expect(designTitle({ design_title: 'Realtime Inbox', design_doc: '/p/x.md' })).toBe('Realtime Inbox');
+    expect(designTitle({ design_doc: '/p/user-main-design-x.md' })).toBe('user-main-design-x.md');
+    expect(designTitle({ project_slug: 'my-app' })).toBe('my-app');
+    expect(designTitle({})).toBe('');
+  });
+});

--- a/test/skill-e2e-office-hours-auto-mode.test.ts
+++ b/test/skill-e2e-office-hours-auto-mode.test.ts
@@ -5,7 +5,8 @@
  * `--disallowedTools AskUserQuestion --permission-mode default` (verified
  * by inspecting the parent claude process via `ps`). office-hours' first
  * step issues a startup-vs-builder mode AskUserQuestion
- * (office-hours/SKILL.md.tmpl:69); when AskUserQuestion is disallowed at
+ * (Phase 1 step 5 — the "what's your goal with this?" question); when
+ * AskUserQuestion is disallowed at
  * the tool-registry level the model cannot ask and silently picks one mode,
  * breaking the whole interactive premise. This test asserts that question
  * still surfaces — fix must route through mcp__conductor__AskUserQuestion


### PR DESCRIPTION
## The bug (P0: silent data loss)

`/office-hours` persists session state by appending to `~/.gstack/builder-profile.jsonl`, but the read path (`gstack-builder-profile` → `gstack-developer-profile --read`) **migrates that file into `developer-profile.json` on the first read and renames the original away** — then never re-reads it. So from a user's **second** session onward, every append lands in a file the reader no longer consults:

- `SESSION_COUNT`, `TIER`, `ACCUMULATED_SIGNALS`, `RESOURCES_SHOWN`, the journey summary — all **frozen at session 1**
- the relationship-deepening closing greets a 5th-time user as a 2nd-timer with a stale assignment
- resource dedup never accumulates, so the same YC videos resurface every session

Reproducible: append session 1 → read (migrates) → append session 2 → read still returns `SESSION_COUNT 1`.

## The fix

A write-through path so the skill writes to the same store it reads from:

- **`gstack-developer-profile --append-session` / `--append-resources`** — new subcommands that `ensure_profile`, JSON-encode in the binary (no shell-assembled JSON), and atomically merge. Logic lives in a new, unit-tested `scripts/profile-store.ts`.
- Phase 4.5 / Phase 6 of the skill now call those instead of `echo … >> builder-profile.jsonl`.
- A **reconcile step** folds orphaned legacy appends back in on read, healing installs already affected.

## Also fixed in this wave (from a full audit of the skill)

| Area | Fix |
|---|---|
| JSON corruption | quoted/apostrophe/newline assignment text silently produced invalid JSONL that the parser dropped → JSON now built in the binary |
| Tier inflation | `mode:"resources"` rows were counted as sessions (tier ~2× too fast) → excluded from count/tier |
| Silent failures | malformed lines dropped with no warning; read fallback laundered a hard failure into a first-time-user greeting → both now loud |
| Plugin installs | state root now honors `CLAUDE_PLUGIN_DATA` like `gstack-paths` (writer/reader were diverging) |
| Analytics path | written under `$GSTACK_STATE_ROOT`, not a hardcoded `~/.gstack` |
| Design titles | `DESIGN_TITLES`/`LAST_DESIGN_TITLE` surface the title, not a slug or raw path |
| gbrain queries | context query points at the live `developer-profile.json`; `prior-sessions` query + save tag aligned on `repo:<slug>` so it actually matches office-hours pages |
| Dedup gate | hardcoded "34" made size-agnostic + a pool-integrity guard test |
| Cross-platform | bare macOS `open` → `gstack-open-url` (looped, not `&&`-chained) |
| Spec | builder escape hatch no longer skips Premise Challenge; orphan routing stage wired to a Phase-1 option; resume affordance added; Distribution-Plan templates aligned; time-anchored blurbs freshened |

## Tests

- `test/office-hours-profile.test.ts` — write-through round-trip across migration, JSON-safety (quotes/newlines), resources-not-counted, plugin root, reconcile, loud malformed warnings
- `test/profile-store.test.ts` — pure-function unit coverage
- `test/office-hours-structure.test.ts` — pool/gate coupling, required design-doc sections, privacy gate, Phase-4 STOP gate, cross-platform open, and a **write-through regression guard** (skill must never revert to raw `builder-profile.jsonl` appends)
- `test/office-hours-links.test.ts` — opt-in (`LINKCHECK=1`) founder-resource liveness check
- existing `builder-profile` / `gstack-developer-profile` suites updated for the design-title fix

All deterministic suites green; generated `SKILL.md` regenerated and fresh (`skill:check` office-hours ✅). No new failures vs. `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
