### PR TITLE
fix(gbrain): strip leaked db env for PGLite probes

### DIFF
--- a/lib/gbrain-exec.ts
+++ b/lib/gbrain-exec.ts
@@ -38,6 +38,8 @@ import { spawnSync, spawn, execFileSync, type SpawnSyncReturns, type ChildProces
 
 interface GbrainConfig {
   database_url?: string;
+  engine?: string;
+  database_path?: string;
 }
 
 export interface BuildGbrainEnvOptions {
@@ -80,8 +82,13 @@ export function isTransactionModePooler(url: string): boolean {
  * unchanged when:
  *   - `GSTACK_RESPECT_ENV_DATABASE_URL=1` (intentional opt-out),
  *   - the config file is missing or unparseable,
- *   - the config has no `database_url`,
+ *   - the config has no `database_url` and is not a local PGLite config,
  *   - the caller already set DATABASE_URL to the same value.
+ *
+ * For PGLite configs, there is no DATABASE_URL to seed. In that case we
+ * strip caller-supplied database URLs so Bun's project `.env` autoload
+ * cannot make gbrain probe an unrelated app database and classify a healthy
+ * file-backed brain as `broken-db`.
  *
  * When the effective DATABASE_URL targets a PgBouncer transaction-mode
  * pooler (port 6543), sets `GBRAIN_PREPARE=true` so gbrain re-enables
@@ -108,7 +115,13 @@ export function buildGbrainEnv(opts: BuildGbrainEnvOptions = {}): NodeJS.Process
   } catch {
     return out;
   }
-  if (!cfg.database_url) return out;
+  if (!cfg.database_url) {
+    if (cfg.engine === "pglite" || cfg.database_path) {
+      delete out.DATABASE_URL;
+      delete out.GBRAIN_DATABASE_URL;
+    }
+    return out;
+  }
 
   const hadCaller = baseEnv.DATABASE_URL !== undefined;
   const alreadyMatch = baseEnv.DATABASE_URL === cfg.database_url;

--- a/test/build-gbrain-env.test.ts
+++ b/test/build-gbrain-env.test.ts
@@ -70,11 +70,26 @@ describe("buildGbrainEnv", () => {
     expect(result.DATABASE_URL).toBe("postgresql://app/db");
   });
 
-  it("returns caller env unchanged when config has no database_url field", () => {
-    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ engine: "pglite" }));
+  it("returns caller env unchanged when config has no database_url field and no local-engine signal", () => {
+    writeFileSync(join(gbrainHome, "config.json"), JSON.stringify({ profile: "legacy" }));
     const baseEnv = { HOME: home, DATABASE_URL: "postgresql://app/db" };
     const result = buildGbrainEnv({ baseEnv });
     expect(result.DATABASE_URL).toBe("postgresql://app/db");
+  });
+
+  it("strips caller database URLs for PGLite configs without a database_url", () => {
+    writeFileSync(
+      join(gbrainHome, "config.json"),
+      JSON.stringify({ engine: "pglite", database_path: join(gbrainHome, "gbrain.db") }),
+    );
+    const baseEnv = {
+      HOME: home,
+      DATABASE_URL: "sqlite:///app.db",
+      GBRAIN_DATABASE_URL: "postgresql://wrong/db",
+    };
+    const result = buildGbrainEnv({ baseEnv });
+    expect(result.DATABASE_URL).toBeUndefined();
+    expect(result.GBRAIN_DATABASE_URL).toBeUndefined();
   });
 
   it("honors GBRAIN_HOME when set (config aligned with detectEngineTier)", () => {

--- a/test/gbrain-local-status.test.ts
+++ b/test/gbrain-local-status.test.ts
@@ -55,8 +55,9 @@ interface FakeEnv {
  */
 function makeEnv(opts: {
   withGbrain?: boolean;
-  gbrainBehavior?: "ok" | "broken-db" | "broken-config" | "throws";
+  gbrainBehavior?: "ok" | "broken-db" | "broken-config" | "throws" | "fail-on-database-url";
   withConfig?: boolean;
+  configJson?: Record<string, unknown>;
 }): FakeEnv {
   const tmp = mkdtempSync(join(tmpdir(), "gbrain-local-status-test-"));
   const bindir = join(tmp, "bin");
@@ -73,7 +74,7 @@ function makeEnv(opts: {
   if (opts.withConfig) {
     writeFileSync(
       configPath,
-      JSON.stringify({ engine: "pglite", database_url: "pglite:///fake" }),
+      JSON.stringify(opts.configJson ?? { engine: "pglite", database_url: "pglite:///fake" }),
     );
   }
 
@@ -96,7 +97,7 @@ function makeEnv(opts: {
 }
 
 function makeFakeGbrainScript(
-  behavior: "ok" | "broken-db" | "broken-config" | "throws",
+  behavior: "ok" | "broken-db" | "broken-config" | "throws" | "fail-on-database-url",
 ): string {
   const stderrLine =
     behavior === "broken-db"
@@ -113,6 +114,14 @@ if [ "$1" = "--version" ]; then
   exit 0
 fi
 if [ "$1 $2" = "sources list" ]; then
+  if [ "${behavior}" = "fail-on-database-url" ]; then
+    if [ -n "$DATABASE_URL" ] || [ -n "$GBRAIN_DATABASE_URL" ]; then
+      echo "Cannot connect to database: leaked DATABASE_URL" >&2
+      exit 1
+    fi
+    echo '{"sources":[]}'
+    exit 0
+  fi
   if [ ${exitCode} -eq 0 ]; then
     echo '{"sources":[]}'
     exit 0
@@ -136,6 +145,8 @@ function applyEnv(env: FakeEnv): () => void {
     HOME: process.env.HOME,
     PATH: process.env.PATH,
     GSTACK_HOME: process.env.GSTACK_HOME,
+    DATABASE_URL: process.env.DATABASE_URL,
+    GBRAIN_DATABASE_URL: process.env.GBRAIN_DATABASE_URL,
   };
   process.env.HOME = env.home;
   process.env.PATH = `${env.bindir}:/usr/bin:/bin`;
@@ -147,6 +158,10 @@ function applyEnv(env: FakeEnv): () => void {
     else process.env.PATH = prev.PATH;
     if (prev.GSTACK_HOME === undefined) delete process.env.GSTACK_HOME;
     else process.env.GSTACK_HOME = prev.GSTACK_HOME;
+    if (prev.DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prev.DATABASE_URL;
+    if (prev.GBRAIN_DATABASE_URL === undefined) delete process.env.GBRAIN_DATABASE_URL;
+    else process.env.GBRAIN_DATABASE_URL = prev.GBRAIN_DATABASE_URL;
   };
 }
 
@@ -204,6 +219,20 @@ describe("lib/gbrain-local-status — five status cases", () => {
   it("returns 'ok' when sources list succeeds", () => {
     env = makeEnv({ withGbrain: true, gbrainBehavior: "ok", withConfig: true });
     restoreEnv = applyEnv(env);
+    expect(localEngineStatus({ noCache: true })).toBe("ok");
+  });
+
+  it("does not misclassify a PGLite brain as broken-db when caller env leaks DATABASE_URL", () => {
+    env = makeEnv({
+      withGbrain: true,
+      gbrainBehavior: "fail-on-database-url",
+      withConfig: true,
+      configJson: { engine: "pglite", database_path: "local/pglite.db" },
+    });
+    restoreEnv = applyEnv(env);
+    process.env.DATABASE_URL = "sqlite:///app.db";
+    process.env.GBRAIN_DATABASE_URL = "postgresql://wrong/db";
+
     expect(localEngineStatus({ noCache: true })).toBe("ok");
   });
 });


### PR DESCRIPTION
## Summary
- Prevent PGLite gbrain probes from inheriting caller `DATABASE_URL` / `GBRAIN_DATABASE_URL` when `~/.gbrain/config.json` has no `database_url`.
- Preserve the `GSTACK_RESPECT_ENV_DATABASE_URL=1` escape hatch and existing Postgres seeding behavior.
- Add regression coverage at both the env-helper layer and the `gbrain_local_status` classifier layer.

Closes #1917

## Verification
- RED: `bun test test/build-gbrain-env.test.ts test/gbrain-local-status.test.ts` failed before the fix with the new PGLite leaked-env regression tests.
- GREEN: `bun test test/build-gbrain-env.test.ts test/gbrain-local-status.test.ts test/gbrain-exec-invariant.test.ts` passed, 36 tests.
- Full non-eval suite: `bun test browse/test/ test/ make-pdf/test/ --ignore 'test/skill-e2e-*.test.ts' --ignore test/skill-llm-eval.test.ts --ignore test/skill-routing-e2e.test.ts --ignore test/codex-e2e.test.ts --ignore test/gemini-e2e.test.ts` passed.
- Build: `bun run build` passed.
- API/CLI smoke: synthetic `bin/gstack-gbrain-detect` run with a fake PGLite config and poisoned caller DB env returned `{"gbrain_engine":"pglite","gbrain_local_status":"ok","gbrain_on_path":true}`.
- Whitespace: `git diff --check` passed.
- Autoreview: Codex review found no blocking findings.

## Notes
- `bun run test:windows` was attempted, but failed in an unrelated pre-existing source-level guard in `browse/test/terminal-agent.test.ts`; this PR does not touch browse terminal-agent files. Focused Windows-safe coverage for the changed files is included in the targeted tests above.
