### PR TITLE
fix(browse): honor GSTACK_CHROMIUM_PATH in headless launch

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -371,6 +371,10 @@ export class BrowserManager {
 
     this.browser = await chromium.launch({
       headless: useHeadless,
+      // Honor a custom Chromium binary via GSTACK_CHROMIUM_PATH (e.g. distro
+      // Chromium on Linux/Arch where Playwright's bundled chrome-headless-shell
+      // isn't available). Mirrors the executablePath support in launchHeaded().
+      ...(process.env.GSTACK_CHROMIUM_PATH ? { executablePath: process.env.GSTACK_CHROMIUM_PATH } : {}),
       // On Windows, Chromium's sandbox fails when the server is spawned through
       // the Bun→Node process chain (GitHub #276). Disable it — local daemon
       // browsing user-specified URLs has marginal sandbox benefit. Also disabled


### PR DESCRIPTION
launchHeaded() already respects executablePath from GSTACK_CHROMIUM_PATH, but the default headless chromium.launch() in BrowserManager did not. On Linux distros where Playwright's bundled chrome-headless-shell isn't available (e.g. Arch — Playwright downloads an unsupported Ubuntu fallback build and the chrome-headless-shell fetch hangs), the headless daemon could never start even with a working system Chromium installed.

Mirror the headed path: spread executablePath from GSTACK_CHROMIUM_PATH into the headless launch so the default daemon can use a system Chromium (e.g. /usr/bin/chromium). No-op when the env var is unset.