### PR TITLE
fix(browse): honor GSTACK_CHROMIUM_PATH in headless launch()

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -377,6 +377,10 @@ export class BrowserManager {
       // on Linux root/CI/container, where the sandbox requires unprivileged user
       // namespaces that aren't available.
       chromiumSandbox: shouldEnableChromiumSandbox(),
+      // Honor GSTACK_CHROMIUM_PATH here too. The bundled Playwright
+      // chrome-headless-shell can't load shared libs on NixOS; pointing at a
+      // system Chromium fixes headless rendering (e.g. make-pdf).
+      ...(process.env.GSTACK_CHROMIUM_PATH ? { executablePath: process.env.GSTACK_CHROMIUM_PATH } : {}),
       ...(launchArgs.length > 0 ? { args: launchArgs } : {}),
       ...(this.proxyConfig ? { proxy: this.proxyConfig } : {}),
     });


### PR DESCRIPTION
## Problem

The headed `launchPersistentContext()` path honors `GSTACK_CHROMIUM_PATH`, but the headless `chromium.launch()` path does not. There is no way to point headless rendering at a custom Chromium.

On NixOS this breaks `make-pdf` (and any headless screenshot/PDF flow): Playwright's bundled `chrome-headless-shell` is FHS-linked and can't load its shared libs, so the daemon fails to launch Chromium and `make-pdf` produces no output. Setting `GSTACK_CHROMIUM_PATH` to a system Chromium has no effect because the headless path ignores it.

## Fix

Mirror the headed path: pass `executablePath` to `chromium.launch()` when `GSTACK_CHROMIUM_PATH` is set. Four lines, gated on the env var so default behavior is unchanged.

```ts
chromiumSandbox: shouldEnableChromiumSandbox(),
...(process.env.GSTACK_CHROMIUM_PATH ? { executablePath: process.env.GSTACK_CHROMIUM_PATH } : {}),
```

## Verification

On NixOS with `GSTACK_CHROMIUM_PATH` pointing at a Nix-built `ungoogled-chromium`, `make-pdf generate` now renders a correct multi-element PDF (heading, bold, inline code, lists) — confirmed via `pdftotext` extraction and a rendered PNG. Without the patch the same setup fails at Chromium launch.

## Note (separate issue)

`make-pdf`'s `browseClient` binary discovery (argv[0]-based) misresolves for the Bun-compiled `pdf` binary and needs `GSTACK_BROWSE_BIN` pinned to reliably use the right daemon. That's independent of this change and not addressed here.