### PR TITLE
[codex] Add ChatGPT consumer session import

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -66,6 +66,13 @@ import {
 } from "../lib/gstack-memory-helpers";
 import { execGbrainText, spawnGbrainAsync } from "../lib/gbrain-exec";
 import { checkOwnedStagingDir, STAGING_MARKER } from "../lib/staging-guard";
+import {
+  consumerSessionStateKey,
+  discoverConsumerSessionFiles,
+  parseNormalizedConsumerSessionExport,
+  renderConsumerSessionPages,
+  walkConsumerSessionNormalizedFiles,
+} from "../lib/consumer-sessions";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -80,6 +87,7 @@ interface CliArgs {
   sources: Set<MemoryType>;
   limit: number | null;
   noWrite: boolean;
+  consumerSessionsDryRun: boolean;
   /**
    * Opt-in per-file gitleaks scan during the prepare phase. Off by
    * default — the cross-machine boundary (gstack-brain-sync, git push)
@@ -96,7 +104,8 @@ type MemoryType =
   | "ceo-plan"
   | "design-doc"
   | "retro"
-  | "builder-profile-entry";
+  | "builder-profile-entry"
+  | "consumer-session";
 
 interface PageRecord {
   slug: string;
@@ -127,6 +136,20 @@ interface IngestState {
       sha256: string;
       ingested_at: string;
       page_slug: string;
+      partial?: boolean;
+    }
+  >;
+  consumer_sessions?: Record<
+    string,
+    {
+      content_sha256: string;
+      ingested_at: string;
+      page_slugs: string[];
+      raw_path?: string;
+      export_path?: string;
+      provider: string;
+      conversation_id: string;
+      chunk_count: number;
       partial?: boolean;
     }
   >;
@@ -176,6 +199,7 @@ const ALL_TYPES: MemoryType[] = [
   "design-doc",
   "retro",
   "builder-profile-entry",
+  "consumer-session",
 ];
 
 // ── CLI ────────────────────────────────────────────────────────────────────
@@ -195,6 +219,9 @@ Options:
   --all-history        Walk transcripts older than 90 days too.
   --sources <list>     Comma-separated subset: ${ALL_TYPES.join(",")}
   --limit <N>          Stop after N pages written (smoke testing).
+  --consumer-sessions-dry-run
+                       Discover raw/normalized consumer session exports under
+                       the local inbox without printing chat text or raw values.
   --no-write           Skip gbrain put calls (still updates state file).
                        Used by tests + dry runs without actual ingest.
   --scan-secrets       Opt-in per-file gitleaks scan during prepare. Off by
@@ -214,6 +241,7 @@ function parseArgs(): CliArgs {
   let limit: number | null = null;
   let sources: Set<MemoryType> = new Set(ALL_TYPES);
   let noWrite = process.env.GSTACK_MEMORY_INGEST_NO_WRITE === "1";
+  let consumerSessionsDryRun = false;
   let scanSecrets = process.env.GSTACK_MEMORY_INGEST_SCAN_SECRETS === "1";
 
   for (let i = 0; i < args.length; i++) {
@@ -227,6 +255,7 @@ function parseArgs(): CliArgs {
       case "--include-unattributed": includeUnattributed = true; break;
       case "--all-history": allHistory = true; break;
       case "--no-write": noWrite = true; break;
+      case "--consumer-sessions-dry-run": consumerSessionsDryRun = true; break;
       case "--scan-secrets": scanSecrets = true; break;
       case "--limit":
         limit = parseInt(args[++i] || "0", 10);
@@ -255,7 +284,7 @@ function parseArgs(): CliArgs {
     }
   }
 
-  return { mode, quiet, benchmark, includeUnattributed, allHistory, sources, limit, noWrite, scanSecrets };
+  return { mode, quiet, benchmark, includeUnattributed, allHistory, sources, limit, noWrite, consumerSessionsDryRun, scanSecrets };
 }
 
 // ── State file ─────────────────────────────────────────────────────────────
@@ -523,6 +552,11 @@ function* walkAllSources(ctx: WalkContext): Generator<{ path: string; type: Memo
   if (ctx.args.sources.has("transcript")) {
     yield* walkClaudeCodeProjects(ctx);
     yield* walkCodexSessions(ctx);
+  }
+  if (ctx.args.sources.has("consumer-session")) {
+    for (const path of walkConsumerSessionNormalizedFiles(GSTACK_HOME)) {
+      yield { path, type: "consumer-session" };
+    }
   }
   yield* walkGstackArtifacts(ctx);
 }
@@ -886,6 +920,15 @@ interface PreparedPage {
   /** Carry-through fields for state recording on success. */
   page_slug: string;
   partial: boolean;
+  consumer_session?: {
+    state_key: string;
+    content_sha256: string;
+    raw_path?: string;
+    export_path?: string;
+    provider: string;
+    conversation_id: string;
+    chunk_count: number;
+  };
 }
 
 interface StagingResult {
@@ -1030,6 +1073,74 @@ export function readNewFailures(
   return failed;
 }
 
+function recordPreparedSuccesses(
+  state: IngestState,
+  prepared: PreparedPage[],
+  failedSources: Set<string>,
+  nowIso: string,
+  quiet: boolean,
+): number {
+  let written = 0;
+  const consumerGroups = new Map<string, PreparedPage[]>();
+
+  for (const p of prepared) {
+    if (failedSources.has(p.source_path)) continue;
+    if (p.consumer_session) {
+      const group = consumerGroups.get(p.consumer_session.state_key) || [];
+      group.push(p);
+      consumerGroups.set(p.consumer_session.state_key, group);
+      written++;
+      if (!quiet) {
+        const tag = p.partial ? " [partial]" : "";
+        console.log(`[${written}] ${p.page_slug}${tag}`);
+      }
+      continue;
+    }
+
+    try {
+      state.sessions[p.source_path] = {
+        mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
+        sha256: fileSha256(p.source_path),
+        ingested_at: nowIso,
+        page_slug: p.page_slug,
+        partial: p.partial,
+      };
+      written++;
+      if (!quiet) {
+        const tag = p.partial ? " [partial]" : "";
+        console.log(`[${written}] ${p.page_slug}${tag}`);
+      }
+    } catch (err) {
+      // statSync can fail if the source file was removed mid-run; skip
+      // recording but don't fail the whole pass.
+      console.error(
+        `[state-record] ${p.source_path}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  if (consumerGroups.size > 0 && !state.consumer_sessions) {
+    state.consumer_sessions = {};
+  }
+  for (const [stateKey, group] of consumerGroups) {
+    const meta = group[0]?.consumer_session;
+    if (!meta || !state.consumer_sessions) continue;
+    state.consumer_sessions[stateKey] = {
+      content_sha256: meta.content_sha256,
+      ingested_at: nowIso,
+      page_slugs: group.map((p) => p.page_slug),
+      raw_path: meta.raw_path,
+      export_path: meta.export_path,
+      provider: meta.provider,
+      conversation_id: meta.conversation_id,
+      chunk_count: meta.chunk_count,
+      partial: group.some((p) => p.partial),
+    };
+  }
+
+  return written;
+}
+
 // ── Main ingest passes ─────────────────────────────────────────────────────
 
 async function probeMode(args: CliArgs): Promise<ProbeReport> {
@@ -1045,6 +1156,7 @@ async function probeMode(args: CliArgs): Promise<ProbeReport> {
     "design-doc": { count: 0, bytes: 0 },
     retro: { count: 0, bytes: 0 },
     "builder-profile-entry": { count: 0, bytes: 0 },
+    "consumer-session": { count: 0, bytes: 0 },
   };
 
   let totalFiles = 0;
@@ -1130,7 +1242,7 @@ function preparePages(
   for (const { path, type } of walkAllSources(ctx)) {
     if (args.limit !== null && prepared.length >= args.limit) break;
 
-    if (args.mode === "incremental" && !fileChangedSinceState(path, state)) {
+    if (type !== "consumer-session" && args.mode === "incremental" && !fileChangedSinceState(path, state)) {
       skippedDedup++;
       continue;
     }
@@ -1156,7 +1268,50 @@ function preparePages(
 
     let page: PageRecord;
     try {
-      if (type === "transcript") {
+      if (type === "consumer-session") {
+        const sessions = parseNormalizedConsumerSessionExport(path);
+        for (const session of sessions) {
+          const pages = renderConsumerSessionPages(session);
+          const stateKey = consumerSessionStateKey(session);
+          const existing = state.consumer_sessions?.[stateKey];
+          if (args.mode === "incremental" && existing?.content_sha256 === pages[0]?.content_sha256) {
+            skippedDedup++;
+            continue;
+          }
+          if (session.completeness.partial) partialPages++;
+          for (const rendered of pages) {
+            if (args.limit !== null && prepared.length >= args.limit) break;
+            prepared.push({
+              slug: rendered.slug,
+              source_path: path,
+              rendered_body: renderPageBody({
+                slug: rendered.slug,
+                title: rendered.title,
+                type: "consumer-session",
+                body: rendered.body,
+                tags: rendered.tags,
+                source_path: path,
+                session_id: rendered.session_id,
+                partial: rendered.partial,
+                size_bytes: statSync(path).size,
+                content_sha256: rendered.content_sha256,
+              }),
+              page_slug: rendered.slug,
+              partial: rendered.partial,
+              consumer_session: {
+                state_key: rendered.conversation_key,
+                content_sha256: rendered.content_sha256,
+                raw_path: session.source_receipt.raw_path,
+                export_path: session.source_receipt.export_path || path,
+                provider: session.provider,
+                conversation_id: session.conversation_id,
+                chunk_count: rendered.chunk_count,
+              },
+            });
+          }
+        }
+        continue;
+      } else if (type === "transcript") {
         const session = parseTranscriptJsonl(path);
         if (!session) {
           parseFailed++;
@@ -1475,20 +1630,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // the prior contract from --help: "Skip gbrain put calls (still
     // updates state file)".
     const nowIso = new Date().toISOString();
-    for (const p of prep.prepared) {
-      try {
-        state.sessions[p.source_path] = {
-          mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-          sha256: fileSha256(p.source_path),
-          ingested_at: nowIso,
-          page_slug: p.page_slug,
-          partial: p.partial,
-        };
-        written++;
-      } catch {
-        // best-effort state record
-      }
-    }
+    written = recordPreparedSuccesses(state, prep.prepared, new Set(), nowIso, true);
     state.last_full_walk = new Date().toISOString();
     state.last_writer = "gstack-memory-ingest";
     saveState(state);
@@ -1644,22 +1786,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // machine's perspective, the act of staging IS the write.
     if (remoteHttpMode) {
       const nowIso = new Date().toISOString();
-      for (const p of prep.prepared) {
-        try {
-          state.sessions[p.source_path] = {
-            mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-            sha256: fileSha256(p.source_path),
-            ingested_at: nowIso,
-            page_slug: p.page_slug,
-            partial: p.partial,
-          };
-          written++;
-        } catch (err) {
-          console.error(
-            `[state-record] ${p.source_path}: ${(err as Error).message}`,
-          );
-        }
-      }
+      written = recordPreparedSuccesses(state, prep.prepared, new Set(), nowIso, args.quiet);
       state.last_full_walk = nowIso;
       state.last_writer = "gstack-memory-ingest (remote-http mode)";
       saveState(state);
@@ -1787,29 +1914,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // left un-state'd so the next run re-prepares them and gbrain's
     // content_hash dedup short-circuits the import.
     const nowIso = new Date().toISOString();
-    for (const p of prep.prepared) {
-      if (failedSources.has(p.source_path)) continue;
-      try {
-        state.sessions[p.source_path] = {
-          mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-          sha256: fileSha256(p.source_path),
-          ingested_at: nowIso,
-          page_slug: p.page_slug,
-          partial: p.partial,
-        };
-        written++;
-        if (!args.quiet) {
-          const tag = p.partial ? " [partial]" : "";
-          console.log(`[${written}] ${p.page_slug}${tag}`);
-        }
-      } catch (err) {
-        // statSync can fail if the source file was removed mid-run; skip
-        // recording but don't fail the whole pass.
-        console.error(
-          `[state-record] ${p.source_path}: ${(err as Error).message}`,
-        );
-      }
-    }
+    written = recordPreparedSuccesses(state, prep.prepared, failedSources, nowIso, args.quiet);
 
     if (!args.quiet) {
       console.error(
@@ -1893,10 +1998,20 @@ function printBulkResult(r: BulkResult, args: CliArgs): void {
   }
 }
 
+function printConsumerSessionsDryRun(): void {
+  const report = discoverConsumerSessionFiles(GSTACK_HOME);
+  console.log(JSON.stringify(report, null, 2));
+}
+
 // ── Entry point ────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
   const args = parseArgs();
+
+  if (args.consumerSessionsDryRun) {
+    printConsumerSessionsDryRun();
+    return;
+  }
 
   // Engine tier detection — informational; routing happens in gbrain server-side.
   const engine = detectEngineTier();

--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -67,6 +67,7 @@ import {
 import { execGbrainText, spawnGbrainAsync } from "../lib/gbrain-exec";
 import { checkOwnedStagingDir, STAGING_MARKER } from "../lib/staging-guard";
 import {
+  consumerSessionContentHash,
   consumerSessionStateKey,
   discoverConsumerSessionFiles,
   parseNormalizedConsumerSessionExport,
@@ -202,6 +203,8 @@ const ALL_TYPES: MemoryType[] = [
   "consumer-session",
 ];
 
+const DEFAULT_TYPES: MemoryType[] = ALL_TYPES.filter((t) => t !== "consumer-session");
+
 // ── CLI ────────────────────────────────────────────────────────────────────
 
 function printUsage(): void {
@@ -218,6 +221,8 @@ Options:
   --include-unattributed  Ingest sessions with no resolvable git remote.
   --all-history        Walk transcripts older than 90 days too.
   --sources <list>     Comma-separated subset: ${ALL_TYPES.join(",")}
+                       Default excludes consumer-session; opt in explicitly
+                       with --sources consumer-session.
   --limit <N>          Stop after N pages written (smoke testing).
   --consumer-sessions-dry-run
                        Discover raw/normalized consumer session exports under
@@ -239,7 +244,7 @@ function parseArgs(): CliArgs {
   let includeUnattributed = false;
   let allHistory = false;
   let limit: number | null = null;
-  let sources: Set<MemoryType> = new Set(ALL_TYPES);
+  let sources: Set<MemoryType> = new Set(DEFAULT_TYPES);
   let noWrite = process.env.GSTACK_MEMORY_INGEST_NO_WRITE === "1";
   let consumerSessionsDryRun = false;
   let scanSecrets = process.env.GSTACK_MEMORY_INGEST_SCAN_SECRETS === "1";
@@ -1141,6 +1146,34 @@ function recordPreparedSuccesses(
   return written;
 }
 
+function consumerSessionProbeStatus(
+  path: string,
+  state: IngestState,
+): "new" | "updated" | "unchanged" {
+  let sessions;
+  try {
+    sessions = parseNormalizedConsumerSessionExport(path);
+  } catch {
+    return "new";
+  }
+
+  if (sessions.length === 0) return "new";
+  let sawExisting = false;
+  for (const session of sessions) {
+    const stateKey = consumerSessionStateKey(session);
+    const existing = state.consumer_sessions?.[stateKey];
+    if (!existing) return sawExisting ? "updated" : "new";
+    sawExisting = true;
+    if (existing.content_sha256 !== consumerSessionContentHash(session)) {
+      return "updated";
+    }
+    if (existing.page_slugs.length !== existing.chunk_count) {
+      return "updated";
+    }
+  }
+  return "unchanged";
+}
+
 // ── Main ingest passes ─────────────────────────────────────────────────────
 
 async function probeMode(args: CliArgs): Promise<ProbeReport> {
@@ -1177,10 +1210,17 @@ async function probeMode(args: CliArgs): Promise<ProbeReport> {
     byType[type].bytes += size;
     totalBytes += size;
 
-    const entry = state.sessions[path];
-    if (!entry) newCount++;
-    else if (fileChangedSinceState(path, state)) updatedCount++;
-    else unchangedCount++;
+    if (type === "consumer-session") {
+      const status = consumerSessionProbeStatus(path, state);
+      if (status === "new") newCount++;
+      else if (status === "updated") updatedCount++;
+      else unchangedCount++;
+    } else {
+      const entry = state.sessions[path];
+      if (!entry) newCount++;
+      else if (fileChangedSinceState(path, state)) updatedCount++;
+      else unchangedCount++;
+    }
   }
 
   // Per ED2: ~25-35 min for ~11.7K transcripts = ~150ms/page synchronous
@@ -1274,13 +1314,23 @@ function preparePages(
           const pages = renderConsumerSessionPages(session);
           const stateKey = consumerSessionStateKey(session);
           const existing = state.consumer_sessions?.[stateKey];
-          if (args.mode === "incremental" && existing?.content_sha256 === pages[0]?.content_sha256) {
+          if (
+            args.mode === "incremental"
+            && existing?.content_sha256 === pages[0]?.content_sha256
+            && existing.page_slugs.length === existing.chunk_count
+          ) {
             skippedDedup++;
             continue;
           }
+          const remainingLimit = args.limit === null
+            ? Number.POSITIVE_INFINITY
+            : args.limit - prepared.length;
+          if (pages.length > remainingLimit) {
+            skippedDedup++;
+            break;
+          }
           if (session.completeness.partial) partialPages++;
           for (const rendered of pages) {
-            if (args.limit !== null && prepared.length >= args.limit) break;
             prepared.push({
               slug: rendered.slug,
               source_path: path,

--- a/lib/consumer-session-chatgpt.ts
+++ b/lib/consumer-session-chatgpt.ts
@@ -1,0 +1,698 @@
+import { createHash } from "crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { hostname, platform, tmpdir } from "os";
+import { basename, extname, join, relative, resolve } from "path";
+import { spawnSync } from "child_process";
+import {
+  CONSUMER_SESSION_SCHEMA_VERSION,
+  consumerSessionRoots,
+  consumerSessionStableId,
+  type NormalizedConsumerSession,
+  type NormalizedConsumerSessionAttachment,
+  type NormalizedConsumerSessionTurn,
+} from "./consumer-sessions";
+
+export interface ChatGptImportOptions {
+  inputPath?: string;
+  outputPath?: string;
+  gstackHome?: string;
+  dryRun?: boolean;
+}
+
+export interface ChatGptImportPlannedOutput {
+  path: string;
+  conversation_id: string;
+  turn_count: number;
+  attachment_count: number;
+  complete: boolean;
+  partial: boolean;
+}
+
+export interface ChatGptImportReport {
+  input_path: string;
+  output_path: string;
+  provider: "chatgpt";
+  provider_export_kind: string;
+  conversation_count: number;
+  duplicate_count: number;
+  turn_count: number;
+  attachment_count: number;
+  planned_outputs: ChatGptImportPlannedOutput[];
+  wrote: boolean;
+}
+
+export interface PreparedExport {
+  root: string;
+  conversationsPath: string;
+  providerExportKind: string;
+  cleanup?: () => void;
+}
+
+interface ChatGptConversation {
+  id?: unknown;
+  title?: unknown;
+  create_time?: unknown;
+  update_time?: unknown;
+  current_node?: unknown;
+  mapping?: unknown;
+}
+
+interface ChatGptNode {
+  id?: unknown;
+  parent?: unknown;
+  children?: unknown;
+  message?: unknown;
+}
+
+interface ChatGptMessage {
+  id?: unknown;
+  author?: unknown;
+  create_time?: unknown;
+  update_time?: unknown;
+  content?: unknown;
+  metadata?: unknown;
+  recipient?: unknown;
+}
+
+export function defaultChatGptRawPath(gstackHome = defaultGstackHome()): string {
+  return join(consumerSessionRoots(gstackHome).raw, "chatgpt");
+}
+
+export function defaultChatGptNormalizedPath(gstackHome = defaultGstackHome()): string {
+  return join(consumerSessionRoots(gstackHome).normalized, "chatgpt");
+}
+
+export function importChatGptConsumerSessions(options: ChatGptImportOptions = {}): ChatGptImportReport {
+  const gstackHome = options.gstackHome || defaultGstackHome();
+  const inputPath = resolve(options.inputPath || defaultChatGptRawPath(gstackHome));
+  const outputPath = resolve(options.outputPath || defaultChatGptNormalizedPath(gstackHome));
+  const prepared = prepareChatGptExport(inputPath);
+  try {
+    const sessions = normalizeChatGptExport(prepared);
+    const byIdentity = new Map<string, NormalizedConsumerSession>();
+    let duplicateCount = 0;
+    for (const session of sessions) {
+      const key = `${session.account_hash}:${session.conversation_id}`;
+      if (byIdentity.has(key)) duplicateCount++;
+      byIdentity.set(key, session);
+    }
+
+    const uniqueSessions = [...byIdentity.values()].sort((a, b) => {
+      const aTime = a.updated_at || a.created_at || "";
+      const bTime = b.updated_at || b.created_at || "";
+      return aTime.localeCompare(bTime) || a.conversation_id.localeCompare(b.conversation_id);
+    });
+    const plannedOutputs = uniqueSessions.map((session) => {
+      const path = outputFileForSession(outputPath, session);
+      return {
+        path,
+        conversation_id: session.conversation_id,
+        turn_count: session.turns.length,
+        attachment_count: countAttachments(session),
+        complete: session.completeness.complete,
+        partial: session.completeness.partial,
+      };
+    });
+
+    if (!options.dryRun) {
+      mkdirSync(outputPath, { recursive: true });
+      for (let i = 0; i < uniqueSessions.length; i++) {
+        writeFileSync(plannedOutputs[i].path, `${stableJson(uniqueSessions[i])}\n`, "utf-8");
+      }
+    }
+
+    return {
+      input_path: inputPath,
+      output_path: outputPath,
+      provider: "chatgpt",
+      provider_export_kind: prepared.providerExportKind,
+      conversation_count: uniqueSessions.length,
+      duplicate_count: duplicateCount,
+      turn_count: uniqueSessions.reduce((sum, session) => sum + session.turns.length, 0),
+      attachment_count: uniqueSessions.reduce((sum, session) => sum + countAttachments(session), 0),
+      planned_outputs: plannedOutputs,
+      wrote: !options.dryRun,
+    };
+  } finally {
+    prepared.cleanup?.();
+  }
+}
+
+export function normalizeChatGptExport(prepared: PreparedExport): NormalizedConsumerSession[] {
+  const conversationsRaw = readJson(prepared.conversationsPath);
+  const conversations = coerceConversationArray(conversationsRaw);
+  const accountHash = accountHashForExport(prepared.root, prepared.conversationsPath);
+  const contentHash = sha256(readFileSync(prepared.conversationsPath));
+  return conversations.map((conversation, index) =>
+    normalizeConversation(conversation, {
+      accountHash,
+      contentHash,
+      providerExportKind: prepared.providerExportKind,
+      rawPath: prepared.conversationsPath,
+      fallbackIndex: index,
+    })
+  );
+}
+
+export function prepareChatGptExport(inputPath: string): PreparedExport {
+  const resolved = resolve(inputPath);
+  if (!existsSync(resolved)) {
+    throw new Error(`chatgpt_export_not_found:${resolved}`);
+  }
+  const st = statSync(resolved);
+  if (st.isFile() && extname(resolved).toLowerCase() === ".zip") {
+    return prepareZipExport(resolved);
+  }
+
+  if (st.isFile()) {
+    const name = basename(resolved).toLowerCase();
+    if (name !== "conversations.json" && extname(resolved).toLowerCase() !== ".json") {
+      throw new Error("chatgpt_export_schema_error:unsupported_file");
+    }
+    return {
+      root: resolve(resolved, ".."),
+      conversationsPath: resolved,
+      providerExportKind: "chatgpt-official-conversations-json",
+    };
+  }
+
+  if (st.isDirectory()) {
+    const conversationsPath = findConversationsJson(resolved);
+    if (!conversationsPath) {
+      const zipPaths = findFilesByExtension(resolved, ".zip");
+      if (zipPaths.length === 1) return prepareZipExport(zipPaths[0]);
+      if (zipPaths.length > 1) throw new Error("chatgpt_export_schema_error:multiple_zip_exports");
+      throw new Error("chatgpt_export_schema_error:missing_conversations_json");
+    }
+    return {
+      root: resolved,
+      conversationsPath,
+      providerExportKind: "chatgpt-official-export-directory",
+    };
+  }
+
+  throw new Error("chatgpt_export_schema_error:unsupported_input");
+}
+
+function prepareZipExport(zipPath: string): PreparedExport {
+  const tmp = mkdtempSync(join(tmpdir(), "gstack-chatgpt-export-"));
+  const unzip = spawnSync("unzip", ["-qq", zipPath, "-d", tmp], { encoding: "utf-8" });
+  if (unzip.status !== 0) {
+    rmSync(tmp, { recursive: true, force: true });
+    const detail = (unzip.stderr || unzip.stdout || "system unzip failed").trim();
+    throw new Error(`chatgpt_zip_unzip_failed:${detail}`);
+  }
+  const conversationsPath = findConversationsJson(tmp);
+  if (!conversationsPath) {
+    rmSync(tmp, { recursive: true, force: true });
+    throw new Error("chatgpt_export_schema_error:missing_conversations_json");
+  }
+  return {
+    root: tmp,
+    conversationsPath,
+    providerExportKind: "chatgpt-official-export-zip",
+    cleanup: () => rmSync(tmp, { recursive: true, force: true }),
+  };
+}
+
+function normalizeConversation(
+  conversation: ChatGptConversation,
+  context: {
+    accountHash: string;
+    contentHash: string;
+    providerExportKind: string;
+    rawPath: string;
+    fallbackIndex: number;
+  },
+): NormalizedConsumerSession {
+  const mapping = coerceMapping(conversation.mapping);
+  const orderedNodes = orderedMessageNodes(mapping, stringOrUndefined(conversation.current_node));
+  const turns: NormalizedConsumerSessionTurn[] = [];
+  const sessionAttachments = new Map<string, NormalizedConsumerSessionAttachment>();
+  let partial = false;
+  let partialReason = "";
+
+  for (const node of orderedNodes) {
+    const message = coerceMessage(node.message);
+    if (!message) continue;
+    const normalized = normalizeMessage(message, turns.length);
+    if (!normalized) {
+      partial = true;
+      partialReason ||= "unsupported_or_empty_messages";
+      continue;
+    }
+    if (normalized.partial) {
+      partial = true;
+      partialReason ||= normalized.reason || "unsupported_content";
+    }
+    for (const attachment of normalized.turn.attachments || []) {
+      const key = attachment.provider_attachment_id || attachment.id || attachment.name || stableJson(attachment);
+      sessionAttachments.set(key, attachment);
+    }
+    turns.push(normalized.turn);
+  }
+
+  if (turns.length === 0) {
+    partial = true;
+    partialReason ||= "no_supported_turns";
+  }
+
+  const createdAt = isoFromChatGptTimestamp(conversation.create_time) || firstTurnTime(turns);
+  const updatedAt = isoFromChatGptTimestamp(conversation.update_time) || lastTurnTime(turns) || createdAt;
+  const conversationId = stableConversationId(conversation, context.fallbackIndex);
+  return {
+    schema_version: CONSUMER_SESSION_SCHEMA_VERSION,
+    provider: "chatgpt",
+    account_hash: context.accountHash,
+    conversation_id: conversationId,
+    title: stringOrUndefined(conversation.title) || `ChatGPT conversation ${context.fallbackIndex + 1}`,
+    created_at: createdAt,
+    updated_at: updatedAt,
+    turns,
+    attachments: [...sessionAttachments.values()],
+    source_receipt: {
+      raw_path: context.rawPath,
+      provider_export_kind: context.providerExportKind,
+      content_sha256: context.contentHash,
+    },
+    host: {
+      hostname: process.env.GSTACK_HOSTNAME || hostname(),
+      platform: platform(),
+    },
+    completeness: {
+      complete: !partial,
+      partial,
+      truncated: false,
+      missing_turns: turns.length === 0 ? true : undefined,
+      source_complete: !partial,
+      reason: partialReason || undefined,
+    },
+  };
+}
+
+function normalizeMessage(
+  message: ChatGptMessage,
+  index: number,
+): { turn: NormalizedConsumerSessionTurn; partial: boolean; reason?: string } | undefined {
+  const author = objectOrUndefined(message.author);
+  const role = normalizeRole(stringOrUndefined(author?.role));
+  const contentResult = contentFromMessage(message);
+  const attachments = attachmentsFromMessage(message);
+  if (!contentResult.text && attachments.length === 0 && role === "other") return undefined;
+  return {
+    turn: {
+      index,
+      id: stringOrUndefined(message.id),
+      role,
+      created_at: isoFromChatGptTimestamp(message.create_time) || isoFromChatGptTimestamp(message.update_time),
+      content: contentResult.text,
+      attachments,
+      metadata: {
+        recipient: stringOrUndefined(message.recipient),
+        author_name: stringOrUndefined(author?.name),
+        unsupported_content_type: contentResult.unsupportedContentType,
+      },
+    },
+    partial: Boolean(contentResult.unsupportedContentType),
+    reason: contentResult.unsupportedContentType ? `unsupported_content_type:${contentResult.unsupportedContentType}` : undefined,
+  };
+}
+
+function contentFromMessage(message: ChatGptMessage): { text: string; unsupportedContentType?: string } {
+  const content = objectOrUndefined(message.content);
+  if (!content) return { text: "" };
+  const contentType = stringOrUndefined(content.content_type);
+  if (contentType === "text" || contentType === "multimodal_text") {
+    return textFromParts(content.parts);
+  }
+  if (contentType === "code") {
+    const text = stringOrUndefined(content.text) || textFromParts(content.parts).text;
+    return { text };
+  }
+  if (contentType === "execution_output") {
+    const text = stringOrUndefined(content.text) || stringOrUndefined(content.stdout) || stringOrUndefined(content.stderr) || "";
+    return { text };
+  }
+  if (contentType === "tether_browsing_display" || contentType === "system_error") {
+    return { text: stringOrUndefined(content.result) || stringOrUndefined(content.text) || "" };
+  }
+  if (!contentType && Array.isArray(content.parts)) return textFromParts(content.parts);
+  return { text: "", unsupportedContentType: contentType || "unknown" };
+}
+
+function textFromParts(parts: unknown): { text: string; unsupportedContentType?: string } {
+  if (!Array.isArray(parts)) return { text: "" };
+  const text: string[] = [];
+  let unsupportedContentType: string | undefined;
+  for (const part of parts) {
+    if (typeof part === "string") {
+      if (part.length > 0) text.push(part);
+      continue;
+    }
+    const obj = objectOrUndefined(part);
+    if (!obj) continue;
+    const partType = stringOrUndefined(obj.content_type) || stringOrUndefined(obj.type);
+    const partText = stringOrUndefined(obj.text) || stringOrUndefined(obj.transcript);
+    if (partText) text.push(partText);
+    if (!partText && partType && !isAttachmentContentType(partType)) unsupportedContentType ||= partType;
+  }
+  return { text: text.join("\n\n"), unsupportedContentType };
+}
+
+function attachmentsFromMessage(message: ChatGptMessage): NormalizedConsumerSessionAttachment[] {
+  const out = new Map<string, NormalizedConsumerSessionAttachment>();
+  const metadata = objectOrUndefined(message.metadata);
+  collectAttachmentList(out, metadata?.attachments, "metadata_attachment");
+  collectAttachmentList(out, metadata?.files, "metadata_file");
+
+  const content = objectOrUndefined(message.content);
+  const parts = content?.parts;
+  if (Array.isArray(parts)) {
+    for (const part of parts) {
+      const obj = objectOrUndefined(part);
+      if (!obj) continue;
+      const type = stringOrUndefined(obj.content_type) || stringOrUndefined(obj.type);
+      if (type && isAttachmentContentType(type)) {
+        addAttachment(out, attachmentFromObject(obj, type));
+      }
+    }
+  }
+  return [...out.values()];
+}
+
+function collectAttachmentList(
+  out: Map<string, NormalizedConsumerSessionAttachment>,
+  value: unknown,
+  sourceKind: string,
+): void {
+  if (!Array.isArray(value)) return;
+  for (const item of value) {
+    addAttachment(out, attachmentFromObject(item, sourceKind));
+  }
+}
+
+function attachmentFromObject(value: unknown, sourceKind: string): NormalizedConsumerSessionAttachment {
+  const obj = objectOrUndefined(value) || {};
+  const providerId = stringOrUndefined(obj.id)
+    || stringOrUndefined(obj.file_id)
+    || stringOrUndefined(obj.asset_pointer)
+    || stringOrUndefined(obj.download_url);
+  const name = stringOrUndefined(obj.name)
+    || stringOrUndefined(obj.file_name)
+    || stringOrUndefined(obj.filename)
+    || stringOrUndefined(obj.title);
+  const mimeType = stringOrUndefined(obj.mime_type)
+    || stringOrUndefined(obj.mimeType)
+    || stringOrUndefined(obj.content_type);
+  const size = numberOrUndefined(obj.size_bytes) || numberOrUndefined(obj.size);
+  const stableKey = providerId || `${name || "attachment"}:${mimeType || ""}:${size || ""}`;
+  return {
+    id: `att_${sha256(stableKey).slice(0, 16)}`,
+    name,
+    mime_type: mimeType,
+    size_bytes: size,
+    source_kind: sourceKind,
+    provider_attachment_id: providerId,
+    sha256: stringOrUndefined(obj.sha256),
+  };
+}
+
+function addAttachment(out: Map<string, NormalizedConsumerSessionAttachment>, attachment: NormalizedConsumerSessionAttachment): void {
+  const key = attachment.provider_attachment_id || attachment.id || attachment.name || stableJson(attachment);
+  out.set(key, attachment);
+}
+
+function orderedMessageNodes(mapping: Map<string, ChatGptNode>, currentNode: string | undefined): ChatGptNode[] {
+  if (mapping.size === 0) return [];
+  if (currentNode && mapping.has(currentNode)) {
+    const lineage: ChatGptNode[] = [];
+    const seen = new Set<string>();
+    let next: string | undefined = currentNode;
+    while (next && mapping.has(next) && !seen.has(next)) {
+      seen.add(next);
+      const node = mapping.get(next);
+      if (!node) break;
+      lineage.push(node);
+      next = stringOrUndefined(node.parent);
+    }
+    return lineage.reverse();
+  }
+
+  return [...mapping.values()].sort((a, b) => {
+    const aMsg = coerceMessage(a.message);
+    const bMsg = coerceMessage(b.message);
+    const aTime = numericTimestamp(aMsg?.create_time) ?? Number.MAX_SAFE_INTEGER;
+    const bTime = numericTimestamp(bMsg?.create_time) ?? Number.MAX_SAFE_INTEGER;
+    return aTime - bTime || (stringOrUndefined(a.id) || "").localeCompare(stringOrUndefined(b.id) || "");
+  });
+}
+
+function coerceConversationArray(value: unknown): ChatGptConversation[] {
+  if (Array.isArray(value)) return value.map(coerceConversation);
+  const obj = objectOrUndefined(value);
+  if (Array.isArray(obj?.conversations)) return obj.conversations.map(coerceConversation);
+  throw new Error("chatgpt_export_schema_error:conversations_json_not_array");
+}
+
+function coerceConversation(value: unknown): ChatGptConversation {
+  const obj = objectOrUndefined(value);
+  if (!obj || !obj.mapping || typeof obj.mapping !== "object") {
+    throw new Error("chatgpt_export_schema_error:conversation_missing_mapping");
+  }
+  return obj;
+}
+
+function coerceMapping(value: unknown): Map<string, ChatGptNode> {
+  const obj = objectOrUndefined(value);
+  const mapping = new Map<string, ChatGptNode>();
+  if (!obj) return mapping;
+  for (const [key, rawNode] of Object.entries(obj)) {
+    const node = objectOrUndefined(rawNode);
+    if (!node) continue;
+    mapping.set(key, node);
+  }
+  return mapping;
+}
+
+function coerceMessage(value: unknown): ChatGptMessage | undefined {
+  if (value === null || value === undefined) return undefined;
+  return objectOrUndefined(value);
+}
+
+function accountHashForExport(root: string, conversationsPath: string): string {
+  const accountMaterial = readAccountMaterial(root) || `path:${resolve(conversationsPath)}`;
+  return `acct_${sha256(accountMaterial).slice(0, 32)}`;
+}
+
+function readAccountMaterial(root: string): string | undefined {
+  const userJsonPath = findFileNamed(root, "user.json");
+  if (!userJsonPath) return undefined;
+  try {
+    const user = objectOrUndefined(readJson(userJsonPath));
+    if (!user) return undefined;
+    const id = stringOrUndefined(user.id) || stringOrUndefined(user.user_id);
+    const email = stringOrUndefined(user.email);
+    const name = stringOrUndefined(user.name);
+    const material = [id, email, name].filter(Boolean).join("|");
+    return material || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function findConversationsJson(root: string): string | undefined {
+  return findFileNamed(root, "conversations.json");
+}
+
+function findFileNamed(root: string, fileName: string): string | undefined {
+  const wanted = fileName.toLowerCase();
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.shift()!;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    entries.sort();
+    for (const entry of entries) {
+      const path = join(dir, entry);
+      let st;
+      try {
+        st = statSync(path);
+      } catch {
+        continue;
+      }
+      if (st.isFile() && entry.toLowerCase() === wanted) return path;
+      if (st.isDirectory()) stack.push(path);
+    }
+  }
+  return undefined;
+}
+
+function findFilesByExtension(root: string, extension: string): string[] {
+  const out: string[] = [];
+  const wanted = extension.toLowerCase();
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.shift()!;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    entries.sort();
+    for (const entry of entries) {
+      const path = join(dir, entry);
+      let st;
+      try {
+        st = statSync(path);
+      } catch {
+        continue;
+      }
+      if (st.isFile() && extname(entry).toLowerCase() === wanted) out.push(path);
+      if (st.isDirectory()) stack.push(path);
+    }
+  }
+  return out.sort();
+}
+
+function outputFileForSession(outputPath: string, session: NormalizedConsumerSession): string {
+  const id = safePathSegment(session.conversation_id).slice(0, 80) || "conversation";
+  const stableId = consumerSessionStableId(session).slice(0, 12);
+  return join(outputPath, `${id}-${stableId}.json`);
+}
+
+function stableConversationId(conversation: ChatGptConversation, fallbackIndex: number): string {
+  const explicit = stringOrUndefined(conversation.id);
+  if (explicit) return explicit;
+  const source = stableJson({
+    title: stringOrUndefined(conversation.title),
+    create_time: conversation.create_time,
+    update_time: conversation.update_time,
+    current_node: conversation.current_node,
+    mapping_keys: objectOrUndefined(conversation.mapping) ? Object.keys(objectOrUndefined(conversation.mapping)!).sort() : [],
+    fallbackIndex,
+  });
+  return `chatgpt_${sha256(source).slice(0, 24)}`;
+}
+
+function normalizeRole(role: string | undefined): NormalizedConsumerSessionTurn["role"] {
+  switch (role) {
+    case "system":
+    case "user":
+    case "assistant":
+    case "tool":
+      return role;
+    case "critic":
+    case "developer":
+      return "system";
+    default:
+      return role || "other";
+  }
+}
+
+function isAttachmentContentType(type: string): boolean {
+  return [
+    "audio_asset_pointer",
+    "file_asset_pointer",
+    "image_asset_pointer",
+    "video_asset_pointer",
+  ].includes(type);
+}
+
+function isoFromChatGptTimestamp(value: unknown): string | undefined {
+  const numeric = numericTimestamp(value);
+  if (numeric === undefined) return undefined;
+  const millis = numeric > 10_000_000_000 ? numeric : numeric * 1000;
+  const date = new Date(millis);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function numericTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return undefined;
+}
+
+function firstTurnTime(turns: NormalizedConsumerSessionTurn[]): string | undefined {
+  return turns.find((turn) => turn.created_at)?.created_at;
+}
+
+function lastTurnTime(turns: NormalizedConsumerSessionTurn[]): string | undefined {
+  for (let i = turns.length - 1; i >= 0; i--) {
+    if (turns[i].created_at) return turns[i].created_at;
+  }
+  return undefined;
+}
+
+function countAttachments(session: NormalizedConsumerSession): number {
+  const attachments = new Map<string, NormalizedConsumerSessionAttachment>();
+  for (const attachment of session.attachments || []) {
+    addAttachment(attachments, attachment);
+  }
+  for (const turn of session.turns) {
+    for (const attachment of turn.attachments || []) {
+      addAttachment(attachments, attachment);
+    }
+  }
+  return attachments.size;
+}
+
+function defaultGstackHome(): string {
+  return process.env.GSTACK_HOME || join(process.env.HOME || ".", ".gstack");
+}
+
+function readJson(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`chatgpt_export_schema_error:invalid_json:${relative(process.cwd(), path)}:${detail}`);
+  }
+}
+
+function objectOrUndefined(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function safePathSegment(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "unknown";
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableJson(v)}`).join(",")}}`;
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/lib/consumer-session-chatgpt.ts
+++ b/lib/consumer-session-chatgpt.ts
@@ -1,16 +1,18 @@
 import { createHash } from "crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
-  statSync,
+  unlinkSync,
   writeFileSync,
 } from "fs";
 import { hostname, platform, tmpdir } from "os";
-import { basename, extname, join, relative, resolve } from "path";
+import { basename, extname, join, resolve } from "path";
 import { spawnSync } from "child_process";
 import {
   CONSUMER_SESSION_SCHEMA_VERSION,
@@ -53,6 +55,7 @@ export interface ChatGptImportReport {
 export interface PreparedExport {
   root: string;
   conversationsPath: string;
+  identityPath: string;
   providerExportKind: string;
   cleanup?: () => void;
 }
@@ -126,8 +129,10 @@ export function importChatGptConsumerSessions(options: ChatGptImportOptions = {}
     if (!options.dryRun) {
       mkdirSync(outputPath, { recursive: true });
       for (let i = 0; i < uniqueSessions.length; i++) {
-        writeFileSync(plannedOutputs[i].path, `${stableJson(uniqueSessions[i])}\n`, "utf-8");
+        writeFileAtomic(plannedOutputs[i].path, `${stableJson(uniqueSessions[i])}\n`);
       }
+      removeStaleManifestOutputs(outputPath, plannedOutputs.map((output) => basename(output.path)));
+      writeManifest(outputPath, plannedOutputs.map((output) => basename(output.path)));
     }
 
     return {
@@ -150,7 +155,7 @@ export function importChatGptConsumerSessions(options: ChatGptImportOptions = {}
 export function normalizeChatGptExport(prepared: PreparedExport): NormalizedConsumerSession[] {
   const conversationsRaw = readJson(prepared.conversationsPath);
   const conversations = coerceConversationArray(conversationsRaw);
-  const accountHash = accountHashForExport(prepared.root, prepared.conversationsPath);
+  const accountHash = accountHashForExport(prepared.root, prepared.identityPath);
   const contentHash = sha256(readFileSync(prepared.conversationsPath));
   return conversations.map((conversation, index) =>
     normalizeConversation(conversation, {
@@ -166,9 +171,10 @@ export function normalizeChatGptExport(prepared: PreparedExport): NormalizedCons
 export function prepareChatGptExport(inputPath: string): PreparedExport {
   const resolved = resolve(inputPath);
   if (!existsSync(resolved)) {
-    throw new Error(`chatgpt_export_not_found:${resolved}`);
+    throw new Error("chatgpt_export_not_found");
   }
-  const st = statSync(resolved);
+  const st = lstatSync(resolved);
+  if (st.isSymbolicLink()) throw new Error("chatgpt_export_schema_error:symlink_input");
   if (st.isFile() && extname(resolved).toLowerCase() === ".zip") {
     return prepareZipExport(resolved);
   }
@@ -181,6 +187,7 @@ export function prepareChatGptExport(inputPath: string): PreparedExport {
     return {
       root: resolve(resolved, ".."),
       conversationsPath: resolved,
+      identityPath: resolved,
       providerExportKind: "chatgpt-official-conversations-json",
     };
   }
@@ -196,6 +203,7 @@ export function prepareChatGptExport(inputPath: string): PreparedExport {
     return {
       root: resolved,
       conversationsPath,
+      identityPath: resolved,
       providerExportKind: "chatgpt-official-export-directory",
     };
   }
@@ -205,11 +213,10 @@ export function prepareChatGptExport(inputPath: string): PreparedExport {
 
 function prepareZipExport(zipPath: string): PreparedExport {
   const tmp = mkdtempSync(join(tmpdir(), "gstack-chatgpt-export-"));
-  const unzip = spawnSync("unzip", ["-qq", zipPath, "-d", tmp], { encoding: "utf-8" });
-  if (unzip.status !== 0) {
+  const extraction = extractZipSafely(zipPath, tmp);
+  if (!extraction.ok) {
     rmSync(tmp, { recursive: true, force: true });
-    const detail = (unzip.stderr || unzip.stdout || "system unzip failed").trim();
-    throw new Error(`chatgpt_zip_unzip_failed:${detail}`);
+    throw new Error(`chatgpt_zip_extract_failed:${extraction.reason}`);
   }
   const conversationsPath = findConversationsJson(tmp);
   if (!conversationsPath) {
@@ -219,8 +226,21 @@ function prepareZipExport(zipPath: string): PreparedExport {
   return {
     root: tmp,
     conversationsPath,
+    identityPath: zipPath,
     providerExportKind: "chatgpt-official-export-zip",
     cleanup: () => rmSync(tmp, { recursive: true, force: true }),
+  };
+}
+
+export function displayChatGptImportReport(report: ChatGptImportReport): ChatGptImportReport {
+  return {
+    ...report,
+    input_path: "<redacted-chatgpt-input>",
+    output_path: "consumer-sessions/normalized/chatgpt",
+    planned_outputs: report.planned_outputs.map((output, index) => ({
+      ...output,
+      path: `consumer-sessions/normalized/chatgpt/<redacted-output-${String(index + 1).padStart(3, "0")}.json>`,
+    })),
   };
 }
 
@@ -404,8 +424,7 @@ function attachmentFromObject(value: unknown, sourceKind: string): NormalizedCon
   const obj = objectOrUndefined(value) || {};
   const providerId = stringOrUndefined(obj.id)
     || stringOrUndefined(obj.file_id)
-    || stringOrUndefined(obj.asset_pointer)
-    || stringOrUndefined(obj.download_url);
+    || stringOrUndefined(obj.asset_pointer);
   const name = stringOrUndefined(obj.name)
     || stringOrUndefined(obj.file_name)
     || stringOrUndefined(obj.filename)
@@ -444,16 +463,23 @@ function orderedMessageNodes(mapping: Map<string, ChatGptNode>, currentNode: str
       lineage.push(node);
       next = stringOrUndefined(node.parent);
     }
-    return lineage.reverse();
+    const activeLineage = lineage.reverse();
+    const branchNodes = [...mapping.entries()]
+      .filter(([id, node]) => !seen.has(id) && coerceMessage(node.message))
+      .map(([, node]) => node)
+      .sort(compareMessageNodes);
+    return [...activeLineage, ...branchNodes];
   }
 
-  return [...mapping.values()].sort((a, b) => {
-    const aMsg = coerceMessage(a.message);
-    const bMsg = coerceMessage(b.message);
-    const aTime = numericTimestamp(aMsg?.create_time) ?? Number.MAX_SAFE_INTEGER;
-    const bTime = numericTimestamp(bMsg?.create_time) ?? Number.MAX_SAFE_INTEGER;
-    return aTime - bTime || (stringOrUndefined(a.id) || "").localeCompare(stringOrUndefined(b.id) || "");
-  });
+  return [...mapping.values()].sort(compareMessageNodes);
+}
+
+function compareMessageNodes(a: ChatGptNode, b: ChatGptNode): number {
+  const aMsg = coerceMessage(a.message);
+  const bMsg = coerceMessage(b.message);
+  const aTime = numericTimestamp(aMsg?.create_time) ?? Number.MAX_SAFE_INTEGER;
+  const bTime = numericTimestamp(bMsg?.create_time) ?? Number.MAX_SAFE_INTEGER;
+  return aTime - bTime || (stringOrUndefined(a.id) || "").localeCompare(stringOrUndefined(b.id) || "");
 }
 
 function coerceConversationArray(value: unknown): ChatGptConversation[] {
@@ -488,8 +514,8 @@ function coerceMessage(value: unknown): ChatGptMessage | undefined {
   return objectOrUndefined(value);
 }
 
-function accountHashForExport(root: string, conversationsPath: string): string {
-  const accountMaterial = readAccountMaterial(root) || `path:${resolve(conversationsPath)}`;
+function accountHashForExport(root: string, identityPath: string): string {
+  const accountMaterial = readAccountMaterial(root) || `source:${sha256(resolve(identityPath))}`;
   return `acct_${sha256(accountMaterial).slice(0, 32)}`;
 }
 
@@ -529,10 +555,11 @@ function findFileNamed(root: string, fileName: string): string | undefined {
       const path = join(dir, entry);
       let st;
       try {
-        st = statSync(path);
+        st = lstatSync(path);
       } catch {
         continue;
       }
+      if (st.isSymbolicLink()) continue;
       if (st.isFile() && entry.toLowerCase() === wanted) return path;
       if (st.isDirectory()) stack.push(path);
     }
@@ -557,10 +584,11 @@ function findFilesByExtension(root: string, extension: string): string[] {
       const path = join(dir, entry);
       let st;
       try {
-        st = statSync(path);
+        st = lstatSync(path);
       } catch {
         continue;
       }
+      if (st.isSymbolicLink()) continue;
       if (st.isFile() && extname(entry).toLowerCase() === wanted) out.push(path);
       if (st.isDirectory()) stack.push(path);
     }
@@ -661,8 +689,7 @@ function readJson(path: string): unknown {
   try {
     return JSON.parse(readFileSync(path, "utf-8"));
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    throw new Error(`chatgpt_export_schema_error:invalid_json:${relative(process.cwd(), path)}:${detail}`);
+    throw new Error(`chatgpt_export_schema_error:invalid_json:${redactedPath(path)}`);
   }
 }
 
@@ -695,4 +722,95 @@ function stableJson(value: unknown): string {
 
 function sha256(value: string | Buffer): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+function extractZipSafely(zipPath: string, dest: string): { ok: true } | { ok: false; reason: string } {
+  const result = spawnSync("python3", ["-c", SAFE_ZIP_EXTRACTOR, zipPath, dest], {
+    encoding: "utf-8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.status === 0) return { ok: true };
+  const raw = (result.stderr || result.stdout || "python_zip_extract_failed").trim().split(/\r?\n/)[0] || "python_zip_extract_failed";
+  return { ok: false, reason: raw.replace(/[^a-z0-9_:-]/gi, "_").slice(0, 80) };
+}
+
+const SAFE_ZIP_EXTRACTOR = String.raw`
+import os, shutil, stat, sys, zipfile
+
+zip_path, dest = sys.argv[1:3]
+dest_abs = os.path.abspath(dest)
+
+def fail(reason):
+    print(reason, file=sys.stderr)
+    sys.exit(1)
+
+try:
+    with zipfile.ZipFile(zip_path) as zf:
+        for info in zf.infolist():
+            raw = info.filename or ""
+            norm = raw.replace("\\", "/")
+            if not norm:
+                continue
+            parts = [part for part in norm.split("/") if part]
+            if norm.startswith("/") or (parts and ":" in parts[0]) or any(part == ".." for part in parts):
+                fail("unsafe_zip_path")
+            mode = (info.external_attr >> 16) & 0o170000
+            if mode == stat.S_IFLNK:
+                fail("unsafe_zip_symlink")
+            target = os.path.abspath(os.path.join(dest_abs, *parts))
+            if target != dest_abs and not target.startswith(dest_abs + os.sep):
+                fail("unsafe_zip_escape")
+            if info.is_dir() or raw.endswith("/"):
+                os.makedirs(target, mode=0o700, exist_ok=True)
+                continue
+            os.makedirs(os.path.dirname(target), mode=0o700, exist_ok=True)
+            with zf.open(info) as src, open(target, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            os.chmod(target, 0o600)
+except zipfile.BadZipFile:
+    fail("invalid_zip")
+except OSError:
+    fail("zip_extract_io_error")
+`;
+
+const MANIFEST_NAME = ".chatgpt-import-manifest";
+
+function writeFileAtomic(path: string, body: string): void {
+  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
+  writeFileSync(tmp, body, "utf-8");
+  renameSync(tmp, path);
+}
+
+function readManifest(outputPath: string): string[] {
+  try {
+    const parsed = JSON.parse(readFileSync(join(outputPath, MANIFEST_NAME), "utf-8"));
+    return Array.isArray(parsed?.files)
+      ? parsed.files.filter((file: unknown) => typeof file === "string" && basename(file) === file)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeManifest(outputPath: string, files: string[]): void {
+  writeFileAtomic(join(outputPath, MANIFEST_NAME), `${stableJson({ files: [...files].sort() })}\n`);
+}
+
+function removeStaleManifestOutputs(outputPath: string, nextFiles: string[]): void {
+  const keep = new Set(nextFiles);
+  for (const previous of readManifest(outputPath)) {
+    if (keep.has(previous)) continue;
+    try {
+      unlinkSync(join(outputPath, previous));
+    } catch {
+      // Missing stale outputs are already gone.
+    }
+  }
+}
+
+function redactedPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  if (normalized.includes("consumer-sessions/raw/chatgpt")) return "consumer-sessions/raw/chatgpt/<redacted>";
+  if (normalized.includes("consumer-sessions/normalized/chatgpt")) return "consumer-sessions/normalized/chatgpt/<redacted>";
+  return `<redacted-${sha256(path).slice(0, 8)}>`;
 }

--- a/lib/consumer-sessions.ts
+++ b/lib/consumer-sessions.ts
@@ -1,0 +1,547 @@
+import { createHash } from "crypto";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { hostname, platform } from "os";
+import { basename, join, relative } from "path";
+
+export const CONSUMER_SESSION_SCHEMA_VERSION = 1;
+export const DEFAULT_CONSUMER_SESSION_CHUNK_CHARS = 80_000;
+
+export type ConsumerSessionProvider = "chatgpt" | "claude-ai" | "gemini" | "grok" | string;
+
+export interface NormalizedConsumerSessionAttachment {
+  id?: string;
+  name?: string;
+  mime_type?: string;
+  size_bytes?: number;
+  source_kind?: string;
+  provider_attachment_id?: string;
+  sha256?: string;
+}
+
+export interface NormalizedConsumerSessionTurn {
+  index: number;
+  id?: string;
+  role: "system" | "user" | "assistant" | "tool" | "other" | string;
+  created_at?: string;
+  content: string;
+  attachments?: NormalizedConsumerSessionAttachment[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface NormalizedConsumerSessionReceipt {
+  raw_path?: string;
+  receipt_missing?: boolean;
+  provider_export_kind: string;
+  export_path?: string;
+  content_sha256?: string;
+  imported_at?: string;
+}
+
+export interface NormalizedConsumerSessionHost {
+  hostname: string;
+  platform?: string;
+}
+
+export interface NormalizedConsumerSessionCompleteness {
+  complete: boolean;
+  partial: boolean;
+  truncated: boolean;
+  missing_turns?: boolean;
+  source_complete?: boolean;
+  reason?: string;
+}
+
+export interface NormalizedConsumerSession {
+  schema_version: 1;
+  provider: ConsumerSessionProvider;
+  account_hash: string;
+  conversation_id: string;
+  title: string;
+  created_at?: string;
+  updated_at?: string;
+  turns: NormalizedConsumerSessionTurn[];
+  attachments?: NormalizedConsumerSessionAttachment[];
+  source_receipt: NormalizedConsumerSessionReceipt;
+  host: NormalizedConsumerSessionHost;
+  completeness: NormalizedConsumerSessionCompleteness;
+}
+
+export interface ConsumerSessionRoots {
+  root: string;
+  raw: string;
+  normalized: string;
+  rendered: string;
+}
+
+export interface ConsumerSessionDryRunFile {
+  path: string;
+  provider_kind: string;
+  provider_export_kind: string;
+  size_bytes: number;
+  mtime: string;
+  conversation_count: number;
+  turn_count: number;
+  attachment_count: number;
+  parser_status: "ok" | "unsupported_raw_pending_adapter" | "invalid_json" | "schema_error" | "unreadable";
+}
+
+export interface ConsumerSessionDryRunReport {
+  roots: ConsumerSessionRoots;
+  files: ConsumerSessionDryRunFile[];
+}
+
+export interface RenderedConsumerSessionPage {
+  slug: string;
+  title: string;
+  tags: string[];
+  body: string;
+  session_id: string;
+  conversation_key: string;
+  content_sha256: string;
+  chunk_index: number;
+  chunk_count: number;
+  partial: boolean;
+}
+
+export function consumerSessionRoots(gstackHome: string): ConsumerSessionRoots {
+  const root = process.env.GSTACK_CONSUMER_SESSIONS_ROOT || join(gstackHome, "consumer-sessions");
+  return {
+    root,
+    raw: join(root, "raw"),
+    normalized: join(root, "normalized"),
+    rendered: join(gstackHome, "sessions"),
+  };
+}
+
+export function walkConsumerSessionNormalizedFiles(gstackHome: string): string[] {
+  return walkFiles(consumerSessionRoots(gstackHome).normalized, (path) => {
+    const name = basename(path).toLowerCase();
+    return name.endsWith(".json");
+  });
+}
+
+export function discoverConsumerSessionFiles(gstackHome: string): ConsumerSessionDryRunReport {
+  const roots = consumerSessionRoots(gstackHome);
+  const files: ConsumerSessionDryRunFile[] = [];
+
+  for (const path of walkFiles(roots.raw, () => true)) {
+    files.push(buildRawDiscovery(path, roots.raw));
+  }
+
+  for (const path of walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"))) {
+    files.push(buildNormalizedDiscovery(path, roots.normalized));
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return { roots, files };
+}
+
+export function parseNormalizedConsumerSessionExport(path: string): NormalizedConsumerSession[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    throw new Error("invalid_json");
+  }
+
+  const rawSessions = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === "object" && Array.isArray((parsed as { sessions?: unknown }).sessions)
+      ? (parsed as { sessions: unknown[] }).sessions
+      : parsed && typeof parsed === "object"
+        ? [parsed]
+        : [];
+
+  if (rawSessions.length === 0) throw new Error("schema_error");
+  return rawSessions.map((value, index) => coerceSession(value, path, index));
+}
+
+export function consumerSessionContentHash(session: NormalizedConsumerSession): string {
+  return sha256(stableJson(normalizeForHash(session)));
+}
+
+export function consumerSessionStableId(session: NormalizedConsumerSession): string {
+  const key = `${session.provider}:${session.account_hash}:${session.conversation_id}`;
+  return sha256(key).slice(0, 32);
+}
+
+export function consumerSessionStateKey(session: NormalizedConsumerSession): string {
+  return `consumer:${safePathSegment(session.provider)}:${safePathSegment(session.account_hash)}:${consumerSessionStableId(session)}`;
+}
+
+export function renderConsumerSessionPages(
+  session: NormalizedConsumerSession,
+  options: { maxChunkChars?: number } = {},
+): RenderedConsumerSessionPage[] {
+  const maxChunkChars = options.maxChunkChars ?? DEFAULT_CONSUMER_SESSION_CHUNK_CHARS;
+  const sessionId = consumerSessionStableId(session);
+  const contentHash = consumerSessionContentHash(session);
+  const providerFolder = safePathSegment(session.provider);
+  const accountFolder = safePathSegment(session.account_hash);
+  const date = dateOnly(session.created_at || session.updated_at);
+  const titleSlug = safePathSegment(session.title || session.conversation_id).slice(0, 48) || "conversation";
+  const baseSlug = `sessions/${providerFolder}/${accountFolder}/${date}-${titleSlug}-${sessionId.slice(0, 12)}`;
+  const turnSections = renderTurnSections(session, maxChunkChars);
+  const chunks = chunkSections(turnSections, maxChunkChars);
+  const chunkCount = chunks.length;
+  const commonTags = [
+    "session",
+    "consumer-session",
+    `provider:${providerFolder}`,
+    `date:${date}`,
+  ];
+  if (session.completeness.partial) commonTags.push("partial:true");
+  if (session.completeness.truncated) commonTags.push("truncated:true");
+
+  return chunks.map((chunk, index) => {
+    const chunkIndex = index + 1;
+    const chunkSuffix = chunkCount > 1 ? `-part-${String(chunkIndex).padStart(4, "0")}-of-${String(chunkCount).padStart(4, "0")}` : "";
+    const slug = `${baseSlug}${chunkSuffix}`;
+    const pageTitle = chunkCount > 1
+      ? `${session.title || session.conversation_id} (${chunkIndex}/${chunkCount})`
+      : session.title || session.conversation_id;
+    const body = [
+      "---",
+      `provider: ${JSON.stringify(session.provider)}`,
+      `account_hash: ${JSON.stringify(session.account_hash)}`,
+      `conversation_id: ${JSON.stringify(session.conversation_id)}`,
+      `session_id: ${sessionId}`,
+      `provider_export_kind: ${JSON.stringify(session.source_receipt.provider_export_kind)}`,
+      `host: ${JSON.stringify(session.host.hostname)}`,
+      session.source_receipt.raw_path
+        ? `raw_path: ${JSON.stringify(session.source_receipt.raw_path)}`
+        : "receipt_missing: true",
+      `created_at: ${session.created_at || ""}`,
+      `updated_at: ${session.updated_at || ""}`,
+      `complete: ${session.completeness.complete ? "true" : "false"}`,
+      `partial: ${session.completeness.partial ? "true" : "false"}`,
+      `truncated: ${session.completeness.truncated ? "true" : "false"}`,
+      `chunk_index: ${chunkIndex}`,
+      `chunk_count: ${chunkCount}`,
+      `content_sha256: ${contentHash}`,
+      "---",
+      "",
+      chunk.join("\n\n"),
+      "",
+    ].join("\n");
+    return {
+      slug,
+      title: pageTitle,
+      tags: commonTags,
+      body,
+      session_id: sessionId,
+      conversation_key: consumerSessionStateKey(session),
+      content_sha256: contentHash,
+      chunk_index: chunkIndex,
+      chunk_count: chunkCount,
+      partial: session.completeness.partial,
+    };
+  });
+}
+
+function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRunFile {
+  const st = safeStat(path);
+  return {
+    path,
+    provider_kind: providerKindFromPath(path, rawRoot),
+    provider_export_kind: "raw-provider-export",
+    size_bytes: st.size,
+    mtime: st.mtime,
+    conversation_count: 0,
+    turn_count: 0,
+    attachment_count: 0,
+    parser_status: st.ok ? "unsupported_raw_pending_adapter" : "unreadable",
+  };
+}
+
+function buildNormalizedDiscovery(path: string, normalizedRoot: string): ConsumerSessionDryRunFile {
+  const st = safeStat(path);
+  if (!st.ok) {
+    return {
+      path,
+      provider_kind: providerKindFromPath(path, normalizedRoot),
+      provider_export_kind: "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: 0,
+      turn_count: 0,
+      attachment_count: 0,
+      parser_status: "unreadable",
+    };
+  }
+  try {
+    const sessions = parseNormalizedConsumerSessionExport(path);
+    return {
+      path,
+      provider_kind: providerKindFromSessionOrPath(sessions[0], path, normalizedRoot),
+      provider_export_kind: sessions[0]?.source_receipt.provider_export_kind || "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: sessions.length,
+      turn_count: sessions.reduce((sum, session) => sum + session.turns.length, 0),
+      attachment_count: sessions.reduce((sum, session) => sum + (session.attachments?.length || 0) + session.turns.reduce((n, turn) => n + (turn.attachments?.length || 0), 0), 0),
+      parser_status: "ok",
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+    return {
+      path,
+      provider_kind: providerKindFromPath(path, normalizedRoot),
+      provider_export_kind: "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: 0,
+      turn_count: 0,
+      attachment_count: 0,
+      parser_status: message === "invalid_json" ? "invalid_json" : "schema_error",
+    };
+  }
+}
+
+function coerceSession(value: unknown, path: string, index: number): NormalizedConsumerSession {
+  if (!value || typeof value !== "object") throw new Error("schema_error");
+  const obj = value as Record<string, unknown>;
+  const provider = requireString(obj.provider, "provider");
+  const accountHash = requireString(obj.account_hash, "account_hash");
+  const conversationId = requireString(obj.conversation_id, "conversation_id");
+  const turnsRaw = obj.turns;
+  if (!Array.isArray(turnsRaw)) throw new Error("schema_error");
+  const turns = turnsRaw.map((turn, turnIndex) => coerceTurn(turn, turnIndex));
+  const receipt = coerceReceipt(obj.source_receipt, path);
+  const host = coerceHost(obj.host);
+  const completeness = coerceCompleteness(obj.completeness);
+  return {
+    schema_version: CONSUMER_SESSION_SCHEMA_VERSION,
+    provider,
+    account_hash: accountHash,
+    conversation_id: conversationId,
+    title: typeof obj.title === "string" && obj.title.trim() ? obj.title : `Conversation ${index + 1}`,
+    created_at: optionalString(obj.created_at),
+    updated_at: optionalString(obj.updated_at),
+    turns,
+    attachments: Array.isArray(obj.attachments) ? obj.attachments.map(coerceAttachment) : [],
+    source_receipt: receipt,
+    host,
+    completeness,
+  };
+}
+
+function coerceTurn(value: unknown, index: number): NormalizedConsumerSessionTurn {
+  if (!value || typeof value !== "object") throw new Error("schema_error");
+  const obj = value as Record<string, unknown>;
+  return {
+    index: typeof obj.index === "number" ? obj.index : index,
+    id: optionalString(obj.id),
+    role: typeof obj.role === "string" ? obj.role : "other",
+    created_at: optionalString(obj.created_at),
+    content: typeof obj.content === "string" ? obj.content : "",
+    attachments: Array.isArray(obj.attachments) ? obj.attachments.map(coerceAttachment) : [],
+    metadata: obj.metadata && typeof obj.metadata === "object" && !Array.isArray(obj.metadata)
+      ? obj.metadata as Record<string, unknown>
+      : undefined,
+  };
+}
+
+function coerceAttachment(value: unknown): NormalizedConsumerSessionAttachment {
+  if (!value || typeof value !== "object") return {};
+  const obj = value as Record<string, unknown>;
+  return {
+    id: optionalString(obj.id),
+    name: optionalString(obj.name),
+    mime_type: optionalString(obj.mime_type),
+    size_bytes: typeof obj.size_bytes === "number" ? obj.size_bytes : undefined,
+    source_kind: optionalString(obj.source_kind),
+    provider_attachment_id: optionalString(obj.provider_attachment_id),
+    sha256: optionalString(obj.sha256),
+  };
+}
+
+function coerceReceipt(value: unknown, exportPath: string): NormalizedConsumerSessionReceipt {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  const rawPath = optionalString(obj.raw_path);
+  const receiptMissing = typeof obj.receipt_missing === "boolean" ? obj.receipt_missing : !rawPath;
+  return {
+    raw_path: rawPath,
+    receipt_missing: receiptMissing,
+    provider_export_kind: optionalString(obj.provider_export_kind) || "normalized-consumer-session",
+    export_path: optionalString(obj.export_path) || exportPath,
+    content_sha256: optionalString(obj.content_sha256),
+    imported_at: optionalString(obj.imported_at),
+  };
+}
+
+function coerceHost(value: unknown): NormalizedConsumerSessionHost {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  return {
+    hostname: optionalString(obj.hostname) || process.env.GSTACK_HOSTNAME || hostname(),
+    platform: optionalString(obj.platform) || platform(),
+  };
+}
+
+function coerceCompleteness(value: unknown): NormalizedConsumerSessionCompleteness {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  const partial = Boolean(obj.partial);
+  const truncated = Boolean(obj.truncated);
+  return {
+    complete: typeof obj.complete === "boolean" ? obj.complete : !partial && !truncated,
+    partial,
+    truncated,
+    missing_turns: typeof obj.missing_turns === "boolean" ? obj.missing_turns : undefined,
+    source_complete: typeof obj.source_complete === "boolean" ? obj.source_complete : undefined,
+    reason: optionalString(obj.reason),
+  };
+}
+
+function renderTurnSections(session: NormalizedConsumerSession, maxChunkChars: number): string[] {
+  const sorted = [...session.turns].sort((a, b) => a.index - b.index);
+  const sections: string[] = [];
+  for (const turn of sorted) {
+    const label = turn.role.charAt(0).toUpperCase() + turn.role.slice(1);
+    const head = [`## Turn ${turn.index + 1}: ${label}`];
+    if (turn.created_at) head.push(`Time: ${turn.created_at}`);
+    if (turn.attachments && turn.attachments.length > 0) {
+      head.push(`Attachments: ${turn.attachments.length}`);
+    }
+    const prefix = `${head.join("\n")}\n\n`;
+    const content = turn.content || "";
+    if (prefix.length + content.length <= maxChunkChars) {
+      sections.push(prefix + content);
+      continue;
+    }
+    const parts = splitStringByMax(content, Math.max(1, maxChunkChars - prefix.length - 80));
+    for (let i = 0; i < parts.length; i++) {
+      sections.push(`${prefix}_Continuation ${i + 1}/${parts.length}_\n\n${parts[i]}`);
+    }
+  }
+  return sections;
+}
+
+function chunkSections(sections: string[], maxChunkChars: number): string[][] {
+  const chunks: string[][] = [];
+  let current: string[] = [];
+  let currentSize = 0;
+  for (const section of sections) {
+    const nextSize = currentSize + (current.length > 0 ? 2 : 0) + section.length;
+    if (current.length > 0 && nextSize > maxChunkChars) {
+      chunks.push(current);
+      current = [];
+      currentSize = 0;
+    }
+    current.push(section);
+    currentSize += (current.length > 1 ? 2 : 0) + section.length;
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks.length > 0 ? chunks : [[""]];
+}
+
+function splitStringByMax(text: string, maxChars: number): string[] {
+  const parts: string[] = [];
+  for (let i = 0; i < text.length; i += maxChars) {
+    parts.push(text.slice(i, i + maxChars));
+  }
+  return parts.length > 0 ? parts : [""];
+}
+
+function walkFiles(root: string, predicate: (path: string) => boolean): string[] {
+  if (!existsSync(root)) return [];
+  const out: string[] = [];
+  function visit(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry);
+      let st;
+      try {
+        st = statSync(path);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) visit(path);
+      else if (st.isFile() && predicate(path)) out.push(path);
+    }
+  }
+  visit(root);
+  out.sort();
+  return out;
+}
+
+function safeStat(path: string): { ok: boolean; size: number; mtime: string } {
+  try {
+    const st = statSync(path);
+    return { ok: true, size: st.size, mtime: new Date(st.mtimeMs).toISOString() };
+  } catch {
+    return { ok: false, size: 0, mtime: "" };
+  }
+}
+
+function providerKindFromSessionOrPath(session: NormalizedConsumerSession | undefined, path: string, root: string): string {
+  return session?.provider ? safePathSegment(session.provider) : providerKindFromPath(path, root);
+}
+
+function providerKindFromPath(path: string, root: string): string {
+  const rel = relative(root, path).split(/[\\/]/).filter(Boolean);
+  return safePathSegment(rel[0] || "unknown");
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`schema_error:${field}`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function safePathSegment(value: string): string {
+  const cleaned = value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned || "unknown";
+}
+
+function dateOnly(ts: string | undefined): string {
+  if (!ts) return "undated";
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "undated";
+  return d.toISOString().slice(0, 10);
+}
+
+function normalizeForHash(session: NormalizedConsumerSession): unknown {
+  return {
+    schema_version: session.schema_version,
+    provider: session.provider,
+    account_hash: session.account_hash,
+    conversation_id: session.conversation_id,
+    title: session.title,
+    created_at: session.created_at,
+    updated_at: session.updated_at,
+    turns: [...session.turns].sort((a, b) => a.index - b.index),
+    attachments: session.attachments || [],
+    source_receipt: session.source_receipt,
+    host: session.host,
+    completeness: session.completeness,
+  };
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableJson(v)}`).join(",")}}`;
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}

