### PR TITLE
fix(careful): warn on chained rm even when the last target is safe

### DIFF
--- a/careful/bin/check-careful.sh
+++ b/careful/bin/check-careful.sh
@@ -26,7 +26,19 @@ fi
 CMD_LOWER=$(printf '%s' "$CMD" | tr '[:upper:]' '[:lower:]')
 
 # --- Check for safe exceptions (rm -rf of build artifacts) ---
-if printf '%s' "$CMD" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+|--recursive\s+)' 2>/dev/null; then
+# Only whitelist when the command is a SINGLE rm invocation. The target
+# extraction below greedily matches the LAST `rm ` in the string, so a chained
+# command like `rm -rf /; rm -rf node_modules` would be judged solely by its
+# final (safe) targets and wave through the destructive earlier `rm -rf /`.
+# When any shell separator is present, skip the shortcut and fall through to the
+# destructive-pattern check, which warns on any recursive rm.
+HAS_SEPARATOR=false
+case "$CMD" in
+  # Real separators, plus JSON-escaped newlines (\n / \r) which survive the
+  # grep extraction path as literal two-char sequences and still mark a chain.
+  *';'*|*'|'*|*'&'*|*$'\n'*|*$'\r'*|*'\n'*|*'\r'*) HAS_SEPARATOR=true ;;
+esac
+if [ "$HAS_SEPARATOR" = false ] && printf '%s' "$CMD" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+|--recursive\s+)' 2>/dev/null; then
   SAFE_ONLY=true
   RM_ARGS=$(printf '%s' "$CMD" | sed -E 's/.*rm[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*//;s/--recursive[[:space:]]*//')
   for target in $RM_ARGS; do

--- a/test/hook-scripts.test.ts
+++ b/test/hook-scripts.test.ts
@@ -96,6 +96,31 @@ describe('check-careful.sh', () => {
       expect(output.permissionDecision).toBe('ask');
       expect(output.message).toContain('recursive delete');
     });
+
+    // Regression: the safe-exception extracts targets from only the LAST `rm` in
+    // the command (greedy match), so a chain that ends in a safe target must not
+    // wave through a destructive earlier rm. The shortcut only applies to a
+    // single rm invocation; any shell separator falls through to the warning.
+    test('rm -rf /; rm -rf node_modules warns (semicolon chain, dangerous first)', () => {
+      const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('rm -rf /; rm -rf node_modules'));
+      expect(exitCode).toBe(0);
+      expect(output.permissionDecision).toBe('ask');
+      expect(output.message).toContain('recursive delete');
+    });
+
+    test('rm -rf /etc/data && rm -rf dist warns (&& chain, dangerous first)', () => {
+      const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('rm -rf /etc/data && rm -rf dist'));
+      expect(exitCode).toBe(0);
+      expect(output.permissionDecision).toBe('ask');
+      expect(output.message).toContain('recursive delete');
+    });
+
+    test('rm -rf node_modules; rm -rf /home/user/data warns (safe first, dangerous last)', () => {
+      const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('rm -rf node_modules; rm -rf /home/user/data'));
+      expect(exitCode).toBe(0);
+      expect(output.permissionDecision).toBe('ask');
+      expect(output.message).toContain('recursive delete');
+    });
   });
 
   // --- SQL destructive commands ---


### PR DESCRIPTION
Fixes #2039

## Problem

The `/careful` PreToolUse hook fails open on chained `rm -r` commands. Its "safe exception" block (whitelisting `rm -rf` of build artifacts like `node_modules`, `dist`, `.next`) extracts the rm targets with a single greedy match:

```sh
RM_ARGS=$(printf '%s' "$CMD" | sed -E 's/.*rm[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*//;...')
```

`.*rm` is greedy, so it only inspects the **last** `rm` in the command. A chain whose final rm targets a safe directory gets the whole command whitelisted, so a destructive earlier rm is silently allowed:

```
$ printf '{"tool_input":{"command":"rm -rf /; rm -rf node_modules"}}' | bash careful/bin/check-careful.sh
{}        # no warning — rm -rf / waved through
```

Reversing the order correctly warns, confirming the cause is the last-rm-only extraction.

## Root cause

The target-extraction shortcut is only reliable for a single `rm` invocation. With a chained command, the greedy match collapses to the final rm's arguments and ignores everything before it.

## Fix

Gate the safe-exception so it only applies to a single rm command. When any shell separator is present (`;`, `|`, `&`, real newline, or the JSON-escaped `\n`/`\r` that survives the grep extraction path as a literal two-char sequence), skip the shortcut and fall through to the existing destructive-pattern check, which already warns on any `rm -r`. This is the fail-safe direction for a safety guard, and single-command artifact cleanups (`rm -rf node_modules`, `rm -rf .next dist`) still allow.

## Testing

`bun test test/hook-scripts.test.ts` — 35 pass, 0 fail (3 new regression tests for semicolon and `&&` chains in both orders; existing safe-exception and mixed-target tests unchanged).

Verified before/after:

| command | before | after |
|---|---|---|
| `rm -rf /; rm -rf node_modules` | `{}` (allowed) | `ask` |
| `rm -rf /etc/data && rm -rf dist` | `{}` (allowed) | `ask` |
| `rm -rf node_modules` (single safe) | `{}` | `{}` |
| `rm -rf .next dist` (single safe) | `{}` | `{}` |
| `rm -rf /var/data` (single dangerous) | `ask` | `ask` |

## Not a duplicate

Distinct from the other open `check-careful.sh` PRs: #1110 targets text-output false positives (over-warning, opposite direction — it turns `;` into a space and re-feeds the same greedy safe-exception, so it does not address this), and #1509 changes hook activation + output shape, not the detection logic.

## Notes

External-fork CI: the eval/E2E and report jobs may fail on missing secrets for a fork PR; the changed test (`test/hook-scripts.test.ts`) is a free deterministic gate-tier test and passes locally.
