### PR TITLE
fix(browse): make local route waits cold-aware

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -906,7 +906,7 @@ Refs are invalidated on navigation — run `snapshot` again after `goto`.
 | `upload <sel> <file> [file2...]` | Upload file(s) |
 | `useragent <string>` | Set user agent |
 | `viewport [<WxH>] [--scale <n>]` | Set viewport size and optional deviceScaleFactor (1-3, for retina screenshots). --scale requires a context rebuild. |
-| `wait <sel|--networkidle|--load>` | Wait for element, network idle, or page load (timeout: 15s) |
+| `wait <sel|--networkidle|--load> [timeoutMs]` | Wait for element, network idle, or page load (timeout: 15s; first local dev route hit: 90s unless explicit ms is passed) |
 
 ### Inspection
 | Command | Description |

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -918,7 +918,7 @@ $B prettyscreenshot --cleanup --scroll-to ".pricing" --width 1440 ~/Desktop/hero
 | `upload <sel> <file> [file2...]` | Upload file(s) |
 | `useragent <string>` | Set user agent |
 | `viewport [<WxH>] [--scale <n>]` | Set viewport size and optional deviceScaleFactor (1-3, for retina screenshots). --scale requires a context rebuild. |
-| `wait <sel|--networkidle|--load>` | Wait for element, network idle, or page load (timeout: 15s) |
+| `wait <sel|--networkidle|--load> [timeoutMs]` | Wait for element, network idle, or page load (timeout: 15s; first local dev route hit: 90s unless explicit ms is passed) |
 
 ### Inspection
 | Command | Description |

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -18,10 +18,18 @@ import { resolveConfig, ensureStateDir, readVersionHash } from './config';
 import { parseProxyConfig, computeConfigHash, ProxyConfigError } from './proxy-config';
 import { redactProxyUrl } from './proxy-redact';
 import { spawnTerminalAgent } from './terminal-agent-control';
+import {
+  COLD_LOCAL_ROUTE_TIMEOUT_MS,
+  MAX_WAIT_TIMEOUT_MS,
+  localRouteKey,
+  parseWaitTimeout,
+} from './wait-timeouts';
 
 const config = resolveConfig();
 const IS_WINDOWS = process.platform === 'win32';
 const MAX_START_WAIT = IS_WINDOWS ? 15000 : (process.env.CI ? 30000 : 8000); // Node+Chromium takes longer on Windows
