### PR TITLE
feat(codex): document native image generation in /codex skill

### DIFF
--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -1514,6 +1514,29 @@ or `/codex challenge -m gpt-5.2`), pass the `-m` flag through to codex.
 
 ---
 
+## Image Generation
+
+Codex ships a native image-generation tool (`image_gen.imagegen`) — it produces real
+raster images (illustrations, photo-style renders, diagrams) from a text prompt, not
+just code that draws SVGs. Verified by having Codex enumerate its tools and generate
+a PNG. Image *input* is separate and always available (`codex -i screenshot.png`).
+
+When a consult asks Codex to MAKE an image (not analyze one):
+
+1. **Swap the sandbox.** The tool call works in any sandbox, but saving the result
+   needs write access — run that exec with `-s workspace-write` instead of `-s read-only`.
+2. **Scope the writes to a scratch dir.** Point `-C` at a fresh directory under
+   `$TMP_ROOT` and add `--skip-git-repo-check` (the scratch dir isn't a repo). This
+   keeps generated files out of the user's repo.
+3. **Show the result.** Read the generated image and open it for the user, then
+   report the file path.
+
+This is the one exception to "Never modify files" below — image bytes can't come back
+inline through the CLI, so writing the file is the deliverable. Writes stay confined
+to the scratch directory.
+
+---
+
 ## Cost Estimation
 
 Parse token count from stderr. Codex prints `tokens used\nN` to stderr.
@@ -1541,6 +1564,8 @@ If token count is not available, display: `Tokens: unknown`
 ## Important Rules
 
 - **Never modify files.** This skill is read-only. Codex runs in read-only sandbox mode.
+  Sole exception: image-generation consults, where Codex writes the generated file to a
+  scratch directory (see Image Generation).
 - **Present output verbatim.** Do not truncate, summarize, or editorialize Codex's output
   before showing it. Show it in full inside the CODEX SAYS block.
 - **Add synthesis after, not instead of.** Any Claude commentary comes after the full output.

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -625,6 +625,29 @@ or `/codex challenge -m gpt-5.2`), pass the `-m` flag through to codex.
 
 ---
 
+## Image Generation
+
+Codex ships a native image-generation tool (`image_gen.imagegen`) — it produces real
+raster images (illustrations, photo-style renders, diagrams) from a text prompt, not
+just code that draws SVGs. Verified by having Codex enumerate its tools and generate
+a PNG. Image *input* is separate and always available (`codex -i screenshot.png`).
+
+When a consult asks Codex to MAKE an image (not analyze one):
+
+1. **Swap the sandbox.** The tool call works in any sandbox, but saving the result
+   needs write access — run that exec with `-s workspace-write` instead of `-s read-only`.
+2. **Scope the writes to a scratch dir.** Point `-C` at a fresh directory under
+   `$TMP_ROOT` and add `--skip-git-repo-check` (the scratch dir isn't a repo). This
+   keeps generated files out of the user's repo.
+3. **Show the result.** Read the generated image and open it for the user, then
+   report the file path.
+
+This is the one exception to "Never modify files" below — image bytes can't come back
+inline through the CLI, so writing the file is the deliverable. Writes stay confined
+to the scratch directory.
+
+---
+
 ## Cost Estimation
 
 Parse token count from stderr. Codex prints `tokens used\nN` to stderr.
@@ -652,6 +675,8 @@ If token count is not available, display: `Tokens: unknown`
 ## Important Rules
 
 - **Never modify files.** This skill is read-only. Codex runs in read-only sandbox mode.
+  Sole exception: image-generation consults, where Codex writes the generated file to a
+  scratch directory (see Image Generation).
 - **Present output verbatim.** Do not truncate, summarize, or editorialize Codex's output
   before showing it. Show it in full inside the CODEX SAYS block.
 - **Add synthesis after, not instead of.** Any Claude commentary comes after the full output.


### PR DESCRIPTION
## TL;DR

Codex CLI ships a native image-generation tool (`image_gen.imagegen`), but the /codex skill's hard "read-only, never modify files" rule makes image-generation consults silently fail — the tool call succeeds, the generated PNG just can't be saved. This documents the capability and the one sanctioned exception.

## What changed

- New `## Image Generation` section in `codex/SKILL.md.tmpl` (after Model & Reasoning):
  - swap `-s read-only` → `-s workspace-write` when the consult asks Codex to MAKE an image (not analyze one)
  - scope writes to a scratch dir under `$TMP_ROOT` via `-C` + `--skip-git-repo-check`, so nothing lands in the user's repo
  - read + open the result for the user, report the file path
- `Important Rules` first bullet now names this as the sole exception to "Never modify files"
- `codex/SKILL.md` regenerated via `bun run gen:skill-docs`

## Verified

Asked Codex to enumerate its callable tools and generate an image with code-drawing fallbacks (SVG/matplotlib) explicitly forbidden: it listed `image_gen.imagegen` and produced a real 1254×1254 PNG. Saving worked under `workspace-write`; the skill's default `read-only` sandbox blocks it.