### PR TITLE
[codex] Add desktop AI chat storage discovery spike

### DIFF
--- a/docs/spikes/desktop-ai-chat-storage-feasibility.md
+++ b/docs/spikes/desktop-ai-chat-storage-feasibility.md
@@ -1,0 +1,178 @@
+# Spike: macOS local AI chat storage feasibility without private content reads
+
+**Status:** complete (2026-06-21)
+**Issue:** Linear MAT-19
+**Surfaces:** desktop AI chat storage discovery, privacy-safe ingestion planning
+**Downstream consumers:** follow-up ingestion issues must use synthetic fixtures or user-approved export/cache samples
+
+## Question This Spike Answers
+
+Can gstack detect installed macOS desktop AI chat apps and assess local storage
+parser feasibility without printing or logging private chat content?
+
+## Privacy Boundary
+
+Discovery is metadata-only. The detector reports paths, file/directory types,
+sizes, mtimes, bundle identifiers, storage technologies, and parser feasibility.
+It must not emit:
+
+- raw chat text
+- auth tokens, cookies, localStorage values, or IndexedDB keys/values
+- screenshots or cached attachment names
+- database rows or LevelDB records
+- header bytes or string-scan excerpts from private files
+
+The added detector follows that boundary:
+
+```bash
+bun run scripts/desktop-ai-chat-storage-discovery.ts --existing-only --format markdown
+```
+
+The script uses `stat` metadata, app `Info.plist` bundle identifiers, shallow
+known-path discovery, and magic-byte/header classification for ChatGPT `.data`
+files. It does not dump bytes or parse private records.
+
+## Local Discovery Snapshot
+
+Measured on Matt's macOS machine on 2026-06-21 with the metadata-only detector.
+
+| Provider | Installed | Decision | Evidence |
+|---|---:|---|---|
+| ChatGPT Desktop | yes | promising but brittle | `/Applications/ChatGPT.app` bundle `com.openai.chat`; `~/Library/Application Support/com.openai.chat`; `.data` files under `conversations-v3-*`, `drafts-v2-*`, model/gizmo/helper caches |
+| Claude Desktop | yes | metadata-only | `/Applications/Claude.app` bundle `com.anthropic.claudefordesktop`; `~/Library/Application Support/Claude`; Chromium-style `IndexedDB`, `Local Storage`, `Session Storage`, `Cookies`, `Service Worker` paths |
+| Gemini | no | not feasible | no dedicated `/Applications/Gemini.app` detected; browser/PWA cache inspection is out of scope |
+| Grok | no | not feasible | no dedicated `/Applications/Grok.app` or local Grok/xAI app container detected |
+| Perplexity | yes | promising but brittle | `/Applications/Perplexity.app` bundle `ai.perplexity.macv3`; `~/Library/Containers/ai.perplexity.mac`; `~/Library/Application Support/Perplexity`; Perplexity group containers |
+| Comet | yes | promising but brittle | `/Applications/Comet.app` bundle `ai.perplexity.comet`; `~/Library/Application Support/Comet`; Chromium-style `Default/IndexedDB` and `Default/Local Storage`; Perplexity group containers |
+
+## Provider Findings
+
+### ChatGPT Desktop
+
+Detected:
+
+| Path | Type/technology | Parser feasibility |
+|---|---|---|
+| `/Applications/ChatGPT.app` | macOS app bundle, `com.openai.chat` | installed app detection is reliable |
+| `~/Library/Application Support/com.openai.chat` | Application Support root | structural discovery is reliable |
+| `~/Library/Application Support/com.openai.chat/conversations-v3-*/<id>.data` | `.data` files, mixed protobuf-like/msgpack-like/custom-binary guesses by header only | promising but brittle |
+| `~/Library/Application Support/com.openai.chat/drafts-v2-*/NewThreadDraft.data` | `.data` file, protobuf-like by header only | drafts likely recoverable only with approved fixtures |
+| `~/Library/Group Containers/group.com.openai.chat` | macOS group container | metadata-only |
+
+Header-only classification found `.data` files that are not SQLite and not
+plain gzip/lz4/zstd. Some look Apple-binary-plist, msgpack-like, protobuf-like,
+or custom/encrypted binary. The classifier intentionally does not print header
+bytes or run string scans.
+
+**Decision:** promising but brittle. There are clear local conversation-shaped
+files, but record extraction needs synthetic fixtures or user-approved samples
+to avoid reading private values.
+
+### Claude Desktop
+
+Detected:
+
+| Path | Type/technology | Parser feasibility |
+|---|---|---|
+| `/Applications/Claude.app` | macOS app bundle, `com.anthropic.claudefordesktop` | installed app detection is reliable |
+| `~/Library/Application Support/Claude/IndexedDB` | Chromium IndexedDB, usually LevelDB-backed | metadata-only |
+| `~/Library/Application Support/Claude/Local Storage/leveldb` | Chromium Local Storage LevelDB | not an ingestion source; sensitive values skipped |
+| `~/Library/Application Support/Claude/Session Storage` | Chromium Session Storage | not an ingestion source; sensitive values skipped |
+| `~/Library/Application Support/Claude/Cookies` | cookie store path | not inspected |
+
+The safe evidence proves Claude Desktop uses Chromium/Electron storage shapes.
+It does not prove whether IndexedDB contains complete conversation records,
+drafts, cache, or metadata. Proving complete recoverability would require
+reading LevelDB keys/values or equivalent private payloads, so this spike stops
+there.
+
+**Decision:** metadata-only. Follow-up work needs synthetic Claude Desktop
+fixtures or explicitly user-approved cache/export samples.
+
+### Gemini
+
+No dedicated Gemini macOS app bundle was detected. The detector reports Gemini
+as not installed unless a local `/Applications/Gemini.app`-style target exists.
+Browser profile or PWA cache inspection is intentionally out of scope.
+
+**Decision:** not feasible.
+
+### Grok
+
+No dedicated Grok macOS app bundle or local Grok/xAI container was detected.
+The detector reports Grok as not installed/no dedicated macOS target unless a
+local app or container exists.
+
+**Decision:** not feasible.
+
+### Perplexity
+
+Detected:
+
+| Path | Type/technology | Parser feasibility |
+|---|---|---|
+| `/Applications/Perplexity.app` | macOS app bundle, `ai.perplexity.macv3` | installed app detection is reliable |
+| `~/Library/Containers/ai.perplexity.mac` | macOS sandbox container | metadata-only |
+| `~/Library/Application Support/Perplexity` | Application Support root | structural discovery is reliable |
+| `~/Library/Group Containers/7S8W4W365S.ai.perplexity.macv3.shared` | macOS group container | metadata-only |
+| `~/Library/Group Containers/group.ai.perplexity.app` | macOS group container | metadata-only |
+| `~/Library/Group Containers/group.ai.perplexity.mac` | macOS group container | metadata-only |
+
+**Decision:** promising but brittle. App/container detection is straightforward,
+but ingestion requires documented provider formats, synthetic fixtures, or
+user-approved exports/cache samples.
+
+### Comet
+
+Detected:
+
+| Path | Type/technology | Parser feasibility |
+|---|---|---|
+| `/Applications/Comet.app` | macOS app bundle, `ai.perplexity.comet` | installed app detection is reliable |
+| `~/Library/Application Support/Comet` | Application Support root | structural discovery is reliable |
+| `~/Library/Application Support/Comet/Default/IndexedDB` | Chromium IndexedDB, usually LevelDB-backed | metadata-only unless fixture-backed |
+| `~/Library/Application Support/Comet/Default/Local Storage` | Chromium Local Storage | not an ingestion source; sensitive values skipped |
+
+**Decision:** promising but brittle. Comet appears Chromium-like; app detection
+is clean, but chat ingestion from browser-style storage is brittle without
+fixture-backed provider-specific parsing.
+
+## Implementation Asset
+
+Added `scripts/desktop-ai-chat-storage-discovery.ts`:
+
+- provider-aware candidates for ChatGPT, Claude, Gemini, Grok, Perplexity, and
+  Comet
+- exact Perplexity/Comet paths requested in MAT-19/MAT-24 comments
+- app bundle ID extraction from `Info.plist`
+- metadata-only structural storage detection
+- ChatGPT `.data` classification by header/magic-byte categories only
+- JSON and Markdown output modes
+- test hooks for synthetic home/application roots
+
+## Test Coverage
+
+Added `test/desktop-ai-chat-storage-discovery.test.ts`:
+
+- verifies synthetic ChatGPT app/storage metadata detection
+- verifies synthetic private-looking chat text is not present in JSON or
+  Markdown output
+- verifies Gemini remains `not feasible` without a dedicated app bundle
+- verifies `.data` header classification for SQLite, gzip, and unknown binary
+
+Focused test command:
+
+```bash
+bun test test/desktop-ai-chat-storage-discovery.test.ts
+```
+
+## Follow-Up Guardrail
+
+Any ingestion issue after this spike must require one of:
+
+- synthetic fixtures created specifically for parser development
+- user-approved exports
+- user-approved cache samples with explicit scope and redaction expectations
+
+Do not build parsers by scanning private LevelDB/SQLite/blob values from a real
+user profile.

