### PR TITLE
[codex] Add consumer session ingest contract

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -66,6 +66,13 @@ import {
 } from "../lib/gstack-memory-helpers";
 import { execGbrainText, spawnGbrainAsync } from "../lib/gbrain-exec";
 import { checkOwnedStagingDir, STAGING_MARKER } from "../lib/staging-guard";
+import {
+  consumerSessionStateKey,
+  discoverConsumerSessionFiles,
+  parseNormalizedConsumerSessionExport,
+  renderConsumerSessionPages,
+  walkConsumerSessionNormalizedFiles,
+} from "../lib/consumer-sessions";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -80,6 +87,7 @@ interface CliArgs {
   sources: Set<MemoryType>;
   limit: number | null;
   noWrite: boolean;
+  consumerSessionsDryRun: boolean;
   /**
    * Opt-in per-file gitleaks scan during the prepare phase. Off by
    * default — the cross-machine boundary (gstack-brain-sync, git push)
@@ -96,7 +104,8 @@ type MemoryType =
   | "ceo-plan"
   | "design-doc"
   | "retro"
-  | "builder-profile-entry";
+  | "builder-profile-entry"
+  | "consumer-session";
 
 interface PageRecord {
   slug: string;
@@ -127,6 +136,20 @@ interface IngestState {
       sha256: string;
       ingested_at: string;
       page_slug: string;
+      partial?: boolean;
+    }
+  >;
+  consumer_sessions?: Record<
+    string,
+    {
+      content_sha256: string;
+      ingested_at: string;
+      page_slugs: string[];
+      raw_path?: string;
+      export_path?: string;
+      provider: string;
+      conversation_id: string;
+      chunk_count: number;
       partial?: boolean;
     }
   >;
@@ -176,6 +199,7 @@ const ALL_TYPES: MemoryType[] = [
   "design-doc",
   "retro",
   "builder-profile-entry",
+  "consumer-session",
 ];
 
 // ── CLI ────────────────────────────────────────────────────────────────────
@@ -195,6 +219,9 @@ Options:
   --all-history        Walk transcripts older than 90 days too.
   --sources <list>     Comma-separated subset: ${ALL_TYPES.join(",")}
   --limit <N>          Stop after N pages written (smoke testing).
+  --consumer-sessions-dry-run
+                       Discover raw/normalized consumer session exports under
+                       the local inbox without printing chat text or raw values.
   --no-write           Skip gbrain put calls (still updates state file).
                        Used by tests + dry runs without actual ingest.
   --scan-secrets       Opt-in per-file gitleaks scan during prepare. Off by
@@ -214,6 +241,7 @@ function parseArgs(): CliArgs {
   let limit: number | null = null;
   let sources: Set<MemoryType> = new Set(ALL_TYPES);
   let noWrite = process.env.GSTACK_MEMORY_INGEST_NO_WRITE === "1";
+  let consumerSessionsDryRun = false;
   let scanSecrets = process.env.GSTACK_MEMORY_INGEST_SCAN_SECRETS === "1";
 
   for (let i = 0; i < args.length; i++) {
@@ -227,6 +255,7 @@ function parseArgs(): CliArgs {
       case "--include-unattributed": includeUnattributed = true; break;
       case "--all-history": allHistory = true; break;
       case "--no-write": noWrite = true; break;
+      case "--consumer-sessions-dry-run": consumerSessionsDryRun = true; break;
       case "--scan-secrets": scanSecrets = true; break;
       case "--limit":
         limit = parseInt(args[++i] || "0", 10);
@@ -255,7 +284,7 @@ function parseArgs(): CliArgs {
     }
   }
 
-  return { mode, quiet, benchmark, includeUnattributed, allHistory, sources, limit, noWrite, scanSecrets };
+  return { mode, quiet, benchmark, includeUnattributed, allHistory, sources, limit, noWrite, consumerSessionsDryRun, scanSecrets };
 }
 
 // ── State file ─────────────────────────────────────────────────────────────
@@ -523,6 +552,11 @@ function* walkAllSources(ctx: WalkContext): Generator<{ path: string; type: Memo
   if (ctx.args.sources.has("transcript")) {
     yield* walkClaudeCodeProjects(ctx);
     yield* walkCodexSessions(ctx);
+  }
+  if (ctx.args.sources.has("consumer-session")) {
+    for (const path of walkConsumerSessionNormalizedFiles(GSTACK_HOME)) {
+      yield { path, type: "consumer-session" };
+    }
   }
   yield* walkGstackArtifacts(ctx);
 }
@@ -886,6 +920,15 @@ interface PreparedPage {
   /** Carry-through fields for state recording on success. */
   page_slug: string;
   partial: boolean;
+  consumer_session?: {
+    state_key: string;
+    content_sha256: string;
+    raw_path?: string;
+    export_path?: string;
+    provider: string;
+    conversation_id: string;
+    chunk_count: number;
+  };
 }
 
 interface StagingResult {
@@ -1030,6 +1073,74 @@ export function readNewFailures(
   return failed;
 }
 
+function recordPreparedSuccesses(
+  state: IngestState,
+  prepared: PreparedPage[],
+  failedSources: Set<string>,
+  nowIso: string,
+  quiet: boolean,
+): number {
+  let written = 0;
+  const consumerGroups = new Map<string, PreparedPage[]>();
+
+  for (const p of prepared) {
+    if (failedSources.has(p.source_path)) continue;
+    if (p.consumer_session) {
+      const group = consumerGroups.get(p.consumer_session.state_key) || [];
+      group.push(p);
+      consumerGroups.set(p.consumer_session.state_key, group);
+      written++;
+      if (!quiet) {
+        const tag = p.partial ? " [partial]" : "";
+        console.log(`[${written}] ${p.page_slug}${tag}`);
+      }
+      continue;
+    }
+
+    try {
+      state.sessions[p.source_path] = {
+        mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
+        sha256: fileSha256(p.source_path),
+        ingested_at: nowIso,
+        page_slug: p.page_slug,
+        partial: p.partial,
+      };
+      written++;
+      if (!quiet) {
+        const tag = p.partial ? " [partial]" : "";
+        console.log(`[${written}] ${p.page_slug}${tag}`);
+      }
+    } catch (err) {
+      // statSync can fail if the source file was removed mid-run; skip
+      // recording but don't fail the whole pass.
+      console.error(
+        `[state-record] ${p.source_path}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  if (consumerGroups.size > 0 && !state.consumer_sessions) {
+    state.consumer_sessions = {};
+  }
+  for (const [stateKey, group] of consumerGroups) {
+    const meta = group[0]?.consumer_session;
+    if (!meta || !state.consumer_sessions) continue;
+    state.consumer_sessions[stateKey] = {
+      content_sha256: meta.content_sha256,
+      ingested_at: nowIso,
+      page_slugs: group.map((p) => p.page_slug),
+      raw_path: meta.raw_path,
+      export_path: meta.export_path,
+      provider: meta.provider,
+      conversation_id: meta.conversation_id,
+      chunk_count: meta.chunk_count,
+      partial: group.some((p) => p.partial),
+    };
+  }
+
+  return written;
+}
+
 // ── Main ingest passes ─────────────────────────────────────────────────────
 
 async function probeMode(args: CliArgs): Promise<ProbeReport> {
@@ -1045,6 +1156,7 @@ async function probeMode(args: CliArgs): Promise<ProbeReport> {
     "design-doc": { count: 0, bytes: 0 },
     retro: { count: 0, bytes: 0 },
     "builder-profile-entry": { count: 0, bytes: 0 },
+    "consumer-session": { count: 0, bytes: 0 },
   };
 
   let totalFiles = 0;
@@ -1130,7 +1242,7 @@ function preparePages(
   for (const { path, type } of walkAllSources(ctx)) {
     if (args.limit !== null && prepared.length >= args.limit) break;
 
-    if (args.mode === "incremental" && !fileChangedSinceState(path, state)) {
+    if (type !== "consumer-session" && args.mode === "incremental" && !fileChangedSinceState(path, state)) {
       skippedDedup++;
       continue;
     }
@@ -1156,7 +1268,50 @@ function preparePages(
 
     let page: PageRecord;
     try {
-      if (type === "transcript") {
+      if (type === "consumer-session") {
+        const sessions = parseNormalizedConsumerSessionExport(path);
+        for (const session of sessions) {
+          const pages = renderConsumerSessionPages(session);
+          const stateKey = consumerSessionStateKey(session);
+          const existing = state.consumer_sessions?.[stateKey];
+          if (args.mode === "incremental" && existing?.content_sha256 === pages[0]?.content_sha256) {
+            skippedDedup++;
+            continue;
+          }
+          if (session.completeness.partial) partialPages++;
+          for (const rendered of pages) {
+            if (args.limit !== null && prepared.length >= args.limit) break;
+            prepared.push({
+              slug: rendered.slug,
+              source_path: path,
+              rendered_body: renderPageBody({
+                slug: rendered.slug,
+                title: rendered.title,
+                type: "consumer-session",
+                body: rendered.body,
+                tags: rendered.tags,
+                source_path: path,
+                session_id: rendered.session_id,
+                partial: rendered.partial,
+                size_bytes: statSync(path).size,
+                content_sha256: rendered.content_sha256,
+              }),
+              page_slug: rendered.slug,
+              partial: rendered.partial,
+              consumer_session: {
+                state_key: rendered.conversation_key,
+                content_sha256: rendered.content_sha256,
+                raw_path: session.source_receipt.raw_path,
+                export_path: session.source_receipt.export_path || path,
+                provider: session.provider,
+                conversation_id: session.conversation_id,
+                chunk_count: rendered.chunk_count,
+              },
+            });
+          }
+        }
+        continue;
+      } else if (type === "transcript") {
         const session = parseTranscriptJsonl(path);
         if (!session) {
           parseFailed++;
@@ -1475,20 +1630,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // the prior contract from --help: "Skip gbrain put calls (still
     // updates state file)".
     const nowIso = new Date().toISOString();
-    for (const p of prep.prepared) {
-      try {
-        state.sessions[p.source_path] = {
-          mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-          sha256: fileSha256(p.source_path),
-          ingested_at: nowIso,
-          page_slug: p.page_slug,
-          partial: p.partial,
-        };
-        written++;
-      } catch {
-        // best-effort state record
-      }
-    }
+    written = recordPreparedSuccesses(state, prep.prepared, new Set(), nowIso, true);
     state.last_full_walk = new Date().toISOString();
     state.last_writer = "gstack-memory-ingest";
     saveState(state);
@@ -1644,22 +1786,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // machine's perspective, the act of staging IS the write.
     if (remoteHttpMode) {
       const nowIso = new Date().toISOString();
-      for (const p of prep.prepared) {
-        try {
-          state.sessions[p.source_path] = {
-            mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-            sha256: fileSha256(p.source_path),
-            ingested_at: nowIso,
-            page_slug: p.page_slug,
-            partial: p.partial,
-          };
-          written++;
-        } catch (err) {
-          console.error(
-            `[state-record] ${p.source_path}: ${(err as Error).message}`,
-          );
-        }
-      }
+      written = recordPreparedSuccesses(state, prep.prepared, new Set(), nowIso, args.quiet);
       state.last_full_walk = nowIso;
       state.last_writer = "gstack-memory-ingest (remote-http mode)";
       saveState(state);
@@ -1787,29 +1914,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // left un-state'd so the next run re-prepares them and gbrain's
     // content_hash dedup short-circuits the import.
     const nowIso = new Date().toISOString();
-    for (const p of prep.prepared) {
-      if (failedSources.has(p.source_path)) continue;
-      try {
-        state.sessions[p.source_path] = {
-          mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-          sha256: fileSha256(p.source_path),
-          ingested_at: nowIso,
-          page_slug: p.page_slug,
-          partial: p.partial,
-        };
-        written++;
-        if (!args.quiet) {
-          const tag = p.partial ? " [partial]" : "";
-          console.log(`[${written}] ${p.page_slug}${tag}`);
-        }
-      } catch (err) {
-        // statSync can fail if the source file was removed mid-run; skip
-        // recording but don't fail the whole pass.
-        console.error(
-          `[state-record] ${p.source_path}: ${(err as Error).message}`,
-        );
-      }
-    }
+    written = recordPreparedSuccesses(state, prep.prepared, failedSources, nowIso, args.quiet);
 
     if (!args.quiet) {
       console.error(
@@ -1893,10 +1998,20 @@ function printBulkResult(r: BulkResult, args: CliArgs): void {
   }
 }
 
+function printConsumerSessionsDryRun(): void {
+  const report = discoverConsumerSessionFiles(GSTACK_HOME);
+  console.log(JSON.stringify(report, null, 2));
+}
+
 // ── Entry point ────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
   const args = parseArgs();
+
+  if (args.consumerSessionsDryRun) {
+    printConsumerSessionsDryRun();
+    return;
+  }
 
   // Engine tier detection — informational; routing happens in gbrain server-side.
   const engine = detectEngineTier();

--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -67,6 +67,7 @@ import {
 import { execGbrainText, spawnGbrainAsync } from "../lib/gbrain-exec";
 import { checkOwnedStagingDir, STAGING_MARKER } from "../lib/staging-guard";
 import {
+  consumerSessionContentHash,
   consumerSessionStateKey,
   discoverConsumerSessionFiles,
   parseNormalizedConsumerSessionExport,
@@ -202,6 +203,8 @@ const ALL_TYPES: MemoryType[] = [
   "consumer-session",
 ];
 
+const DEFAULT_TYPES: MemoryType[] = ALL_TYPES.filter((t) => t !== "consumer-session");
+
 // ── CLI ────────────────────────────────────────────────────────────────────
 
 function printUsage(): void {
@@ -218,6 +221,8 @@ Options:
   --include-unattributed  Ingest sessions with no resolvable git remote.
   --all-history        Walk transcripts older than 90 days too.
   --sources <list>     Comma-separated subset: ${ALL_TYPES.join(",")}
+                       Default excludes consumer-session; opt in explicitly
+                       with --sources consumer-session.
   --limit <N>          Stop after N pages written (smoke testing).
   --consumer-sessions-dry-run
                        Discover raw/normalized consumer session exports under
@@ -239,7 +244,7 @@ function parseArgs(): CliArgs {
   let includeUnattributed = false;
   let allHistory = false;
   let limit: number | null = null;
-  let sources: Set<MemoryType> = new Set(ALL_TYPES);
+  let sources: Set<MemoryType> = new Set(DEFAULT_TYPES);
   let noWrite = process.env.GSTACK_MEMORY_INGEST_NO_WRITE === "1";
   let consumerSessionsDryRun = false;
   let scanSecrets = process.env.GSTACK_MEMORY_INGEST_SCAN_SECRETS === "1";
@@ -1141,6 +1146,34 @@ function recordPreparedSuccesses(
   return written;
 }
 
+function consumerSessionProbeStatus(
+  path: string,
+  state: IngestState,
+): "new" | "updated" | "unchanged" {
+  let sessions;
+  try {
+    sessions = parseNormalizedConsumerSessionExport(path);
+  } catch {
+    return "new";
+  }
+
+  if (sessions.length === 0) return "new";
+  let sawExisting = false;
+  for (const session of sessions) {
+    const stateKey = consumerSessionStateKey(session);
+    const existing = state.consumer_sessions?.[stateKey];
+    if (!existing) return sawExisting ? "updated" : "new";
+    sawExisting = true;
+    if (existing.content_sha256 !== consumerSessionContentHash(session)) {
+      return "updated";
+    }
+    if (existing.page_slugs.length !== existing.chunk_count) {
+      return "updated";
+    }
+  }
+  return "unchanged";
+}
+
 // ── Main ingest passes ─────────────────────────────────────────────────────
 
 async function probeMode(args: CliArgs): Promise<ProbeReport> {
@@ -1177,10 +1210,17 @@ async function probeMode(args: CliArgs): Promise<ProbeReport> {
     byType[type].bytes += size;
     totalBytes += size;
 
-    const entry = state.sessions[path];
-    if (!entry) newCount++;
-    else if (fileChangedSinceState(path, state)) updatedCount++;
-    else unchangedCount++;
+    if (type === "consumer-session") {
+      const status = consumerSessionProbeStatus(path, state);
+      if (status === "new") newCount++;
+      else if (status === "updated") updatedCount++;
+      else unchangedCount++;
+    } else {
+      const entry = state.sessions[path];
+      if (!entry) newCount++;
+      else if (fileChangedSinceState(path, state)) updatedCount++;
+      else unchangedCount++;
+    }
   }
 
   // Per ED2: ~25-35 min for ~11.7K transcripts = ~150ms/page synchronous
@@ -1274,13 +1314,23 @@ function preparePages(
           const pages = renderConsumerSessionPages(session);
           const stateKey = consumerSessionStateKey(session);
           const existing = state.consumer_sessions?.[stateKey];
-          if (args.mode === "incremental" && existing?.content_sha256 === pages[0]?.content_sha256) {
+          if (
+            args.mode === "incremental"
+            && existing?.content_sha256 === pages[0]?.content_sha256
+            && existing.page_slugs.length === existing.chunk_count
+          ) {
             skippedDedup++;
             continue;
           }
+          const remainingLimit = args.limit === null
+            ? Number.POSITIVE_INFINITY
+            : args.limit - prepared.length;
+          if (pages.length > remainingLimit) {
+            skippedDedup++;
+            break;
+          }
           if (session.completeness.partial) partialPages++;
           for (const rendered of pages) {
-            if (args.limit !== null && prepared.length >= args.limit) break;
             prepared.push({
               slug: rendered.slug,
               source_path: path,

--- a/lib/consumer-sessions.ts
+++ b/lib/consumer-sessions.ts
@@ -1,0 +1,547 @@
+import { createHash } from "crypto";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { hostname, platform } from "os";
+import { basename, join, relative } from "path";
+
+export const CONSUMER_SESSION_SCHEMA_VERSION = 1;
+export const DEFAULT_CONSUMER_SESSION_CHUNK_CHARS = 80_000;
+
+export type ConsumerSessionProvider = "chatgpt" | "claude-ai" | "gemini" | "grok" | string;
+
+export interface NormalizedConsumerSessionAttachment {
+  id?: string;
+  name?: string;
+  mime_type?: string;
+  size_bytes?: number;
+  source_kind?: string;
+  provider_attachment_id?: string;
+  sha256?: string;
+}
+
+export interface NormalizedConsumerSessionTurn {
+  index: number;
+  id?: string;
+  role: "system" | "user" | "assistant" | "tool" | "other" | string;
+  created_at?: string;
+  content: string;
+  attachments?: NormalizedConsumerSessionAttachment[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface NormalizedConsumerSessionReceipt {
+  raw_path?: string;
+  receipt_missing?: boolean;
+  provider_export_kind: string;
+  export_path?: string;
+  content_sha256?: string;
+  imported_at?: string;
+}
+
+export interface NormalizedConsumerSessionHost {
+  hostname: string;
+  platform?: string;
+}
+
+export interface NormalizedConsumerSessionCompleteness {
+  complete: boolean;
+  partial: boolean;
+  truncated: boolean;
+  missing_turns?: boolean;
+  source_complete?: boolean;
+  reason?: string;
+}
+
+export interface NormalizedConsumerSession {
+  schema_version: 1;
+  provider: ConsumerSessionProvider;
+  account_hash: string;
+  conversation_id: string;
+  title: string;
+  created_at?: string;
+  updated_at?: string;
+  turns: NormalizedConsumerSessionTurn[];
+  attachments?: NormalizedConsumerSessionAttachment[];
+  source_receipt: NormalizedConsumerSessionReceipt;
+  host: NormalizedConsumerSessionHost;
+  completeness: NormalizedConsumerSessionCompleteness;
+}
+
+export interface ConsumerSessionRoots {
+  root: string;
+  raw: string;
+  normalized: string;
+  rendered: string;
+}
+
+export interface ConsumerSessionDryRunFile {
+  path: string;
+  provider_kind: string;
+  provider_export_kind: string;
+  size_bytes: number;
+  mtime: string;
+  conversation_count: number;
+  turn_count: number;
+  attachment_count: number;
+  parser_status: "ok" | "unsupported_raw_pending_adapter" | "invalid_json" | "schema_error" | "unreadable";
+}
+
+export interface ConsumerSessionDryRunReport {
+  roots: ConsumerSessionRoots;
+  files: ConsumerSessionDryRunFile[];
+}
+
+export interface RenderedConsumerSessionPage {
+  slug: string;
+  title: string;
+  tags: string[];
+  body: string;
+  session_id: string;
+  conversation_key: string;
+  content_sha256: string;
+  chunk_index: number;
+  chunk_count: number;
+  partial: boolean;
+}
+
+export function consumerSessionRoots(gstackHome: string): ConsumerSessionRoots {
+  const root = process.env.GSTACK_CONSUMER_SESSIONS_ROOT || join(gstackHome, "consumer-sessions");
+  return {
+    root,
+    raw: join(root, "raw"),
+    normalized: join(root, "normalized"),
+    rendered: join(gstackHome, "sessions"),
+  };
+}
+
+export function walkConsumerSessionNormalizedFiles(gstackHome: string): string[] {
+  return walkFiles(consumerSessionRoots(gstackHome).normalized, (path) => {
+    const name = basename(path).toLowerCase();
+    return name.endsWith(".json");
+  });
+}
+
+export function discoverConsumerSessionFiles(gstackHome: string): ConsumerSessionDryRunReport {
+  const roots = consumerSessionRoots(gstackHome);
+  const files: ConsumerSessionDryRunFile[] = [];
+
+  for (const path of walkFiles(roots.raw, () => true)) {
+    files.push(buildRawDiscovery(path, roots.raw));
+  }
+
+  for (const path of walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"))) {
+    files.push(buildNormalizedDiscovery(path, roots.normalized));
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return { roots, files };
+}
+
+export function parseNormalizedConsumerSessionExport(path: string): NormalizedConsumerSession[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    throw new Error("invalid_json");
+  }
+
+  const rawSessions = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === "object" && Array.isArray((parsed as { sessions?: unknown }).sessions)
+      ? (parsed as { sessions: unknown[] }).sessions
+      : parsed && typeof parsed === "object"
+        ? [parsed]
+        : [];
+
+  if (rawSessions.length === 0) throw new Error("schema_error");
+  return rawSessions.map((value, index) => coerceSession(value, path, index));
+}
+
+export function consumerSessionContentHash(session: NormalizedConsumerSession): string {
+  return sha256(stableJson(normalizeForHash(session)));
+}
+
+export function consumerSessionStableId(session: NormalizedConsumerSession): string {
+  const key = `${session.provider}:${session.account_hash}:${session.conversation_id}`;
+  return sha256(key).slice(0, 32);
+}
+
+export function consumerSessionStateKey(session: NormalizedConsumerSession): string {
+  return `consumer:${safePathSegment(session.provider)}:${safePathSegment(session.account_hash)}:${consumerSessionStableId(session)}`;
+}
+
+export function renderConsumerSessionPages(
+  session: NormalizedConsumerSession,
+  options: { maxChunkChars?: number } = {},
+): RenderedConsumerSessionPage[] {
+  const maxChunkChars = options.maxChunkChars ?? DEFAULT_CONSUMER_SESSION_CHUNK_CHARS;
+  const sessionId = consumerSessionStableId(session);
+  const contentHash = consumerSessionContentHash(session);
+  const providerFolder = safePathSegment(session.provider);
+  const accountFolder = safePathSegment(session.account_hash);
+  const date = dateOnly(session.created_at || session.updated_at);
+  const titleSlug = safePathSegment(session.title || session.conversation_id).slice(0, 48) || "conversation";
+  const baseSlug = `sessions/${providerFolder}/${accountFolder}/${date}-${titleSlug}-${sessionId.slice(0, 12)}`;
+  const turnSections = renderTurnSections(session, maxChunkChars);
+  const chunks = chunkSections(turnSections, maxChunkChars);
+  const chunkCount = chunks.length;
+  const commonTags = [
+    "session",
+    "consumer-session",
+    `provider:${providerFolder}`,
+    `date:${date}`,
+  ];
+  if (session.completeness.partial) commonTags.push("partial:true");
+  if (session.completeness.truncated) commonTags.push("truncated:true");
+
+  return chunks.map((chunk, index) => {
+    const chunkIndex = index + 1;
+    const chunkSuffix = chunkCount > 1 ? `-part-${String(chunkIndex).padStart(4, "0")}-of-${String(chunkCount).padStart(4, "0")}` : "";
+    const slug = `${baseSlug}${chunkSuffix}`;
+    const pageTitle = chunkCount > 1
+      ? `${session.title || session.conversation_id} (${chunkIndex}/${chunkCount})`
+      : session.title || session.conversation_id;
+    const body = [
+      "---",
+      `provider: ${JSON.stringify(session.provider)}`,
+      `account_hash: ${JSON.stringify(session.account_hash)}`,
+      `conversation_id: ${JSON.stringify(session.conversation_id)}`,
+      `session_id: ${sessionId}`,
+      `provider_export_kind: ${JSON.stringify(session.source_receipt.provider_export_kind)}`,
+      `host: ${JSON.stringify(session.host.hostname)}`,
+      session.source_receipt.raw_path
+        ? `raw_path: ${JSON.stringify(session.source_receipt.raw_path)}`
+        : "receipt_missing: true",
+      `created_at: ${session.created_at || ""}`,
+      `updated_at: ${session.updated_at || ""}`,
+      `complete: ${session.completeness.complete ? "true" : "false"}`,
+      `partial: ${session.completeness.partial ? "true" : "false"}`,
+      `truncated: ${session.completeness.truncated ? "true" : "false"}`,
+      `chunk_index: ${chunkIndex}`,
+      `chunk_count: ${chunkCount}`,
+      `content_sha256: ${contentHash}`,
+      "---",
+      "",
+      chunk.join("\n\n"),
+      "",
+    ].join("\n");
+    return {
+      slug,
+      title: pageTitle,
+      tags: commonTags,
+      body,
+      session_id: sessionId,
+      conversation_key: consumerSessionStateKey(session),
+      content_sha256: contentHash,
+      chunk_index: chunkIndex,
+      chunk_count: chunkCount,
+      partial: session.completeness.partial,
+    };
+  });
+}
+
+function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRunFile {
+  const st = safeStat(path);
+  return {
+    path,
+    provider_kind: providerKindFromPath(path, rawRoot),
+    provider_export_kind: "raw-provider-export",
+    size_bytes: st.size,
+    mtime: st.mtime,
+    conversation_count: 0,
+    turn_count: 0,
+    attachment_count: 0,
+    parser_status: st.ok ? "unsupported_raw_pending_adapter" : "unreadable",
+  };
+}
+
+function buildNormalizedDiscovery(path: string, normalizedRoot: string): ConsumerSessionDryRunFile {
+  const st = safeStat(path);
+  if (!st.ok) {
+    return {
+      path,
+      provider_kind: providerKindFromPath(path, normalizedRoot),
+      provider_export_kind: "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: 0,
+      turn_count: 0,
+      attachment_count: 0,
+      parser_status: "unreadable",
+    };
+  }
+  try {
+    const sessions = parseNormalizedConsumerSessionExport(path);
+    return {
+      path,
+      provider_kind: providerKindFromSessionOrPath(sessions[0], path, normalizedRoot),
+      provider_export_kind: sessions[0]?.source_receipt.provider_export_kind || "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: sessions.length,
+      turn_count: sessions.reduce((sum, session) => sum + session.turns.length, 0),
+      attachment_count: sessions.reduce((sum, session) => sum + (session.attachments?.length || 0) + session.turns.reduce((n, turn) => n + (turn.attachments?.length || 0), 0), 0),
+      parser_status: "ok",
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+    return {
+      path,
+      provider_kind: providerKindFromPath(path, normalizedRoot),
+      provider_export_kind: "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: 0,
+      turn_count: 0,
+      attachment_count: 0,
+      parser_status: message === "invalid_json" ? "invalid_json" : "schema_error",
+    };
+  }
+}
+
+function coerceSession(value: unknown, path: string, index: number): NormalizedConsumerSession {
+  if (!value || typeof value !== "object") throw new Error("schema_error");
+  const obj = value as Record<string, unknown>;
+  const provider = requireString(obj.provider, "provider");
+  const accountHash = requireString(obj.account_hash, "account_hash");
+  const conversationId = requireString(obj.conversation_id, "conversation_id");
+  const turnsRaw = obj.turns;
+  if (!Array.isArray(turnsRaw)) throw new Error("schema_error");
+  const turns = turnsRaw.map((turn, turnIndex) => coerceTurn(turn, turnIndex));
+  const receipt = coerceReceipt(obj.source_receipt, path);
+  const host = coerceHost(obj.host);
+  const completeness = coerceCompleteness(obj.completeness);
+  return {
+    schema_version: CONSUMER_SESSION_SCHEMA_VERSION,
+    provider,
+    account_hash: accountHash,
+    conversation_id: conversationId,
+    title: typeof obj.title === "string" && obj.title.trim() ? obj.title : `Conversation ${index + 1}`,
+    created_at: optionalString(obj.created_at),
+    updated_at: optionalString(obj.updated_at),
+    turns,
+    attachments: Array.isArray(obj.attachments) ? obj.attachments.map(coerceAttachment) : [],
+    source_receipt: receipt,
+    host,
+    completeness,
+  };
+}
+
+function coerceTurn(value: unknown, index: number): NormalizedConsumerSessionTurn {
+  if (!value || typeof value !== "object") throw new Error("schema_error");
+  const obj = value as Record<string, unknown>;
+  return {
+    index: typeof obj.index === "number" ? obj.index : index,
+    id: optionalString(obj.id),
+    role: typeof obj.role === "string" ? obj.role : "other",
+    created_at: optionalString(obj.created_at),
+    content: typeof obj.content === "string" ? obj.content : "",
+    attachments: Array.isArray(obj.attachments) ? obj.attachments.map(coerceAttachment) : [],
+    metadata: obj.metadata && typeof obj.metadata === "object" && !Array.isArray(obj.metadata)
+      ? obj.metadata as Record<string, unknown>
+      : undefined,
+  };
+}
+
+function coerceAttachment(value: unknown): NormalizedConsumerSessionAttachment {
+  if (!value || typeof value !== "object") return {};
+  const obj = value as Record<string, unknown>;
+  return {
+    id: optionalString(obj.id),
+    name: optionalString(obj.name),
+    mime_type: optionalString(obj.mime_type),
+    size_bytes: typeof obj.size_bytes === "number" ? obj.size_bytes : undefined,
+    source_kind: optionalString(obj.source_kind),
+    provider_attachment_id: optionalString(obj.provider_attachment_id),
+    sha256: optionalString(obj.sha256),
+  };
+}
+
+function coerceReceipt(value: unknown, exportPath: string): NormalizedConsumerSessionReceipt {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  const rawPath = optionalString(obj.raw_path);
+  const receiptMissing = typeof obj.receipt_missing === "boolean" ? obj.receipt_missing : !rawPath;
+  return {
+    raw_path: rawPath,
+    receipt_missing: receiptMissing,
+    provider_export_kind: optionalString(obj.provider_export_kind) || "normalized-consumer-session",
+    export_path: optionalString(obj.export_path) || exportPath,
+    content_sha256: optionalString(obj.content_sha256),
+    imported_at: optionalString(obj.imported_at),
+  };
+}
+
+function coerceHost(value: unknown): NormalizedConsumerSessionHost {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  return {
+    hostname: optionalString(obj.hostname) || process.env.GSTACK_HOSTNAME || hostname(),
+    platform: optionalString(obj.platform) || platform(),
+  };
+}
+
+function coerceCompleteness(value: unknown): NormalizedConsumerSessionCompleteness {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  const partial = Boolean(obj.partial);
+  const truncated = Boolean(obj.truncated);
+  return {
+    complete: typeof obj.complete === "boolean" ? obj.complete : !partial && !truncated,
+    partial,
+    truncated,
+    missing_turns: typeof obj.missing_turns === "boolean" ? obj.missing_turns : undefined,
+    source_complete: typeof obj.source_complete === "boolean" ? obj.source_complete : undefined,
+    reason: optionalString(obj.reason),
+  };
+}
+
+function renderTurnSections(session: NormalizedConsumerSession, maxChunkChars: number): string[] {
+  const sorted = [...session.turns].sort((a, b) => a.index - b.index);
+  const sections: string[] = [];
+  for (const turn of sorted) {
+    const label = turn.role.charAt(0).toUpperCase() + turn.role.slice(1);
+    const head = [`## Turn ${turn.index + 1}: ${label}`];
+    if (turn.created_at) head.push(`Time: ${turn.created_at}`);
+    if (turn.attachments && turn.attachments.length > 0) {
+      head.push(`Attachments: ${turn.attachments.length}`);
+    }
+    const prefix = `${head.join("\n")}\n\n`;
+    const content = turn.content || "";
+    if (prefix.length + content.length <= maxChunkChars) {
+      sections.push(prefix + content);
+      continue;
+    }
+    const parts = splitStringByMax(content, Math.max(1, maxChunkChars - prefix.length - 80));
+    for (let i = 0; i < parts.length; i++) {
+      sections.push(`${prefix}_Continuation ${i + 1}/${parts.length}_\n\n${parts[i]}`);
+    }
+  }
+  return sections;
+}
+
+function chunkSections(sections: string[], maxChunkChars: number): string[][] {
+  const chunks: string[][] = [];
+  let current: string[] = [];
+  let currentSize = 0;
+  for (const section of sections) {
+    const nextSize = currentSize + (current.length > 0 ? 2 : 0) + section.length;
+    if (current.length > 0 && nextSize > maxChunkChars) {
+      chunks.push(current);
+      current = [];
+      currentSize = 0;
+    }
+    current.push(section);
+    currentSize += (current.length > 1 ? 2 : 0) + section.length;
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks.length > 0 ? chunks : [[""]];
+}
+
+function splitStringByMax(text: string, maxChars: number): string[] {
+  const parts: string[] = [];
+  for (let i = 0; i < text.length; i += maxChars) {
+    parts.push(text.slice(i, i + maxChars));
+  }
+  return parts.length > 0 ? parts : [""];
+}
+
+function walkFiles(root: string, predicate: (path: string) => boolean): string[] {
+  if (!existsSync(root)) return [];
+  const out: string[] = [];
+  function visit(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry);
+      let st;
+      try {
+        st = statSync(path);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) visit(path);
+      else if (st.isFile() && predicate(path)) out.push(path);
+    }
+  }
+  visit(root);
+  out.sort();
+  return out;
+}
+
+function safeStat(path: string): { ok: boolean; size: number; mtime: string } {
+  try {
+    const st = statSync(path);
+    return { ok: true, size: st.size, mtime: new Date(st.mtimeMs).toISOString() };
+  } catch {
+    return { ok: false, size: 0, mtime: "" };
+  }
+}
+
+function providerKindFromSessionOrPath(session: NormalizedConsumerSession | undefined, path: string, root: string): string {
+  return session?.provider ? safePathSegment(session.provider) : providerKindFromPath(path, root);
+}
+
+function providerKindFromPath(path: string, root: string): string {
+  const rel = relative(root, path).split(/[\\/]/).filter(Boolean);
+  return safePathSegment(rel[0] || "unknown");
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`schema_error:${field}`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function safePathSegment(value: string): string {
+  const cleaned = value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned || "unknown";
+}
+
+function dateOnly(ts: string | undefined): string {
+  if (!ts) return "undated";
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "undated";
+  return d.toISOString().slice(0, 10);
+}
+
+function normalizeForHash(session: NormalizedConsumerSession): unknown {
+  return {
+    schema_version: session.schema_version,
+    provider: session.provider,
+    account_hash: session.account_hash,
+    conversation_id: session.conversation_id,
+    title: session.title,
+    created_at: session.created_at,
+    updated_at: session.updated_at,
+    turns: [...session.turns].sort((a, b) => a.index - b.index),
+    attachments: session.attachments || [],
+    source_receipt: session.source_receipt,
+    host: session.host,
+    completeness: session.completeness,
+  };
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableJson(v)}`).join(",")}}`;
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}

--- a/lib/consumer-sessions.ts
+++ b/lib/consumer-sessions.ts
@@ -1,7 +1,7 @@
 import { createHash } from "crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { hostname, platform } from "os";
-import { basename, join, relative } from "path";
+import { basename, extname, join, relative } from "path";
 
 export const CONSUMER_SESSION_SCHEMA_VERSION = 1;
 export const DEFAULT_CONSUMER_SESSION_CHUNK_CHARS = 80_000;
@@ -109,7 +109,7 @@ export function consumerSessionRoots(gstackHome: string): ConsumerSessionRoots {
     root,
     raw: join(root, "raw"),
     normalized: join(root, "normalized"),
-    rendered: join(gstackHome, "sessions"),
+    rendered: join(root, "rendered"),
   };
 }
 
@@ -124,16 +124,22 @@ export function discoverConsumerSessionFiles(gstackHome: string): ConsumerSessio
   const roots = consumerSessionRoots(gstackHome);
   const files: ConsumerSessionDryRunFile[] = [];
 
-  for (const path of walkFiles(roots.raw, () => true)) {
-    files.push(buildRawDiscovery(path, roots.raw));
+  const rawFiles = walkFiles(roots.raw, () => true);
+  for (let i = 0; i < rawFiles.length; i++) {
+    files.push(buildRawDiscovery(rawFiles[i], roots.raw, displayConsumerSessionPath("raw", roots.raw, rawFiles[i], i + 1)));
   }
 
-  for (const path of walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"))) {
-    files.push(buildNormalizedDiscovery(path, roots.normalized));
+  const normalizedFiles = walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"));
+  for (let i = 0; i < normalizedFiles.length; i++) {
+    files.push(buildNormalizedDiscovery(
+      normalizedFiles[i],
+      roots.normalized,
+      displayConsumerSessionPath("normalized", roots.normalized, normalizedFiles[i], i + 1),
+    ));
   }
 
   files.sort((a, b) => a.path.localeCompare(b.path));
-  return { roots, files };
+  return { roots: displayConsumerSessionRoots(), files };
 }
 
 export function parseNormalizedConsumerSessionExport(path: string): NormalizedConsumerSession[] {
@@ -239,10 +245,10 @@ export function renderConsumerSessionPages(
   });
 }
 
-function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRunFile {
+function buildRawDiscovery(path: string, rawRoot: string, displayPath: string): ConsumerSessionDryRunFile {
   const st = safeStat(path);
   return {
-    path,
+    path: displayPath,
     provider_kind: providerKindFromPath(path, rawRoot),
     provider_export_kind: "raw-provider-export",
     size_bytes: st.size,
@@ -254,11 +260,11 @@ function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRun
   };
 }
 
-function buildNormalizedDiscovery(path: string, normalizedRoot: string): ConsumerSessionDryRunFile {
+function buildNormalizedDiscovery(path: string, normalizedRoot: string, displayPath: string): ConsumerSessionDryRunFile {
   const st = safeStat(path);
   if (!st.ok) {
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromPath(path, normalizedRoot),
       provider_export_kind: "normalized-consumer-session",
       size_bytes: st.size,
@@ -272,7 +278,7 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
   try {
     const sessions = parseNormalizedConsumerSessionExport(path);
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromSessionOrPath(sessions[0], path, normalizedRoot),
       provider_export_kind: sessions[0]?.source_receipt.provider_export_kind || "normalized-consumer-session",
       size_bytes: st.size,
@@ -285,7 +291,7 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
   } catch (err) {
     const message = err instanceof Error ? err.message : "";
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromPath(path, normalizedRoot),
       provider_export_kind: "normalized-consumer-session",
       size_bytes: st.size,
@@ -296,6 +302,23 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
       parser_status: message === "invalid_json" ? "invalid_json" : "schema_error",
     };
   }
+}
+
+function displayConsumerSessionRoots(): ConsumerSessionRoots {
+  return {
+    root: "consumer-sessions",
+    raw: "consumer-sessions/raw",
+    normalized: "consumer-sessions/normalized",
+    rendered: "consumer-sessions/rendered",
+  };
+}
+
+function displayConsumerSessionPath(kind: "raw" | "normalized", root: string, filePath: string, index: number): string {
+  const provider = providerKindFromPath(filePath, root);
+  const rawExt = extname(filePath).replace(/^\./, "");
+  const ext = rawExt ? safePathSegment(rawExt) : "";
+  const ordinal = String(index).padStart(3, "0");
+  return `consumer-sessions/${kind}/${provider}/<redacted-export-${ordinal}${ext ? `.${ext}` : ""}>`;
 }
 
 function coerceSession(value: unknown, path: string, index: number): NormalizedConsumerSession {

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -766,3 +766,189 @@ exit 0
     rmSync(home, { recursive: true, force: true });
   });
 });
