### PR TITLE
ci: add Dependency Review Action to block vulnerable dependency changes

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+# Blocks pull requests that introduce dependencies with known vulnerabilities.
+# Uses GitHub's Dependency Graph to diff base...head, so it only runs on PRs.
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubicloud-standard-8
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          # Fail the check when a PR adds a dependency with a high or critical
+          # advisory. Lower the threshold to `moderate`/`low` to tighten.
+          fail-on-severity: high


### PR DESCRIPTION
## Problem

gstack ships dependency-bearing manifests (`package.json`, `bun.lock`) but has **no pull-request dependency-review gate**. A PR can currently add or bump an npm/Bun dependency without any CI check that blocks newly introduced known vulnerabilities.

Confirmed on `origin/main` (c7ae6320): the workflows present are `actionlint`, `ci-image`, `evals`, `evals-periodic`, `make-pdf-gate`, `pr-title-sync`, `skill-docs`, `version-gate`, `windows-free-tests`, `windows-setup-e2e` — none of them does dependency review, and `git grep -E 'dependency-review|osv-scanner|scorecard|codeql|attestation|Dependabot'` over `.github` / `package.json` / `bun.lock` returns nothing.

## Fix

Add `.github/workflows/dependency-review.yml` using GitHub's official `actions/dependency-review-action`. On every pull request it diffs the dependency graph (`base...head`) and fails the check when a change introduces a dependency with a **high or critical** advisory. The action only runs in `pull_request` context (it needs a base/head diff), so the trigger is scoped to `pull_request`.

- `fail-on-severity: high` is a conservative first threshold (blocks high/critical, ignores low/moderate noise). Documented inline and trivial to tighten to `moderate`/`low`.
- `permissions: contents: read` only — fork-safe, no comment-summary, no write scope needed.
- Matches existing house style: `runs-on: ubicloud-standard-8`, version-tagged actions (`actions/checkout@v4`).

## Testing

- Validated with **actionlint 1.7.12** — the same linter run by `.github/workflows/actionlint.yml` (`rhysd/actionlint`): **no issues**.
- This workflow is self-demonstrating: it runs on this very PR.

## Scope

One new file. No VERSION/CHANGELOG bump required (`version-gate` only triggers on `VERSION`/`CHANGELOG.md`/`package.json` changes).

Fixes #1987

🤖 Generated with [Claude Code](https://claude.com/claude-code)