--- a/docs/spikes/desktop-ai-chat-storage-feasibility.md
+++ b/docs/spikes/desktop-ai-chat-storage-feasibility.md
@@ -28,9 +28,11 @@ The added detector follows that boundary:
 bun run scripts/desktop-ai-chat-storage-discovery.ts --existing-only --format markdown
 ```
 
-The script uses `stat` metadata, app `Info.plist` bundle identifiers, shallow
-known-path discovery, and magic-byte/header classification for ChatGPT `.data`
-files. It does not dump bytes or parse private records.
+The script uses `stat` metadata, app `Info.plist` bundle identifiers, and
+shallow known-path discovery. By default it does not open private provider cache
+files for header inspection. Magic-byte/header classification is available only
+with `--allow-header-read`, which is reserved for synthetic fixtures or
+explicitly approved samples.
 
 ## Local Discovery Snapshot
 
@@ -38,7 +40,7 @@ Measured on Matt's macOS machine on 2026-06-21 with the metadata-only detector.
 
 | Provider | Installed | Decision | Evidence |
 |---|---:|---|---|
-| ChatGPT Desktop | yes | promising but brittle | `/Applications/ChatGPT.app` bundle `com.openai.chat`; `~/Library/Application Support/com.openai.chat`; `.data` files under `conversations-v3-*`, `drafts-v2-*`, model/gizmo/helper caches |
+| ChatGPT Desktop | yes | promising but brittle | `/Applications/ChatGPT.app` bundle `com.openai.chat`; `~/Library/Application Support/com.openai.chat`; metadata-only `.data` file evidence under conversation/draft/cache roots |
 | Claude Desktop | yes | metadata-only | `/Applications/Claude.app` bundle `com.anthropic.claudefordesktop`; `~/Library/Application Support/Claude`; Chromium-style `IndexedDB`, `Local Storage`, `Session Storage`, `Cookies`, `Service Worker` paths |
 | Gemini | no | not feasible | no dedicated `/Applications/Gemini.app` detected; browser/PWA cache inspection is out of scope |
 | Grok | no | not feasible | no dedicated `/Applications/Grok.app` or local Grok/xAI app container detected |
@@ -59,14 +61,15 @@ Detected:
 | `~/Library/Application Support/com.openai.chat/drafts-v2-*/NewThreadDraft.data` | `.data` file, protobuf-like by header only | drafts likely recoverable only with approved fixtures |
 | `~/Library/Group Containers/group.com.openai.chat` | macOS group container | metadata-only |
 
-Header-only classification found `.data` files that are not SQLite and not
-plain gzip/lz4/zstd. Some look Apple-binary-plist, msgpack-like, protobuf-like,
-or custom/encrypted binary. The classifier intentionally does not print header
-bytes or run string scans.
+Metadata-only discovery found `.data` files under conversation-shaped roots.
+Default discovery deliberately does not classify those files by reading headers,
+because even a small prefix read could load private plaintext into memory if a
+provider changes formats. Header-only classification is opt-in for synthetic
+fixtures or explicitly approved samples.
 
 **Decision:** promising but brittle. There are clear local conversation-shaped
-files, but record extraction needs synthetic fixtures or user-approved samples
-to avoid reading private values.
+files, but record extraction and binary classification need synthetic fixtures
+or user-approved samples.
 
 ### Claude Desktop
 
@@ -146,7 +149,9 @@ Added `scripts/desktop-ai-chat-storage-discovery.ts`:
 - exact Perplexity/Comet paths requested in MAT-19/MAT-24 comments
 - app bundle ID extraction from `Info.plist`
 - metadata-only structural storage detection
-- ChatGPT `.data` classification by header/magic-byte categories only
+- ChatGPT `.data` metadata discovery by default
+- opt-in ChatGPT `.data` header/magic-byte classification for synthetic or
+  explicitly approved samples
 - JSON and Markdown output modes
 - test hooks for synthetic home/application roots
 
@@ -155,8 +160,9 @@ Added `scripts/desktop-ai-chat-storage-discovery.ts`:
 Added `test/desktop-ai-chat-storage-discovery.test.ts`:
 
 - verifies synthetic ChatGPT app/storage metadata detection
-- verifies synthetic private-looking chat text is not present in JSON or
-  Markdown output
+- verifies synthetic private-looking chat text and private-looking filenames are
+  not present in JSON or Markdown output
+- verifies header classification is explicit opt-in
 - verifies Gemini remains `not feasible` without a dedicated app bundle
 - verifies `.data` header classification for SQLite, gzip, and unknown binary
 

--- a/scripts/desktop-ai-chat-storage-discovery.ts
+++ b/scripts/desktop-ai-chat-storage-discovery.ts
@@ -23,6 +23,12 @@ export interface DiscoveryOptions {
   homeDir?: string;
   applicationsDirs?: string[];
   includeMissing?: boolean;
+  /**
+   * Off by default. Reading even a small prefix from provider cache files can
+   * load private chat content into memory if the provider stores plaintext.
+   * Enable only for synthetic fixtures or explicitly approved samples.
+   */
+  allowHeaderRead?: boolean;
 }
 
 export interface DiscoveryEntry {
@@ -84,6 +90,7 @@ interface ProviderSpec {
   appNames: string[];
   storageRoots: (homeDir: string) => string[];
   dynamicRoots?: (homeDir: string) => string[];
+  installedFromStorage?: (entry: DiscoveryEntry) => boolean;
   decision: ProviderDecision;
   limitations: string[];
   installedRequiresApp?: boolean;
@@ -106,7 +113,7 @@ function providerSpecs(applicationsDirs: string[]): ProviderSpec[] {
       decision: 'promising but brittle',
       dataExtensions: CHATGPT_DATA_EXTENSIONS,
       limitations: [
-        '.data files can be classified by headers and magic bytes only; extracting records needs synthetic fixtures or user-approved samples.',
+        '.data files are discovered by metadata only by default; header classification is opt-in for synthetic fixtures or user-approved samples.',
       ],
     },
     {
@@ -148,7 +155,6 @@ function providerSpecs(applicationsDirs: string[]): ProviderSpec[] {
       ],
       dynamicRoots: homeDir => groupContainersMatching(homeDir, /grok|xai/i),
       decision: 'not feasible',
-      installedRequiresApp: true,
       limitations: [
         'Report as not installed/no dedicated macOS target unless a local app bundle or container exists.',
       ],
@@ -173,6 +179,10 @@ function providerSpecs(applicationsDirs: string[]): ProviderSpec[] {
         path.join(homeDir, 'Library/Application Support/Comet'),
       ],
       dynamicRoots: homeDir => groupContainersMatching(homeDir, /comet|perplexity/i),
+      installedFromStorage: entry =>
+        entry.path.includes('/Library/Application Support/Comet')
+        || entry.path.includes('/Library/Containers/ai.perplexity.comet')
+        || entry.path.toLowerCase().includes('/comet'),
       decision: 'promising but brittle',
       limitations: [
         'Comet is Chromium-like browser storage; app-level ingestion is brittle unless provider-owned data formats are documented or fixture-backed.',
@@ -192,17 +202,27 @@ export function discoverDesktopAiChatStorage(options: DiscoveryOptions = {}): Pr
       ...(spec.dynamicRoots ? spec.dynamicRoots(homeDir) : []),
     ]);
     const directEntries = candidates
-      .map(candidate => describePath(candidate, options.includeMissing ?? true))
+      .map(candidate => describePath(candidate, options.includeMissing ?? true, {
+        allowHeaderRead: options.allowHeaderRead ?? false,
+      }))
       .filter((entry): entry is DiscoveryEntry => Boolean(entry));
 
     const existingRoots = directEntries.filter(entry => entry.exists && entry.kind !== 'file');
     const structuralEntries = existingRoots.flatMap(entry =>
-      describeStructuralStorage(entry.path, spec.dataExtensions)
+      describeStructuralStorage(entry.path, {
+        dataExtensions: spec.dataExtensions,
+        allowHeaderRead: options.allowHeaderRead ?? false,
+      })
     );
 
     const entries = uniqueEntries([...directEntries, ...structuralEntries]);
     const hasApp = directEntries.some(entry => entry.exists && entry.kind === 'app-bundle');
-    const hasStorage = directEntries.some(entry => entry.exists && entry.kind !== 'missing' && entry.kind !== 'app-bundle');
+    const hasStorage = directEntries.some(entry =>
+      entry.exists
+      && entry.kind !== 'missing'
+      && entry.kind !== 'app-bundle'
+      && (spec.installedFromStorage ? spec.installedFromStorage(entry) : true)
+    );
     const installed = spec.installedRequiresApp ? hasApp : hasApp || hasStorage;
 
     return {
@@ -228,14 +248,15 @@ export function formatDiscoveryMarkdown(discoveries: ProviderDiscovery[]): strin
     lines.push(`- Installed: ${discovery.installed ? 'yes' : 'no'}`);
     lines.push(`- Decision: ${discovery.decision}`);
     lines.push('');
-    lines.push('| Path | Kind | Type/technology | Size | Modified | Bundle ID | Note |');
-    lines.push('|---|---|---|---:|---|---|---|');
+    lines.push('| Path | Kind | Type/technology | Parser feasibility | Size | Modified | Bundle ID | Note |');
+    lines.push('|---|---|---|---|---:|---|---|---|');
 
     for (const entry of discovery.entries) {
       lines.push([
         entry.path,
         entry.kind,
         entry.storageTechnology ?? entry.fileType ?? '',
+        entry.parserFeasibility ?? '',
         entry.sizeBytes === undefined ? '' : String(entry.sizeBytes),
         entry.modifiedAt ?? '',
         entry.bundleIdentifier ?? '',
@@ -254,47 +275,65 @@ export function formatDiscoveryMarkdown(discoveries: ProviderDiscovery[]): strin
   return lines.join('\n');
 }
 
-function describePath(targetPath: string, includeMissing: boolean): DiscoveryEntry | null {
+function describePath(
+  targetPath: string,
+  includeMissing: boolean,
+  options: { allowHeaderRead?: boolean; displayPath?: string } = {},
+): DiscoveryEntry | null {
   let stat: fs.Stats;
   try {
     stat = fs.statSync(targetPath);
   } catch {
     return includeMissing
-      ? { path: targetPath, exists: false, kind: 'missing', note: 'not installed / not found' }
+      ? { path: options.displayPath ?? targetPath, exists: false, kind: 'missing', note: 'not installed / not found' }
       : null;
   }
 
   const isApp = isAppBundle(targetPath, stat);
   const kind = isApp ? 'app-bundle' : stat.isDirectory() ? 'directory' : 'file';
   return {
-    path: targetPath,
+    path: options.displayPath ?? targetPath,
     exists: true,
     kind,
-    fileType: kind === 'file' ? classifyFile(targetPath) : undefined,
+    fileType: kind === 'file' ? classifyFile(targetPath, options.allowHeaderRead ?? false) : undefined,
     sizeBytes: stat.size,
     modifiedAt: stat.mtime.toISOString(),
     bundleIdentifier: isApp ? readBundleIdentifier(targetPath) : undefined,
-    storageTechnology: inferStorageTechnology(targetPath, kind),
+    storageTechnology: inferStorageTechnology(options.displayPath ?? targetPath, kind),
   };
 }
 
-function describeStructuralStorage(root: string, dataExtensions?: Set<string>): DiscoveryEntry[] {
+function describeStructuralStorage(
+  root: string,
+  options: { dataExtensions?: Set<string>; allowHeaderRead?: boolean },
+): DiscoveryEntry[] {
   const entries: DiscoveryEntry[] = [];
 
   for (const relPath of STRUCTURAL_RELATIVE_PATHS) {
     const fullPath = path.join(root, relPath);
-    const entry = describePath(fullPath, false);
+    const entry = describePath(fullPath, false, {
+      allowHeaderRead: options.allowHeaderRead ?? false,
+    });
     if (!entry) continue;
     entry.parserFeasibility = feasibilityFor(entry);
     entries.push(entry);
   }
 
-  if (dataExtensions && dataExtensions.size > 0) {
-    for (const filePath of findFilesByExtension(root, dataExtensions, 5, 100)) {
-      const entry = describePath(filePath, false);
+  if (options.dataExtensions && options.dataExtensions.size > 0) {
+    const filePaths = findFilesByExtension(root, options.dataExtensions, 5, 100);
+    for (let i = 0; i < filePaths.length; i++) {
+      const filePath = filePaths[i];
+      const entry = describePath(filePath, false, {
+        allowHeaderRead: options.allowHeaderRead ?? false,
+        displayPath: redactedPrivateFilePath(root, filePath, i + 1),
+      });
       if (!entry) continue;
-      entry.storageTechnology = classifyDataFile(filePath);
-      entry.parserFeasibility = 'header-only classification; do not parse private values without fixture approval';
+      entry.storageTechnology = options.allowHeaderRead
+        ? classifyDataFile(filePath)
+        : '.data file; private header/content not inspected';
+      entry.parserFeasibility = options.allowHeaderRead
+        ? 'header-only classification on synthetic/user-approved sample; do not parse private values'
+        : 'metadata-only; rerun with --allow-header-read only for synthetic/user-approved samples';
       entries.push(entry);
     }
   }
@@ -343,12 +382,14 @@ function inferStorageTechnology(targetPath: string, kind: DiscoveryEntry['kind']
   return undefined;
 }
 
-function classifyFile(filePath: string): string {
+function classifyFile(filePath: string, allowHeaderRead: boolean): string {
   const ext = path.extname(filePath).toLowerCase();
   if (ext === '.sqlite' || ext === '.sqlite3' || ext === '.db') {
-    return classifySqliteLike(filePath);
+    return allowHeaderRead ? classifySqliteLike(filePath) : 'database-like file; private header/content not inspected';
   }
-  if (ext === '.data') return classifyDataFile(filePath);
+  if (ext === '.data') {
+    return allowHeaderRead ? classifyDataFile(filePath) : '.data file; private header/content not inspected';
+  }
   return ext ? `${ext.slice(1)} file` : 'file';
 }
 
@@ -409,6 +450,12 @@ function readPrefix(filePath: string, bytes: number): Buffer | null {
   } finally {
     if (fd !== null) fs.closeSync(fd);
   }
+}
+
+function redactedPrivateFilePath(root: string, filePath: string, index: number): string {
+  const ext = path.extname(filePath) || '.file';
+  const ordinal = String(index).padStart(3, '0');
+  return path.join(root, '...', `<redacted-private-file-${ordinal}${ext}>`);
 }
 
 function readBundleIdentifier(appPath: string): string | undefined {
@@ -496,6 +543,8 @@ function parseArgs(argv: string[]) {
       options.applicationsDirs = [...(options.applicationsDirs ?? []), argv[++i]];
     } else if (arg === '--existing-only') {
       options.includeMissing = false;
+    } else if (arg === '--allow-header-read') {
+      options.allowHeaderRead = true;
     } else if (arg === '--help') {
       printHelp();
       process.exit(0);
@@ -515,9 +564,12 @@ Options:
   --home PATH                  Home directory to inspect. Default: current user home.
   --applications-dir PATH      Applications directory. Can be repeated.
   --existing-only              Omit missing candidate paths.
+  --allow-header-read          Opt in to magic-byte classification for synthetic
+                               or explicitly approved samples. Off by default.
   --help                       Show this help.
 
-Privacy invariant: emits metadata and structural classifications only.`);
+Privacy invariant: emits metadata and structural classifications only. By default,
+private cache files are not opened for header inspection.`);
 }
 
 if (import.meta.main) {

--- a/scripts/desktop-ai-chat-storage-discovery.ts
+++ b/scripts/desktop-ai-chat-storage-discovery.ts
@@ -1,0 +1,536 @@
+#!/usr/bin/env bun
+/**
+ * Metadata-only discovery for local desktop AI chat app storage on macOS.
+ *
+ * Privacy invariant: this script never prints file contents, database values,
+ * localStorage values, IndexedDB keys/values, cookies, screenshots, or cached
+ * attachment names. It reports known app/container roots plus structural storage
+ * paths and file classifications derived from metadata and magic bytes only.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+
+export type ProviderDecision =
+  | 'supported'
+  | 'promising but brittle'
+  | 'metadata-only'
+  | 'not feasible';
+
+export interface DiscoveryOptions {
+  homeDir?: string;
+  applicationsDirs?: string[];
+  includeMissing?: boolean;
+}
+
+export interface DiscoveryEntry {
+  path: string;
+  exists: boolean;
+  kind: 'app-bundle' | 'directory' | 'file' | 'missing';
+  fileType?: string;
+  sizeBytes?: number;
+  modifiedAt?: string;
+  bundleIdentifier?: string;
+  storageTechnology?: string;
+  parserFeasibility?: string;
+  note?: string;
+}
+
+export interface ProviderDiscovery {
+  provider: string;
+  decision: ProviderDecision;
+  installed: boolean;
+  entries: DiscoveryEntry[];
+  limitations: string[];
+}
+
+const STRUCTURAL_RELATIVE_PATHS = [
+  'IndexedDB',
+  'Default/IndexedDB',
+  'Partitions',
+  'Local Storage',
+  'Local Storage/leveldb',
+  'Default/Local Storage',
+  'Session Storage',
+  'databases',
+  'Database',
+  'Network',
+  'Network/Cookies',
+  'Cookies',
+  'blob_storage',
+  'Service Worker',
+  'Service Worker/Database',
+];
+
+const CHATGPT_DATA_EXTENSIONS = new Set(['.data']);
+const SKIPPED_DISCOVERY_DIRS = new Set([
+  'Cache',
+  'CacheStorage',
+  'Code Cache',
+  'GPUCache',
+  'DawnCache',
+  'Crashpad',
+  'logs',
+  'tmp',
+  'attachments',
+  'Attachments',
+  'Downloads',
+]);
+
+interface ProviderSpec {
+  provider: string;
+  appNames: string[];
+  storageRoots: (homeDir: string) => string[];
+  dynamicRoots?: (homeDir: string) => string[];
+  decision: ProviderDecision;
+  limitations: string[];
+  installedRequiresApp?: boolean;
+  dataExtensions?: Set<string>;
+}
+
+function providerSpecs(applicationsDirs: string[]): ProviderSpec[] {
+  const applicationApp = (name: string) => applicationsDirs.map(dir => path.join(dir, `${name}.app`));
+
+  return [
+    {
+      provider: 'ChatGPT Desktop',
+      appNames: applicationApp('ChatGPT'),
+      storageRoots: homeDir => [
+        path.join(homeDir, 'Library/Containers/com.openai.chat'),
+        path.join(homeDir, 'Library/Application Support/ChatGPT'),
+        path.join(homeDir, 'Library/Application Support/com.openai.chat'),
+      ],
+      dynamicRoots: homeDir => groupContainersMatching(homeDir, /openai|chatgpt/i),
+      decision: 'promising but brittle',
+      dataExtensions: CHATGPT_DATA_EXTENSIONS,
+      limitations: [
+        '.data files can be classified by headers and magic bytes only; extracting records needs synthetic fixtures or user-approved samples.',
+      ],
+    },
+    {
+      provider: 'Claude Desktop',
+      appNames: applicationApp('Claude'),
+      storageRoots: homeDir => [
+        path.join(homeDir, 'Library/Application Support/Claude'),
+        path.join(homeDir, 'Library/Containers/com.anthropic.claude'),
+        path.join(homeDir, 'Library/Containers/com.anthropic.claudefordesktop'),
+      ],
+      dynamicRoots: homeDir => groupContainersMatching(homeDir, /anthropic|claude/i),
+      decision: 'metadata-only',
+      limitations: [
+        'IndexedDB/LevelDB metadata can prove storage shape, but complete conversation recovery cannot be proven without reading private values.',
+      ],
+    },
+    {
+      provider: 'Gemini',
+      appNames: applicationApp('Gemini'),
+      storageRoots: homeDir => [
+        path.join(homeDir, 'Library/Application Support/Gemini'),
+        path.join(homeDir, 'Library/Containers/com.google.Gemini'),
+        path.join(homeDir, 'Library/Containers/com.google.gemini'),
+      ],
+      dynamicRoots: homeDir => groupContainersMatching(homeDir, /gemini/i),
+      decision: 'not feasible',
+      installedRequiresApp: true,
+      limitations: [
+        'Report as not installed unless a dedicated Gemini macOS app bundle exists; browser/PWA cache discovery is out of scope.',
+      ],
+    },
+    {
+      provider: 'Grok',
+      appNames: applicationApp('Grok'),
+      storageRoots: homeDir => [
+        path.join(homeDir, 'Library/Application Support/Grok'),
+        path.join(homeDir, 'Library/Containers/ai.x.grok'),
+        path.join(homeDir, 'Library/Containers/com.xai.grok'),
+      ],
+      dynamicRoots: homeDir => groupContainersMatching(homeDir, /grok|xai/i),
+      decision: 'not feasible',
+      installedRequiresApp: true,
+      limitations: [
+        'Report as not installed/no dedicated macOS target unless a local app bundle or container exists.',
+      ],
+    },
+    {
+      provider: 'Perplexity',
+      appNames: applicationApp('Perplexity'),
+      storageRoots: homeDir => [
+        path.join(homeDir, 'Library/Containers/ai.perplexity.mac'),
+        path.join(homeDir, 'Library/Application Support/Perplexity'),
+      ],
+      dynamicRoots: homeDir => groupContainersMatching(homeDir, /perplexity/i),
+      decision: 'promising but brittle',
+      limitations: [
+        'Perplexity app storage is inspectable as app/container metadata; ingestion requires synthetic fixtures or user-approved exports/cache samples.',
+      ],
+    },
+    {
+      provider: 'Comet',
+      appNames: applicationApp('Comet'),
+      storageRoots: homeDir => [
+        path.join(homeDir, 'Library/Application Support/Comet'),
+      ],
+      dynamicRoots: homeDir => groupContainersMatching(homeDir, /comet|perplexity/i),
+      decision: 'promising but brittle',
+      limitations: [
+        'Comet is Chromium-like browser storage; app-level ingestion is brittle unless provider-owned data formats are documented or fixture-backed.',
+      ],
+    },
+  ];
+}
+
+export function discoverDesktopAiChatStorage(options: DiscoveryOptions = {}): ProviderDiscovery[] {
+  const homeDir = options.homeDir ?? os.homedir();
+  const applicationsDirs = options.applicationsDirs ?? ['/Applications', path.join(homeDir, 'Applications')];
+
+  return providerSpecs(applicationsDirs).map(spec => {
+    const candidates = uniquePaths([
+      ...spec.appNames,
+      ...spec.storageRoots(homeDir),
+      ...(spec.dynamicRoots ? spec.dynamicRoots(homeDir) : []),
+    ]);
+    const directEntries = candidates
+      .map(candidate => describePath(candidate, options.includeMissing ?? true))
+      .filter((entry): entry is DiscoveryEntry => Boolean(entry));
+
+    const existingRoots = directEntries.filter(entry => entry.exists && entry.kind !== 'file');
+    const structuralEntries = existingRoots.flatMap(entry =>
+      describeStructuralStorage(entry.path, spec.dataExtensions)
+    );
+
+    const entries = uniqueEntries([...directEntries, ...structuralEntries]);
+    const hasApp = directEntries.some(entry => entry.exists && entry.kind === 'app-bundle');
+    const hasStorage = directEntries.some(entry => entry.exists && entry.kind !== 'missing' && entry.kind !== 'app-bundle');
+    const installed = spec.installedRequiresApp ? hasApp : hasApp || hasStorage;
+
+    return {
+      provider: spec.provider,
+      decision: installed ? spec.decision : 'not feasible',
+      installed,
+      entries,
+      limitations: spec.limitations,
+    };
+  });
+}
+
+export function formatDiscoveryMarkdown(discoveries: ProviderDiscovery[]): string {
+  const lines: string[] = [];
+  lines.push('# Desktop AI Chat Storage Discovery');
+  lines.push('');
+  lines.push('Privacy mode: metadata only. No file contents, database values, localStorage values, IndexedDB values, cookies, screenshots, or cached attachment names are emitted.');
+  lines.push('');
+
+  for (const discovery of discoveries) {
+    lines.push(`## ${discovery.provider}`);
+    lines.push('');
+    lines.push(`- Installed: ${discovery.installed ? 'yes' : 'no'}`);
+    lines.push(`- Decision: ${discovery.decision}`);
+    lines.push('');
+    lines.push('| Path | Kind | Type/technology | Size | Modified | Bundle ID | Note |');
+    lines.push('|---|---|---|---:|---|---|---|');
+
+    for (const entry of discovery.entries) {
+      lines.push([
+        entry.path,
+        entry.kind,
+        entry.storageTechnology ?? entry.fileType ?? '',
+        entry.sizeBytes === undefined ? '' : String(entry.sizeBytes),
+        entry.modifiedAt ?? '',
+        entry.bundleIdentifier ?? '',
+        entry.note ?? '',
+      ].map(markdownCell).join('|').replace(/^/, '|').replace(/$/, '|'));
+    }
+
+    if (discovery.limitations.length > 0) {
+      lines.push('');
+      lines.push('Limitations:');
+      for (const limitation of discovery.limitations) lines.push(`- ${limitation}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function describePath(targetPath: string, includeMissing: boolean): DiscoveryEntry | null {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(targetPath);
+  } catch {
+    return includeMissing
+      ? { path: targetPath, exists: false, kind: 'missing', note: 'not installed / not found' }
+      : null;
+  }
+
+  const isApp = isAppBundle(targetPath, stat);
+  const kind = isApp ? 'app-bundle' : stat.isDirectory() ? 'directory' : 'file';
+  return {
+    path: targetPath,
+    exists: true,
+    kind,
+    fileType: kind === 'file' ? classifyFile(targetPath) : undefined,
+    sizeBytes: stat.size,
+    modifiedAt: stat.mtime.toISOString(),
+    bundleIdentifier: isApp ? readBundleIdentifier(targetPath) : undefined,
+    storageTechnology: inferStorageTechnology(targetPath, kind),
+  };
+}
+
+function describeStructuralStorage(root: string, dataExtensions?: Set<string>): DiscoveryEntry[] {
+  const entries: DiscoveryEntry[] = [];
+
+  for (const relPath of STRUCTURAL_RELATIVE_PATHS) {
+    const fullPath = path.join(root, relPath);
+    const entry = describePath(fullPath, false);
+    if (!entry) continue;
+    entry.parserFeasibility = feasibilityFor(entry);
+    entries.push(entry);
+  }
+
+  if (dataExtensions && dataExtensions.size > 0) {
+    for (const filePath of findFilesByExtension(root, dataExtensions, 5, 100)) {
+      const entry = describePath(filePath, false);
+      if (!entry) continue;
+      entry.storageTechnology = classifyDataFile(filePath);
+      entry.parserFeasibility = 'header-only classification; do not parse private values without fixture approval';
+      entries.push(entry);
+    }
+  }
+
+  return entries;
+}
+
+function findFilesByExtension(root: string, extensions: Set<string>, maxDepth: number, limit: number): string[] {
+  const found: string[] = [];
+
+  function walk(current: string, depth: number) {
+    if (found.length >= limit || depth > maxDepth) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (found.length >= limit) return;
+      if (SKIPPED_DISCOVERY_DIRS.has(entry.name)) continue;
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath, depth + 1);
+      } else if (entry.isFile() && extensions.has(path.extname(entry.name))) {
+        found.push(fullPath);
+      }
+    }
+  }
+
+  walk(root, 0);
+  return found.sort();
+}
+
+function inferStorageTechnology(targetPath: string, kind: DiscoveryEntry['kind']): string | undefined {
+  const normalized = targetPath.toLowerCase();
+  if (kind === 'app-bundle') return 'macOS app bundle';
+  if (normalized.includes('indexeddb')) return 'IndexedDB directory, usually LevelDB-backed in Electron/Chromium';
+  if (normalized.includes('local storage')) return 'Chromium Local Storage directory; values intentionally not inspected';
+  if (normalized.includes('session storage')) return 'Chromium Session Storage directory; values intentionally not inspected';
+  if (normalized.includes('cookies')) return 'cookie store path; values intentionally not inspected';
+  if (normalized.includes('service worker')) return 'Chromium Service Worker storage';
+  if (normalized.includes('application support')) return 'Application Support root';
+  if (normalized.includes('/containers/') || normalized.includes('/group containers/')) return 'macOS sandbox/group container root';
+  return undefined;
+}
+
+function classifyFile(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.sqlite' || ext === '.sqlite3' || ext === '.db') {
+    return classifySqliteLike(filePath);
+  }
+  if (ext === '.data') return classifyDataFile(filePath);
+  return ext ? `${ext.slice(1)} file` : 'file';
+}
+
+function classifySqliteLike(filePath: string): string {
+  const header = readPrefix(filePath, 16);
+  return header?.equals(Buffer.from('SQLite format 3\0', 'binary'))
+    ? 'SQLite database'
+    : 'database-like file, not SQLite header';
+}
+
+export function classifyDataFile(filePath: string): string {
+  const prefix = readPrefix(filePath, 512);
+  if (!prefix || prefix.length === 0) return '.data file, empty or unreadable';
+  if (prefix.subarray(0, 16).equals(Buffer.from('SQLite format 3\0', 'binary'))) return '.data file, SQLite database';
+  if (prefix.subarray(0, 2).equals(Buffer.from([0x1f, 0x8b]))) return '.data file, gzip-compressed';
+  if (prefix.subarray(0, 4).equals(Buffer.from([0x28, 0xb5, 0x2f, 0xfd]))) return '.data file, zstd-compressed';
+  if (prefix.subarray(0, 4).equals(Buffer.from([0x04, 0x22, 0x4d, 0x18]))) return '.data file, lz4-compressed';
+  if (prefix.subarray(0, 8).toString('ascii') === 'bplist00') return '.data file, Apple binary plist';
+  if (looksLikeUtf8Text(prefix)) return '.data file, plaintext/JSON-like by byte class; contents not emitted';
+  if (looksLikeMsgpack(prefix)) return '.data file, msgpack-like binary; structural guess only';
+  if (looksLikeProtobuf(prefix)) return '.data file, protobuf-like binary; structural guess only';
+  return '.data file, custom/encrypted binary or unknown compression';
+}
+
+function looksLikeUtf8Text(prefix: Buffer): boolean {
+  let printable = 0;
+  let considered = 0;
+  for (const byte of prefix) {
+    if (byte === 0) return false;
+    if (byte === 0x09 || byte === 0x0a || byte === 0x0d || (byte >= 0x20 && byte <= 0x7e)) printable++;
+    considered++;
+  }
+  return considered > 0 && printable / considered > 0.9;
+}
+
+function looksLikeMsgpack(prefix: Buffer): boolean {
+  const first = prefix[0];
+  return first >= 0x80 && first <= 0x9f || first >= 0xde && first <= 0xdf;
+}
+
+function looksLikeProtobuf(prefix: Buffer): boolean {
+  if (prefix.length < 2) return false;
+  const first = prefix[0];
+  const wireType = first & 0x07;
+  const fieldNumber = first >> 3;
+  return fieldNumber > 0 && [0, 1, 2, 5].includes(wireType);
+}
+
+function readPrefix(filePath: string, bytes: number): Buffer | null {
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const buffer = Buffer.alloc(bytes);
+    const read = fs.readSync(fd, buffer, 0, bytes, 0);
+    return buffer.subarray(0, read);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) fs.closeSync(fd);
+  }
+}
+
+function readBundleIdentifier(appPath: string): string | undefined {
+  const plistPath = path.join(appPath, 'Contents/Info.plist');
+  if (!fs.existsSync(plistPath)) return undefined;
+
+  const plutil = spawnSync('/usr/bin/plutil', ['-extract', 'CFBundleIdentifier', 'raw', '-o', '-', plistPath], {
+    encoding: 'utf8',
+  });
+  if (plutil.status === 0) {
+    const value = plutil.stdout.trim();
+    return value || undefined;
+  }
+
+  try {
+    const xml = fs.readFileSync(plistPath, 'utf8');
+    const match = xml.match(/<key>CFBundleIdentifier<\/key>\s*<string>([^<]+)<\/string>/);
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+function isAppBundle(targetPath: string, stat: fs.Stats): boolean {
+  return targetPath.endsWith('.app')
+    && stat.isDirectory()
+    && fs.existsSync(path.join(targetPath, 'Contents/Info.plist'));
+}
+
+function groupContainersMatching(homeDir: string, pattern: RegExp): string[] {
+  const root = path.join(homeDir, 'Library/Group Containers');
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(root);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter(name => pattern.test(name))
+    .map(name => path.join(root, name));
+}
+
+function feasibilityFor(entry: DiscoveryEntry): string {
+  const tech = entry.storageTechnology ?? '';
+  if (tech.includes('IndexedDB')) return 'metadata-only unless synthetic/user-approved LevelDB values are available';
+  if (tech.includes('Local Storage') || tech.includes('Session Storage') || tech.includes('cookie')) {
+    return 'not an ingestion source; sensitive values intentionally skipped';
+  }
+  return 'metadata-only';
+}
+
+function uniquePaths(paths: string[]): string[] {
+  return [...new Set(paths)].sort();
+}
+
+function uniqueEntries(entries: DiscoveryEntry[]): DiscoveryEntry[] {
+  const seen = new Set<string>();
+  const unique: DiscoveryEntry[] = [];
+  for (const entry of entries) {
+    const key = `${entry.path}\0${entry.kind}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(entry);
+  }
+  return unique.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function markdownCell(value: string): string {
+  return value.replaceAll('|', '\\|').replaceAll('\n', ' ');
+}
+
+function parseArgs(argv: string[]) {
+  const options: DiscoveryOptions = {};
+  let format: 'json' | 'markdown' = 'json';
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--format' && argv[i + 1]) {
+      const next = argv[++i];
+      if (next !== 'json' && next !== 'markdown') throw new Error('--format must be json or markdown');
+      format = next;
+    } else if (arg === '--home' && argv[i + 1]) {
+      options.homeDir = argv[++i];
+    } else if (arg === '--applications-dir' && argv[i + 1]) {
+      options.applicationsDirs = [...(options.applicationsDirs ?? []), argv[++i]];
+    } else if (arg === '--existing-only') {
+      options.includeMissing = false;
+    } else if (arg === '--help') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return { options, format };
+}
+
+function printHelp() {
+  console.log(`Usage: bun run scripts/desktop-ai-chat-storage-discovery.ts [options]
+
+Options:
+  --format json|markdown       Output format. Default: json.
+  --home PATH                  Home directory to inspect. Default: current user home.
+  --applications-dir PATH      Applications directory. Can be repeated.
+  --existing-only              Omit missing candidate paths.
+  --help                       Show this help.
+
+Privacy invariant: emits metadata and structural classifications only.`);
+}
+
+if (import.meta.main) {
+  try {
+    const { options, format } = parseArgs(process.argv.slice(2));
+    const discoveries = discoverDesktopAiChatStorage(options);
+    if (format === 'markdown') {
+      console.log(formatDiscoveryMarkdown(discoveries));
+    } else {
+      console.log(JSON.stringify(discoveries, null, 2));
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/test/desktop-ai-chat-storage-discovery.test.ts
+++ b/test/desktop-ai-chat-storage-discovery.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  classifyDataFile,
+  discoverDesktopAiChatStorage,
+  formatDiscoveryMarkdown,
+} from '../scripts/desktop-ai-chat-storage-discovery';
+
+function withTempHome(fn: (root: string) => void) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-ai-storage-'));
+  try {
+    fn(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function mkdirp(targetPath: string) {
+  fs.mkdirSync(targetPath, { recursive: true });
+}
+
+describe('desktop AI chat storage discovery', () => {
+  test('reports only metadata for synthetic app and storage roots', () => {
+    withTempHome(root => {
+      const appsDir = path.join(root, 'Applications');
+      const appDir = path.join(appsDir, 'ChatGPT.app');
+      mkdirp(path.join(appDir, 'Contents'));
+      fs.writeFileSync(
+        path.join(appDir, 'Contents/Info.plist'),
+        `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>com.openai.chat.test</string>
+</dict></plist>`
+      );
+
+      const supportDir = path.join(root, 'Library/Application Support/ChatGPT');
+      const indexedDbDir = path.join(supportDir, 'IndexedDB');
+      mkdirp(indexedDbDir);
+      fs.writeFileSync(path.join(indexedDbDir, 'CURRENT'), 'MANIFEST-000001');
+      fs.writeFileSync(path.join(supportDir, 'conversation.data'), 'PRIVATE_CHAT_SECRET: hello world');
+
+      const discoveries = discoverDesktopAiChatStorage({
+        homeDir: root,
+        applicationsDirs: [appsDir],
+      });
+      const chatgpt = discoveries.find(discovery => discovery.provider === 'ChatGPT Desktop');
+
+      expect(chatgpt?.installed).toBe(true);
+      expect(chatgpt?.decision).toBe('promising but brittle');
+      expect(chatgpt?.entries.some(entry => entry.bundleIdentifier === 'com.openai.chat.test')).toBe(true);
+      expect(chatgpt?.entries.some(entry => entry.path.endsWith('conversation.data'))).toBe(true);
+
+      const jsonOutput = JSON.stringify(discoveries, null, 2);
+      const markdownOutput = formatDiscoveryMarkdown(discoveries);
+      expect(jsonOutput).not.toContain('PRIVATE_CHAT_SECRET');
+      expect(markdownOutput).not.toContain('PRIVATE_CHAT_SECRET');
+      expect(jsonOutput).toContain('plaintext/JSON-like by byte class');
+    });
+  });
+
+  test('treats Gemini as not installed without a dedicated app bundle', () => {
+    withTempHome(root => {
+      const supportDir = path.join(root, 'Library/Application Support/Gemini');
+      mkdirp(path.join(supportDir, 'IndexedDB'));
+
+      const discoveries = discoverDesktopAiChatStorage({
+        homeDir: root,
+        applicationsDirs: [path.join(root, 'Applications')],
+      });
+      const gemini = discoveries.find(discovery => discovery.provider === 'Gemini');
+
+      expect(gemini?.installed).toBe(false);
+      expect(gemini?.decision).toBe('not feasible');
+      expect(gemini?.entries.some(entry => entry.path === supportDir && entry.exists)).toBe(true);
+    });
+  });
+
+  test('classifies data-file headers without returning header bytes', () => {
+    withTempHome(root => {
+      const sqliteData = path.join(root, 'sqlite.data');
+      const gzipData = path.join(root, 'gzip.data');
+      const binaryData = path.join(root, 'binary.data');
+      fs.writeFileSync(sqliteData, Buffer.concat([Buffer.from('SQLite format 3\0', 'binary'), Buffer.alloc(16)]));
+      fs.writeFileSync(gzipData, Buffer.from([0x1f, 0x8b, 0x08, 0x00]));
+      fs.writeFileSync(binaryData, Buffer.from([0x00, 0xff, 0xaa, 0x13]));
+
+      expect(classifyDataFile(sqliteData)).toBe('.data file, SQLite database');
+      expect(classifyDataFile(gzipData)).toBe('.data file, gzip-compressed');
+      expect(classifyDataFile(binaryData)).toBe('.data file, custom/encrypted binary or unknown compression');
+    });
+  });
+});

--- a/test/desktop-ai-chat-storage-discovery.test.ts
+++ b/test/desktop-ai-chat-storage-discovery.test.ts
@@ -39,7 +39,7 @@ describe('desktop AI chat storage discovery', () => {
       const indexedDbDir = path.join(supportDir, 'IndexedDB');
       mkdirp(indexedDbDir);
       fs.writeFileSync(path.join(indexedDbDir, 'CURRENT'), 'MANIFEST-000001');
-      fs.writeFileSync(path.join(supportDir, 'conversation.data'), 'PRIVATE_CHAT_SECRET: hello world');
+      fs.writeFileSync(path.join(supportDir, 'salary-discussion.data'), 'PRIVATE_CHAT_SECRET: hello world');
 
       const discoveries = discoverDesktopAiChatStorage({
         homeDir: root,
@@ -50,13 +50,44 @@ describe('desktop AI chat storage discovery', () => {
       expect(chatgpt?.installed).toBe(true);
       expect(chatgpt?.decision).toBe('promising but brittle');
       expect(chatgpt?.entries.some(entry => entry.bundleIdentifier === 'com.openai.chat.test')).toBe(true);
-      expect(chatgpt?.entries.some(entry => entry.path.endsWith('conversation.data'))).toBe(true);
+      expect(chatgpt?.entries.some(entry => entry.path.includes('<redacted-private-file-001.data>'))).toBe(true);
 
       const jsonOutput = JSON.stringify(discoveries, null, 2);
       const markdownOutput = formatDiscoveryMarkdown(discoveries);
       expect(jsonOutput).not.toContain('PRIVATE_CHAT_SECRET');
       expect(markdownOutput).not.toContain('PRIVATE_CHAT_SECRET');
-      expect(jsonOutput).toContain('plaintext/JSON-like by byte class');
+      expect(jsonOutput).not.toContain('salary-discussion.data');
+      expect(markdownOutput).not.toContain('salary-discussion.data');
+      expect(jsonOutput).toContain('private header/content not inspected');
+    });
+  });
+
+  test('header classification is explicit opt-in for synthetic approved samples', () => {
+    withTempHome(root => {
+      const appsDir = path.join(root, 'Applications');
+      const appDir = path.join(appsDir, 'ChatGPT.app');
+      mkdirp(path.join(appDir, 'Contents'));
+      fs.writeFileSync(
+        path.join(appDir, 'Contents/Info.plist'),
+        `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>com.openai.chat.test</string>
+</dict></plist>`
+      );
+
+      const supportDir = path.join(root, 'Library/Application Support/ChatGPT');
+      mkdirp(supportDir);
+      fs.writeFileSync(path.join(supportDir, 'synthetic.data'), Buffer.from([0x1f, 0x8b, 0x08, 0x00]));
+
+      const discoveries = discoverDesktopAiChatStorage({
+        homeDir: root,
+        applicationsDirs: [appsDir],
+        allowHeaderRead: true,
+      });
+      const jsonOutput = JSON.stringify(discoveries, null, 2);
+
+      expect(jsonOutput).toContain('.data file, gzip-compressed');
+      expect(jsonOutput).not.toContain('synthetic.data');
     });
   });
 
@@ -74,6 +105,40 @@ describe('desktop AI chat storage discovery', () => {
       expect(gemini?.installed).toBe(false);
       expect(gemini?.decision).toBe('not feasible');
       expect(gemini?.entries.some(entry => entry.path === supportDir && entry.exists)).toBe(true);
+    });
+  });
+
+  test('does not treat Perplexity-only group containers as Comet installation', () => {
+    withTempHome(root => {
+      mkdirp(path.join(root, 'Library/Group Containers/group.ai.perplexity.app'));
+
+      const discoveries = discoverDesktopAiChatStorage({
+        homeDir: root,
+        applicationsDirs: [path.join(root, 'Applications')],
+      });
+      const comet = discoveries.find(discovery => discovery.provider === 'Comet');
+      const perplexity = discoveries.find(discovery => discovery.provider === 'Perplexity');
+
+      expect(comet?.installed).toBe(false);
+      expect(comet?.decision).toBe('not feasible');
+      expect(perplexity?.installed).toBe(true);
+    });
+  });
+
+  test('treats Grok-like local containers as local target evidence', () => {
+    withTempHome(root => {
+      const grokContainer = path.join(root, 'Library/Containers/com.xai.grok');
+      mkdirp(grokContainer);
+
+      const discoveries = discoverDesktopAiChatStorage({
+        homeDir: root,
+        applicationsDirs: [path.join(root, 'Applications')],
+      });
+      const grok = discoveries.find(discovery => discovery.provider === 'Grok');
+
+      expect(grok?.installed).toBe(true);
+      expect(grok?.decision).toBe('not feasible');
+      expect(grok?.entries.some(entry => entry.path === grokContainer)).toBe(true);
     });
   });
 


### PR DESCRIPTION
Linear: MAT-19

## Summary
- Adds a macOS desktop AI chat storage discovery spike for ChatGPT, Claude, Gemini, Grok, Perplexity, and Comet.
- Adds a metadata-only discovery script with JSON/Markdown output for installed app/storage evidence.
- Documents provider feasibility, local storage signals, parser feasibility, and recommended next steps.

## Adversarial review hardening
- Private provider cache header reads are disabled by default and gated behind `--allow-header-read` for synthetic or explicitly approved samples.
- Recursive private data-file basenames are redacted in output.
- Comet is not reported installed from Perplexity-only group container evidence.
- Grok local container evidence is represented separately from an actual supported app/export path.
- Markdown output includes parser feasibility, not just storage location feasibility.

## Verification
- `bun test test/desktop-ai-chat-storage-discovery.test.ts` - pass, 6 tests.
- `git diff --check origin/main...HEAD` - pass.
