### PR TITLE
fix(retro): count polyglot test files and exclude vendored dirs

### DIFF
--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -996,8 +996,8 @@ cat ~/.gstack/greptile-history.md 2>/dev/null || true
 # 9. TODOS.md backlog (if available)
 cat TODOS.md 2>/dev/null || true
 
-# 10. Test file count
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' 2>/dev/null | grep -v node_modules | wc -l
+# 10. Test file count (polyglot conventions; prunes vendored/virtualenv dirs)
+find . \( -name node_modules -o -name .venv -o -name venv -o -name site-packages -o -name vendor -o -name .git \) -prune -o \( -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' -o -name 'test_*.py' -o -name '*Test.java' \) -type f -print 2>/dev/null | wc -l
 
 # 11. Regression test commits in window
 git log origin/<default> --since="<window>" --oneline --grep="test(qa):" --grep="test(design):" --grep="test: coverage"

--- a/retro/SKILL.md.tmpl
+++ b/retro/SKILL.md.tmpl
@@ -196,8 +196,8 @@ cat ~/.gstack/greptile-history.md 2>/dev/null || true
 # 9. TODOS.md backlog (if available)
 cat TODOS.md 2>/dev/null || true
 
-# 10. Test file count
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' 2>/dev/null | grep -v node_modules | wc -l
+# 10. Test file count (polyglot conventions; prunes vendored/virtualenv dirs)
+find . \( -name node_modules -o -name .venv -o -name venv -o -name site-packages -o -name vendor -o -name .git \) -prune -o \( -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' -o -name 'test_*.py' -o -name '*Test.java' \) -type f -print 2>/dev/null | wc -l
 
 # 11. Regression test commits in window
 git log origin/<default> --since="<window>" --oneline --grep="test(qa):" --grep="test(design):" --grep="test: coverage"


### PR DESCRIPTION
## Problem

`/retro` Step 1 command 10 counts repository test files with a JS/TS-only glob and excludes only `node_modules`:

```bash
find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' 2>/dev/null | grep -v node_modules | wc -l
```

Python's dominant convention is `test_*.py`, which none of those patterns match, so on a Python repo the `test_health.total_test_files` metric never reflects the real count. Step 13 persists it and Step 12 trends it, so the test-health trend line tracks noise. As #1999 notes, a naive widening over-corrects, because virtualenv / vendored dependency trees (`.venv`, `venv`, `site-packages`, `vendor`) carry their own test suites and only `node_modules` was pruned.

## Fix

- Add the common non-JS conventions: `test_*.py` and `*Test.java`. The existing `*_test.*` / `*_spec.*` already cover Go (`*_test.go`), Ruby (`*_test.rb` / `*_spec.rb`), and Python's `*_test.py`, so the genuine gaps are Python's `test_` prefix and Java's separator-less `FooTest.java`.
- Prune vendored and virtualenv directories (`node_modules`, `.venv`, `venv`, `site-packages`, `vendor`, `.git`) inside `find` instead of post-filtering only `node_modules`, so dependency test suites no longer inflate the count.

## Verification

On a polyglot fixture (5 real project test files across ts/js/go/py/java, plus dependency test files under `.venv/` and `node_modules/`):

| glob | count |
|------|-------|
| old (JS-only, node_modules filter) | 4 (misses `test_*.py` + `*Test.java`, counts a `.venv` test) |
| new | 5 (exact project count) |

`bun test test/gen-skill-docs.test.ts test/skill-validation.test.ts` — 734 pass, 0 fail. SKILL.md regenerated from the template.

The same glob shape also lives in the shared `scripts/resolvers/testing.ts` (the `/ship` before/after counts); left out of scope here to keep this focused on the `/retro` trend metric in #1999.

Closes #1999