### PR TITLE
docs(hermes): correct cliCommand and GBrain non-suppression comments

### DIFF
--- a/hosts/hermes.ts
+++ b/hosts/hermes.ts
@@ -3,7 +3,7 @@ import type { HostConfig } from '../scripts/host-config';
 const hermes: HostConfig = {
   name: 'hermes',
   displayName: 'Hermes',
-  cliCommand: 'hermes',
+  cliCommand: 'hermes',  // installed executable is `hermes`; the repo/product is `hermes-agent` (nousresearch/hermes-agent)
   cliAliases: [],
 
   globalRoot: '.hermes/skills/gstack',
@@ -49,9 +49,12 @@ const hermes: HostConfig = {
     'CODEX_SECOND_OPINION',
     'CODEX_PLAN_REVIEW',
     'REVIEW_ARMY',
-    // GBRAIN_CONTEXT_LOAD and GBRAIN_SAVE_RESULTS are NOT suppressed.
-    // The resolvers handle GBrain-not-installed gracefully ("proceed without brain context").
-    // If Hermes has GBrain as a mod, brain features activate automatically.
+    // GBRAIN_CONTEXT_LOAD and GBRAIN_SAVE_RESULTS are NOT suppressed: Hermes is brain-capable
+    // (can carry GBrain as a mod), so with GBrain installed these activate automatically. With
+    // GBrain absent, the rendered blocks still instruct `gbrain` commands, but each ends with a
+    // fallback ("if GBrain is not available, proceed without / skip this step"), so a no-GBrain
+    // agent recovers after a failed probe rather than getting stuck. (gbrain is the only other
+    // non-suppressing host, and it always has GBrain installed.)
   ],
 
   runtimeRoot: {


### PR DESCRIPTION
Two documentation-accuracy fixes to the Hermes host config (`hosts/hermes.ts`), from a review. **Comments only — no behavioral change**, generated output is unchanged.

## 1. `cliCommand: 'hermes'` — documented as verified

The binary name had been flagged as an unverified guess. It is correct: the installed executable is `hermes`. The repo/product is `nousresearch/hermes-agent` — the package name differs from the executable, which is the likely source of the doubt. Added an inline note so it isn't re-flagged.

## 2. GBrain non-suppression comment — corrected

The comment claimed the un-suppressed `GBRAIN_CONTEXT_LOAD` / `GBRAIN_SAVE_RESULTS` resolvers "handle GBrain-not-installed gracefully (proceed without brain context)", which reads as if the rendered output were benign/empty. It isn't: the blocks instruct `gbrain search` / `get_page` / `put_page` commands and only fall back at the end. Reworded to describe the actual behavior — commands are emitted, each block ends with a fallback ("if GBrain is not available, proceed without / skip this step"), and a no-GBrain agent recovers after a failed probe rather than getting stuck.

The design itself (not suppressing these, because Hermes is brain-capable and can carry GBrain as a mod) is correct and unchanged — only the comment was inaccurate.

## Test plan

- [x] `bun run scripts/host-config-export.ts validate` → `All 10 configs valid` (config still loads/parses)
- [x] Comments only; `gen:skill-docs --host hermes` output is byte-identical

Independent of #1935 and #1936.
