### PR TITLE
fix(setup-gbrain): register gbrain MCP via direct bun on Windows to stop console-window popups

### DIFF
--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -1268,7 +1268,28 @@ GBRAIN_BIN=$(command -v gbrain)
 [ -z "$GBRAIN_BIN" ] && GBRAIN_BIN="$HOME/.bun/bin/gbrain"
 claude mcp remove gbrain -s user 2>/dev/null || true
 claude mcp remove gbrain 2>/dev/null || true
-claude mcp add --scope user gbrain -- "$GBRAIN_BIN" serve
+
+# Windows: the bun-generated `gbrain` binstub (gbrain.exe) re-launches the bun
+# runtime in a NEW console, so registering it as the MCP command pops a visible
+# terminal window/tab on every Claude Code session. Registering `bun <entry>
+# serve` directly lets bun attach to Claude Code's headless pseudo-console
+# (the same reason node-based MCP servers don't pop a window). The entry is the
+# gbrain package's `bin` (src/cli.ts), reachable through the bun global
+# node_modules for both `bun install -g` and `bun link`ed clones. POSIX is
+# unaffected; fall back to the binstub if the entry isn't found.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    GBRAIN_ENTRY="$HOME/.bun/install/global/node_modules/gbrain/src/cli.ts"
+    if [ -f "$GBRAIN_ENTRY" ] && [ -f "$HOME/.bun/bin/bun.exe" ]; then
+      claude mcp add --scope user gbrain -- "$HOME/.bun/bin/bun.exe" "$GBRAIN_ENTRY" serve
+    else
+      claude mcp add --scope user gbrain -- "$GBRAIN_BIN" serve
+    fi
+    ;;
+  *)
+    claude mcp add --scope user gbrain -- "$GBRAIN_BIN" serve
+    ;;
+esac
 claude mcp list | grep gbrain  # verify: should show "✓ Connected"
 ```
 

--- a/setup-gbrain/SKILL.md.tmpl
+++ b/setup-gbrain/SKILL.md.tmpl
@@ -543,7 +543,28 @@ GBRAIN_BIN=$(command -v gbrain)
 [ -z "$GBRAIN_BIN" ] && GBRAIN_BIN="$HOME/.bun/bin/gbrain"
 claude mcp remove gbrain -s user 2>/dev/null || true
 claude mcp remove gbrain 2>/dev/null || true
-claude mcp add --scope user gbrain -- "$GBRAIN_BIN" serve
+
+# Windows: the bun-generated `gbrain` binstub (gbrain.exe) re-launches the bun
+# runtime in a NEW console, so registering it as the MCP command pops a visible
+# terminal window/tab on every Claude Code session. Registering `bun <entry>
+# serve` directly lets bun attach to Claude Code's headless pseudo-console
+# (the same reason node-based MCP servers don't pop a window). The entry is the
+# gbrain package's `bin` (src/cli.ts), reachable through the bun global
+# node_modules for both `bun install -g` and `bun link`ed clones. POSIX is
+# unaffected; fall back to the binstub if the entry isn't found.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    GBRAIN_ENTRY="$HOME/.bun/install/global/node_modules/gbrain/src/cli.ts"
+    if [ -f "$GBRAIN_ENTRY" ] && [ -f "$HOME/.bun/bin/bun.exe" ]; then
+      claude mcp add --scope user gbrain -- "$HOME/.bun/bin/bun.exe" "$GBRAIN_ENTRY" serve
+    else
+      claude mcp add --scope user gbrain -- "$GBRAIN_BIN" serve
+    fi
+    ;;
+  *)
+    claude mcp add --scope user gbrain -- "$GBRAIN_BIN" serve
+    ;;
+esac
 claude mcp list | grep gbrain  # verify: should show "✓ Connected"
 ```
 


### PR DESCRIPTION
## Summary

On Windows, `/setup-gbrain` registers the gbrain MCP server with the bun-generated `gbrain` **binstub**:

```bash
GBRAIN_BIN="$HOME/.bun/bin/gbrain"
claude mcp add --scope user gbrain -- "$GBRAIN_BIN" serve
```

`gbrain.exe` (the binstub) re-launches the bun runtime in a **new console**, so Claude Code pops a visible terminal window/tab titled `...\.bun\bin\bun.exe` for the gbrain MCP **on every session**. node-based MCP servers (context7, railway, etc.) don't do this because Claude Code spawns `node.exe` directly and it attaches to the host's headless pseudo-console.

This PR makes the Windows registration launch `bun <entry> serve` directly instead of going through the binstub. POSIX is unchanged.

## Root cause (process-tree evidence, Windows 11)

Before (binstub) — the `conhost` is a child of `gbrain.exe` and renders as a visible Windows Terminal tab:

```
WindowsTerminal.exe
└─ claude.exe
   └─ gbrain.exe   "C:/Users/<u>/.bun/bin/gbrain serve"   <- bun binstub
      ├─ bun.exe   bun ".../gbrain/src/cli.ts" serve       <- the visible tab
      └─ conhost.exe                                        <- visible console
```

After (direct bun) — claude spawns `bun.exe` directly; it attaches to the headless ConPTY, no window:

```
claude.exe
└─ bun.exe   bun ".../gbrain/src/cli.ts" serve
   └─ conhost.exe   (MainWindowHandle = 0, headless — no tab)
```

Verified: with the direct-bun command in `~/.claude.json`, `bun.exe` and its `conhost` both report `MainWindowHandle = 0` (no visible window), across a full Claude Code restart, and `mcp__gbrain__*` tools connect and respond normally. The only difference from the binstub case is that no terminal tab appears.

## Change

`setup-gbrain/SKILL.md.tmpl` (and regenerated `setup-gbrain/SKILL.md`): on `MINGW*/MSYS*/CYGWIN*`, register

```bash
claude mcp add --scope user gbrain -- "$HOME/.bun/bin/bun.exe" \
  "$HOME/.bun/install/global/node_modules/gbrain/src/cli.ts" serve
```

The entry is gbrain's package `bin` (`src/cli.ts`), reachable through the bun global `node_modules` for both `bun install -g` and `bun link`ed clones (the install script's two paths). If the entry script or `bun.exe` isn't found, it falls back to the existing binstub command, so nothing regresses.

## Testing

- `bun run gen:skill-docs` regenerated `setup-gbrain/SKILL.md` from the template (committed separately).
- `bun test test/gen-skill-docs.test.ts test/setup-gbrain-path4-structure.test.ts` — passes for the setup-gbrain structure assertions. (Some pre-existing `gstack-slug` "Executable not found in $PATH" failures reproduce on clean `main` on Windows and are unrelated — bun `spawnSync` can't exec extensionless shell scripts on Windows.)
- Manual Windows 11 verification as described above (no tab; gbrain MCP healthy).

## Notes

- No existing issue/PR covers this. The Windows-console-flash cluster (#1784, #1835, #1952, PRs #1864/#1979/#1998) is all about the `browse` daemon's own spawns — this is a distinct source (the gbrain MCP registration) and a distinct file (`setup-gbrain`).
- This is a fork PR, so eval/E2E CI that needs repo secrets may fail with empty-env auth (per CONTRIBUTING) — the freshness/lint/windows checks should still run. Happy to move the branch to a base-repo branch if you prefer.
