### PR TITLE
Handle squash merge readback in land-and-deploy

### DIFF
--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -1489,7 +1489,7 @@ MERGE_SHA=$(gh pr view --json mergeCommit -q .mergeCommit.oid)
 git fetch origin "$BASE"
 git diff --quiet "$MERGE_SHA" origin/"$BASE" || git log --oneline --decorate -1 "$MERGE_SHA" origin/"$BASE"
 ```
-- If the worktree is clean and only needs to stop looking diverged after a squash merge, prefer non-destructive cleanup such as `git switch --detach "$MERGE_SHA"` for throwaway task worktrees. Do not force-push or reset a user's branch unless they explicitly ask.
+- If the worktree is clean and only needs to stop looking diverged after a squash merge, prefer a named local branch at the merge commit, for example `git switch -c "codex/post-merge-pr-$PR_NUMBER" "$MERGE_SHA"`. Avoid detached HEAD in Codex Desktop worktrees because git action workers often expect `git symbolic-ref --short HEAD` to return a branch. Do not force-push or reset a user's branch unless they explicitly ask.
 
 Worktree cleanup — non-destructive, candidate-based:
 ```bash

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -1479,6 +1479,18 @@ Capture merge SHA:
 gh pr view --json mergeCommit -q .mergeCommit.oid
 ```
 
+Squash/rebase merge readback guard:
+- Do **not** prove success by requiring the PR head SHA to be an ancestor of the base branch. GitHub squash and rebase merges deliberately create a new commit, so `git merge-base --is-ancestor <head_sha> origin/<base>` can fail even when the PR is merged.
+- Once GitHub reports `state == "MERGED"` with a non-null `mergeCommit.oid`, treat that as authoritative. Record the merge SHA and continue.
+- If local cleanup or readback is needed, fetch the base branch and compare/sync against the merge commit, not the old PR branch commit:
+```bash
+BASE=$(gh pr view --json baseRefName -q .baseRefName)
+MERGE_SHA=$(gh pr view --json mergeCommit -q .mergeCommit.oid)
+git fetch origin "$BASE"
+git diff --quiet "$MERGE_SHA" origin/"$BASE" || git log --oneline --decorate -1 "$MERGE_SHA" origin/"$BASE"
+```
+- If the worktree is clean and only needs to stop looking diverged after a squash merge, prefer non-destructive cleanup such as `git switch --detach "$MERGE_SHA"` for throwaway task worktrees. Do not force-push or reset a user's branch unless they explicitly ask.
+
 Worktree cleanup — non-destructive, candidate-based:
 ```bash
 git worktree list --porcelain

--- a/land-and-deploy/SKILL.md.tmpl
+++ b/land-and-deploy/SKILL.md.tmpl
@@ -631,6 +631,18 @@ Capture merge SHA:
 gh pr view --json mergeCommit -q .mergeCommit.oid
 ```
 
+Squash/rebase merge readback guard:
+- Do **not** prove success by requiring the PR head SHA to be an ancestor of the base branch. GitHub squash and rebase merges deliberately create a new commit, so `git merge-base --is-ancestor <head_sha> origin/<base>` can fail even when the PR is merged.
+- Once GitHub reports `state == "MERGED"` with a non-null `mergeCommit.oid`, treat that as authoritative. Record the merge SHA and continue.
+- If local cleanup or readback is needed, fetch the base branch and compare/sync against the merge commit, not the old PR branch commit:
+```bash
+BASE=$(gh pr view --json baseRefName -q .baseRefName)
+MERGE_SHA=$(gh pr view --json mergeCommit -q .mergeCommit.oid)
+git fetch origin "$BASE"
+git diff --quiet "$MERGE_SHA" origin/"$BASE" || git log --oneline --decorate -1 "$MERGE_SHA" origin/"$BASE"
+```
+- If the worktree is clean and only needs to stop looking diverged after a squash merge, prefer non-destructive cleanup such as `git switch --detach "$MERGE_SHA"` for throwaway task worktrees. Do not force-push or reset a user's branch unless they explicitly ask.
+
 Worktree cleanup — non-destructive, candidate-based:
 ```bash
 git worktree list --porcelain

--- a/land-and-deploy/SKILL.md.tmpl
+++ b/land-and-deploy/SKILL.md.tmpl
@@ -641,7 +641,7 @@ MERGE_SHA=$(gh pr view --json mergeCommit -q .mergeCommit.oid)
 git fetch origin "$BASE"
 git diff --quiet "$MERGE_SHA" origin/"$BASE" || git log --oneline --decorate -1 "$MERGE_SHA" origin/"$BASE"
 ```
-- If the worktree is clean and only needs to stop looking diverged after a squash merge, prefer non-destructive cleanup such as `git switch --detach "$MERGE_SHA"` for throwaway task worktrees. Do not force-push or reset a user's branch unless they explicitly ask.
+- If the worktree is clean and only needs to stop looking diverged after a squash merge, prefer a named local branch at the merge commit, for example `git switch -c "codex/post-merge-pr-$PR_NUMBER" "$MERGE_SHA"`. Avoid detached HEAD in Codex Desktop worktrees because git action workers often expect `git symbolic-ref --short HEAD` to return a branch. Do not force-push or reset a user's branch unless they explicitly ask.
 
 Worktree cleanup — non-destructive, candidate-based:
 ```bash


### PR DESCRIPTION
## Summary
- document that GitHub squash/rebase merges create a new commit, so PR head ancestry checks can fail after a successful merge
- make `state == MERGED` plus non-null `mergeCommit.oid` authoritative
- add non-destructive local cleanup guidance for throwaway task worktrees that look diverged after squash merge

## Verification
- docs/workflow-only change
- confirmed generated `SKILL.md` and `SKILL.md.tmpl` sections match