### PR TITLE
fix: stop env-var hosts from doubling $HOME in binary-resolver fallback

### DIFF
--- a/scripts/resolvers/browse.ts
+++ b/scripts/resolvers/browse.ts
@@ -1,4 +1,4 @@
-import type { TemplateContext } from './types';
+import { type TemplateContext, toShellPath } from './types';
 import { COMMAND_DESCRIPTIONS } from '../../browse/src/commands';
 import { SNAPSHOT_FLAGS } from '../../browse/src/snapshot';
 
@@ -106,7 +106,7 @@ export function generateBrowseSetup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse" ] && B="$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse"
-[ -z "$B" ] && B="$HOME${ctx.paths.browseDir.replace(/^~/, '')}/browse"
+[ -z "$B" ] && B="${toShellPath(ctx.paths.browseDir)}/browse"
 if [ -x "$B" ]; then
   echo "READY: $B"
 else

--- a/scripts/resolvers/design.ts
+++ b/scripts/resolvers/design.ts
@@ -1,4 +1,4 @@
-import type { TemplateContext } from './types';
+import { type TemplateContext, toShellPath } from './types';
 import { AI_SLOP_BLACKLIST, OPENAI_HARD_REJECTIONS, OPENAI_LITMUS_CHECKS } from './constants';
 
 export function generateDesignReviewLite(ctx: TemplateContext): string {
@@ -792,7 +792,7 @@ export function generateDesignSetup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 D=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design" ] && D="$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design"
-[ -z "$D" ] && D="$HOME${ctx.paths.designDir.replace(/^~/, '')}/design"
+[ -z "$D" ] && D="${toShellPath(ctx.paths.designDir)}/design"
 if [ -x "$D" ]; then
   echo "DESIGN_READY: $D"
 else
@@ -800,7 +800,7 @@ else
 fi
 B=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse" ] && B="$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse"
-[ -z "$B" ] && B="$HOME${ctx.paths.browseDir.replace(/^~/, '')}/browse"
+[ -z "$B" ] && B="${toShellPath(ctx.paths.browseDir)}/browse"
 if [ -x "$B" ]; then
   echo "BROWSE_READY: $B"
 else
@@ -837,7 +837,7 @@ export function generateDesignMockup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 D=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design" ] && D="$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design"
-[ -z "$D" ] && D="$HOME${ctx.paths.designDir.replace(/^~/, '')}/design"
+[ -z "$D" ] && D="${toShellPath(ctx.paths.designDir)}/design"
 [ -x "$D" ] && echo "DESIGN_READY" || echo "DESIGN_NOT_AVAILABLE"
 \`\`\`
 

--- a/scripts/resolvers/make-pdf.ts
+++ b/scripts/resolvers/make-pdf.ts
@@ -1,4 +1,4 @@
-import type { TemplateContext } from './types';
+import { type TemplateContext, toShellPath } from './types';
 
 /**
  * {{MAKE_PDF_SETUP}} — emits the shell preamble that resolves $P to the
@@ -19,7 +19,7 @@ _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 P=""
 [ -n "$MAKE_PDF_BIN" ] && [ -x "$MAKE_PDF_BIN" ] && P="$MAKE_PDF_BIN"
 [ -z "$P" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf" ] && P="$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf"
-[ -z "$P" ] && P="$HOME${ctx.paths.makePdfDir.replace(/^~/, '')}/pdf"
+[ -z "$P" ] && P="${toShellPath(ctx.paths.makePdfDir)}/pdf"
 if [ -x "$P" ]; then
   echo "MAKE_PDF_READY: $P"
   alias _p_="$P"   # shellcheck alias helper (not exported)

--- a/scripts/resolvers/types.ts
+++ b/scripts/resolvers/types.ts
@@ -50,6 +50,16 @@ function buildHostPaths(): Record<string, HostPaths> {
 
 export const HOST_PATHS: Record<string, HostPaths> = buildHostPaths();
 
+/**
+ * Render a HostPaths binary dir as a shell-expandable absolute path.
+ * Claude-style dirs are `~`-rooted (e.g. `~/.claude/skills/gstack/browse/dist`)
+ * and expand via `$HOME`; env-var hosts already carry an absolute `$GSTACK_*`
+ * value, so they pass through untouched — prepending `$HOME` would double it.
+ */
+export function toShellPath(dir: string): string {
+  return dir.startsWith('~') ? `$HOME${dir.slice(1)}` : dir;
+}
+
 import type { Model } from '../models';
 export type { Model } from '../models';
 


### PR DESCRIPTION
Fixes #2055.

## Problem

Every non-Claude host that resolves binaries through `$GSTACK_*` env vars (codex, factory, cursor, opencode, slate, kiro, hermes, gbrain) ships a **binary-resolver fallback that doubles `$HOME`**, so the global-install fallback path never resolves. The skill reports `NEEDS_SETUP` / `BROWSE_NOT_AVAILABLE` / `DESIGN_NOT_AVAILABLE` even when the binary is built and present.

### Reproduction

```console
$ cd ~/.claude/skills/gstack && ./setup --host codex
$ grep -nE '\] && B=' ~/.codex/skills/gstack-qa/SKILL.md
861:[ -z "$B" ] && B="$HOME$GSTACK_BROWSE/browse"
```

`$GSTACK_BROWSE` is defined earlier in the same preamble as an **absolute** path:

```bash
GSTACK_ROOT="$HOME/.codex/skills/gstack"
GSTACK_BROWSE="$GSTACK_ROOT/browse/dist"
```

so `$HOME$GSTACK_BROWSE/browse` expands to `/Users/me/Users/me/.codex/skills/gstack/browse/dist/browse` — a doubled `$HOME` that does not exist:

```console
$ [ -e "$HOME$GSTACK_BROWSE/browse" ] && echo EXISTS || echo MISSING
MISSING
$ [ -e "$GSTACK_BROWSE/browse" ] && echo EXISTS || echo MISSING
EXISTS
```

The repo-local branch on the line above (`$_ROOT/.agents/skills/.../browse`) resolves first, so this only bites **plain global installs**, not repo-vendored ones — which is exactly the common Codex/Factory case.

### Scope

18 generated skills, three patterns across the browse/design/make-pdf setup blocks:

```
B="$HOME$GSTACK_BROWSE/browse"
D="$HOME$GSTACK_DESIGN/design"
P="$HOME$GSTACK_MAKE_PDF/pdf"
```

## Root cause

`scripts/resolvers/{browse,design,make-pdf}.ts` build the fallback as:

```ts
B="$HOME${ctx.paths.browseDir.replace(/^~/, '')}/browse"
```

This assumes `browseDir` is `~`-rooted — true for Claude (`~/.claude/skills/gstack/browse/dist`), where stripping `~` and prepending `$HOME` is correct. But for env-var hosts `buildHostPaths()` (`scripts/resolvers/types.ts`) sets `browseDir = "$GSTACK_BROWSE"`, so `.replace(/^~/, '')` is a no-op and `$HOME` is prepended to an already-absolute value.

## Fix

One shared helper in `scripts/resolvers/types.ts`, applied at all six call sites:

```ts
export function toShellPath(dir: string): string {
  return dir.startsWith('~') ? `$HOME${dir.slice(1)}` : dir;
}
```

- **Claude** (`~/.claude/.../browse/dist`) → `$HOME/.claude/.../browse/dist` — byte-identical to today.
- **Env-var hosts** (`$GSTACK_BROWSE`) → passes through untouched → `$GSTACK_BROWSE/browse`.

### Before / after (regenerated `gstack-qa`)

```diff
-[ -z "$B" ] && B="$HOME$GSTACK_BROWSE/browse"
+[ -z "$B" ] && B="$GSTACK_BROWSE/browse"
```

## Verification

- `bun run scripts/gen-skill-docs.ts --host all` → **0** remaining `$HOME$GSTACK*` occurrences across `.agents/.factory/.opencode/.cursor`.
- Regenerated Codex `$GSTACK_BROWSE/browse` resolves to an existing binary.
- Claude generated output unchanged (verified the qa/design/make-pdf fallback lines byte-for-byte).
- `tsc --noEmit` clean.
- `bun test test/resolver-entry.test.ts test/host-config.test.ts make-pdf/test/` → **270 pass, 0 fail** (golden `ship` fixtures unaffected — `ship` has no binary-resolver block).

## Call sites changed

- `scripts/resolvers/types.ts` — add `toShellPath()`
- `scripts/resolvers/browse.ts:109`
- `scripts/resolvers/design.ts:795,803,840`
- `scripts/resolvers/make-pdf.ts:22`

No generated/host output is committed (`.agents/` et al. are gitignored); CI regeneration picks up the source change.