--- a/lib/consumer-sessions.ts
+++ b/lib/consumer-sessions.ts
@@ -1,7 +1,7 @@
 import { createHash } from "crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { hostname, platform } from "os";
-import { basename, join, relative } from "path";
+import { basename, extname, join, relative } from "path";
 
 export const CONSUMER_SESSION_SCHEMA_VERSION = 1;
 export const DEFAULT_CONSUMER_SESSION_CHUNK_CHARS = 80_000;
@@ -109,7 +109,7 @@ export function consumerSessionRoots(gstackHome: string): ConsumerSessionRoots {
     root,
     raw: join(root, "raw"),
     normalized: join(root, "normalized"),
-    rendered: join(gstackHome, "sessions"),
+    rendered: join(root, "rendered"),
   };
 }
 
@@ -124,16 +124,22 @@ export function discoverConsumerSessionFiles(gstackHome: string): ConsumerSessio
   const roots = consumerSessionRoots(gstackHome);
   const files: ConsumerSessionDryRunFile[] = [];
 
-  for (const path of walkFiles(roots.raw, () => true)) {
-    files.push(buildRawDiscovery(path, roots.raw));
+  const rawFiles = walkFiles(roots.raw, () => true);
+  for (let i = 0; i < rawFiles.length; i++) {
+    files.push(buildRawDiscovery(rawFiles[i], roots.raw, displayConsumerSessionPath("raw", roots.raw, rawFiles[i], i + 1)));
   }
 
-  for (const path of walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"))) {
-    files.push(buildNormalizedDiscovery(path, roots.normalized));
+  const normalizedFiles = walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"));
+  for (let i = 0; i < normalizedFiles.length; i++) {
+    files.push(buildNormalizedDiscovery(
+      normalizedFiles[i],
+      roots.normalized,
+      displayConsumerSessionPath("normalized", roots.normalized, normalizedFiles[i], i + 1),
+    ));
   }
 
   files.sort((a, b) => a.path.localeCompare(b.path));
-  return { roots, files };
+  return { roots: displayConsumerSessionRoots(), files };
 }
 
 export function parseNormalizedConsumerSessionExport(path: string): NormalizedConsumerSession[] {
@@ -239,10 +245,10 @@ export function renderConsumerSessionPages(
   });
 }
 
