### PR TITLE
feat(browse): env-driven Chromium launch overrides

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -22,6 +22,7 @@ import { emitActivity } from './activity';
 import { validateNavigationUrl } from './url-validation';
 import { TabSession, type RefEntry } from './tab-session';
 import { resolveChromiumProfile, cleanSingletonLocks } from './config';
+import { parseExtraChromiumArgs, parseHttpCredentials } from './launch-overrides';
 import { withCdpSession } from './cdp-bridge';
 import type { MemorySnapshot, MemoryStructureStats, MemoryTabSnapshot, MemoryProcess } from './memory-snapshot';
 
@@ -369,6 +370,9 @@ export class BrowserManager {
       console.log(`[browse] Extensions loaded from: ${extensionsDir}`);
     }
 
+    // User-supplied extra Chromium flags (GSTACK_CHROMIUM_ARGS), no-op when unset.
+    launchArgs.push(...parseExtraChromiumArgs());
+
     this.browser = await chromium.launch({
       headless: useHeadless,
       // On Windows, Chromium's sandbox fails when the server is spawned through
@@ -400,6 +404,12 @@ export class BrowserManager {
     };
     if (this.customUserAgent) {
       contextOptions.userAgent = this.customUserAgent;
+    }
+    // Auto-answer HTTP basic-auth (401) challenges (GSTACK_HTTP_CREDENTIALS),
+    // undefined when unset.
+    const headlessHttpCredentials = parseHttpCredentials();
+    if (headlessHttpCredentials) {
+      contextOptions.httpCredentials = headlessHttpCredentials;
     }
     this.context = await this.browser.newContext(contextOptions);
 
@@ -441,6 +451,8 @@ export class BrowserManager {
       // Anti-bot-detection: remove the navigator.webdriver flag that Playwright sets.
       // Sites like Google and NYTimes check this to block automation browsers.
       '--disable-blink-features=AutomationControlled',
+      // User-supplied extra Chromium flags (GSTACK_CHROMIUM_ARGS), no-op when unset.
+      ...parseExtraChromiumArgs(),
     ];
     if (extensionPath) {
       // Skip --load-extension when running against a custom Chromium build
@@ -563,6 +575,8 @@ export class BrowserManager {
       args: launchArgs,
       viewport: null,  // Use browser's default viewport (real window size)
       userAgent: this.customUserAgent || customUA,
+      // Auto-answer HTTP basic-auth (401) challenges (GSTACK_HTTP_CREDENTIALS).
+      ...(parseHttpCredentials() ? { httpCredentials: parseHttpCredentials() } : {}),
       ...(executablePath ? { executablePath } : {}),
       ...(this.proxyConfig ? { proxy: this.proxyConfig } : {}),
       // Playwright adds flags that block extension loading
@@ -1556,7 +1570,8 @@ export class BrowserManager {
       const fs = require('fs');
       const path = require('path');
       const extensionPath = this.findExtensionPath();
-      const launchArgs = ['--hide-crash-restore-bubble'];
+      // User-supplied extra Chromium flags (GSTACK_CHROMIUM_ARGS), no-op when unset.
+      const launchArgs = ['--hide-crash-restore-bubble', ...parseExtraChromiumArgs()];
       if (extensionPath) {
         launchArgs.push(`--disable-extensions-except=${extensionPath}`);
         launchArgs.push(`--load-extension=${extensionPath}`);
@@ -1578,6 +1593,8 @@ export class BrowserManager {
         chromiumSandbox: shouldEnableChromiumSandbox(),
         args: launchArgs,
         viewport: null,
+        // Auto-answer HTTP basic-auth (401) challenges (GSTACK_HTTP_CREDENTIALS).
+        ...(parseHttpCredentials() ? { httpCredentials: parseHttpCredentials() } : {}),
         ...(this.proxyConfig ? { proxy: this.proxyConfig } : {}),
         ignoreDefaultArgs: [
           '--disable-extensions',

--- a/browse/src/launch-overrides.ts
+++ b/browse/src/launch-overrides.ts
@@ -1,0 +1,59 @@
+/**
+ * User-supplied browser launch overrides, read from the environment so they
+ * apply without patching the source. Both the headless `launch()` and the
+ * headed `launchHeaded()` paths consult these helpers.
+ *
+ *   GSTACK_CHROMIUM_ARGS    extra Chromium command-line flags appended to the
+ *                           launch args. Accepts a JSON array
+ *                           (e.g. '["--use-fake-ui-for-media-stream"]') or a
+ *                           whitespace-separated string
+ *                           (e.g. '--flag-a --flag-b'). Empty/unset → no flags.
+ *
+ *   GSTACK_HTTP_CREDENTIALS HTTP basic-auth credentials as "user:pass", used to
+ *                           auto-answer 401 challenges (e.g. a dev environment
+ *                           behind a shared gate). Empty/unset → no credentials.
+ *
+ * Both default to a no-op, so the out-of-the-box launch behavior is unchanged.
+ */
+
+function stripWrappingQuotes(value: string): string {
+  return value.replace(/^"(.*)"$/, '$1');
+}
+
+/**
+ * Parse extra Chromium launch flags from GSTACK_CHROMIUM_ARGS.
+ * JSON array of strings → used verbatim; any other non-empty string → split on
+ * whitespace (the natural shape for CLI flags). Returns [] when unset/blank.
+ */
+export function parseExtraChromiumArgs(env: NodeJS.ProcessEnv = process.env): string[] {
+  const raw = env.GSTACK_CHROMIUM_ARGS;
+  if (!raw?.trim()) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((v) => typeof v === 'string')) {
+      return parsed.filter((v) => v.trim().length > 0);
+    }
+  } catch {
+    // Not JSON — fall through to whitespace splitting.
+  }
+  return stripWrappingQuotes(raw.trim()).split(/\s+/).filter((v) => v.length > 0);
+}
+
+export interface HttpCredentials {
+  username: string;
+  password: string;
+}
+
+/**
+ * Parse HTTP basic-auth credentials from GSTACK_HTTP_CREDENTIALS ("user:pass").
+ * Splits on the first colon so passwords may contain colons. Returns undefined
+ * when unset, blank, or missing a colon.
+ */
+export function parseHttpCredentials(
+  env: NodeJS.ProcessEnv = process.env,
+): HttpCredentials | undefined {
+  const raw = env.GSTACK_HTTP_CREDENTIALS || '';
+  const idx = raw.indexOf(':');
+  if (idx <= 0) return undefined;
+  return { username: raw.slice(0, idx), password: raw.slice(idx + 1) };
+}

--- a/browse/test/launch-overrides.test.ts
+++ b/browse/test/launch-overrides.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from 'bun:test';
+import { parseExtraChromiumArgs, parseHttpCredentials } from '../src/launch-overrides';
+
+const EMPTY_ENV = {} as NodeJS.ProcessEnv;
+
+describe('parseExtraChromiumArgs', () => {
+  test('unset → []', () => {
+    expect(parseExtraChromiumArgs(EMPTY_ENV)).toEqual([]);
+  });
+
+  test('blank/whitespace → []', () => {
+    expect(parseExtraChromiumArgs({ GSTACK_CHROMIUM_ARGS: '   ' } as NodeJS.ProcessEnv)).toEqual([]);
+  });
+
+  test('JSON array of strings → verbatim', () => {
+    expect(
+      parseExtraChromiumArgs({
+        GSTACK_CHROMIUM_ARGS: '["--use-fake-device-for-media-stream", "--use-fake-ui-for-media-stream"]',
+      } as NodeJS.ProcessEnv),
+    ).toEqual(['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream']);
+  });
+
+  test('whitespace-separated string → split into flags', () => {
+    expect(
+      parseExtraChromiumArgs({
+        GSTACK_CHROMIUM_ARGS: '--flag-a   --flag-b\t--flag-c',
+      } as NodeJS.ProcessEnv),
+    ).toEqual(['--flag-a', '--flag-b', '--flag-c']);
+  });
+
+  test('single flag → one-element array', () => {
+    expect(
+      parseExtraChromiumArgs({ GSTACK_CHROMIUM_ARGS: '--mute-audio' } as NodeJS.ProcessEnv),
+    ).toEqual(['--mute-audio']);
+  });
+
+  test('JSON array drops empty entries', () => {
+    expect(
+      parseExtraChromiumArgs({ GSTACK_CHROMIUM_ARGS: '["--a", "", "  "]' } as NodeJS.ProcessEnv),
+    ).toEqual(['--a']);
+  });
+
+  test('non-array JSON (object) → treated as whitespace string', () => {
+    // '{"a":1}' is valid JSON but not a string array, so it falls through to
+    // whitespace splitting and yields one token.
+    expect(
+      parseExtraChromiumArgs({ GSTACK_CHROMIUM_ARGS: '{"a":1}' } as NodeJS.ProcessEnv),
+    ).toEqual(['{"a":1}']);
+  });
+});
+
+describe('parseHttpCredentials', () => {
+  test('unset → undefined', () => {
+    expect(parseHttpCredentials(EMPTY_ENV)).toBeUndefined();
+  });
+
+  test('blank → undefined', () => {
+    expect(parseHttpCredentials({ GSTACK_HTTP_CREDENTIALS: '' } as NodeJS.ProcessEnv)).toBeUndefined();
+  });
+
+  test('no colon → undefined', () => {
+    expect(
+      parseHttpCredentials({ GSTACK_HTTP_CREDENTIALS: 'usernopass' } as NodeJS.ProcessEnv),
+    ).toBeUndefined();
+  });
+
+  test('leading colon (empty user) → undefined', () => {
+    expect(
+      parseHttpCredentials({ GSTACK_HTTP_CREDENTIALS: ':secret' } as NodeJS.ProcessEnv),
+    ).toBeUndefined();
+  });
+
+  test('user:pass → split on first colon', () => {
+    expect(
+      parseHttpCredentials({ GSTACK_HTTP_CREDENTIALS: 'alice:s3cr3t' } as NodeJS.ProcessEnv),
+    ).toEqual({ username: 'alice', password: 's3cr3t' });
+  });
+
+  test('password may contain colons', () => {
+    expect(
+      parseHttpCredentials({ GSTACK_HTTP_CREDENTIALS: 'alice:a:b:c' } as NodeJS.ProcessEnv),
+    ).toEqual({ username: 'alice', password: 'a:b:c' });
+  });
+});


### PR DESCRIPTION
## What

Two no-op-by-default launch overrides for the browse server's Chromium, read from the environment so users can customize the browser **without patching the source** (which `/gstack-upgrade` wipes via `git reset --hard`):

- **`GSTACK_CHROMIUM_ARGS`** — extra Chromium command-line flags appended to the launch args. Accepts a JSON array of strings (`'["--mute-audio", "--use-fake-ui-for-media-stream"]'`) or a whitespace-separated string (`'--flag-a --flag-b'`).
- **`GSTACK_HTTP_CREDENTIALS`** — HTTP basic-auth as `"user:pass"`, auto-answers 401 challenges (e.g. a dev environment behind a shared gate). Splits on the first colon so passwords may contain colons.

Both default to a no-op, so out-of-the-box launch behavior is unchanged.

## Why

There's currently no supported way to add Chromium flags or basic-auth credentials to the headed/headless browser. The only option is editing `browser-manager.ts` directly, and that edit is lost on every upgrade. This mirrors the existing `GSTACK_CLAUDE_BIN_ARGS` env-override pattern (JSON-array-or-scalar) so the convention is consistent.

## How

- Parsing extracted into a small pure module `browse/src/launch-overrides.ts` (`parseExtraChromiumArgs`, `parseHttpCredentials`) with unit tests.
- Wired into all three launch paths: headless `launch()`, headed `launchHeaded()`, and the headless→headed handoff re-launch.

## Tests

`bun test browse/test/launch-overrides.test.ts` — 13 assertions covering JSON-array, whitespace-split, single-flag, empty-drop, colon-in-password, and the unset/blank/no-colon no-op cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)