### PR TITLE
feat: persist imported cookies across browse daemon restarts

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -24,6 +24,7 @@ import { TabSession, type RefEntry } from './tab-session';
 import { resolveChromiumProfile, cleanSingletonLocks } from './config';
 import { withCdpSession } from './cdp-bridge';
 import type { MemorySnapshot, MemoryStructureStats, MemoryTabSnapshot, MemoryProcess } from './memory-snapshot';
+import { loadPersistedCookies } from './cookie-persistence';
 
 /**
  * Detect whether GSTACK_CHROMIUM_PATH points at a custom Chromium build that
@@ -406,6 +407,8 @@ export class BrowserManager {
     if (Object.keys(this.extraHeaders).length > 0) {
       await this.context.setExtraHTTPHeaders(this.extraHeaders);
     }
+
+    await loadPersistedCookies(this.context);
 
     // D7: mask navigator.webdriver only. The other 3 wintermute patches
     // (plugins, languages, chrome.runtime) are intentionally NOT applied —

--- a/browse/src/cookie-persistence.ts
+++ b/browse/src/cookie-persistence.ts
@@ -1,0 +1,89 @@
+/**
+ * Cookie persistence — auto-save/load cookies across browse sessions.
+ *
+ * Imported cookies are saved to ~/.gstack/saved-cookies.json after every
+ * import/remove operation. On ephemeral context creation, saved cookies
+ * are auto-loaded so the user doesn't have to re-run /setup-browser-cookies.
+ *
+ * File format: { version: 1, savedAt: ISO string, cookies: PlaywrightCookie[] }
+ * Permissions: 0o600 (cookies contain session tokens)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { BrowserContext, Cookie } from 'playwright';
+
+const PERSIST_DIR = path.join(process.env.HOME || '/tmp', '.gstack');
+const PERSIST_PATH = path.join(PERSIST_DIR, 'saved-cookies.json');
+
+// Cookies older than 30 days are considered stale and skipped on load.
+const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface PersistedCookieFile {
+  version: number;
+  savedAt: string;
+  cookies: Cookie[];
+}
+
+/**
+ * Persist all cookies from the browser context to disk.
+ * Call after any cookie import or removal.
+ */
+export async function persistCookies(context: BrowserContext): Promise<void> {
+  try {
+    const cookies = await context.cookies();
+    const data: PersistedCookieFile = {
+      version: 1,
+      savedAt: new Date().toISOString(),
+      cookies,
+    };
+    fs.mkdirSync(PERSIST_DIR, { recursive: true });
+    // Atomic write: write to tmp then rename
+    const tmpPath = PERSIST_PATH + '.tmp';
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+    fs.renameSync(tmpPath, PERSIST_PATH);
+    console.log(`[browse] Persisted ${cookies.length} cookies to ${PERSIST_PATH}`);
+  } catch (err: any) {
+    console.warn(`[browse] Could not persist cookies: ${err.message}`);
+  }
+}
+
+/**
+ * Load persisted cookies and add them to the browser context.
+ * Call after creating an ephemeral context.
+ * Returns the number of cookies loaded, or 0 if none.
+ */
+export async function loadPersistedCookies(context: BrowserContext): Promise<number> {
+  try {
+    if (!fs.existsSync(PERSIST_PATH)) return 0;
+
+    const raw = fs.readFileSync(PERSIST_PATH, 'utf-8');
+    const data: PersistedCookieFile = JSON.parse(raw);
+
+    if (data.version !== 1 || !Array.isArray(data.cookies)) return 0;
+
+    // Skip if the file is too old or has an invalid date
+    if (data.savedAt) {
+      const ageMs = Date.now() - new Date(data.savedAt).getTime();
+      if (isNaN(ageMs) || ageMs > MAX_AGE_MS) {
+        console.warn(`[browse] Saved cookies are stale or have an invalid date — skipping auto-load. Re-import to refresh.`);
+        return 0;
+      }
+    }
+
+    // Filter out expired cookies (expires === -1 means session cookie, keep those)
+    const now = Date.now() / 1000;
+    const valid = data.cookies.filter(c =>
+      c.expires === -1 || c.expires > now
+    );
+
+    if (valid.length === 0) return 0;
+
+    await context.addCookies(valid);
+    console.log(`[browse] Auto-loaded ${valid.length} persisted cookies from previous session`);
+    return valid.length;
+  } catch (err: any) {
+    console.warn(`[browse] Could not load persisted cookies: ${err.message}`);
+    return 0;
+  }
+}

--- a/browse/src/cookie-picker-routes.ts
+++ b/browse/src/cookie-picker-routes.ts
@@ -21,6 +21,7 @@ import * as crypto from 'crypto';
 import type { BrowserManager } from './browser-manager';
 import { findInstalledBrowsers, listProfiles, listDomains, importCookies, importCookiesViaCdp, hasV20Cookies, CookieImportError, type PlaywrightCookie } from './cookie-import-browser';
 import { getCookiePickerHTML } from './cookie-picker-ui';
