### PR TITLE
fix(design/variants): guard --count against NaN/zero/negative input

### DIFF
--- a/design/src/variants.ts
+++ b/design/src/variants.ts
@@ -19,6 +19,23 @@ export interface VariantsOptions {
   viewports?: string; // "desktop,tablet,mobile" — generates at multiple sizes
 }
 
+/**
+ * Normalize a requested variant count to the supported range.
+ *
+ * `--count` reaches us via `parseInt`, which yields `NaN` for non-numeric
+ * input and happily passes zero/negative values through. The generation loop
+ * only capped the upper bound, so any of those silently produced zero variants
+ * and emitted `"count": null`/`0`/negative in the JSON result. Clamp to the
+ * supported `[1, 7]` range; fall back to the default of 3 when the value is not
+ * a finite number (an unparseable flag, not an explicit out-of-range request).
+ *
+ * Exported for direct unit testing.
+ */
+export function normalizeVariantCount(count: number): number {
+  if (!Number.isFinite(count)) return 3;
+  return Math.max(1, Math.min(Math.trunc(count), 7));
+}
+
 const STYLE_VARIATIONS = [
   "", // First variant uses the brief as-is
   "Use a bolder, more dramatic visual style with stronger contrast and larger typography.",
@@ -153,7 +170,7 @@ export async function variants(options: VariantsOptions): Promise<void> {
     return;
   }
 
-  const count = Math.min(options.count, 7); // Cap at 7 style variations
+  const count = normalizeVariantCount(options.count); // Clamp to [1, 7] style variations
   const size = options.size || "1536x1024";
 
   console.error(`Generating ${count} variants...`);

--- a/design/test/variants-retry-after.test.ts
+++ b/design/test/variants-retry-after.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { generateVariant } from "../src/variants";
+import { generateVariant, normalizeVariantCount } from "../src/variants";
 
 // 1x1 transparent PNG, base64 — valid bytes that fs.writeFileSync can write.
 const TINY_PNG_BASE64 =
@@ -129,5 +129,37 @@ describe("generateVariant Retry-After handling", () => {
     expect(calls.length).toBe(2);
     const gap = calls[1].ts - calls[0].ts;
     expect(gap).toBeLessThan(500);
+  });
+});
+
+describe("normalizeVariantCount", () => {
+  test("non-numeric (NaN) falls back to the default of 3", () => {
+    // Regression: `--count abc` -> parseInt -> NaN -> Math.min(NaN, 7) -> NaN,
+    // so the loop ran zero times and the JSON result emitted `"count": null`.
+    expect(normalizeVariantCount(NaN)).toBe(3);
+    expect(normalizeVariantCount(Number.parseInt("abc", 10))).toBe(3);
+  });
+
+  test("zero and negative counts clamp up to the minimum of 1", () => {
+    // Regression: `--count 0` / `--count -2` produced zero variants.
+    expect(normalizeVariantCount(0)).toBe(1);
+    expect(normalizeVariantCount(-2)).toBe(1);
+  });
+
+  test("counts above the cap clamp down to 7", () => {
+    expect(normalizeVariantCount(10)).toBe(7);
+    expect(normalizeVariantCount(7)).toBe(7);
+  });
+
+  test("in-range counts pass through unchanged", () => {
+    expect(normalizeVariantCount(1)).toBe(1);
+    expect(normalizeVariantCount(3)).toBe(3);
+    expect(normalizeVariantCount(6)).toBe(6);
+  });
+
+  test("fractional counts truncate toward zero before clamping", () => {
+    expect(normalizeVariantCount(2.9)).toBe(2);
+    expect(normalizeVariantCount(0.5)).toBe(1);
+    expect(normalizeVariantCount(Infinity)).toBe(3);
   });
 });


### PR DESCRIPTION
## Problem

`design variants --count <bad value>` silently produces **zero** variants and emits a misleading JSON result.

`--count` is parsed with `parseInt` and never validated (`design/src/cli.ts:200`), and `variants()` only clamped the **upper** bound (`design/src/variants.ts`):

```ts
const count = Math.min(options.count, 7); // Cap at 7 style variations
```

So bad inputs flow through. Measured against the real clamp + JSON-emit path on `main` (c7ae6320):

| `--count` | generated | JSON `count` |
|-----------|-----------|--------------|
| `abc`     | 0         | `null`       |
| `0`       | 0         | `0`          |
| `-2`      | 0         | `-2`         |
| `3`       | 3         | `3`          |
| `10`      | 7         | `7`          |

`Math.min(NaN, 7)` is `NaN`, so `for (i = 0; i < NaN; i++)` never runs and the command exits "successfully" having created nothing, reporting `"count": null`. A single typo (`--count e`) is enough.

## Root cause

No lower-bound or NaN guard on the requested count — only the `<= 7` cap.

## Fix

Add a small exported, pure `normalizeVariantCount` helper and use it in place of the bare cap:

```ts
export function normalizeVariantCount(count: number): number {
  if (!Number.isFinite(count)) return 3;            // unparseable -> default
  return Math.max(1, Math.min(Math.trunc(count), 7)); // clamp to [1, 7]
}
```

- non-finite (`NaN`/`Infinity`) -> default 3
- `0` / negative -> 1
- `> 7` -> 7 (unchanged)
- in-range -> unchanged

This mirrors the exported-helper validation shape proposed for `--api-timeout` in #1528, but is independent of it (different flag).

## Testing

`bun test design/test/variants-retry-after.test.ts` -> 10 pass / 0 fail (5 existing + 5 new). Full `bun test design/test/` passes. The helper is pure, so the regression is pinned without an `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`.

## Scope / collision check

- Touches only `design/src/variants.ts` + its test. No behavior change for valid counts.
- Open design PRs are about timeouts and unrelated concerns (#1774 timeout label, #1638 240s bump, #1528 `--api-timeout` guard, #1737 variant preservation) — none guard `--count`. Searched `variants`, `design count`, `design timeout`; no overlap.

Fixes #2032