+const DEFAULT_COMMAND_REQUEST_TIMEOUT_MS = 30_000;
+const COMMAND_TIMEOUT_HEADROOM_MS = 5_000;
 
 export function resolveServerScript(
   env: Record<string, string | undefined> = process.env,
@@ -523,6 +531,26 @@ export function extractTabId(args: string[]): { tabId: number | undefined; args:
   return { tabId, args: stripped };
 }
 
+export function commandRequestTimeoutMs(command: string, args: string[]): number {
+  let timeout = DEFAULT_COMMAND_REQUEST_TIMEOUT_MS;
+
+  if (command === 'goto' && localRouteKey(args[0]) !== null) {
+    timeout = Math.max(timeout, COLD_LOCAL_ROUTE_TIMEOUT_MS + COMMAND_TIMEOUT_HEADROOM_MS);
+  }
+
+  if (command === 'wait') {
+    const selector = args[0];
+    const parsed = parseWaitTimeout(args[1]);
+    if (parsed.explicit) {
+      timeout = Math.max(timeout, parsed.timeout + COMMAND_TIMEOUT_HEADROOM_MS);
+    } else if (selector && selector !== '--load' && selector !== '--domcontentloaded' && selector !== '--networkidle') {
+      timeout = Math.max(timeout, COLD_LOCAL_ROUTE_TIMEOUT_MS + COMMAND_TIMEOUT_HEADROOM_MS);
+    }
+  }
+
+  return Math.min(timeout, MAX_WAIT_TIMEOUT_MS + COMMAND_TIMEOUT_HEADROOM_MS);
+}
+
 // ─── Command Dispatch ──────────────────────────────────────────
 async function sendCommand(state: ServerState, command: string, args: string[], retries = 0): Promise<void> {
   // Precedence: CLI --tab-id flag > BROWSE_TAB env var.
@@ -533,6 +561,7 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
   const envTab = process.env.BROWSE_TAB;
   const tabId = extracted.tabId ?? (envTab ? parseInt(envTab, 10) : undefined);
   const body = JSON.stringify({ command, args, ...(tabId !== undefined && !isNaN(tabId) ? { tabId } : {}) });
+  const requestTimeoutMs = commandRequestTimeoutMs(command, args);
 
   try {
     const resp = await fetch(`http://127.0.0.1:${state.port}/command`, {
@@ -542,7 +571,7 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
         'Authorization': `Bearer ${state.token}`,
       },
       body,
-      signal: AbortSignal.timeout(30000),
+      signal: AbortSignal.timeout(requestTimeoutMs),
     });
 
     if (resp.status === 401) {
@@ -573,14 +602,15 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
     }
   } catch (err: any) {
     if (err.name === 'AbortError') {
-      // #1781: a 30s timeout on a heavy page usually means busy, not dead.
+      // #1781: a command timeout on a heavy page usually means busy, not dead.
       // Don't kill a live server (that's what triggered the crash-loop) — report
       // and exit so the user can retry rather than losing their (headed) window.
       const ts = readState();
       const alive = ts?.pid ? isProcessAlive(ts.pid) : false;
+      const seconds = Math.round(requestTimeoutMs / 1000);
       console.error(alive
-        ? '[browse] Command timed out after 30s (server still alive — busy, not restarting). Retry, or raise load.'
-        : '[browse] Command timed out after 30s');
+        ? `[browse] Command timed out after ${seconds}s (server still alive — busy, not restarting). Retry, or raise load.`
+        : `[browse] Command timed out after ${seconds}s`);
       process.exit(1);
     }
     // Connection error — server may have crashed, OR may just be busy.

--- a/browse/src/commands.ts
+++ b/browse/src/commands.ts
@@ -125,7 +125,7 @@ export const COMMAND_DESCRIPTIONS: Record<string, { category: string; descriptio
   'type':    { category: 'Interaction', description: 'Type into focused element', usage: 'type <text>' },
   'press':   { category: 'Interaction', description: 'Press a Playwright keyboard key against the focused element. Names are case-sensitive: Enter, Tab, Escape, ArrowUp/Down/Left/Right, Backspace, Delete, Home, End, PageUp, PageDown. Modifiers combine with +: Shift+Enter, Control+A, Meta+K. Single printable chars (a, A, 1) work too. Full key list: https://playwright.dev/docs/api/class-keyboard#keyboard-press', usage: 'press <key>' },
   'scroll':  { category: 'Interaction', description: 'With a selector, smooth-scrolls the element into view. Without a selector, jumps to page bottom. No --by/--to amount option; for pixel-precise scrolling use `js window.scrollTo(0, N)`.', usage: 'scroll [sel|@ref]' },
-  'wait':    { category: 'Interaction', description: 'Wait for element, network idle, or page load (timeout: 15s)', usage: 'wait <sel|--networkidle|--load>' },
+  'wait':    { category: 'Interaction', description: 'Wait for element, network idle, or page load (timeout: 15s; first local dev route hit: 90s unless explicit ms is passed)', usage: 'wait <sel|--networkidle|--load> [timeoutMs]' },
   'upload':  { category: 'Interaction', description: 'Upload file(s)', usage: 'upload <sel> <file> [file2...]' },
   'viewport':{ category: 'Interaction', description: 'Set viewport size and optional deviceScaleFactor (1-3, for retina screenshots). --scale requires a context rebuild.', usage: 'viewport [<WxH>] [--scale <n>]' },
   'cookie':  { category: 'Interaction', description: 'Set cookie on current page domain', usage: 'cookie <name>=<value>' },

--- a/browse/src/tab-session.ts
+++ b/browse/src/tab-session.ts
@@ -63,6 +63,13 @@ export class TabSession {
   private loadedHtml: string | null = null;
   private loadedHtmlWaitUntil: SetContentWaitUntil | undefined;
 
+  // ─── Local route warm state ─────────────────────────────────
+  //
+  // Tracks local dev routes that have already completed their first-hit load in
+  // this tab. Keys are computed by write-commands as origin + pathname so
+  // query/hash variants share the same cold-route budget.
+  private warmLocalRoutes: Set<string> = new Set();
+
   constructor(page: Page) {
     this.page = page;
   }
@@ -133,6 +140,17 @@ export class TabSession {
 
   getLastSnapshot(): string | null {
     return this.lastSnapshot;
+  }
+
+  // ─── Local route warm state ─────────────────────────────────
+  isLocalRouteWarm(routeKey: string | null): boolean {
+    return routeKey !== null && this.warmLocalRoutes.has(routeKey);
+  }
+
+  markLocalRouteWarm(routeKey: string | null): void {
+    if (routeKey !== null) {
+      this.warmLocalRoutes.add(routeKey);
+    }
   }
 
   // ─── Frame context ─────────────────────────────────────────

--- a/browse/src/wait-timeouts.ts
+++ b/browse/src/wait-timeouts.ts
@@ -1,0 +1,42 @@
+export const DEFAULT_WAIT_TIMEOUT_MS = 15_000;
+export const COLD_LOCAL_ROUTE_TIMEOUT_MS = 90_000;
+export const MAX_WAIT_TIMEOUT_MS = 300_000;
+export const MIN_WAIT_TIMEOUT_MS = 1_000;
+
+export interface ParsedWaitTimeout {
+  timeout: number;
+  explicit: boolean;
+}
+
+function clampWaitTimeout(timeout: number): number {
+  return Math.min(Math.max(timeout, MIN_WAIT_TIMEOUT_MS), MAX_WAIT_TIMEOUT_MS);
+}
+
+export function parseWaitTimeout(rawTimeout: string | undefined): ParsedWaitTimeout {
+  if (rawTimeout === undefined || rawTimeout === '') {
+    return { timeout: DEFAULT_WAIT_TIMEOUT_MS, explicit: false };
+  }
+  return { timeout: clampWaitTimeout(parseInt(rawTimeout, 10) || MIN_WAIT_TIMEOUT_MS), explicit: true };
+}
+
+function isLocalDevHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === 'localhost' || normalized === '127.0.0.1'
+    || normalized === '::1' || normalized === '[::1]';
+}
+
+export function localRouteKey(rawUrl: string | null | undefined): string | null {
+  if (!rawUrl) return null;
+
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if ((url.protocol !== 'http:' && url.protocol !== 'https:') || !isLocalDevHostname(url.hostname)) {
+    return null;
+  }
+  return `${url.origin}${url.pathname}`;
+}

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -19,6 +19,31 @@ import { TEMP_DIR, isPathWithin } from './platform';
 import { SAFE_DIRECTORIES } from './path-security';
 import { modifyStyle, undoModification, resetModifications, getModificationHistory } from './cdp-inspector';
 import { withCdpSession } from './cdp-bridge';
+import {
+  COLD_LOCAL_ROUTE_TIMEOUT_MS,
+  DEFAULT_WAIT_TIMEOUT_MS,
+  localRouteKey,
+  parseWaitTimeout,
+  type ParsedWaitTimeout,
+} from './wait-timeouts';
+
+export interface RouteAwareTimeout {
+  timeout: number;
+  routeKey: string | null;
+  cold: boolean;
+}
+
+export function routeAwareTimeoutForUrl(
+  session: TabSession,
+  rawUrl: string | null | undefined,
+  parsedTimeout: ParsedWaitTimeout = parseWaitTimeout(undefined)
+): RouteAwareTimeout {
+  const routeKey = localRouteKey(rawUrl);
+  if (!parsedTimeout.explicit && routeKey !== null && !session.isLocalRouteWarm(routeKey)) {
+    return { timeout: COLD_LOCAL_ROUTE_TIMEOUT_MS, routeKey, cold: true };
+  }
+  return { timeout: parsedTimeout.timeout, routeKey, cold: false };
+}
 
 /**
  * Aggressive page cleanup selectors and heuristics.
@@ -149,7 +174,9 @@ export async function handleWriteCommand(
       // must not leave stale content that could resurrect on a later context recreation.
       session.clearLoadedHtml();
       const normalizedUrl = await validateNavigationUrl(url);
-      const response = await page.goto(normalizedUrl, { waitUntil: 'domcontentloaded', timeout: 15000 });
+      const timeoutPlan = routeAwareTimeoutForUrl(session, normalizedUrl);
+      const response = await page.goto(normalizedUrl, { waitUntil: 'domcontentloaded', timeout: timeoutPlan.timeout });
+      session.markLocalRouteWarm(timeoutPlan.routeKey);
       const status = response?.status() || 'unknown';
       return `Navigated to ${normalizedUrl} (${status})`;
     }
@@ -157,21 +184,21 @@ export async function handleWriteCommand(
     case 'back': {
       if (inFrame) throw new Error('Cannot use back inside a frame. Run \'frame main\' first.');
       session.clearLoadedHtml();
-      await page.goBack({ waitUntil: 'domcontentloaded', timeout: 15000 });
+      await page.goBack({ waitUntil: 'domcontentloaded', timeout: DEFAULT_WAIT_TIMEOUT_MS });
       return `Back → ${page.url()}`;
     }
 
     case 'forward': {
       if (inFrame) throw new Error('Cannot use forward inside a frame. Run \'frame main\' first.');
       session.clearLoadedHtml();
-      await page.goForward({ waitUntil: 'domcontentloaded', timeout: 15000 });
+      await page.goForward({ waitUntil: 'domcontentloaded', timeout: DEFAULT_WAIT_TIMEOUT_MS });
       return `Forward → ${page.url()}`;
     }
 
     case 'reload': {
       if (inFrame) throw new Error('Cannot use reload inside a frame. Run \'frame main\' first.');
       session.clearLoadedHtml();
-      await page.reload({ waitUntil: 'domcontentloaded', timeout: 15000 });
+      await page.reload({ waitUntil: 'domcontentloaded', timeout: DEFAULT_WAIT_TIMEOUT_MS });
       return `Reloaded ${page.url()}`;
     }
 
@@ -472,9 +499,7 @@ export async function handleWriteCommand(
       const selector = args[0];
       if (!selector) throw new Error('Usage: browse wait <selector|--networkidle|--load|--domcontentloaded>');
       if (selector === '--networkidle') {
-        const MAX_WAIT_MS = 300_000;
-        const MIN_WAIT_MS = 1_000;
-        const timeout = Math.min(Math.max(args[1] ? parseInt(args[1], 10) || MIN_WAIT_MS : 15000, MIN_WAIT_MS), MAX_WAIT_MS);
+        const { timeout } = parseWaitTimeout(args[1]);
         await page.waitForLoadState('networkidle', { timeout });
         return 'Network idle';
       }
@@ -486,15 +511,14 @@ export async function handleWriteCommand(
         await page.waitForLoadState('domcontentloaded');
         return 'DOM content loaded';
       }
-      const MAX_WAIT_MS = 300_000;
-      const MIN_WAIT_MS = 1_000;
-      const timeout = Math.min(Math.max(args[1] ? parseInt(args[1], 10) || MIN_WAIT_MS : 15000, MIN_WAIT_MS), MAX_WAIT_MS);
+      const timeoutPlan = routeAwareTimeoutForUrl(session, page.url(), parseWaitTimeout(args[1]));
       const resolved = await session.resolveRef(selector);
       if ('locator' in resolved) {
-        await resolved.locator.waitFor({ state: 'visible', timeout });
+        await resolved.locator.waitFor({ state: 'visible', timeout: timeoutPlan.timeout });
       } else {
-        await target.locator(resolved.selector).waitFor({ state: 'visible', timeout });
+        await target.locator(resolved.selector).waitFor({ state: 'visible', timeout: timeoutPlan.timeout });
       }
+      session.markLocalRouteWarm(timeoutPlan.routeKey);
       return `Element ${selector} appeared`;
     }
 

--- a/browse/test/commands.test.ts
+++ b/browse/test/commands.test.ts
@@ -8,9 +8,19 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { startTestServer } from './test-server';
 import { BrowserManager } from '../src/browser-manager';
-import { resolveServerScript } from '../src/cli';
+import { TabSession } from '../src/tab-session';
+import { commandRequestTimeoutMs, resolveServerScript } from '../src/cli';
 import { handleReadCommand as _handleReadCommand, parseOutArgs, hasOutArg, resultToString } from '../src/read-commands';
-import { handleWriteCommand as _handleWriteCommand } from '../src/write-commands';
+import {
+  handleWriteCommand as _handleWriteCommand,
+  routeAwareTimeoutForUrl,
+} from '../src/write-commands';
+import {
+  COLD_LOCAL_ROUTE_TIMEOUT_MS,
+  DEFAULT_WAIT_TIMEOUT_MS,
+  localRouteKey,
+  parseWaitTimeout,
+} from '../src/wait-timeouts';
 import { handleMetaCommand } from '../src/meta-commands';
 import { consoleBuffer, networkBuffer, dialogBuffer, addConsoleEntry, addNetworkEntry, addDialogEntry, CircularBuffer } from '../src/buffers';
 import * as fs from 'fs';
@@ -79,6 +89,108 @@ describe('resultToString — byte-for-byte with pre-refactor behavior', () => {
   test('primitives use String()', () => {
     expect(resultToString(42)).toBe('42');
     expect(resultToString(true)).toBe('true');
+  });
+});
+
+describe('cold local route timeout selection', () => {
+  test('local first-hit goto uses 90s, second hit uses 15s', async () => {
+    const timeouts: number[] = [];
+    let currentUrl = 'about:blank';
+    const page = {
+      goto: async (url: string, opts: { timeout: number }) => {
+        timeouts.push(opts.timeout);
+        currentUrl = url;
+        return { status: () => 200 };
+      },
+      url: () => currentUrl,
+    };
+    const session = new TabSession(page as any);
+
+    await _handleWriteCommand('goto', ['http://127.0.0.1:3000/admin/products?view=all#top'], session, {} as BrowserManager);
+    await _handleWriteCommand('goto', ['http://127.0.0.1:3000/admin/products?view=archived#bottom'], session, {} as BrowserManager);
+
+    expect(timeouts).toEqual([COLD_LOCAL_ROUTE_TIMEOUT_MS, DEFAULT_WAIT_TIMEOUT_MS]);
+  });
+
+  test('query and hash variants share the same local route key', () => {
+    expect(localRouteKey('http://localhost:3000/admin/products?view=all#top'))
+      .toBe('http://localhost:3000/admin/products');
+    expect(localRouteKey('http://localhost:3000/admin/products?view=archived#bottom'))
+      .toBe('http://localhost:3000/admin/products');
+    expect(localRouteKey('http://[::1]:3000/admin/products?x=1#y'))
+      .toBe('http://[::1]:3000/admin/products');
+  });
+
+  test('remote URLs stay on the normal 15s default', () => {
+    const session = new TabSession({} as any);
+    const plan = routeAwareTimeoutForUrl(session, 'https://example.com/admin/products');
+    expect(plan.timeout).toBe(DEFAULT_WAIT_TIMEOUT_MS);
+    expect(plan.cold).toBe(false);
+    expect(plan.routeKey).toBeNull();
+  });
+
+  test('explicit timeout overrides cold local wait behavior', async () => {
+    let observedTimeout = 0;
+    const page = {
+      url: () => 'http://127.0.0.1:3000/admin/products',
+      locator: () => ({
+        waitFor: async (opts: { timeout: number }) => { observedTimeout = opts.timeout; },
+      }),
+    };
+    const session = new TabSession(page as any);
+
+    await _handleWriteCommand('wait', ['#products-marker', '12345'], session, {} as BrowserManager);
+
+    expect(observedTimeout).toBe(12345);
+    expect(parseWaitTimeout('999999').timeout).toBe(300_000);
+  });
+
+  test('failed navigation does not mark the route warm', async () => {
+    const page = {
+      goto: async () => { throw new Error('simulated navigation failure'); },
+      url: () => 'about:blank',
+    };
+    const session = new TabSession(page as any);
+    const url = 'http://127.0.0.1:3000/admin/products';
+    const routeKey = localRouteKey(url);
+
+    await expect(_handleWriteCommand('goto', [url], session, {} as BrowserManager))
+      .rejects.toThrow(/simulated navigation failure/);
+
+    expect(session.isLocalRouteWarm(routeKey)).toBe(false);
+  });
+
+  test('mocked slow local first-hit navigation succeeds because default budget is cold-aware', async () => {
+    let observedTimeout = 0;
+    const page = {
+      goto: async (_url: string, opts: { timeout: number }) => {
+        observedTimeout = opts.timeout;
+        if (opts.timeout <= DEFAULT_WAIT_TIMEOUT_MS) {
+          throw new Error('simulated route compile exceeded 15s');
+        }
+        return { status: () => 200 };
+      },
+      url: () => 'about:blank',
+    };
+    const session = new TabSession(page as any);
+
+    const result = await _handleWriteCommand('goto', ['http://127.0.0.1:3000/slow-cold-route'], session, {} as BrowserManager);
+
+    expect(observedTimeout).toBe(COLD_LOCAL_ROUTE_TIMEOUT_MS);
+    expect(result).toContain('Navigated to');
+  });
+
+  test('CLI command request timeout has cold-route headroom', () => {
+    expect(commandRequestTimeoutMs('goto', ['http://127.0.0.1:3000/admin/products']))
+      .toBe(COLD_LOCAL_ROUTE_TIMEOUT_MS + 5_000);
+    expect(commandRequestTimeoutMs('goto', ['https://example.com/admin/products']))
+      .toBe(30_000);
+    expect(commandRequestTimeoutMs('wait', ['text=Products']))
+      .toBe(COLD_LOCAL_ROUTE_TIMEOUT_MS + 5_000);
+    expect(commandRequestTimeoutMs('wait', ['text=Products', '60000']))
+      .toBe(65_000);
+    expect(commandRequestTimeoutMs('wait', ['text=Products', '999999']))
+      .toBe(305_000);
   });
 });
 

--- a/gstack/llms.txt
+++ b/gstack/llms.txt
@@ -109,7 +109,7 @@ Run with `browse <command> [args]`. Full reference: `browse/SKILL.md`.
 - `upload <sel> <file> [file2...]`: Upload file(s)
 - `useragent <string>`: Set user agent
 - `viewport [<WxH>] [--scale <n>]`: Set viewport size and optional deviceScaleFactor (1-3, for retina screenshots).
-- `wait <sel|--networkidle|--load>`: Wait for element, network idle, or page load (timeout: 15s)
+- `wait <sel|--networkidle|--load> [timeoutMs]`: Wait for element, network idle, or page load (timeout: 15s; first local dev route hit: 90s unless explicit ms is passed)
 
 ### Meta
 - `chain  (JSON via stdin)`: Run a sequence of commands from JSON on stdin.


### PR DESCRIPTION
## Summary
- Add shared browse wait constants: default 15s, cold local route 90s, max cap 300s.
- Track per-tab local route warm state keyed by `origin + pathname` for `localhost`, `127.0.0.1`, and `::1`; query/hash variants share warmth.
- Apply the cold local first-hit budget to `goto` and selector `wait` when no explicit timeout is passed.
- Extend the CLI `/command` request timeout for cold local `goto` / selector `wait` and explicit wait timeouts, so the transport no longer aborts before the harness budget.
- Keep remote/default waits at 15s and explicit `browse wait <selector> <ms>` authoritative.
- Regenerate browse command docs/llms metadata.

## Validation
- `bun test --timeout 60000 browse/test/commands.test.ts` → 250 passed
- `bun run build` → passed; rebuilt ignored `browse/dist/*` artifacts locally

## Cold Lease Proof
- OHN main proof worktree fast-forwarded to `origin/main` commit `bcfd8ef`; cleared `.next` immediately before start.
- Started fresh lease-backed dev server with `npm run setup:dogfood-workspace -- run --modules database,mail --tunnel wss`.
- Lease: `wlease_orderhubnow_limeapple_20260610T192525_678b89eb`
- DB: `teamdog_warm_orderhubnow_limeapple_058_golden_2026_06_10T03_10_53Z`
- Dev URL: `http://localhost:3011`
- Minted admin cookie with `npm run dogfood:admin-login -- --base http://localhost:3011 --json`; set it in isolated browse state.
- First protected route hit: `browse goto http://localhost:3011/admin/products` with no custom timeout → `Navigated to http://localhost:3011/admin/products (200)`.
- Next cold compile evidence: `GET /admin/products 200 in 4.1s (compile: 2.9s, proxy.ts: 29ms, render: 1185ms)`.
- Marker wait with no custom timeout: `browse wait 'h1:has-text("Products")'` → `Element h1:has-text("Products") appeared`, elapsed `240ms`.
- Literal `browse wait "text=Products"` reached the page but failed as ambiguous (`Selector matched multiple elements`), so the proof used the unique heading marker.
- Release: explicit `npm run dogfood:release` returned DB/mail/linear released; inbound release reported failed. Proof-local WSS sidecar/cloudflared were then killed and verified gone.