+import { persistCookies } from './cookie-persistence';
 
 // ─── Auth State ─────────────────────────────────────────────────
 // One-time codes for the cookie picker UI (code → expiry timestamp).
@@ -268,6 +269,7 @@ export async function handleCookiePickerRoute(
       // Add to Playwright context
       const page = bm.getActiveSession().getPage();
       await page.context().addCookies(result.cookies);
+      await persistCookies(page.context());
 
       // Track what was imported
       for (const domain of Object.keys(result.domainCounts)) {
@@ -305,6 +307,7 @@ export async function handleCookiePickerRoute(
         importedDomains.delete(domain);
         importedCounts.delete(domain);
       }
+      await persistCookies(context);
 
       console.log(`[cookie-picker] Removed cookies for ${domains.length} domains`);
 

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -19,6 +19,7 @@ import { TEMP_DIR, isPathWithin } from './platform';
 import { SAFE_DIRECTORIES } from './path-security';
 import { modifyStyle, undoModification, resetModifications, getModificationHistory } from './cdp-inspector';
 import { withCdpSession } from './cdp-bridge';
+import { persistCookies } from './cookie-persistence';
 
 /**
  * Aggressive page cleanup selectors and heuristics.
@@ -565,6 +566,7 @@ export async function handleWriteCommand(
         domain: url.hostname,
         path: '/',
       }]);
+      await persistCookies(page.context());
       return `Cookie set: ${name}=****`;
     }
 
@@ -678,6 +680,7 @@ export async function handleWriteCommand(
       }
 
       await page.context().addCookies(cookies);
+      await persistCookies(page.context());
       const importedDomains = [...new Set(cookies.map((c: any) => c.domain).filter(Boolean))];
       if (importedDomains.length > 0) bm.trackCookieImportDomains(importedDomains);
       return `Loaded ${cookies.length} cookies from ${filePath}`;
@@ -711,6 +714,7 @@ export async function handleWriteCommand(
         }
         if (result.cookies.length > 0) {
           await page.context().addCookies(result.cookies);
+          await persistCookies(page.context());
           bm.trackCookieImportDomains([domain]);
         }
         const msg = [`Imported ${result.count} cookies for ${domain} from ${browser}`];
@@ -731,6 +735,7 @@ export async function handleWriteCommand(
         const result = await importCookies(browser, allDomainNames, profile);
         if (result.cookies.length > 0) {
           await page.context().addCookies(result.cookies);
+          await persistCookies(page.context());
           bm.trackCookieImportDomains(allDomainNames);
         }
         const msg = [`Imported ${result.count} cookies across ${Object.keys(result.domainCounts).length} domains from ${browser}`];


### PR DESCRIPTION
## Problem

Cookies imported into the browse daemon (`/setup-browser-cookies`, `cookie-import`, `cookie-import-browser`, or the picker UI) live only in the ephemeral Playwright context. Every daemon restart loses them, so QA flows against auth-gated apps (e.g. a localhost app behind Auth0) need a manual cookie re-import each session. Re-importing isn't always possible: `browse cookies` output redacts session-token values by design, and the source browser may not have the cookie anymore.

## Change

New `browse/src/cookie-persistence.ts` with two helpers:

- `persistCookies(context)` — snapshots `context.cookies()` to `~/.gstack/saved-cookies.json`. Atomic write (tmp + rename), file mode `0600` since the contents are session tokens.
- `loadPersistedCookies(context)` — restores them on context creation. Skips files older than 30 days, drops expired cookies, keeps session cookies (`expires === -1`).

Wire-up:

- `write-commands.ts`: persist after every `addCookies` in the `cookie`, `cookie-import`, and both `cookie-import-browser` direct modes (`--domain`, `--all`).
- `cookie-picker-routes.ts`: persist after picker imports, and after domain removal so deletions stick.
- `browser-manager.ts`: auto-load in `launchBrowser()` after `setExtraHTTPHeaders`, before the first tab.

All persistence calls are try/catch-wrapped warn-only — a failed disk write never breaks the cookie operation itself.

## Testing

Verified on macOS (Bun runtime): imported a real Auth0 `__session` for a localhost app, stopped the daemon, relaunched headless — `[browse] Auto-loaded N persisted cookies from previous session` and the app's SSR loader authenticated without a redirect to login. Domain removal via the picker re-persists correctly.

## Notes

- Mirrors what some users patch in locally today (a community "persistent-cookies" skill); upstreaming removes the need to re-apply that patch after every gstack upgrade.
- To clear persisted state: `rm ~/.gstack/saved-cookies.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)