### PR TITLE
fix(gstack-upgrade): rerun setup for detected hosts

### DIFF
--- a/gstack-upgrade/SKILL.md
+++ b/gstack-upgrade/SKILL.md
@@ -131,7 +131,7 @@ cd "$INSTALL_DIR"
 STASH_OUTPUT=$(git stash 2>&1)
 git fetch origin
 git reset --hard origin/main
-./setup
+./setup --host auto
 ```
 If `$STASH_OUTPUT` contains "Saved working directory", warn the user: "Note: local changes were stashed. Run `git stash pop` in the skill directory to restore them."
 
@@ -142,7 +142,7 @@ TMP_DIR=$(mktemp -d)
 git clone --depth 1 https://github.com/garrytan/gstack.git "$TMP_DIR/gstack"
 mv "$INSTALL_DIR" "$INSTALL_DIR.bak"
 mv "$TMP_DIR/gstack" "$INSTALL_DIR"
-cd "$INSTALL_DIR" && ./setup
+cd "$INSTALL_DIR" && ./setup --host auto
 rm -rf "$INSTALL_DIR.bak" "$TMP_DIR"
 ```
 
@@ -182,7 +182,7 @@ Tell user: "Removed vendored copy at `$LOCAL_GSTACK` (team mode active — globa
 mv "$LOCAL_GSTACK" "$LOCAL_GSTACK.bak"
 cp -Rf "$INSTALL_DIR" "$LOCAL_GSTACK"
 rm -rf "$LOCAL_GSTACK/.git"
-cd "$LOCAL_GSTACK" && ./setup
+cd "$LOCAL_GSTACK" && ./setup --host auto
 rm -rf "$LOCAL_GSTACK.bak"
 ```
 Tell user: "Also updated vendored copy at `$LOCAL_GSTACK` — commit `.claude/skills/gstack/` when you're ready."

--- a/gstack-upgrade/SKILL.md.tmpl
+++ b/gstack-upgrade/SKILL.md.tmpl
@@ -128,7 +128,7 @@ cd "$INSTALL_DIR"
 STASH_OUTPUT=$(git stash 2>&1)
 git fetch origin
 git reset --hard origin/main
-./setup
+./setup --host auto
 ```
 If `$STASH_OUTPUT` contains "Saved working directory", warn the user: "Note: local changes were stashed. Run `git stash pop` in the skill directory to restore them."
 
@@ -139,7 +139,7 @@ TMP_DIR=$(mktemp -d)
 git clone --depth 1 https://github.com/garrytan/gstack.git "$TMP_DIR/gstack"
 mv "$INSTALL_DIR" "$INSTALL_DIR.bak"
 mv "$TMP_DIR/gstack" "$INSTALL_DIR"
-cd "$INSTALL_DIR" && ./setup
+cd "$INSTALL_DIR" && ./setup --host auto
 rm -rf "$INSTALL_DIR.bak" "$TMP_DIR"
 ```
 
@@ -179,7 +179,7 @@ Tell user: "Removed vendored copy at `$LOCAL_GSTACK` (team mode active — globa
 mv "$LOCAL_GSTACK" "$LOCAL_GSTACK.bak"
 cp -Rf "$INSTALL_DIR" "$LOCAL_GSTACK"
 rm -rf "$LOCAL_GSTACK/.git"
-cd "$LOCAL_GSTACK" && ./setup
+cd "$LOCAL_GSTACK" && ./setup --host auto
 rm -rf "$LOCAL_GSTACK.bak"
 ```
 Tell user: "Also updated vendored copy at `$LOCAL_GSTACK` — commit `.claude/skills/gstack/` when you're ready."

--- a/test/gstack-upgrade-host-auto.test.ts
+++ b/test/gstack-upgrade-host-auto.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const TEMPLATE = fs.readFileSync(path.join(ROOT, 'gstack-upgrade', 'SKILL.md.tmpl'), 'utf-8');
+const GENERATED = fs.readFileSync(path.join(ROOT, 'gstack-upgrade', 'SKILL.md'), 'utf-8');
+
+function setupCommandLines(src: string): string[] {
+  return src
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.includes('./setup'));
+}
+
+describe('/gstack-upgrade host refresh', () => {
+  test('source template re-registers auto-detected hosts after every upgrade', () => {
+    const lines = setupCommandLines(TEMPLATE);
+
+    expect(lines.length).toBeGreaterThanOrEqual(3);
+    expect(lines).toEqual(expect.arrayContaining([
+      './setup --host auto',
+      'cd "$INSTALL_DIR" && ./setup --host auto',
+      'cd "$LOCAL_GSTACK" && ./setup --host auto',
+    ]));
+    expect(lines.filter(line => line === './setup' || line.endsWith('&& ./setup'))).toEqual([]);
+  });
+
+  test('generated skill matches the host-aware upgrade contract', () => {
+    const lines = setupCommandLines(GENERATED);
+
+    expect(lines).toEqual(expect.arrayContaining([
+      './setup --host auto',
+      'cd "$INSTALL_DIR" && ./setup --host auto',
+      'cd "$LOCAL_GSTACK" && ./setup --host auto',
+    ]));
+    expect(lines.filter(line => line === './setup' || line.endsWith('&& ./setup'))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- update gstack-upgrade install refresh paths to rerun ./setup --host auto
- cover template and generated skill docs with a regression test

Fixes #1925.

## Verification
- bun test test/gstack-upgrade-host-auto.test.ts

## Notes
- Branch is based on the fork main because the agent token lacks GitHub workflow scope for pushing upstream workflow history changes.
