### PR TITLE
feat: validate suppressedResolvers against the resolver registry

### DIFF
--- a/scripts/host-config-export.ts
+++ b/scripts/host-config-export.ts
@@ -15,6 +15,7 @@
 
 import { ALL_HOST_CONFIGS, getHostConfig, ALL_HOST_NAMES } from '../hosts/index';
 import { validateAllConfigs } from './host-config';
+import { RESOLVERS } from './resolvers';
 import { execSync } from 'child_process';
 
 const CLI_REGEX = /^[a-z][a-z0-9_-]*$/;
@@ -82,7 +83,7 @@ switch (command) {
   }
 
   case 'validate': {
-    const errors = validateAllConfigs(ALL_HOST_CONFIGS);
+    const errors = validateAllConfigs(ALL_HOST_CONFIGS, new Set(Object.keys(RESOLVERS)));
     if (errors.length > 0) {
       for (const error of errors) {
         console.error(`ERROR: ${error}`);

--- a/scripts/host-config.ts
+++ b/scripts/host-config.ts
@@ -117,7 +117,7 @@ const NAME_REGEX = /^[a-z][a-z0-9-]*$/;
 const PATH_REGEX = /^[a-zA-Z0-9_.\/${}~-]+$/;
 const CLI_REGEX = /^[a-z][a-z0-9_-]*$/;
 
-export function validateHostConfig(config: HostConfig): string[] {
+export function validateHostConfig(config: HostConfig, validResolverNames?: ReadonlySet<string>): string[] {
   const errors: string[] = [];
 
   if (!NAME_REGEX.test(config.name)) {
@@ -152,15 +152,27 @@ export function validateHostConfig(config: HostConfig): string[] {
     errors.push(`install.linkingStrategy must be 'real-dir-symlink' or 'symlink-generated'`);
   }
 
+  // Cross-check suppressedResolvers against the known resolver names (injected to avoid a
+  // circular import on the resolver registry). A typo would otherwise silently no-op: the
+  // generator short-circuits suppressed names before the "unknown placeholder" throw, so an
+  // unknown entry never surfaces at generation time either.
+  if (validResolverNames && config.suppressedResolvers) {
+    for (const name of config.suppressedResolvers) {
+      if (!validResolverNames.has(name)) {
+        errors.push(`suppressedResolvers entry '${name}' is not a known resolver`);
+      }
+    }
+  }
+
   return errors;
 }
 
-export function validateAllConfigs(configs: HostConfig[]): string[] {
+export function validateAllConfigs(configs: HostConfig[], validResolverNames?: ReadonlySet<string>): string[] {
   const errors: string[] = [];
 
   // Per-config validation
   for (const config of configs) {
-    const configErrors = validateHostConfig(config);
+    const configErrors = validateHostConfig(config, validResolverNames);
     errors.push(...configErrors.map(e => `[${config.name}] ${e}`));
   }
 

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -24,8 +24,10 @@ import {
   openclaw,
 } from '../hosts/index';
 import { HOST_PATHS } from '../scripts/resolvers/types';
+import { RESOLVERS } from '../scripts/resolvers';
 
 const ROOT = path.resolve(import.meta.dir, '..');
+const RESOLVER_NAMES = new Set(Object.keys(RESOLVERS));
 
 // ─── hosts/index.ts ─────────────────────────────────────────
 
@@ -205,13 +207,32 @@ describe('validateHostConfig', () => {
     c.cliCommand = 'opencode;rm -rf /';
     expect(validateHostConfig(c).some(e => e.includes('cliCommand'))).toBe(true);
   });
+
+  test('valid suppressedResolvers pass when resolver names provided', () => {
+    const c = makeValid();
+    c.suppressedResolvers = ['DESIGN_OUTSIDE_VOICES', 'REVIEW_ARMY'];
+    expect(validateHostConfig(c, RESOLVER_NAMES)).toEqual([]);
+  });
+
+  test('unknown suppressedResolvers entry is caught', () => {
+    const c = makeValid();
+    c.suppressedResolvers = ['DESIGN_OUTSIDE_VOICES', 'NONEXISTENT_RESOLVER'];
+    const errors = validateHostConfig(c, RESOLVER_NAMES);
+    expect(errors.some(e => e.includes('NONEXISTENT_RESOLVER'))).toBe(true);
+  });
+
+  test('suppressedResolvers unchecked when resolver names omitted', () => {
+    const c = makeValid();
+    c.suppressedResolvers = ['TYPO_RESOLVER'];
+    expect(validateHostConfig(c)).toEqual([]);
+  });
 });
 
 // ─── validateAllConfigs ─────────────────────────────────────
 
 describe('validateAllConfigs', () => {
   test('real configs all pass validation', () => {
-    const errors = validateAllConfigs(ALL_HOST_CONFIGS);
+    const errors = validateAllConfigs(ALL_HOST_CONFIGS, RESOLVER_NAMES);
     expect(errors).toEqual([]);
   });
 
@@ -231,6 +252,12 @@ describe('validateAllConfigs', () => {
     const dup = { ...codex, name: 'dup-host', hostSubdir: '.dup', globalRoot: '.claude/skills/gstack' } as HostConfig;
     const errors = validateAllConfigs([claude, dup]);
     expect(errors.some(e => e.includes('Duplicate globalRoot'))).toBe(true);
+  });
+
+  test('unknown suppressedResolvers entry surfaces with host-name prefix', () => {
+    const bad = { ...codex, name: 'bad-host', hostSubdir: '.bad', globalRoot: '.bad/skills/gstack', suppressedResolvers: ['BOGUS_RESOLVER'] } as HostConfig;
+    const errors = validateAllConfigs([bad], RESOLVER_NAMES);
+    expect(errors.some(e => e.startsWith('[bad-host]') && e.includes('BOGUS_RESOLVER'))).toBe(true);
   });
 
   test('per-config validation errors are prefixed with host name', () => {


### PR DESCRIPTION
## Problem

A typo in any host's `suppressedResolvers` silently no-ops. `gen-skill-docs` short-circuits suppressed resolver names (returns `''`) **before** the `Unknown placeholder {{...}}` throw, and `validateHostConfig` never cross-checked the entries — so an unknown id fails neither at config validation nor at doc generation. A typo would therefore either silently leave a resolver un-suppressed (its content leaks into generated docs) or make a suppression a no-op, with zero error anywhere.

## Fix

`validateHostConfig` / `validateAllConfigs` now accept an optional set of valid resolver names and flag any `suppressedResolvers` entry that isn't one.

The names are **injected rather than imported** to avoid a circular import: `resolvers/index → resolvers/types` (`buildHostPaths()` iterates `ALL_HOST_CONFIGS`) `→ hosts/index → host-config`. Pulling `RESOLVERS` into `host-config.ts` directly would close that loop.

Wired at both validation entry points:
- the `validate` CLI subcommand (`host-config-export.ts`) passes `Object.keys(RESOLVERS)`
- the host-config test suite's "real configs all pass" guard passes the same

So a future typo fails `bun test` instead of silently leaking content into generated docs. Backward compatible: callers that don't pass resolver names (existing per-field validation tests) skip the new check.

## Verification

- `bun run scripts/host-config-export.ts validate` → `All 10 configs valid` (the strengthened guard confirms there are no existing typos)
- a bogus entry → `suppressedResolvers entry 'TYPO_RESOLVER' is not a known resolver`
- omitting resolver names → check skipped (backward-compatible)

## Test plan

- [x] `bun test test/host-config.test.ts` → **77 pass, 0 fail** (4 new `suppressedResolvers` cases: valid pass, unknown caught, host-prefixed in `validateAllConfigs`, unchecked when names omitted)
- [x] `bun test test/host-config.test.ts test/gen-skill-docs.test.ts` → **437 pass, 0 fail**
- [ ] _(maintainer)_ VERSION bump + CHANGELOG entry — left to your `/ship` flow

Independent of #1935 (different files; this branch is based on `main`).