+
+// ── Consumer session contract and synthetic normalized adapter ─────────────
+
+function makeConsumerSession(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    provider: "chatgpt",
+    account_hash: "acct_0123456789abcdef",
+    conversation_id: "conv-001",
+    title: "Synthetic planning session",
+    created_at: "2026-06-01T10:00:00Z",
+    updated_at: "2026-06-01T10:05:00Z",
+    turns: [
+      { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: "first prompt" },
+      { index: 1, role: "assistant", created_at: "2026-06-01T10:01:00Z", content: "first answer" },
+    ],
+    attachments: [
+      { id: "att-1", name: "context.txt", mime_type: "text/plain", size_bytes: 42, sha256: "a".repeat(64) },
+    ],
+    source_receipt: {
+      raw_path: "/exports/chatgpt/raw-export.json",
+      provider_export_kind: "synthetic-normalized-v1",
+    },
+    host: { hostname: "macbook-fixture", platform: "darwin" },
+    completeness: { complete: true, partial: false, truncated: false },
+    ...overrides,
+  };
+}
+
+function writeConsumerSessions(gstackHome: string, provider: string, fileName: string, sessions: Record<string, unknown>[]): string {
+  const dir = join(gstackHome, "consumer-sessions", "normalized", provider);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, fileName);
+  writeFileSync(file, JSON.stringify({ sessions }, null, 2), "utf-8");
+  return file;
+}
+
+describe("gstack-memory-ingest consumer-session normalized contract", () => {
+  it("dry-run discovery reports metadata only and never prints chat/storage values", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    const rawDir = join(gstackHome, "consumer-sessions", "raw", "chatgpt");
+    mkdirSync(rawDir, { recursive: true });
+    writeFileSync(
+      join(rawDir, "export.json"),
+      JSON.stringify({
+        text: "DO NOT LEAK CHAT TEXT",
+        cookie: "cookie-secret-value",
+        localStorage: { auth: "local-storage-secret" },
+        indexedDB: { auth: "indexed-db-secret" },
+      }),
+      "utf-8",
+    );
+    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+      makeConsumerSession({
+        turns: [{ index: 0, role: "user", content: "NORMALIZED CHAT SECRET" }],
+      }),
+    ]);
+
+    const r = runScript(["--consumer-sessions-dry-run"], { HOME: home, GSTACK_HOME: gstackHome });
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.files.length).toBe(2);
+    expect(r.stdout).toContain("provider_kind");
+    expect(r.stdout).toContain("provider_export_kind");
+    expect(r.stdout).toContain("parser_status");
+    expect(r.stdout).toContain("conversation_count");
+    expect(r.stdout).not.toContain("DO NOT LEAK CHAT TEXT");
+    expect(r.stdout).not.toContain("cookie-secret-value");
+    expect(r.stdout).not.toContain("local-storage-secret");
+    expect(r.stdout).not.toContain("indexed-db-secret");
+    expect(r.stdout).not.toContain("NORMALIZED CHAT SECRET");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("renders synthetic normalized sessions under sessions/<provider> and chunks long conversations", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const stagingCopy = join(home, "consumer-staging-copy");
+    const binDir = join(home, "fake-bin");
+    mkdirSync(binDir, { recursive: true });
+    const fake = `#!/usr/bin/env bash
+case "\${1:-}" in
+  --help|-h) echo "Usage: gbrain"; echo "Commands:"; echo "  import <dir>   Import"; exit 0 ;;
+  import)
+    DIR="\${2:-}"
+    cp -R "\$DIR" "${stagingCopy}" 2>/dev/null || true
+    TOTAL=\$(find "\$DIR" -name "*.md" -type f | wc -l | tr -d ' ')
+    echo "{\\"status\\":\\"success\\",\\"duration_s\\":0.1,\\"imported\\":\$TOTAL,\\"skipped\\":0,\\"errors\\":0,\\"chunks\\":\$TOTAL,\\"total_files\\":\$TOTAL}"
+    exit 0 ;;
+  *) exit 2 ;;
+esac
+`;
+    const fakePath = join(binDir, "gbrain");
+    writeFileSync(fakePath, fake, "utf-8");
+    chmodSync(fakePath, 0o755);
+
+    const longContent = `start\n${"x".repeat(170_000)}\ntail-marker`;
+    writeConsumerSessions(gstackHome, "chatgpt", "long.json", [
+      makeConsumerSession({
+        turns: [
+          { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: longContent },
+        ],
+      }),
+    ]);
+
+    const r = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(r.exitCode).toBe(0);
+
+    const findMd = spawnSync("find", [stagingCopy, "-name", "*.md", "-type", "f"], { encoding: "utf-8" });
+    const mdPaths = (findMd.stdout || "").trim().split("\n").filter(Boolean).sort();
+    expect(mdPaths.length).toBeGreaterThan(1);
+    for (const mdPath of mdPaths) {
+      expect(mdPath).toContain("/sessions/chatgpt/");
+    }
+    const bodies = mdPaths.map((p) => readFileSync(p, "utf-8"));
+    expect(bodies[0]).toContain("type: consumer-session");
+    expect(bodies[0]).toContain("raw_path: \"/exports/chatgpt/raw-export.json\"");
+    expect(bodies[0]).toContain("provider_export_kind: \"synthetic-normalized-v1\"");
+    expect(bodies[0]).toContain("host: \"macbook-fixture\"");
+    expect(bodies[0]).toMatch(/session_id: [a-f0-9]{32}/);
+    expect(bodies[0]).toContain("consumer-session");
+    expect(bodies.join("\n")).toContain("tail-marker");
+
+    const state = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    const entries = Object.values(state.consumer_sessions || {}) as Array<{ page_slugs: string[]; content_sha256: string; chunk_count: number }>;
+    expect(entries.length).toBe(1);
+    expect(entries[0].page_slugs.length).toBe(mdPaths.length);
+    expect(entries[0].content_sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(entries[0].chunk_count).toBe(mdPaths.length);
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("incremental state is per normalized conversation content hash, not export-file mtime only", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir, stagingListFile } = installFakeGbrain(home);
+
+    const sessionA = makeConsumerSession({
+      conversation_id: "conv-a",
+      title: "Conversation A",
+      turns: [{ index: 0, role: "user", content: "unchanged A" }],
+    });
+    const sessionB = makeConsumerSession({
+      conversation_id: "conv-b",
+      title: "Conversation B",
+      turns: [{ index: 0, role: "user", content: "before B" }],
+    });
+    const exportPath = writeConsumerSessions(gstackHome, "chatgpt", "bundle.json", [sessionA, sessionB]);
+
+    const first = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(first.exitCode).toBe(0);
+    expect(readFileSync(stagingListFile, "utf-8").match(/\.md/g)?.length).toBe(2);
+
+    writeFileSync(
+      exportPath,
+      JSON.stringify({ sessions: [sessionA, { ...sessionB, turns: [{ index: 0, role: "user", content: "after B" }] }] }, null, 2),
+      "utf-8",
+    );
+
+    const second = runScript(["--incremental", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(second.exitCode).toBe(0);
+    const stagedList = readFileSync(stagingListFile, "utf-8");
+    expect(stagedList.match(/\.md/g)?.length).toBe(1);
+    expect(stagedList).toContain("conversation-b");
+    expect(stagedList).not.toContain("conversation-a");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+});

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -804,13 +804,29 @@ function writeConsumerSessions(gstackHome: string, provider: string, fileName: s
 }
 
 describe("gstack-memory-ingest consumer-session normalized contract", () => {
+  it("does not include consumer sessions in the default source set", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+      makeConsumerSession(),
+    ]);
+
+    const r = runScript(["--probe"], { HOME: home, GSTACK_HOME: gstackHome });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("Total files in window: 0");
+    expect(r.stdout).not.toContain("consumer-session");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
   it("dry-run discovery reports metadata only and never prints chat/storage values", () => {
     const home = makeTestHome();
     const gstackHome = join(home, ".gstack");
     const rawDir = join(gstackHome, "consumer-sessions", "raw", "chatgpt");
     mkdirSync(rawDir, { recursive: true });
     writeFileSync(
-      join(rawDir, "export.json"),
+      join(rawDir, "matt@example.com salary chat export.json"),
       JSON.stringify({
         text: "DO NOT LEAK CHAT TEXT",
         cookie: "cookie-secret-value",
@@ -819,7 +835,7 @@ describe("gstack-memory-ingest consumer-session normalized contract", () => {
       }),
       "utf-8",
     );
-    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+    writeConsumerSessions(gstackHome, "chatgpt", "private conversation title.json", [
       makeConsumerSession({
         turns: [{ index: 0, role: "user", content: "NORMALIZED CHAT SECRET" }],
       }),
@@ -838,6 +854,12 @@ describe("gstack-memory-ingest consumer-session normalized contract", () => {
     expect(r.stdout).not.toContain("local-storage-secret");
     expect(r.stdout).not.toContain("indexed-db-secret");
     expect(r.stdout).not.toContain("NORMALIZED CHAT SECRET");
+    expect(r.stdout).not.toContain("matt@example.com");
+    expect(r.stdout).not.toContain("salary chat");
+    expect(r.stdout).not.toContain("private conversation title");
+    expect(r.stdout).toContain("consumer-sessions/raw/chatgpt/<redacted-export-001.json>");
+    expect(r.stdout).toContain("consumer-sessions/normalized/chatgpt/<redacted-export-001.json>");
+    expect(parsed.roots.root).toBe("consumer-sessions");
 
     rmSync(home, { recursive: true, force: true });
   });
@@ -948,6 +970,75 @@ esac
     expect(stagedList.match(/\.md/g)?.length).toBe(1);
     expect(stagedList).toContain("conversation-b");
     expect(stagedList).not.toContain("conversation-a");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("probe treats unchanged consumer sessions as unchanged after ingest", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir } = installFakeGbrain(home);
+
+    writeConsumerSessions(gstackHome, "chatgpt", "bundle.json", [
+      makeConsumerSession(),
+    ]);
+
+    const first = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(first.exitCode).toBe(0);
+
+    const probe = runScript(["--probe", "--sources", "consumer-session"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+    });
+    expect(probe.exitCode).toBe(0);
+    expect(probe.stdout).toContain("Total files in window: 1");
+    expect(probe.stdout).toContain("New (never ingested):  0");
+    expect(probe.stdout).toContain("Updated (mtime/hash):  0");
+    expect(probe.stdout).toContain("Unchanged:             1");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("--limit does not mark an incomplete multi-chunk consumer session as ingested", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir } = installFakeGbrain(home);
+
+    const longContent = `start\n${"x".repeat(170_000)}\ntail-marker`;
+    writeConsumerSessions(gstackHome, "chatgpt", "long.json", [
+      makeConsumerSession({
+        turns: [
+          { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: longContent },
+        ],
+      }),
+    ]);
+
+    const limited = runScript(["--bulk", "--sources", "consumer-session", "--limit", "1", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(limited.exitCode).toBe(0);
+    const limitedState = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    expect(Object.keys(limitedState.consumer_sessions || {}).length).toBe(0);
+
+    const full = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(full.exitCode).toBe(0);
+    const fullState = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    const entries = Object.values(fullState.consumer_sessions || {}) as Array<{ page_slugs: string[]; chunk_count: number }>;
+    expect(entries.length).toBe(1);
+    expect(entries[0].page_slugs.length).toBe(entries[0].chunk_count);
+    expect(entries[0].chunk_count).toBeGreaterThan(1);
 
     rmSync(home, { recursive: true, force: true });
   });


### PR DESCRIPTION
Linear: MAT-14

## Summary
- Adds a normalized consumer AI chat session contract for future provider importers.
- Extends `gstack-memory-ingest` with an explicit `consumer-session` source, metadata-only dry-run, deterministic rendering/chunking, and per-conversation incremental state.
- Keeps consumer sessions out of the default ingest source set until provider importers and consent UX land.

## Adversarial review hardening
- `consumer-session` ingest now requires explicit `--sources consumer-session` opt-in.
- `--limit` does not record partially staged multi-chunk conversations as ingested.
- Probe accounting compares consumer-session content hashes against state.
- Dry-run output uses sanitized relative roots and does not expose absolute local paths or private storage filenames.

## Verification
- `bun test test/gstack-memory-ingest.test.ts test/gstack-gbrain-sync.test.ts test/gbrain-source-gitignore.test.ts` - pass, 72 tests.
- `git diff --check origin/main...HEAD` - pass.
- `bun run build` - blocked before this change by missing local dependency artifact: `node_modules/xterm/lib/xterm.js`.
