### PR TITLE
fix(one-way-doors): unify credential noun list across revoke/reset/rotate

### DIFF
--- a/scripts/one-way-doors.ts
+++ b/scripts/one-way-doors.ts
@@ -62,9 +62,12 @@ const DESTRUCTIVE_PATTERNS: RegExp[] = [
   /\bterraform\s+destroy\b/i,
   /\brollback\b/i,
 
-  // Credentials / auth — allow filler words ("the", "my") between verb and noun
-  /\brevoke\s+[\w\s]*\b(api key|token|credential|access key|password)\b/i,
-  /\breset\s+[\w\s]*\b(api key|token|password|credential)\b/i,
+  // Credentials / auth — allow filler words ("the", "my") between verb and noun.
+  // Keep the noun alternation identical across revoke/reset/rotate so the three
+  // verbs stay parallel; a noun in one but not the others is a false-negative
+  // safety hole (e.g. "reset my secret" must be one-way just like "rotate my secret").
+  /\brevoke\s+[\w\s]*\b(api key|token|secret|credential|access key|password)\b/i,
+  /\breset\s+[\w\s]*\b(api key|token|secret|credential|access key|password)\b/i,
   /\brotate\s+[\w\s]*\b(api key|token|secret|credential|access key|password)\b/i,
 
   // Scope / architecture forks (reversible with effort — still deserve confirmation)

--- a/test/one-way-doors.test.ts
+++ b/test/one-way-doors.test.ts
@@ -29,4 +29,17 @@ describe("one-way-door credential keyword net (#1839)", () => {
       expect(classifyQuestion({ summary: `rotate my ${noun}` }).oneWay).toBe(true);
     }
   });
+
+  // revoke/reset/rotate must all share the same credential noun list. Previously
+  // "secret" was only in rotate (missing from revoke and reset) and "access key"
+  // was missing from reset, so "revoke my secret" / "reset my secret" /
+  // "reset my access key" leaked through as two-way (auto-decidable).
+  test("revoke/reset/rotate are all parallel for every credential noun", () => {
+    for (const verb of ["revoke", "reset", "rotate"]) {
+      for (const noun of ["api key", "token", "secret", "credential", "access key", "password"]) {
+        const r = classifyQuestion({ summary: `${verb} my ${noun}` });
+        expect(r.oneWay, `${verb} my ${noun} should be one-way`).toBe(true);
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Problem

`scripts/one-way-doors.ts` is the secondary keyword safety net for AskUserQuestion calls that fire without a registry id. A false negative here auto-approves a destructive op (the question is treated as two-way / preference-suppressible instead of one-way / always-ask).

Its three credential patterns are meant to be parallel across `revoke`/`reset`/`rotate` (the inline comment says they "allow filler words between verb and noun"; the `#1839` test header states the patterns "must be parallel across revoke/reset/rotate"). They were not:

```
revoke: api key | token |          credential | access key | password   (missing: secret)
reset:  api key | token |          credential |              password   (missing: secret, access key)
rotate: api key | token | secret | credential | access key | password   (complete)
```

## Root cause

`secret` lived only in the `rotate` alternation, and `access key` was absent from `reset`. So these phrasings slipped through as two-way on `main` (c7ae6320, v1.58.1.0):

```
two-way   revoke my secret      <- should be one-way
two-way   reset my secret       <- should be one-way
two-way   reset my access key   <- should be one-way
ONE-WAY   rotate my secret
```

This is the same false-negative class `#1839` fixed for `rotate ... password`; that fix unified one verb's nouns but left `revoke`/`reset` short.

## Fix

Give all three verbs an identical credential noun alternation (`api key | token | secret | credential | access key | password`). Pure widening of an over-narrow safety net: no previously-caught phrasing stops matching, and the additions are conservative (a credential verb + credential noun is exactly what this net is for).

## Testing

`bun test test/one-way-doors.test.ts` — 4 pass, 28 assertions. Added a regression test asserting every `<verb> my <noun>` pair across all three verbs and all six nouns classifies one-way; it fails on `main` for the three cases above and passes with this change.

Fixes #2024
