### PR TITLE
fix(resolvers): correct design/browse/make-pdf fallback path on env-var hosts (#1159)

### DIFF
--- a/scripts/resolvers/browse.ts
+++ b/scripts/resolvers/browse.ts
@@ -1,4 +1,5 @@
 import type { TemplateContext } from './types';
+import { runtimeFallbackPath } from './types';
 import { COMMAND_DESCRIPTIONS } from '../../browse/src/commands';
 import { SNAPSHOT_FLAGS } from '../../browse/src/snapshot';
 
@@ -106,7 +107,7 @@ export function generateBrowseSetup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse" ] && B="$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse"
-[ -z "$B" ] && B="$HOME${ctx.paths.browseDir.replace(/^~/, '')}/browse"
+[ -z "$B" ] && B="${runtimeFallbackPath(ctx.paths.browseDir, 'browse')}"
 if [ -x "$B" ]; then
   echo "READY: $B"
 else

--- a/scripts/resolvers/design.ts
+++ b/scripts/resolvers/design.ts
@@ -1,4 +1,5 @@
 import type { TemplateContext } from './types';
+import { runtimeFallbackPath } from './types';
 import { AI_SLOP_BLACKLIST, OPENAI_HARD_REJECTIONS, OPENAI_LITMUS_CHECKS } from './constants';
 
 export function generateDesignReviewLite(ctx: TemplateContext): string {
@@ -792,7 +793,7 @@ export function generateDesignSetup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 D=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design" ] && D="$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design"
-[ -z "$D" ] && D="$HOME${ctx.paths.designDir.replace(/^~/, '')}/design"
+[ -z "$D" ] && D="${runtimeFallbackPath(ctx.paths.designDir, 'design')}"
 if [ -x "$D" ]; then
   echo "DESIGN_READY: $D"
 else
@@ -800,7 +801,7 @@ else
 fi
 B=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse" ] && B="$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse"
-[ -z "$B" ] && B="$HOME${ctx.paths.browseDir.replace(/^~/, '')}/browse"
+[ -z "$B" ] && B="${runtimeFallbackPath(ctx.paths.browseDir, 'browse')}"
 if [ -x "$B" ]; then
   echo "BROWSE_READY: $B"
 else
@@ -837,7 +838,7 @@ export function generateDesignMockup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 D=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design" ] && D="$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design"
-[ -z "$D" ] && D="$HOME${ctx.paths.designDir.replace(/^~/, '')}/design"
+[ -z "$D" ] && D="${runtimeFallbackPath(ctx.paths.designDir, 'design')}"
 [ -x "$D" ] && echo "DESIGN_READY" || echo "DESIGN_NOT_AVAILABLE"
 \`\`\`
 

--- a/scripts/resolvers/make-pdf.ts
+++ b/scripts/resolvers/make-pdf.ts
@@ -1,4 +1,5 @@
 import type { TemplateContext } from './types';
+import { runtimeFallbackPath } from './types';
 
 /**
  * {{MAKE_PDF_SETUP}} — emits the shell preamble that resolves $P to the
@@ -19,7 +20,7 @@ _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 P=""
 [ -n "$MAKE_PDF_BIN" ] && [ -x "$MAKE_PDF_BIN" ] && P="$MAKE_PDF_BIN"
 [ -z "$P" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf" ] && P="$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf"
-[ -z "$P" ] && P="$HOME${ctx.paths.makePdfDir.replace(/^~/, '')}/pdf"
+[ -z "$P" ] && P="${runtimeFallbackPath(ctx.paths.makePdfDir, 'pdf')}"
 if [ -x "$P" ]; then
   echo "MAKE_PDF_READY: $P"
   alias _p_="$P"   # shellcheck alias helper (not exported)

--- a/scripts/resolvers/types.ts
+++ b/scripts/resolvers/types.ts
@@ -50,6 +50,30 @@ function buildHostPaths(): Record<string, HostPaths> {
 
 export const HOST_PATHS: Record<string, HostPaths> = buildHostPaths();
 
+/**
+ * Build a shell-safe global fallback path for a runtime binary.
+ *
+ * `HostPaths` dirs come in two shapes:
+ *  - `~`-style (Claude): `~/.claude/skills/gstack/design/dist` — needs `$HOME`
+ *    substituted for the leading `~` so the path resolves in a non-interactive
+ *    shell that doesn't do tilde expansion inside a quoted string.
+ *  - `$`-style (env-var hosts like codex/hermes): `$GSTACK_DESIGN` — already an
+ *    absolute root exported by the preamble. Must be used verbatim.
+ *
+ * Naively doing `"$HOME${dir.replace(/^~/, '')}"` left env-var roots untouched
+ * by the `~` strip and then prepended `$HOME`, producing invalid paths like
+ * `$HOME$GSTACK_DESIGN/design`. Those never resolve, so design/browse/make-pdf
+ * were reported NOT_AVAILABLE on env-var hosts even when installed. See
+ * garrytan/gstack#1159.
+ *
+ * @param dir   a HostPaths dir (`browseDir` / `designDir` / `makePdfDir`)
+ * @param bin   the binary basename appended to the resolved root (e.g. `design`)
+ */
+export function runtimeFallbackPath(dir: string, bin: string): string {
+  if (dir.startsWith('$')) return `${dir}/${bin}`;
+  return `$HOME${dir.replace(/^~/, '')}/${bin}`;
+}
+
 import type { Model } from '../models';
 export type { Model } from '../models';
 

--- a/test/runtime-fallback-path.test.ts
+++ b/test/runtime-fallback-path.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression tests for runtime binary fallback path resolution.
+ *
+ * Guards garrytan/gstack#1159: env-var hosts (codex, hermes) export their
+ * runtime roots as shell variables ($GSTACK_DESIGN, $GSTACK_BROWSE,
+ * $GSTACK_MAKE_PDF). The global-fallback path builder used to unconditionally
+ * prepend $HOME, producing invalid paths like `$HOME$GSTACK_DESIGN/design`
+ * that never resolve — so the design/browse/make-pdf binaries were reported
+ * NOT_AVAILABLE on those hosts even when installed.
+ *
+ * The fix: a `$`-prefixed dir is an absolute root and is used verbatim; only
+ * `~`-style dirs (Claude) get $HOME substituted for the leading tilde.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { HOST_PATHS, runtimeFallbackPath } from '../scripts/resolvers/types';
+import { generateDesignSetup } from '../scripts/resolvers/design';
+import { generateMakePdfSetup } from '../scripts/resolvers/make-pdf';
+import { ALL_HOST_CONFIGS } from '../hosts/index';
+import type { TemplateContext } from '../scripts/resolvers/types';
+
+function makeCtx(host: string): TemplateContext {
+  return {
+    skillName: 'test-skill',
+    tmplPath: '/tmp/test/SKILL.md.tmpl',
+    host: host as TemplateContext['host'],
+    paths: HOST_PATHS[host],
+  };
+}
+
+describe('runtimeFallbackPath', () => {
+  test('env-var ($-prefixed) roots are used verbatim, never $HOME-prefixed', () => {
+    expect(runtimeFallbackPath('$GSTACK_DESIGN', 'design')).toBe('$GSTACK_DESIGN/design');
+    expect(runtimeFallbackPath('$GSTACK_BROWSE', 'browse')).toBe('$GSTACK_BROWSE/browse');
+    expect(runtimeFallbackPath('$GSTACK_MAKE_PDF', 'pdf')).toBe('$GSTACK_MAKE_PDF/pdf');
+  });
+
+  test('~-style roots get $HOME substituted for the leading tilde', () => {
+    expect(runtimeFallbackPath('~/.claude/skills/gstack/design/dist', 'design')).toBe(
+      '$HOME/.claude/skills/gstack/design/dist/design',
+    );
+  });
+
+  test('never produces the malformed $HOME$GSTACK_* shape', () => {
+    expect(runtimeFallbackPath('$GSTACK_DESIGN', 'design')).not.toContain('$HOME$GSTACK');
+  });
+});
+
+describe('generated setup blocks — env-var hosts (#1159)', () => {
+  const envVarHosts = ALL_HOST_CONFIGS.filter(c => c.usesEnvVars).map(c => c.name);
+
+  test('at least codex and hermes are env-var hosts', () => {
+    expect(envVarHosts).toEqual(expect.arrayContaining(['codex', 'hermes']));
+  });
+
+  for (const host of envVarHosts) {
+    test(`${host}: no setup block emits the malformed $HOME$GSTACK_* path`, () => {
+      const ctx = makeCtx(host);
+      // generateDesignSetup emits both the design (D=) and browse (B=) fallbacks.
+      const blocks = generateDesignSetup(ctx) + generateMakePdfSetup(ctx);
+      expect(blocks).not.toContain('$HOME$GSTACK_DESIGN');
+      expect(blocks).not.toContain('$HOME$GSTACK_BROWSE');
+      expect(blocks).not.toContain('$HOME$GSTACK_MAKE_PDF');
+    });
+
+    test(`${host}: design + browse fallbacks resolve under their env-var roots`, () => {
+      const setup = generateDesignSetup(makeCtx(host));
+      expect(setup).toContain('D="$GSTACK_DESIGN/design"');
+      expect(setup).toContain('B="$GSTACK_BROWSE/browse"');
+    });
+
+    test(`${host}: make-pdf fallback resolves to $GSTACK_MAKE_PDF/pdf`, () => {
+      const setup = generateMakePdfSetup(makeCtx(host));
+      expect(setup).toContain('P="$GSTACK_MAKE_PDF/pdf"');
+    });
+  }
+});
+
+describe('generated setup blocks — Claude host unaffected', () => {
+  test('design fallback still resolves under $HOME', () => {
+    const setup = generateDesignSetup(makeCtx('claude'));
+    expect(setup).toContain('D="$HOME/.claude/skills/gstack/design/dist/design"');
+    expect(setup).not.toContain('$HOME$');
+  });
+});


### PR DESCRIPTION
## What changed and why

On env-var hosts (codex, hermes — `usesEnvVars: true`), the design/browse/make-pdf setup blocks computed their global fallback path as `"$HOME${dir.replace(/^~/, '')}"`. That only strips a leading `~`. For these hosts the dir is already an exported absolute root (`$GSTACK_DESIGN` / `$GSTACK_BROWSE` / `$GSTACK_MAKE_PDF`), so the `~`-strip was a no-op and `$HOME` got prepended anyway, emitting an invalid path like `$HOME$GSTACK_DESIGN/design`. That never resolves, so the binaries were reported `DESIGN_NOT_AVAILABLE` even when installed.

This extracts a single `runtimeFallbackPath(dir, bin)` helper in `scripts/resolvers/types.ts` that uses `$`-rooted dirs verbatim and only substitutes `$HOME` for a leading `~`. All five fallback sites (design x2, browse, make-pdf) route through it.

- codex/hermes before: `D="$HOME$GSTACK_DESIGN/design"` (broken)
- codex/hermes after: `D="$GSTACK_DESIGN/design"` (correct)
- claude before/after: `D="$HOME/.claude/skills/gstack/design/dist/design"` (byte-identical, unaffected)

Fixes #1159.

## How to test

```bash
bun test test/runtime-fallback-path.test.ts
```

32 pass / 0 fail. Covers the helper directly plus the generated design/browse/make-pdf setup blocks for every env-var host (asserts no `$HOME$GSTACK_*` shape) and a Claude-unaffected guard.

## Duplicate check

No open or merged PR touches the design/browse/make-pdf fallback path resolution.

## Notes / scope

- Committed docs (Claude host) are unchanged, so `bun run gen:skill-docs` yields no SKILL.md diff (codex/hermes docs are generated at install time).
- Kept tight to the confirmed root cause. A commenter suggested also adding `design/dist`/`make-pdf/dist` to hermes `globalSymlinks`; that is not the cause here (`$GSTACK_DESIGN` already points at the real on-disk location, and the working Claude host omits those symlinks too), so it's intentionally left out.
