### PR TITLE
fix browse lifecycle on Windows

### DIFF
--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -91,6 +91,7 @@ globalThis.Bun = {
       stdio,
       env: options.env,
       cwd: options.cwd,
+      windowsHide: true,
     });
 
     return {

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -143,7 +143,7 @@ async function killServer(pid: number): Promise<void> {
     try {
       Bun.spawnSync(
         ['taskkill', '/PID', String(pid), '/T', '/F'],
-        { stdout: 'pipe', stderr: 'pipe', timeout: 5000 }
+        { stdout: 'pipe', stderr: 'pipe', timeout: 5000, windowsHide: true }
       );
     } catch (err: any) {
       if (err?.code !== 'ENOENT') throw err;
@@ -323,9 +323,9 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     const launcherCode =
       `const{spawn}=require('child_process');` +
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
-      `{detached:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
+      `{detached:true,stdio:['ignore','ignore','ignore'],windowsHide:true,env:Object.assign({},process.env,` +
       `${extraEnvStr})}).unref()`;
-    Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'] });
+    Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'], windowsHide: true });
   } else {
     // macOS/Linux: Bun.spawn().unref() only removes the child from Bun's event
     // loop — it does NOT call setsid(), so the spawned server stays in the
@@ -499,6 +499,75 @@ async function ensureServer(flags?: GlobalFlags): Promise<ServerState> {
   } finally {
     releaseLock();
   }
+}
+
+async function printPassiveStatus(): Promise<void> {
+  const state = readState();
+  if (!state) {
+    console.log('Status: stopped');
+    return;
+  }
+
+  try {
+    const resp = await fetch(`http://127.0.0.1:${state.port}/status`, {
+      headers: { 'Authorization': `Bearer ${state.token}` },
+      signal: AbortSignal.timeout(2000),
+    });
+    if (resp.ok) {
+      const body = await resp.json() as any;
+      console.log([
+        `Status: ${body.status || 'unknown'}`,
+        `Mode: ${body.mode || state.mode || 'unknown'}`,
+        `URL: ${body.url || '(unknown)'}`,
+        `Tabs: ${body.tabs ?? '?'}`,
+        `PID: ${body.pid || state.pid}`,
+      ].join('\n'));
+      return;
+    }
+  } catch {
+    // Fall through to stopped/unavailable summary.
+  }
+
+  console.log([
+    'Status: stopped',
+    `PID: ${state.pid}`,
+    `Port: ${state.port}`,
+    'Reason: daemon is not responding',
+  ].join('\n'));
+}
+
+async function stopExistingServer(): Promise<void> {
+  const state = readState();
+  if (!state) {
+    console.log('No browse server running.');
+    return;
+  }
+
+  if (await isServerHealthy(state.port)) {
+    try {
+      await fetch(`http://127.0.0.1:${state.port}/command`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${state.token}`,
+        },
+        body: JSON.stringify({ command: 'stop', args: [] }),
+        signal: AbortSignal.timeout(1000),
+      });
+    } catch {
+      // The daemon often exits before it can return the HTTP response.
+    }
+    await Bun.sleep(500);
+  }
+
+  if (state.pid && isProcessAlive(state.pid)) {
+    await killServer(state.pid);
+  }
+
+  await killOrphanChromium();
+  cleanChromiumProfileLocks();
+  safeUnlinkQuiet(config.stateFile);
+  console.log('Browse server stopped.');
 }
 
 /**
@@ -1038,6 +1107,17 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
 
   const command = args[0];
   const commandArgs = args.slice(1);
+
+  // Passive lifecycle commands must not create a daemon.
+  if (command === 'status') {
+    await printPassiveStatus();
+    process.exit(0);
+  }
+
+  if (command === 'stop') {
+    await stopExistingServer();
+    process.exit(0);
+  }
 
   // ─── Headed Connect (pre-server command) ────────────────────
   // connect must be handled BEFORE ensureServer() because it needs

--- a/browse/src/cookie-import-browser.ts
+++ b/browse/src/cookie-import-browser.ts
@@ -529,6 +529,7 @@ async function dpapiDecrypt(encryptedBytes: Buffer): Promise<Buffer> {
     stdin: 'pipe',
     stdout: 'pipe',
     stderr: 'pipe',
+    windowsHide: true,
   });
 
   proc.stdin.write(encryptedBytes.toString('base64'));
@@ -779,6 +780,7 @@ function isBrowserRunning(browserName: string): Promise<boolean> {
   return new Promise((resolve) => {
     const proc = Bun.spawn(['tasklist', '/FI', `IMAGENAME eq ${exe}`, '/NH'], {
       stdout: 'pipe', stderr: 'pipe',
+      windowsHide: true,
     });
     proc.exited.then(async () => {
       const out = await new Response(proc.stdout).text();
@@ -869,7 +871,7 @@ export async function importCookiesViaCdp(
     '--disable-extensions',
     '--disable-sync',
     '--no-default-browser-check',
-  ], { stdout: 'pipe', stderr: 'pipe' });
+  ], { stdout: 'pipe', stderr: 'pipe', windowsHide: true });
 
   // Wait for Chrome to start, then find a page target's WebSocket URL.
   // Network.getAllCookies is only available on page targets, not browser.

--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -5,7 +5,7 @@
  *   Bun.serve HTTP on localhost → routes commands to Playwright
  *   Console/network/dialog buffers: CircularBuffer in-memory + async disk flush
  *   Chromium crash → server EXITS with clear error (CLI auto-restarts)
- *   Auto-shutdown after BROWSE_IDLE_TIMEOUT (default 30 min)
+ *   Auto-shutdown after BROWSE_IDLE_TIMEOUT (default 30 min, 5 min on Windows)
  *
  * State:
  *   State file: <project-root>/.gstack/browse.json (set via BROWSE_STATE_FILE env)
@@ -140,7 +140,8 @@ function sanitizeAuthToken(raw: string | undefined): string | null {
 // and factory-scoped validateAuth closes over the same value. start() reads
 // env once via resolveConfigFromEnv() and threads the result through.
 const BROWSE_PORT = parseInt(process.env.BROWSE_PORT || '0', 10);
-const IDLE_TIMEOUT_MS = parseInt(process.env.BROWSE_IDLE_TIMEOUT || '1800000', 10); // 30 min
+const DEFAULT_IDLE_TIMEOUT_MS = process.platform === 'win32' ? 300_000 : 1_800_000;
+const IDLE_TIMEOUT_MS = parseInt(process.env.BROWSE_IDLE_TIMEOUT || String(DEFAULT_IDLE_TIMEOUT_MS), 10);
 
 /**
  * Port the local listener bound to. Set once the daemon picks a port.
@@ -1800,6 +1801,28 @@ export function buildFetchHandler(cfg: ServerConfig): ServerHandle {
           // `pty-session-cookie.ts` for the rationale (codex outside-voice
           // finding #2: don't reuse this endpoint for shell auth).
           terminalPort: readTerminalPort(),
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Status snapshot — auth required, does NOT reset idle timer.
+      if (url.pathname === '/status' && req.method === 'GET') {
+        if (!validateAuth(req)) {
+          return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+            status: 401,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        const healthy = await browserManager.isHealthy();
+        return new Response(JSON.stringify({
+          status: healthy ? 'healthy' : 'unhealthy',
+          mode: browserManager.getConnectionMode(),
+          uptime: Math.floor((Date.now() - startTime) / 1000),
+          url: browserManager.getCurrentUrl(),
+          tabs: browserManager.getTabCount(),
+          pid: process.pid,
         }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },

--- a/browse/test/cli-lifecycle.test.ts
+++ b/browse/test/cli-lifecycle.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from 'bun:test';
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+function cliEnv(stateFile: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  env.BROWSE_STATE_FILE = stateFile;
+  return env;
+}
+
+function runCli(args: string[], stateFile: string): Promise<{ code: number; stdout: string; stderr: string }> {
+  const cliPath = path.resolve(__dirname, '../src/cli.ts');
+  return new Promise((resolve) => {
+    const proc = spawn('bun', ['run', cliPath, ...args], {
+      timeout: 15_000,
+      env: cliEnv(stateFile),
+    });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (data) => stdout += data.toString());
+    proc.stderr.on('data', (data) => stderr += data.toString());
+    proc.on('close', (code) => resolve({ code: code ?? 1, stdout, stderr }));
+  });
+}
+
+describe('CLI lifecycle commands', () => {
+  test('status with no state does not start a daemon', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-cli-lifecycle-'));
+    const stateFile = path.join(dir, 'browse.json');
+    try {
+      const result = await runCli(['status'], stateFile);
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Status: stopped');
+      expect(result.stderr).not.toContain('Starting server');
+      expect(fs.existsSync(stateFile)).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test('status on a dead state file does not start a daemon', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-cli-lifecycle-'));
+    const stateFile = path.join(dir, 'browse.json');
+    try {
+      fs.writeFileSync(stateFile, JSON.stringify({
+        port: 1,
+        token: 'fake',
+        pid: 999999,
+      }));
+
+      const result = await runCli(['status'], stateFile);
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Status: stopped');
+      expect(result.stdout).toContain('Reason: daemon is not responding');
+      expect(result.stderr).not.toContain('Starting server');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 20_000);
+});

--- a/browse/test/commands.test.ts
+++ b/browse/test/commands.test.ts
@@ -14,7 +14,6 @@ import { handleWriteCommand as _handleWriteCommand } from '../src/write-commands
 import { handleMetaCommand } from '../src/meta-commands';
 import { consoleBuffer, networkBuffer, dialogBuffer, addConsoleEntry, addNetworkEntry, addDialogEntry, CircularBuffer } from '../src/buffers';
 import * as fs from 'fs';
-import { spawn } from 'child_process';
 import * as path from 'path';
 
 // Thin wrappers that bridge old test calls (bm as 3rd arg) to new signatures (session + bm)
@@ -860,50 +859,6 @@ describe('CLI server script resolution', () => {
 
     fs.rmSync(root, { recursive: true, force: true });
   });
-});
-
-// ─── CLI lifecycle ──────────────────────────────────────────────
-
-describe('CLI lifecycle', () => {
-  test('dead state file triggers a clean restart', async () => {
-    const stateFile = `/tmp/browse-test-state-${Date.now()}.json`;
-    fs.writeFileSync(stateFile, JSON.stringify({
-      port: 1,
-      token: 'fake',
-      pid: 999999,
-    }));
-
-    const cliPath = path.resolve(__dirname, '../src/cli.ts');
-    const cliEnv: Record<string, string> = {};
-    for (const [k, v] of Object.entries(process.env)) {
-      if (v !== undefined) cliEnv[k] = v;
-    }
-    cliEnv.BROWSE_STATE_FILE = stateFile;
-    const result = await new Promise<{ code: number; stdout: string; stderr: string }>((resolve) => {
-      const proc = spawn('bun', ['run', cliPath, 'status'], {
-        timeout: 15000,
-        env: cliEnv,
-      });
-      let stdout = '';
-      let stderr = '';
-      proc.stdout.on('data', (d) => stdout += d.toString());
-      proc.stderr.on('data', (d) => stderr += d.toString());
-      proc.on('close', (code) => resolve({ code: code ?? 1, stdout, stderr }));
-    });
-
-    let restartedPid: number | null = null;
-    if (fs.existsSync(stateFile)) {
-      restartedPid = JSON.parse(fs.readFileSync(stateFile, 'utf-8')).pid;
-      fs.unlinkSync(stateFile);
-    }
-    if (restartedPid) {
-      try { process.kill(restartedPid, 'SIGTERM'); } catch {}
-    }
-
-    expect(result.code).toBe(0);
-    expect(result.stdout).toContain('Status: healthy');
-    expect(result.stderr).toContain('Starting server');
-  }, 20000);
 });
 
 // ─── Buffer bounds ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the Windows browse lifecycle path so status/stop do not accidentally start or leave behind a headless daemon, and hides gstack-owned helper subprocess windows on Windows.

## What changed

- make `browse status` passive by reading the state file and querying a new authenticated `/status` endpoint instead of calling `ensureServer()`
- make `browse stop` operate on an existing state file without autostarting a daemon
- add `windowsHide: true` to gstack-owned Windows subprocess launches, including taskkill, Node daemon launch, Bun polyfill subprocesses, and cookie-import helpers
- shorten the default Windows headless idle timeout to 5 minutes while keeping non-Windows at 30 minutes
- add focused CLI lifecycle tests that verify passive status behavior without booting the full browser integration suite

## Why

On Windows, browse commands can surface short-lived PowerShell/console windows while agents are active. Separately, `browse status` previously went through the normal server setup path, so checking whether a daemon existed could create one. That made stale or stray daemon investigation harder and could keep the chrome-headless-shell process cycling after a session appeared to be done.

This addresses the behavior reported in #1835 and #1784.

## Validation

- `bun test browse/test/cli-lifecycle.test.ts browse/test/cli-setsid-daemonize.test.ts browse/test/cookie-import-browser.test.ts`
- `git diff --cached --check`

I also smoke-tested the patched local install on Windows before extracting this PR: `browse status` with no daemon stayed stopped, `browse goto https://example.com` launched successfully, and `browse stop` removed the daemon and child headless Chromium processes.

## Notes

This PR only changes tracked gstack source. I intentionally did not include a direct local patch to `node_modules/playwright-core`; if Playwright's internal process launcher still contributes visible windows after this, that should be handled as a separate build-time patch or upstream Playwright issue.
