### PR TITLE
fix(team-init): emit PreToolUse deny in hookSpecificOutput shape

### DIFF
--- a/bin/gstack-team-init
+++ b/bin/gstack-team-init
@@ -127,7 +127,7 @@ Install it:
 
 Then restart your AI coding tool.
 MSG
-  echo '{"permissionDecision":"deny","message":"gstack is required but not installed. See stderr for install instructions."}'
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"gstack is required but not installed. See stderr for install instructions."}}'
   exit 0
 fi
 

--- a/test/team-mode.test.ts
+++ b/test/team-mode.test.ts
@@ -240,6 +240,29 @@ describe('gstack-team-init', () => {
     expect(stat.mode & 0o111).toBeGreaterThan(0);
   });
 
+  test('required: hook emits PreToolUse deny in hookSpecificOutput shape when gstack is missing', () => {
+    run(`${TEAM_INIT} required`, { cwd: tmpDir });
+    const hookPath = path.join(tmpDir, '.claude', 'hooks', 'check-gstack.sh');
+
+    // HOME without gstack → must deny via hookSpecificOutput (top-level
+    // permissionDecision is ignored by Claude Code's PreToolUse schema)
+    const fakeHome = path.join(tmpDir, 'fake-home');
+    fs.mkdirSync(fakeHome, { recursive: true });
+    const denied = run(`bash ${hookPath}`, { env: { HOME: fakeHome } });
+    expect(denied.exitCode).toBe(0);
+    const deniedJson = JSON.parse(denied.stdout.trim());
+    expect(deniedJson.hookSpecificOutput.hookEventName).toBe('PreToolUse');
+    expect(deniedJson.hookSpecificOutput.permissionDecision).toBe('deny');
+    expect(deniedJson.hookSpecificOutput.permissionDecisionReason).toContain('gstack is required');
+
+    // HOME with gstack installed → no-op {}
+    const homeWithGstack = path.join(tmpDir, 'home-with-gstack');
+    fs.mkdirSync(path.join(homeWithGstack, '.claude', 'skills', 'gstack', 'bin'), { recursive: true });
+    const allowed = run(`bash ${hookPath}`, { env: { HOME: homeWithGstack } });
+    expect(allowed.exitCode).toBe(0);
+    expect(JSON.parse(allowed.stdout.trim())).toEqual({});
+  });
+
   test('required: creates project settings.json with PreToolUse hook', () => {
     run(`${TEAM_INIT} required`, { cwd: tmpDir });
     const settingsPath = path.join(tmpDir, '.claude', 'settings.json');


### PR DESCRIPTION
## Problem

The `check-gstack.sh` enforcement hook generated by `bin/gstack-team-init required` prints its deny decision as a **top-level** `permissionDecision`:

```json
{"permissionDecision":"deny","message":"gstack is required but not installed. ..."}
```

Claude Code's PreToolUse decision control only reads `hookSpecificOutput.permissionDecision` (with `hookEventName: "PreToolUse"`) — the deprecated top-level fields are `decision`/`reason`, not `permissionDecision`/`message`. The output is therefore treated as a no-op, and **the required-mode gate never actually blocks** skill usage when gstack is missing. Teams adopting `gstack-team-init required` get an enforcement hook that silently enforces nothing.

Found via `codex review` while rolling team mode out across our org's repos; verified against Claude Code's hook output validation (it rejects `hookSpecificOutput` without `hookEventName` and ignores unknown top-level fields).

## Fix

Emit the deny in the supported shape — the same one #1509 adopts for `careful`/`freeze`:

```json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"gstack is required but not installed. See stderr for install instructions."}}
```

The stderr install instructions are unchanged.

## Tests

Added a test that runs `gstack-team-init required` and then **executes the generated hook** in both scenarios:
- `HOME` without gstack → structured `hookSpecificOutput` deny
- `HOME` with gstack installed → `{}` no-op

```
bun test test/team-mode.test.ts
 25 pass, 0 fail (57 expect() calls)
```

## Note (out of scope)

The settings matcher generated by team-init only gates the `Skill` tool, so plain `Read`/`Edit`/`Bash` work proceeds without gstack. If the intent of required mode is to gate *all* AI-assisted work, a catch-all matcher might be worth considering — left out of this PR since it's a design decision (and `team-mode.test.ts` pins `matcher === 'Skill'`). Happy to follow up if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)