-function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRunFile {
+function buildRawDiscovery(path: string, rawRoot: string, displayPath: string): ConsumerSessionDryRunFile {
   const st = safeStat(path);
   return {
-    path,
+    path: displayPath,
     provider_kind: providerKindFromPath(path, rawRoot),
     provider_export_kind: "raw-provider-export",
     size_bytes: st.size,
@@ -254,11 +260,11 @@ function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRun
   };
 }
 
-function buildNormalizedDiscovery(path: string, normalizedRoot: string): ConsumerSessionDryRunFile {
+function buildNormalizedDiscovery(path: string, normalizedRoot: string, displayPath: string): ConsumerSessionDryRunFile {
   const st = safeStat(path);
   if (!st.ok) {
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromPath(path, normalizedRoot),
       provider_export_kind: "normalized-consumer-session",
       size_bytes: st.size,
@@ -272,7 +278,7 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
   try {
     const sessions = parseNormalizedConsumerSessionExport(path);
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromSessionOrPath(sessions[0], path, normalizedRoot),
       provider_export_kind: sessions[0]?.source_receipt.provider_export_kind || "normalized-consumer-session",
       size_bytes: st.size,
@@ -285,7 +291,7 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
   } catch (err) {
     const message = err instanceof Error ? err.message : "";
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromPath(path, normalizedRoot),
       provider_export_kind: "normalized-consumer-session",
       size_bytes: st.size,
@@ -296,6 +302,23 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
       parser_status: message === "invalid_json" ? "invalid_json" : "schema_error",
     };
   }
+}
+
+function displayConsumerSessionRoots(): ConsumerSessionRoots {
+  return {
+    root: "consumer-sessions",
+    raw: "consumer-sessions/raw",
+    normalized: "consumer-sessions/normalized",
+    rendered: "consumer-sessions/rendered",
+  };
+}
+
+function displayConsumerSessionPath(kind: "raw" | "normalized", root: string, filePath: string, index: number): string {
+  const provider = providerKindFromPath(filePath, root);
+  const rawExt = extname(filePath).replace(/^\./, "");
+  const ext = rawExt ? safePathSegment(rawExt) : "";
+  const ordinal = String(index).padStart(3, "0");
+  return `consumer-sessions/${kind}/${provider}/<redacted-export-${ordinal}${ext ? `.${ext}` : ""}>`;
 }
 
 function coerceSession(value: unknown, path: string, index: number): NormalizedConsumerSession {

--- a/scripts/consumer-session-chatgpt-import.ts
+++ b/scripts/consumer-session-chatgpt-import.ts
@@ -3,6 +3,7 @@
 import {
   defaultChatGptNormalizedPath,
   defaultChatGptRawPath,
+  displayChatGptImportReport,
   importChatGptConsumerSessions,
 } from "../lib/consumer-session-chatgpt";
 
@@ -24,7 +25,7 @@ try {
     outputPath: args.output,
     dryRun: args.dryRun,
   });
-  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(args.dryRun ? displayChatGptImportReport(report) : report, null, 2)}\n`);
 } catch (err) {
   const message = err instanceof Error ? err.message : String(err);
   process.stderr.write(`consumer-session-chatgpt-import: ${message}\n`);
@@ -83,7 +84,7 @@ Defaults:
 Supported input shapes:
   - extracted official export directory containing conversations.json
   - direct conversations.json file
-  - .zip official export, extracted with system unzip
+  - .zip official export, extracted with a safe built-in extractor
 
 Dry-run prints counts and planned output paths only; it does not print chat text.
 `);

