### PR TITLE
fix(autoplan): label single-voice review rows and banner single-voice mode

### DIFF
--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -1198,8 +1198,10 @@ CEO DUAL VOICES — CONSENSUS TABLE:
   5. Competitive/market risks covered? —       —      —
   6. 6-month trajectory sound?         —       —      —
 ═══════════════════════════════════════════════════════════════
-CONFIRMED = both agree. DISAGREE = models differ (→ taste decision).
-Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = flagged regardless.
+CONFIRMED = both voices agree. CONFIRMED-1V = only one voice ran (other N/A); the
+orchestrator concurs with the sole reviewer, so the row is NOT dual-confirmed.
+DISAGREE = models differ (→ taste decision). A missing voice is N/A, never CONFIRMED.
+Single critical finding from one voice = flagged regardless.
 ```
 
 Sections 1-10 — for EACH section, run the evaluation criteria from the loaded skill file:
@@ -1388,8 +1390,10 @@ ENG DUAL VOICES — CONSENSUS TABLE:
   5. Error paths handled?              —       —      —
   6. Deployment risk manageable?       —       —      —
 ═══════════════════════════════════════════════════════════════
-CONFIRMED = both agree. DISAGREE = models differ (→ taste decision).
-Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = flagged regardless.
+CONFIRMED = both voices agree. CONFIRMED-1V = only one voice ran (other N/A); the
+orchestrator concurs with the sole reviewer, so the row is NOT dual-confirmed.
+DISAGREE = models differ (→ taste decision). A missing voice is N/A, never CONFIRMED.
+Single critical finding from one voice = flagged regardless.
 ```
 
 3. Section 1 (Architecture): Produce ASCII dependency graph showing new components
@@ -1511,8 +1515,10 @@ DX DUAL VOICES — CONSENSUS TABLE:
   5. Upgrade path safe?                —       —      —
   6. Dev environment friction-free?    —       —      —
 ═══════════════════════════════════════════════════════════════
-CONFIRMED = both agree. DISAGREE = models differ (→ taste decision).
-Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = flagged regardless.
+CONFIRMED = both voices agree. CONFIRMED-1V = only one voice ran (other N/A); the
+orchestrator concurs with the sole reviewer, so the row is NOT dual-confirmed.
+DISAGREE = models differ (→ taste decision). A missing voice is N/A, never CONFIRMED.
+Single critical finding from one voice = flagged regardless.
 ```
 
 3. Passes 1-8: Run each from loaded skill. Rate 0-10. Auto-decide each issue.
@@ -1692,6 +1698,14 @@ Present as a message, then use AskUserQuestion:
 ```
 ## /autoplan Review Complete
 
+### Review Mode
+[If any review phase ran single-voice (Codex unavailable/degraded — see the
+degradation matrix), show this banner; otherwise omit the whole section:]
+⚠ SINGLE-VOICE MODE — Codex unavailable for [N] of [M] review phases. The
+consensus columns for those phases reflect one independent reviewer, not two;
+their confirmed rows read CONFIRMED-1V (orchestrator concurs with the sole
+reviewer), not CONFIRMED.
+
 ### Plan Summary
 [1-3 sentence summary]
 
@@ -1742,6 +1756,7 @@ I recommend [X] — [principle]. But [Y] is also viable:
 ```
 
 **Cognitive load management:**
+- All review phases ran dual voices: skip the "Review Mode" banner. Any phase single-voice (Codex unavailable): show it, with N = phases that ran without Codex and M = total review phases.
 - 0 user challenges: skip "User Challenges" section
 - 0 taste decisions: skip "Your Choices" section
 - 1-7 taste decisions: flat list

--- a/autoplan/SKILL.md.tmpl
+++ b/autoplan/SKILL.md.tmpl
@@ -363,8 +363,10 @@ CEO DUAL VOICES — CONSENSUS TABLE:
   5. Competitive/market risks covered? —       —      —
   6. 6-month trajectory sound?         —       —      —
 ═══════════════════════════════════════════════════════════════
-CONFIRMED = both agree. DISAGREE = models differ (→ taste decision).
-Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = flagged regardless.
+CONFIRMED = both voices agree. CONFIRMED-1V = only one voice ran (other N/A); the
+orchestrator concurs with the sole reviewer, so the row is NOT dual-confirmed.
+DISAGREE = models differ (→ taste decision). A missing voice is N/A, never CONFIRMED.
+Single critical finding from one voice = flagged regardless.
 ```
 
 Sections 1-10 — for EACH section, run the evaluation criteria from the loaded skill file:
@@ -553,8 +555,10 @@ ENG DUAL VOICES — CONSENSUS TABLE:
   5. Error paths handled?              —       —      —
   6. Deployment risk manageable?       —       —      —
 ═══════════════════════════════════════════════════════════════
-CONFIRMED = both agree. DISAGREE = models differ (→ taste decision).
-Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = flagged regardless.
+CONFIRMED = both voices agree. CONFIRMED-1V = only one voice ran (other N/A); the
+orchestrator concurs with the sole reviewer, so the row is NOT dual-confirmed.
+DISAGREE = models differ (→ taste decision). A missing voice is N/A, never CONFIRMED.
+Single critical finding from one voice = flagged regardless.
 ```
 
 3. Section 1 (Architecture): Produce ASCII dependency graph showing new components
@@ -676,8 +680,10 @@ DX DUAL VOICES — CONSENSUS TABLE:
   5. Upgrade path safe?                —       —      —
   6. Dev environment friction-free?    —       —      —
 ═══════════════════════════════════════════════════════════════
-CONFIRMED = both agree. DISAGREE = models differ (→ taste decision).
-Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = flagged regardless.
+CONFIRMED = both voices agree. CONFIRMED-1V = only one voice ran (other N/A); the
+orchestrator concurs with the sole reviewer, so the row is NOT dual-confirmed.
+DISAGREE = models differ (→ taste decision). A missing voice is N/A, never CONFIRMED.
+Single critical finding from one voice = flagged regardless.
 ```
 
 3. Passes 1-8: Run each from loaded skill. Rate 0-10. Auto-decide each issue.
