### PR TITLE
fix: add ios qa daemon help

### DIFF
--- a/bin/gstack-ios-qa-daemon
+++ b/bin/gstack-ios-qa-daemon
@@ -22,6 +22,39 @@
 
 set -euo pipefail
 
+print_usage() {
+  cat <<'EOF'
+Usage:
+  gstack-ios-qa-daemon [--tailnet]
+  gstack-ios-qa-daemon --help
+
+Mac-side broker for /ios-qa and /ios-design-review. By default it binds a
+loopback listener for a USB-connected iPhone running the in-app StateServer.
+Pass --tailnet to also open the Tailscale listener after the local tailscaled
+identity probe succeeds.
+
+Options:
+  --tailnet   Enable the authenticated tailnet listener in addition to loopback.
+  -h, --help  Print this help and exit without starting the daemon.
+
+Environment:
+  GSTACK_IOS_DAEMON_PORT       Loopback listener port. Default: 9099.
+  GSTACK_IOS_TARGET_UDID       Target iOS device UDID. Optional.
+  GSTACK_IOS_TARGET_BUNDLE_ID  Bundle ID hosting StateServer. Default: com.gstack.iosqa.fixture.
+
+Readiness:
+  The daemon prints "READY: port=<n> pid=<pid>" once the listener is bound.
+  Probe local health with: curl -sf http://127.0.0.1:${GSTACK_IOS_DAEMON_PORT:-9099}/healthz
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    print_usage
+    exit 0
+    ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GSTACK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 ENTRY="$GSTACK_DIR/ios-qa/daemon/src/index.ts"

--- a/test/ios-qa-daemon-cli.test.ts
+++ b/test/ios-qa-daemon-cli.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'child_process';
+import { join } from 'path';
+
+const ROOT = join(import.meta.dir, '..');
+const DAEMON_BIN = join(ROOT, 'bin/gstack-ios-qa-daemon');
+
+describe('gstack-ios-qa-daemon CLI', () => {
+  test('--help prints usage and exits without starting the daemon', () => {
+    const result = spawnSync('bash', [DAEMON_BIN, '--help'], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      timeout: 2_000,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage:');
+    expect(result.stdout).toContain('gstack-ios-qa-daemon');
+    expect(result.stdout).toContain('--tailnet');
+    expect(result.stdout).toContain('GSTACK_IOS_DAEMON_PORT');
+    expect(result.stdout).toContain('/healthz');
+    expect(result.stderr).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the `gstack-ios-qa-daemon --help` first-run failure called out as bug #2 in #1735.

Before this change, `--help` fell through to the daemon startup path, printed `READY`, created the single-instance pidfile, and then ran forever. That makes the most normal first-run diagnostic command look like a hung/broken install.

This PR adds a no-side-effect `-h` / `--help` path in the shell wrapper before any daemon startup or Bun entrypoint checks run.

## Scope

- Adds usage text for `gstack-ios-qa-daemon`.
- Documents the default loopback mode, `--tailnet`, the relevant env vars, and `/healthz` readiness probe.
- Adds a regression test proving `--help` exits 0, prints usage, writes nothing to stderr, and does not hang.

Related to #1735. This intentionally does not claim to close the whole issue because #1735 tracks 7 bugs. Open PR #1766 already covers the overlapping SwiftPM P0 blockers (#3, #5, #6).

## Verification

- RED: `bun test test/ios-qa-daemon-cli.test.ts` initially failed with `spawnSync bash ETIMEDOUT`, reproducing the hang.
- GREEN: `bun test test/ios-qa-daemon-cli.test.ts` passed.
- Focused daemon tests: `bun test test/ios-qa-daemon-cli.test.ts ios-qa/daemon/test/single-instance.test.ts ios-qa/daemon/test/daemon-integration.test.ts` passed, 19 tests.
- Syntax: `bash -n bin/gstack-ios-qa-daemon` passed.
- CLI smoke: `./bin/gstack-ios-qa-daemon --help` prints usage and exits.
- Autoreview: Hermes subagent review returned CLEAN, no blocking findings.

## Notes

A filtered `bun test test/gen-skill-docs.test.ts --grep 'generated files are fresh|every skill has a generated SKILL.md|frontmatter parses'` run hit an unrelated existing test-file top-level load error for missing `.agents/skills/gstack-office-hours/SKILL.md`; the four filtered tests themselves passed before Bun reported the top-level load error. Not caused by this diff.