--- a/scripts/consumer-session-chatgpt-import.ts
+++ b/scripts/consumer-session-chatgpt-import.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env bun
+
+import {
+  defaultChatGptNormalizedPath,
+  defaultChatGptRawPath,
+  importChatGptConsumerSessions,
+} from "../lib/consumer-session-chatgpt";
+
+interface Args {
+  input?: string;
+  output?: string;
+  dryRun: boolean;
+  help: boolean;
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  const report = importChatGptConsumerSessions({
+    inputPath: args.input,
+    outputPath: args.output,
+    dryRun: args.dryRun,
+  });
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`consumer-session-chatgpt-import: ${message}\n`);
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): Args {
+  const parsed: Args = { dryRun: false, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      parsed.dryRun = true;
+      continue;
+    }
+    if (arg === "--input") {
+      parsed.input = requireValue(argv, ++i, "--input");
+      continue;
+    }
+    if (arg.startsWith("--input=")) {
+      parsed.input = arg.slice("--input=".length);
+      continue;
+    }
+    if (arg === "--output") {
+      parsed.output = requireValue(argv, ++i, "--output");
+      continue;
+    }
+    if (arg.startsWith("--output=")) {
+      parsed.output = arg.slice("--output=".length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}
+
+function requireValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function printHelp(): void {
+  const gstackHome = process.env.GSTACK_HOME || `${process.env.HOME || "~"}/.gstack`;
+  process.stderr.write(`Usage: consumer-session-chatgpt-import [--input PATH] [--output PATH] [--dry-run]
+
+Normalize a ChatGPT official export into ConsumerSession JSON.
+
+Defaults:
+  input:  ${defaultChatGptRawPath(gstackHome)}
+  output: ${defaultChatGptNormalizedPath(gstackHome)}
+
+Supported input shapes:
+  - extracted official export directory containing conversations.json
+  - direct conversations.json file
+  - .zip official export, extracted with system unzip
+
+Dry-run prints counts and planned output paths only; it does not print chat text.
+`);
+}

--- a/test/consumer-session-chatgpt.test.ts
+++ b/test/consumer-session-chatgpt.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it } from "bun:test";
+import { spawnSync } from "child_process";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  importChatGptConsumerSessions,
+  prepareChatGptExport,
+  normalizeChatGptExport,
+} from "../lib/consumer-session-chatgpt";
+import {
+  parseNormalizedConsumerSessionExport,
+  renderConsumerSessionPages,
+} from "../lib/consumer-sessions";
+
+const SCRIPT = join(import.meta.dir, "..", "scripts", "consumer-session-chatgpt-import.ts");
+
+describe("ChatGPT official export consumer-session importer", () => {
+  it("normalizes an extracted official export and writes idempotent per-conversation output", () => {
+    const home = makeHome();
+    const input = join(home, ".gstack", "consumer-sessions", "raw", "chatgpt");
+    const output = join(home, ".gstack", "consumer-sessions", "normalized", "chatgpt");
+    writeChatGptExport(input, {
+      conversations: [
+        fixtureConversation({ id: "conv-alpha", title: "Synthetic alpha" }),
+        fixtureConversation({ id: "conv-alpha", title: "Synthetic alpha duplicate" }),
+      ],
+    });
+
+    const first = importChatGptConsumerSessions({ gstackHome: join(home, ".gstack") });
+    const second = importChatGptConsumerSessions({ gstackHome: join(home, ".gstack") });
+    expect(first.conversation_count).toBe(1);
+    expect(first.duplicate_count).toBe(1);
+    expect(first.turn_count).toBe(4);
+    expect(first.planned_outputs).toEqual(second.planned_outputs);
+    expect(first.planned_outputs[0].path).not.toContain("Synthetic");
+    expect(existsSync(first.planned_outputs[0].path)).toBe(true);
+
+    const sessions = parseNormalizedConsumerSessionExport(first.planned_outputs[0].path);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].provider).toBe("chatgpt");
+    expect(sessions[0].conversation_id).toBe("conv-alpha");
+    expect(sessions[0].account_hash).toMatch(/^acct_[a-f0-9]{32}$/);
+    expect(sessions[0].source_receipt.raw_path).toBe(join(input, "conversations.json"));
+    expect(sessions[0].source_receipt.provider_export_kind).toBe("chatgpt-official-export-directory");
+    expect(sessions[0].source_receipt.content_sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(sessions[0].host.hostname).toBeTruthy();
+    expect(sessions[0].turns.map((turn) => turn.role)).toEqual(["system", "user", "assistant", "tool"]);
+    expect(sessions[0].turns.map((turn) => turn.content)).toEqual([
+      "System fixture instruction",
+      "Synthetic user prompt",
+      "Synthetic assistant reply",
+      "Synthetic tool result",
+    ]);
+
+    expect(first.planned_outputs[0].path.startsWith(output)).toBe(true);
+    const before = readFileSync(first.planned_outputs[0].path, "utf-8");
+    const third = importChatGptConsumerSessions({ gstackHome: join(home, ".gstack") });
+    expect(readFileSync(third.planned_outputs[0].path, "utf-8")).toBe(before);
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("dry-run reports counts and planned paths without chat text", () => {
+    const home = makeHome();
+    const input = join(home, ".gstack", "consumer-sessions", "raw", "chatgpt");
+    writeChatGptExport(input, {
+      conversations: [
+        fixtureConversation({
+          id: "conv-dry",
+          title: "Sensitive synthetic title",
+          userText: "DO NOT PRINT SYNTHETIC USER TEXT",
+          assistantText: "DO NOT PRINT SYNTHETIC ASSISTANT TEXT",
+        }),
+      ],
+    });
+
+    const result = spawnSync("bun", [SCRIPT, "--dry-run"], {
+      encoding: "utf-8",
+      env: { ...process.env, HOME: home, GSTACK_HOME: join(home, ".gstack") },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("\"conversation_count\": 1");
+    expect(result.stdout).toContain("\"planned_outputs\"");
+    expect(result.stdout).not.toContain("DO NOT PRINT");
+    expect(result.stdout).not.toContain("Sensitive synthetic title");
+    expect(result.stdout).not.toContain("SYNTHETIC ASSISTANT");
+    expect(result.stdout).not.toContain("SYNTHETIC USER");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("preserves attachment metadata without reading attachment bytes", () => {
+    const home = makeHome();
+    const input = join(home, "export");
+    writeChatGptExport(input, {
+      conversations: [
+        fixtureConversation({
+          id: "conv-attachments",
+          userText: "Please inspect the attached synthetic file.",
+          attachments: [
+            {
+              id: "file-service-id-1",
+              name: "synthetic-plan.txt",
+              mime_type: "text/plain",
+              size_bytes: 128,
+            },
+          ],
+          contentParts: [
+            "Please inspect the attached synthetic file.",
+            {
+              content_type: "image_asset_pointer",
+              asset_pointer: "file-service-image-1",
+              name: "synthetic-diagram.png",
+              mime_type: "image/png",
+              size_bytes: 2048,
+            },
+          ],
+        }),
+      ],
+    });
+
+    const report = importChatGptConsumerSessions({
+      inputPath: input,
+      outputPath: join(home, "normalized"),
+    });
+    const session = parseNormalizedConsumerSessionExport(report.planned_outputs[0].path)[0];
+    expect(report.attachment_count).toBe(2);
+    expect(session.attachments?.map((attachment) => attachment.name).sort()).toEqual([
+      "synthetic-diagram.png",
+      "synthetic-plan.txt",
+    ]);
+    expect(session.turns[1].attachments?.map((attachment) => attachment.provider_attachment_id).sort()).toEqual([
+      "file-service-id-1",
+      "file-service-image-1",
+    ]);
+    expect(session.turns[1].attachments?.find((attachment) => attachment.name === "synthetic-plan.txt")?.size_bytes).toBe(128);
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("normalizes a zipped official export through system unzip when zip tooling is available", () => {
+    const zipVersion = spawnSync("zip", ["-v"], { encoding: "utf-8" });
+    const unzipVersion = spawnSync("unzip", ["-v"], { encoding: "utf-8" });
+    if ((zipVersion.status ?? 1) !== 0 || (unzipVersion.status ?? 1) !== 0) return;
+
+    const home = makeHome();
+    const extracted = join(home, "extracted");
+    writeChatGptExport(extracted, {
+      conversations: [fixtureConversation({ id: "conv-zip", title: "Synthetic zip" })],
+    });
+    const zipPath = join(home, "chatgpt-export.zip");
+    const zip = spawnSync("zip", ["-qr", zipPath, "."], {
+      cwd: extracted,
+      encoding: "utf-8",
+    });
+    expect(zip.status).toBe(0);
+
+    const report = importChatGptConsumerSessions({
+      inputPath: zipPath,
+      outputPath: join(home, "normalized"),
+    });
+    expect(report.provider_export_kind).toBe("chatgpt-official-export-zip");
+    expect(report.conversation_count).toBe(1);
+    const session = parseNormalizedConsumerSessionExport(report.planned_outputs[0].path)[0];
+    expect(session.conversation_id).toBe("conv-zip");
+    expect(session.source_receipt.provider_export_kind).toBe("chatgpt-official-export-zip");
+
+    const rawDir = join(home, ".gstack", "consumer-sessions", "raw", "chatgpt");
+    mkdirSync(rawDir, { recursive: true });
+    copyFileSync(zipPath, join(rawDir, "chatgpt-export.zip"));
+    const defaultPathReport = importChatGptConsumerSessions({ gstackHome: join(home, ".gstack") });
+    expect(defaultPathReport.provider_export_kind).toBe("chatgpt-official-export-zip");
+    expect(defaultPathReport.conversation_count).toBe(1);
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("keeps empty or deleted conversations as partial normalized sessions", () => {
+    const home = makeHome();
+    const input = join(home, "export");
+    writeChatGptExport(input, {
+      conversations: [
+        {
+          id: "conv-empty",
+          title: "Synthetic deleted conversation",
+          create_time: 1780315200,
+          update_time: 1780315200,
+          current_node: "root",
+          mapping: {
+            root: { id: "root", message: null, parent: null, children: [] },
+          },
+        },
+      ],
+    });
+
+    const report = importChatGptConsumerSessions({
+      inputPath: input,
+      outputPath: join(home, "normalized"),
+    });
+    expect(report.conversation_count).toBe(1);
+    expect(report.turn_count).toBe(0);
+    const session = parseNormalizedConsumerSessionExport(report.planned_outputs[0].path)[0];
+    expect(session.turns).toEqual([]);
+    expect(session.completeness).toMatchObject({
+      complete: false,
+      partial: true,
+      truncated: false,
+      missing_turns: true,
+      reason: "no_supported_turns",
+    });
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("renders long normalized ChatGPT conversations with the MAT-14 consumer-session renderer", () => {
+    const home = makeHome();
+    const input = join(home, "export");
+    const longText = `start\n${"x".repeat(170_000)}\ntail-marker`;
+    writeChatGptExport(input, {
+      conversations: [
+        fixtureConversation({
+          id: "conv-long",
+          userText: longText,
+          assistantText: "short synthetic answer",
+        }),
+      ],
+    });
+    const prepared = prepareChatGptExport(input);
+    const session = normalizeChatGptExport(prepared)[0];
+    const pages = renderConsumerSessionPages(session);
+    expect(pages.length).toBeGreaterThan(1);
+    expect(pages.every((page) => page.slug.includes("sessions/chatgpt/"))).toBe(true);
+    expect(pages.map((page) => page.body).join("\n")).toContain("tail-marker");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("fails closed for unsupported JSON shapes before writing output", () => {
+    const home = makeHome();
+    const input = join(home, "export");
+    const output = join(home, "normalized");
+    mkdirSync(input, { recursive: true });
+    writeFileSync(join(input, "conversations.json"), JSON.stringify({ not_conversations: [] }), "utf-8");
+
+    expect(() => importChatGptConsumerSessions({ inputPath: input, outputPath: output })).toThrow(/conversations_json_not_array/);
+    expect(existsSync(output)).toBe(false);
+
+    rmSync(home, { recursive: true, force: true });
+  });
+});
+
+function makeHome(): string {
+  return mkdtempSync(join(tmpdir(), "gstack-chatgpt-import-"));
+}
+
+function writeChatGptExport(dir: string, options: { conversations: unknown[] }): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "user.json"),
+    JSON.stringify({ id: "synthetic-user-id", email: "synthetic@example.test" }, null, 2),
+    "utf-8",
+  );
+  writeFileSync(join(dir, "conversations.json"), JSON.stringify(options.conversations, null, 2), "utf-8");
+}
+
+function fixtureConversation(options: {
+  id?: string;
+  title?: string;
+  userText?: string;
+  assistantText?: string;
+  attachments?: unknown[];
+  contentParts?: unknown[];
+} = {}): Record<string, unknown> {
+  const userParts = options.contentParts || [options.userText || "Synthetic user prompt"];
+  return {
+    id: options.id || "conv-fixture",
+    title: options.title || "Synthetic planning fixture",
+    create_time: 1780315200,
+    update_time: 1780315500,
+    current_node: "tool-1",
+    mapping: {
+      root: { id: "root", message: null, parent: null, children: ["system-1"] },
+      "system-1": {
+        id: "system-1",
+        parent: "root",
+        children: ["user-1"],
+        message: {
+          id: "msg-system-1",
+          author: { role: "system", name: "system" },
+          create_time: 1780315200,
+          content: { content_type: "text", parts: ["System fixture instruction"] },
+          metadata: {},
+        },
+      },
+      "user-1": {
+        id: "user-1",
+        parent: "system-1",
+        children: ["assistant-1"],
+        message: {
+          id: "msg-user-1",
+          author: { role: "user", name: "synthetic-user" },
+          create_time: 1780315260,
+          content: { content_type: "multimodal_text", parts: userParts },
+          metadata: { attachments: options.attachments || [] },
+        },
+      },
+      "assistant-1": {
+        id: "assistant-1",
+        parent: "user-1",
+        children: ["tool-1"],
+        message: {
+          id: "msg-assistant-1",
+          author: { role: "assistant", name: "assistant" },
+          create_time: 1780315320,
+          content: { content_type: "text", parts: [options.assistantText || "Synthetic assistant reply"] },
+          metadata: {},
+        },
+      },
+      "tool-1": {
+        id: "tool-1",
+        parent: "assistant-1",
+        children: [],
+        message: {
+          id: "msg-tool-1",
+          author: { role: "tool", name: "synthetic-tool" },
+          create_time: 1780315380,
+          content: { content_type: "execution_output", text: "Synthetic tool result" },
+          metadata: {},
+          recipient: "synthetic-tool",
+        },
+      },
+    },
+  };
+}

--- a/test/consumer-session-chatgpt.test.ts
+++ b/test/consumer-session-chatgpt.test.ts
@@ -86,6 +86,8 @@ describe("ChatGPT official export consumer-session importer", () => {
     expect(result.stdout).not.toContain("Sensitive synthetic title");
     expect(result.stdout).not.toContain("SYNTHETIC ASSISTANT");
     expect(result.stdout).not.toContain("SYNTHETIC USER");
+    expect(result.stdout).not.toContain(home);
+    expect(result.stdout).toContain("<redacted-chatgpt-input>");
 
     rmSync(home, { recursive: true, force: true });
   });
@@ -104,6 +106,7 @@ describe("ChatGPT official export consumer-session importer", () => {
               name: "synthetic-plan.txt",
               mime_type: "text/plain",
               size_bytes: 128,
+              download_url: "https://signed.example.test/secret-token",
             },
           ],
           contentParts: [
@@ -135,14 +138,15 @@ describe("ChatGPT official export consumer-session importer", () => {
       "file-service-image-1",
     ]);
     expect(session.turns[1].attachments?.find((attachment) => attachment.name === "synthetic-plan.txt")?.size_bytes).toBe(128);
+    expect(JSON.stringify(session)).not.toContain("signed.example.test");
+    expect(JSON.stringify(session)).not.toContain("secret-token");
 
     rmSync(home, { recursive: true, force: true });
   });
 
-  it("normalizes a zipped official export through system unzip when zip tooling is available", () => {
+  it("normalizes a zipped official export through the safe extractor when zip tooling is available", () => {
     const zipVersion = spawnSync("zip", ["-v"], { encoding: "utf-8" });
-    const unzipVersion = spawnSync("unzip", ["-v"], { encoding: "utf-8" });
-    if ((zipVersion.status ?? 1) !== 0 || (unzipVersion.status ?? 1) !== 0) return;
+    if ((zipVersion.status ?? 1) !== 0) return;
 
     const home = makeHome();
     const extracted = join(home, "extracted");
@@ -172,6 +176,34 @@ describe("ChatGPT official export consumer-session importer", () => {
     const defaultPathReport = importChatGptConsumerSessions({ gstackHome: join(home, ".gstack") });
     expect(defaultPathReport.provider_export_kind).toBe("chatgpt-official-export-zip");
     expect(defaultPathReport.conversation_count).toBe(1);
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("rejects zip entries that are symlinks before extraction", () => {
+    const python = spawnSync("python3", ["--version"], { encoding: "utf-8" });
+    if ((python.status ?? 1) !== 0) return;
+
+    const home = makeHome();
+    const zipPath = join(home, "malicious-chatgpt-export.zip");
+    const makeZip = spawnSync("python3", ["-c", `
+import os, stat, zipfile
+zip_path = os.environ["ZIP_PATH"]
+with zipfile.ZipFile(zip_path, "w") as zf:
+    info = zipfile.ZipInfo("linked-export")
+    info.create_system = 3
+    info.external_attr = (stat.S_IFLNK | 0o777) << 16
+    zf.writestr(info, "/tmp")
+`], {
+      env: { ...process.env, ZIP_PATH: zipPath },
+      encoding: "utf-8",
+    });
+    expect(makeZip.status).toBe(0);
+
+    expect(() => importChatGptConsumerSessions({
+      inputPath: zipPath,
+      outputPath: join(home, "normalized"),
+    })).toThrow(/unsafe_zip_symlink/);
 
     rmSync(home, { recursive: true, force: true });
   });
@@ -209,6 +241,56 @@ describe("ChatGPT official export consumer-session importer", () => {
       missing_turns: true,
       reason: "no_supported_turns",
     });
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("preserves non-active ChatGPT branch messages instead of silently dropping them", () => {
+    const home = makeHome();
+    const input = join(home, "export");
+    const conversation = fixtureConversation({ id: "conv-branches" });
+    const mapping = conversation.mapping as Record<string, Record<string, unknown>>;
+    mapping["alt-assistant"] = {
+      id: "alt-assistant",
+      parent: "user-1",
+      children: [],
+      message: {
+        id: "msg-alt-assistant",
+        author: { role: "assistant", name: "assistant" },
+        create_time: 1780315330,
+        content: { content_type: "text", parts: ["Alternative assistant branch"] },
+        metadata: {},
+      },
+    };
+    writeChatGptExport(input, { conversations: [conversation] });
+
+    const report = importChatGptConsumerSessions({
+      inputPath: input,
+      outputPath: join(home, "normalized"),
+    });
+    const session = parseNormalizedConsumerSessionExport(report.planned_outputs[0].path)[0];
+    expect(session.turns.map((turn) => turn.content)).toContain("Alternative assistant branch");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("removes stale normalized outputs from the previous manifest", () => {
+    const home = makeHome();
+    const input = join(home, "export");
+    const output = join(home, "normalized");
+    const convA = fixtureConversation({ id: "conv-a" });
+    const convB = fixtureConversation({ id: "conv-b" });
+    writeChatGptExport(input, { conversations: [convA, convB] });
+
+    const first = importChatGptConsumerSessions({ inputPath: input, outputPath: output });
+    expect(first.planned_outputs).toHaveLength(2);
+    const stalePath = first.planned_outputs.find((planned) => planned.conversation_id === "conv-b")?.path;
+    expect(stalePath).toBeTruthy();
+    expect(existsSync(stalePath!)).toBe(true);
+
+    writeChatGptExport(input, { conversations: [convA] });
+    importChatGptConsumerSessions({ inputPath: input, outputPath: output });
+    expect(existsSync(stalePath!)).toBe(false);
 
     rmSync(home, { recursive: true, force: true });
   });

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -766,3 +766,189 @@ exit 0
     rmSync(home, { recursive: true, force: true });
   });
 });
+
+// ── Consumer session contract and synthetic normalized adapter ─────────────
+
+function makeConsumerSession(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    provider: "chatgpt",
+    account_hash: "acct_0123456789abcdef",
+    conversation_id: "conv-001",
+    title: "Synthetic planning session",
+    created_at: "2026-06-01T10:00:00Z",
+    updated_at: "2026-06-01T10:05:00Z",
+    turns: [
+      { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: "first prompt" },
+      { index: 1, role: "assistant", created_at: "2026-06-01T10:01:00Z", content: "first answer" },
+    ],
+    attachments: [
+      { id: "att-1", name: "context.txt", mime_type: "text/plain", size_bytes: 42, sha256: "a".repeat(64) },
+    ],
+    source_receipt: {
+      raw_path: "/exports/chatgpt/raw-export.json",
+      provider_export_kind: "synthetic-normalized-v1",
+    },
+    host: { hostname: "macbook-fixture", platform: "darwin" },
+    completeness: { complete: true, partial: false, truncated: false },
+    ...overrides,
+  };
+}
+
+function writeConsumerSessions(gstackHome: string, provider: string, fileName: string, sessions: Record<string, unknown>[]): string {
+  const dir = join(gstackHome, "consumer-sessions", "normalized", provider);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, fileName);
+  writeFileSync(file, JSON.stringify({ sessions }, null, 2), "utf-8");
+  return file;
+}
+
+describe("gstack-memory-ingest consumer-session normalized contract", () => {
+  it("dry-run discovery reports metadata only and never prints chat/storage values", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    const rawDir = join(gstackHome, "consumer-sessions", "raw", "chatgpt");
+    mkdirSync(rawDir, { recursive: true });
+    writeFileSync(
+      join(rawDir, "export.json"),
+      JSON.stringify({
+        text: "DO NOT LEAK CHAT TEXT",
+        cookie: "cookie-secret-value",
+        localStorage: { auth: "local-storage-secret" },
+        indexedDB: { auth: "indexed-db-secret" },
+      }),
+      "utf-8",
+    );
+    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+      makeConsumerSession({
+        turns: [{ index: 0, role: "user", content: "NORMALIZED CHAT SECRET" }],
+      }),
+    ]);
+
+    const r = runScript(["--consumer-sessions-dry-run"], { HOME: home, GSTACK_HOME: gstackHome });
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.files.length).toBe(2);
+    expect(r.stdout).toContain("provider_kind");
+    expect(r.stdout).toContain("provider_export_kind");
+    expect(r.stdout).toContain("parser_status");
+    expect(r.stdout).toContain("conversation_count");
+    expect(r.stdout).not.toContain("DO NOT LEAK CHAT TEXT");
+    expect(r.stdout).not.toContain("cookie-secret-value");
+    expect(r.stdout).not.toContain("local-storage-secret");
+    expect(r.stdout).not.toContain("indexed-db-secret");
+    expect(r.stdout).not.toContain("NORMALIZED CHAT SECRET");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("renders synthetic normalized sessions under sessions/<provider> and chunks long conversations", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const stagingCopy = join(home, "consumer-staging-copy");
+    const binDir = join(home, "fake-bin");
+    mkdirSync(binDir, { recursive: true });
+    const fake = `#!/usr/bin/env bash
+case "\${1:-}" in
+  --help|-h) echo "Usage: gbrain"; echo "Commands:"; echo "  import <dir>   Import"; exit 0 ;;
+  import)
+    DIR="\${2:-}"
+    cp -R "\$DIR" "${stagingCopy}" 2>/dev/null || true
+    TOTAL=\$(find "\$DIR" -name "*.md" -type f | wc -l | tr -d ' ')
+    echo "{\\"status\\":\\"success\\",\\"duration_s\\":0.1,\\"imported\\":\$TOTAL,\\"skipped\\":0,\\"errors\\":0,\\"chunks\\":\$TOTAL,\\"total_files\\":\$TOTAL}"
+    exit 0 ;;
+  *) exit 2 ;;
+esac
+`;
+    const fakePath = join(binDir, "gbrain");
+    writeFileSync(fakePath, fake, "utf-8");
+    chmodSync(fakePath, 0o755);
+
+    const longContent = `start\n${"x".repeat(170_000)}\ntail-marker`;
+    writeConsumerSessions(gstackHome, "chatgpt", "long.json", [
+      makeConsumerSession({
+        turns: [
+          { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: longContent },
+        ],
+      }),
+    ]);
+
+    const r = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(r.exitCode).toBe(0);
+
+    const findMd = spawnSync("find", [stagingCopy, "-name", "*.md", "-type", "f"], { encoding: "utf-8" });
+    const mdPaths = (findMd.stdout || "").trim().split("\n").filter(Boolean).sort();
+    expect(mdPaths.length).toBeGreaterThan(1);
+    for (const mdPath of mdPaths) {
+      expect(mdPath).toContain("/sessions/chatgpt/");
+    }
+    const bodies = mdPaths.map((p) => readFileSync(p, "utf-8"));
+    expect(bodies[0]).toContain("type: consumer-session");
+    expect(bodies[0]).toContain("raw_path: \"/exports/chatgpt/raw-export.json\"");
+    expect(bodies[0]).toContain("provider_export_kind: \"synthetic-normalized-v1\"");
+    expect(bodies[0]).toContain("host: \"macbook-fixture\"");
+    expect(bodies[0]).toMatch(/session_id: [a-f0-9]{32}/);
+    expect(bodies[0]).toContain("consumer-session");
+    expect(bodies.join("\n")).toContain("tail-marker");
+
+    const state = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    const entries = Object.values(state.consumer_sessions || {}) as Array<{ page_slugs: string[]; content_sha256: string; chunk_count: number }>;
+    expect(entries.length).toBe(1);
+    expect(entries[0].page_slugs.length).toBe(mdPaths.length);
+    expect(entries[0].content_sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(entries[0].chunk_count).toBe(mdPaths.length);
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("incremental state is per normalized conversation content hash, not export-file mtime only", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir, stagingListFile } = installFakeGbrain(home);
+
+    const sessionA = makeConsumerSession({
+      conversation_id: "conv-a",
+      title: "Conversation A",
+      turns: [{ index: 0, role: "user", content: "unchanged A" }],
+    });
+    const sessionB = makeConsumerSession({
+      conversation_id: "conv-b",
+      title: "Conversation B",
+      turns: [{ index: 0, role: "user", content: "before B" }],
+    });
+    const exportPath = writeConsumerSessions(gstackHome, "chatgpt", "bundle.json", [sessionA, sessionB]);
+
+    const first = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(first.exitCode).toBe(0);
+    expect(readFileSync(stagingListFile, "utf-8").match(/\.md/g)?.length).toBe(2);
+
+    writeFileSync(
+      exportPath,
+      JSON.stringify({ sessions: [sessionA, { ...sessionB, turns: [{ index: 0, role: "user", content: "after B" }] }] }, null, 2),
+      "utf-8",
+    );
+
+    const second = runScript(["--incremental", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(second.exitCode).toBe(0);
+    const stagedList = readFileSync(stagingListFile, "utf-8");
+    expect(stagedList.match(/\.md/g)?.length).toBe(1);
+    expect(stagedList).toContain("conversation-b");
+    expect(stagedList).not.toContain("conversation-a");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+});

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -804,13 +804,29 @@ function writeConsumerSessions(gstackHome: string, provider: string, fileName: s
 }
 
 describe("gstack-memory-ingest consumer-session normalized contract", () => {
+  it("does not include consumer sessions in the default source set", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+      makeConsumerSession(),
+    ]);
+
+    const r = runScript(["--probe"], { HOME: home, GSTACK_HOME: gstackHome });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("Total files in window: 0");
+    expect(r.stdout).not.toContain("consumer-session");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
   it("dry-run discovery reports metadata only and never prints chat/storage values", () => {
     const home = makeTestHome();
     const gstackHome = join(home, ".gstack");
     const rawDir = join(gstackHome, "consumer-sessions", "raw", "chatgpt");
     mkdirSync(rawDir, { recursive: true });
     writeFileSync(
-      join(rawDir, "export.json"),
+      join(rawDir, "matt@example.com salary chat export.json"),
       JSON.stringify({
         text: "DO NOT LEAK CHAT TEXT",
         cookie: "cookie-secret-value",
@@ -819,7 +835,7 @@ describe("gstack-memory-ingest consumer-session normalized contract", () => {
       }),
       "utf-8",
     );
-    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+    writeConsumerSessions(gstackHome, "chatgpt", "private conversation title.json", [
       makeConsumerSession({
         turns: [{ index: 0, role: "user", content: "NORMALIZED CHAT SECRET" }],
       }),
@@ -838,6 +854,12 @@ describe("gstack-memory-ingest consumer-session normalized contract", () => {
     expect(r.stdout).not.toContain("local-storage-secret");
     expect(r.stdout).not.toContain("indexed-db-secret");
     expect(r.stdout).not.toContain("NORMALIZED CHAT SECRET");
+    expect(r.stdout).not.toContain("matt@example.com");
+    expect(r.stdout).not.toContain("salary chat");
+    expect(r.stdout).not.toContain("private conversation title");
+    expect(r.stdout).toContain("consumer-sessions/raw/chatgpt/<redacted-export-001.json>");
+    expect(r.stdout).toContain("consumer-sessions/normalized/chatgpt/<redacted-export-001.json>");
+    expect(parsed.roots.root).toBe("consumer-sessions");
 
     rmSync(home, { recursive: true, force: true });
   });
@@ -948,6 +970,75 @@ esac
     expect(stagedList.match(/\.md/g)?.length).toBe(1);
     expect(stagedList).toContain("conversation-b");
     expect(stagedList).not.toContain("conversation-a");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("probe treats unchanged consumer sessions as unchanged after ingest", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir } = installFakeGbrain(home);
+
+    writeConsumerSessions(gstackHome, "chatgpt", "bundle.json", [
+      makeConsumerSession(),
+    ]);
+
+    const first = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(first.exitCode).toBe(0);
+
+    const probe = runScript(["--probe", "--sources", "consumer-session"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+    });
+    expect(probe.exitCode).toBe(0);
+    expect(probe.stdout).toContain("Total files in window: 1");
+    expect(probe.stdout).toContain("New (never ingested):  0");
+    expect(probe.stdout).toContain("Updated (mtime/hash):  0");
+    expect(probe.stdout).toContain("Unchanged:             1");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("--limit does not mark an incomplete multi-chunk consumer session as ingested", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir } = installFakeGbrain(home);
+
+    const longContent = `start\n${"x".repeat(170_000)}\ntail-marker`;
+    writeConsumerSessions(gstackHome, "chatgpt", "long.json", [
+      makeConsumerSession({
+        turns: [
+          { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: longContent },
+        ],
+      }),
+    ]);
+
+    const limited = runScript(["--bulk", "--sources", "consumer-session", "--limit", "1", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(limited.exitCode).toBe(0);
+    const limitedState = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    expect(Object.keys(limitedState.consumer_sessions || {}).length).toBe(0);
+
+    const full = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(full.exitCode).toBe(0);
+    const fullState = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    const entries = Object.values(fullState.consumer_sessions || {}) as Array<{ page_slugs: string[]; chunk_count: number }>;
+    expect(entries.length).toBe(1);
+    expect(entries[0].page_slugs.length).toBe(entries[0].chunk_count);
+    expect(entries[0].chunk_count).toBeGreaterThan(1);
 
     rmSync(home, { recursive: true, force: true });
   });


### PR DESCRIPTION
Linear: MAT-15

Depends on: #2071 / MAT-14. This branch is stacked on the consumer-session contract and should not merge before #2071. The diff will shrink after #2071 lands.

## Summary
- Adds a ChatGPT official export normalizer for extracted exports, direct `conversations.json`, and ZIP exports.
- Writes normalized ConsumerSession JSON under `consumer-sessions/normalized/chatgpt`.
- Preserves ordered turns, attachment metadata, receipts, account hash, host, completeness, and MAT-14 renderer compatibility.

## Adversarial review hardening
- Replaced `unzip` extraction with safe Python zip extraction that rejects symlinks and path escapes.
- Preserves non-active ChatGPT branch messages instead of silently importing only the current lineage.
- Redacts CLI dry-run paths and avoids leaking local export folders.
- Uses stable fallback account identity for ZIPs without `user.json`.
- Strips raw `download_url` values from attachment identity.
- Writes normalized outputs atomically and removes stale outputs via a manifest.

## Verification
- `bun test test/consumer-session-chatgpt.test.ts test/gstack-memory-ingest.test.ts` - pass, 39 tests.
- `git diff --check` - pass.