@@ -784,6 +790,14 @@ Present as a message, then use AskUserQuestion:
 ```
 ## /autoplan Review Complete
 
+### Review Mode
+[If any review phase ran single-voice (Codex unavailable/degraded — see the
+degradation matrix), show this banner; otherwise omit the whole section:]
+⚠ SINGLE-VOICE MODE — Codex unavailable for [N] of [M] review phases. The
+consensus columns for those phases reflect one independent reviewer, not two;
+their confirmed rows read CONFIRMED-1V (orchestrator concurs with the sole
+reviewer), not CONFIRMED.
+
 ### Plan Summary
 [1-3 sentence summary]
 
@@ -834,6 +848,7 @@ I recommend [X] — [principle]. But [Y] is also viable:
 ```
 
 **Cognitive load management:**
+- All review phases ran dual voices: skip the "Review Mode" banner. Any phase single-voice (Codex unavailable): show it, with N = phases that ran without Codex and M = total review phases.
 - 0 user challenges: skip "User Challenges" section
 - 0 taste decisions: skip "Your Choices" section
 - 1-7 taste decisions: flat list

--- a/test/autoplan-single-voice-label.test.ts
+++ b/test/autoplan-single-voice-label.test.ts
@@ -1,0 +1,53 @@
+/**
+ * /autoplan single-voice consensus labeling (gate tier)
+ *
+ * When Codex is unavailable, every review phase degrades to a single Claude
+ * voice. Before #1956 the Final Approval Gate still printed CONFIRMED for those
+ * rows, which reads as "two independent reviewers agreed" when only one ran —
+ * a silent quality regression. These static checks pin the generated skill so
+ * the degradation stays visible: a CONFIRMED-1V label plus a top-of-gate banner.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const AUTOPLAN = fs.readFileSync(path.join(ROOT, 'autoplan', 'SKILL.md'), 'utf-8');
+const AUTOPLAN_TMPL = fs.readFileSync(path.join(ROOT, 'autoplan', 'SKILL.md.tmpl'), 'utf-8');
+
+describe('autoplan single-voice consensus labeling', () => {
+  test('the consensus legend defines a distinct single-voice label', () => {
+    expect(AUTOPLAN).toContain('CONFIRMED-1V');
+    // It must be explicit that one voice is NOT a dual confirmation.
+    expect(AUTOPLAN).toMatch(/NOT dual-confirmed/);
+  });
+
+  test('a missing voice is never silently rolled into CONFIRMED', () => {
+    expect(AUTOPLAN).toMatch(/missing voice is N\/A, never CONFIRMED/);
+  });
+
+  test('the Final Approval Gate carries a single-voice banner', () => {
+    expect(AUTOPLAN).toContain('SINGLE-VOICE MODE');
+    // The banner must explain WHY the consensus columns are weaker.
+    expect(AUTOPLAN).toMatch(/one independent reviewer, not two/);
+  });
+
+  test('the banner is gated on degradation, not always shown', () => {
+    // Cognitive-load rule: skip when every phase ran dual voices.
+    expect(AUTOPLAN).toMatch(/All review phases ran dual voices: skip the "Review Mode" banner/);
+  });
+
+  test('all three phase legends (CEO, eng, design) carry the label', () => {
+    // The legend block repeats once per dual-voice phase; every copy must
+    // teach the same CONFIRMED-1V semantics so no phase regresses alone.
+    const occurrences = AUTOPLAN.split('CONFIRMED-1V = only one voice ran').length - 1;
+    expect(occurrences).toBeGreaterThanOrEqual(3);
+  });
+
+  test('template and generated skill stay in sync on the labeling', () => {
+    for (const needle of ['CONFIRMED-1V', 'SINGLE-VOICE MODE', 'one independent reviewer, not two']) {
+      expect(AUTOPLAN_TMPL).toContain(needle);
+    }
+  });
+});


### PR DESCRIPTION
## What

When the Codex CLI is unavailable, every `/autoplan` review phase degrades to a single Claude voice. The degradation matrix already tags those phases `[subagent-only]`, but the **Final Approval Gate** still printed `CONFIRMED` in the consensus tables for rows where only one voice ran. A user reasonably reads `CONFIRMED` as "both independent reviewers agreed" — when in fact one reviewer flagged it and the orchestrator concurred. Silent quality regression.

## Fix (prose-only in `autoplan/SKILL.md.tmpl`)

- **`CONFIRMED-1V` label** added to all three phase consensus legends (CEO / eng / design): "only one voice ran (other N/A); the orchestrator concurs with the sole reviewer, so the row is NOT dual-confirmed." A missing voice is N/A, never CONFIRMED.
- **`SINGLE-VOICE MODE` banner** at the top of the Final Approval Gate, shown only when a phase ran without Codex: `⚠ SINGLE-VOICE MODE — Codex unavailable for [N] of [M] review phases...`. Gated via a cognitive-load rule (skipped entirely when every phase ran dual voices).

No behavior/script change — labeling + visibility only.

## Tests

`test/autoplan-single-voice-label.test.ts` (gate tier, 6 checks): pins the CONFIRMED-1V legend, the gate banner, the dual-voice skip rule, the three-phase legend coverage, and template/generated parity. All asserted strings are absent on `main`, so the test fails there too — a real fail-on-main guard.

`bun test test/gen-skill-docs.test.ts test/skill-validation.test.ts` + the new test: green (740 pass).

Closes #1956.