### PR TITLE
fix(browse): suppress remaining Windows console-window flashes (Chromium headless shell + daemon/agent spawns)

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -369,6 +369,16 @@ export class BrowserManager {
       console.log(`[browse] Extensions loaded from: ${extensionsDir}`);
     }
 
+    // Windows: the default headless path launches chrome-headless-shell.exe — a
+    // CONSOLE-subsystem binary that pops a terminal window on every launch. Switch
+    // to Chrome's "new" headless (full chrome.exe, GUI-subsystem → no console
+    // window) by launching non-headless with --headless=new. Other platforms keep
+    // the lighter headless shell (they have no console-window problem).
+    if (process.platform === 'win32' && useHeadless) {
+      launchArgs.push('--headless=new');
+      useHeadless = false;
+    }
+
     this.browser = await chromium.launch({
       headless: useHeadless,
       // On Windows, Chromium's sandbox fails when the server is spawned through

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -323,9 +323,11 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     const launcherCode =
       `const{spawn}=require('child_process');` +
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
-      `{detached:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
+      // windowsHide: a detached spawn on Windows pops a console window unless
+      // explicitly hidden — this flashed on every daemon (re)start.
+      `{detached:true,windowsHide:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
       `${extraEnvStr})}).unref()`;
-    Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'] });
+    Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'], windowsHide: true });
   } else {
     // macOS/Linux: Bun.spawn().unref() only removes the child from Bun's event
     // loop — it does NOT call setsid(), so the spawned server stays in the

--- a/browse/src/terminal-agent-control.ts
+++ b/browse/src/terminal-agent-control.ts
@@ -16,6 +16,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+import { spawn as nodeSpawn } from 'child_process';
 import { safeUnlink, safeKill, isProcessAlive } from './error-handling';
 import { writeSecureFile, mkdirSecure } from './file-permissions';
 
@@ -68,7 +69,10 @@ export function spawnTerminalAgent(opts: {
   }
   const script = opts.scriptPath || resolveTerminalAgentScript();
   if (!script || !fs.existsSync(script)) return null;
-  const proc = (Bun as any).spawn(['bun', 'run', script], {
+  // Spawn via Node's child_process (not Bun.spawn): Node's `windowsHide` reliably
+  // suppresses the console window on Windows, whereas Bun's does not. Same lifecycle:
+  // an unref'd child so it doesn't hold the parent's event loop open.
+  const proc = nodeSpawn('bun', ['run', script], {
     cwd: opts.cwd || process.cwd(),
     env: {
       ...process.env,
@@ -77,6 +81,7 @@ export function spawnTerminalAgent(opts: {
       ...(opts.extraEnv || {}),
     },
     stdio: ['ignore', 'ignore', 'ignore'],
+    windowsHide: true,
   });
   proc.unref?.();
   return proc.pid ?? null;


### PR DESCRIPTION
## Problem

On Windows, the `browse` tool pops console windows during normal use (issue #1952). #1979 fixes one source — the watchdog's `tasklist` call flashing a `conhost.exe` window every 60s. This PR addresses the **other three** sources, which complement that fix.

## Sources fixed

| Window | Cause | Fix |
|--------|-------|-----|
| `chrome-headless-shell.exe` (every browse action) | The default headless path launches the **console-subsystem** headless shell, which pops a window on Windows. | Force Chrome's **`--headless=new`** on Windows → full `chrome.exe` (GUI-subsystem, no console window). Other platforms keep the lighter shell. |
| node daemon (Windows detached spawn) | `detached: true` on Windows creates a console window unless `windowsHide` is set. | `windowsHide: true` on the launcher + the detached server spawn. |
| `bun` terminal-agent | Spawned via `Bun.spawn`, whose `windowsHide` does **not** reliably suppress the window on Windows. | Spawn via Node's `child_process.spawn` with `windowsHide: true` (reliable), same unref'd lifecycle. |

## Changes
- `browse/src/browser-manager.ts` — `--headless=new` on Windows in `launch()`.
- `browse/src/cli.ts` — `windowsHide` on the Windows daemon spawn.
- `browse/src/terminal-agent-control.ts` — Node spawn + `windowsHide` for the terminal-agent.

Source-only; `browse/dist` is gitignored.

## Verification (Windows 11)
- Process list shows `chrome.exe ... --headless=new`, **no** `chrome-headless-shell.exe`.
- Screenshots render correctly under new-headless.
- Single daemon, no stray `bun`/`conhost` windows during normal browsing.

## Notes
- Complements #1979 (no overlap — that PR handles `error-handling.ts`'s `tasklist`; this one touches the three above).
- The `Bun.spawn` → `node:child_process` swap for the terminal-agent is the same lesson #1979 applied: don't rely on Bun's Windows console handling.
