### PR TITLE
fix(setup-deploy): presence-check Render key instead of printing key bytes (#1078)

### DIFF
--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -826,7 +826,7 @@ Ask the user to confirm the production URL. Some Fly apps use custom domains.
 If `render.yaml` detected:
 
 1. Extract service name and type from render.yaml
-2. Check for Render API key: `echo $RENDER_API_KEY | head -c 4` (don't expose the full key)
+2. Check for Render API key (is it available?): `if [ -n "${RENDER_API_KEY:-}" ]; then echo "RENDER_API_KEY: set"; else echo "RENDER_API_KEY: not set"; fi` (presence only — never print any key bytes)
 3. Infer URL: `https://{service-name}.onrender.com`
 4. Render deploys automatically on push to the connected branch — no deploy workflow needed
 5. Set health check: the inferred URL

--- a/setup-deploy/SKILL.md.tmpl
+++ b/setup-deploy/SKILL.md.tmpl
@@ -99,7 +99,7 @@ Ask the user to confirm the production URL. Some Fly apps use custom domains.
 If `render.yaml` detected:
 
 1. Extract service name and type from render.yaml
-2. Check for Render API key: `echo $RENDER_API_KEY | head -c 4` (don't expose the full key)
+2. Check for Render API key (is it available?): `if [ -n "${RENDER_API_KEY:-}" ]; then echo "RENDER_API_KEY: set"; else echo "RENDER_API_KEY: not set"; fi` (presence only — never print any key bytes)
 3. Infer URL: `https://{service-name}.onrender.com`
 4. Render deploys automatically on push to the connected branch — no deploy workflow needed
 5. Set health check: the inferred URL

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -1975,3 +1975,34 @@ describe('Bundled browser-skills frontmatter contract', () => {
     }
   });
 });
+
+describe('setup-deploy — no partial-secret print of API keys', () => {
+  // Regression guard for garrytan/gstack#1078: the Render key check used to
+  // instruct `echo $RENDER_API_KEY | head -c 4`, which prints 4 real bytes of
+  // a live secret into terminal scrollback / screenshots. Presence checks must
+  // never emit ANY key bytes. We scan both the template (source of truth) and
+  // the generated SKILL.md so neither can regress independently.
+  const files = ['SKILL.md.tmpl', 'SKILL.md'].map((f) =>
+    path.join(ROOT, 'setup-deploy', f)
+  );
+
+  // Match a provider key being piped into / sliced by a partial-print primitive.
+  // Covers `$RENDER_API_KEY | head -c N`, `head -c N ... API_KEY`,
+  // `${RENDER_API_KEY:0:4}`, `cut -c1-4 ... API_KEY`, etc.
+  const pipeToHeadCut = /API_KEY[^\n`]*\|\s*(head|cut)\b/i;
+  const headCutToKey = /\b(head\s+-c|cut\s+-c)\b[^\n`]*API_KEY/i;
+  const bashSubstringSlice = /API_KEY:\d+:\d+/i;
+
+  for (const file of files) {
+    test(`${path.basename(file)} never partial-prints an API key`, () => {
+      const content = fs.readFileSync(file, 'utf-8');
+      expect(content).not.toMatch(pipeToHeadCut);
+      expect(content).not.toMatch(headCutToKey);
+      expect(content).not.toMatch(bashSubstringSlice);
+      // The specific issue-#1078 instruction must be gone.
+      expect(content).not.toContain('echo $RENDER_API_KEY | head -c 4');
+      // And the replacement presence check must be present (no key bytes).
+      expect(content).toContain('RENDER_API_KEY: not set');
+    });
+  }
+});


### PR DESCRIPTION
## What changed and why

The setup-deploy skill instructed `echo $RENDER_API_KEY | head -c 4` to check whether the key was set. Even though the intent was "presence only," it still writes the first 4 bytes of a live secret into terminal scrollback, screen recordings, and screenshots — and skill instructions tend to get copied downstream once they ship.

This replaces it with a presence check that writes zero key bytes:

```bash
if [ -n "${RENDER_API_KEY:-}" ]; then echo "RENDER_API_KEY: set"; else echo "RENDER_API_KEY: not set"; fi
```

Edited in `setup-deploy/SKILL.md.tmpl` (the source of truth) and regenerated `setup-deploy/SKILL.md`. This was the only partial-secret-print instance in the skill.

Fixes #1078.

## How to test

```bash
bun test test/skill-validation.test.ts
```

Adds a static guard asserting that setup-deploy (template + generated) never pipes a provider `API_KEY` into `head`/`cut` or slices it via `${KEY:N:M}`. Verified the guard fails red if the old `head -c 4` pattern is reintroduced. 334 pass / 0 fail.

## Duplicate check

No open or merged PR touches setup-deploy or the Render key check.
