### PR TITLE
[codex] Add Gemini Takeout consumer session import

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -66,6 +66,13 @@ import {
 } from "../lib/gstack-memory-helpers";
 import { execGbrainText, spawnGbrainAsync } from "../lib/gbrain-exec";
 import { checkOwnedStagingDir, STAGING_MARKER } from "../lib/staging-guard";
+import {
+  consumerSessionStateKey,
+  discoverConsumerSessionFiles,
+  parseNormalizedConsumerSessionExport,
+  renderConsumerSessionPages,
+  walkConsumerSessionNormalizedFiles,
+} from "../lib/consumer-sessions";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -80,6 +87,7 @@ interface CliArgs {
   sources: Set<MemoryType>;
   limit: number | null;
   noWrite: boolean;
+  consumerSessionsDryRun: boolean;
   /**
    * Opt-in per-file gitleaks scan during the prepare phase. Off by
    * default — the cross-machine boundary (gstack-brain-sync, git push)
@@ -96,7 +104,8 @@ type MemoryType =
   | "ceo-plan"
   | "design-doc"
   | "retro"
-  | "builder-profile-entry";
+  | "builder-profile-entry"
+  | "consumer-session";
 
 interface PageRecord {
   slug: string;
@@ -127,6 +136,20 @@ interface IngestState {
       sha256: string;
       ingested_at: string;
       page_slug: string;
+      partial?: boolean;
+    }
+  >;
+  consumer_sessions?: Record<
+    string,
+    {
+      content_sha256: string;
+      ingested_at: string;
+      page_slugs: string[];
+      raw_path?: string;
+      export_path?: string;
+      provider: string;
+      conversation_id: string;
+      chunk_count: number;
       partial?: boolean;
     }
   >;
@@ -176,6 +199,7 @@ const ALL_TYPES: MemoryType[] = [
   "design-doc",
   "retro",
   "builder-profile-entry",
+  "consumer-session",
 ];
 
 // ── CLI ────────────────────────────────────────────────────────────────────
@@ -195,6 +219,9 @@ Options:
   --all-history        Walk transcripts older than 90 days too.
   --sources <list>     Comma-separated subset: ${ALL_TYPES.join(",")}
   --limit <N>          Stop after N pages written (smoke testing).
+  --consumer-sessions-dry-run
+                       Discover raw/normalized consumer session exports under
+                       the local inbox without printing chat text or raw values.
   --no-write           Skip gbrain put calls (still updates state file).
                        Used by tests + dry runs without actual ingest.
   --scan-secrets       Opt-in per-file gitleaks scan during prepare. Off by
@@ -214,6 +241,7 @@ function parseArgs(): CliArgs {
   let limit: number | null = null;
   let sources: Set<MemoryType> = new Set(ALL_TYPES);
   let noWrite = process.env.GSTACK_MEMORY_INGEST_NO_WRITE === "1";
+  let consumerSessionsDryRun = false;
   let scanSecrets = process.env.GSTACK_MEMORY_INGEST_SCAN_SECRETS === "1";
 
   for (let i = 0; i < args.length; i++) {
@@ -227,6 +255,7 @@ function parseArgs(): CliArgs {
       case "--include-unattributed": includeUnattributed = true; break;
       case "--all-history": allHistory = true; break;
       case "--no-write": noWrite = true; break;
+      case "--consumer-sessions-dry-run": consumerSessionsDryRun = true; break;
       case "--scan-secrets": scanSecrets = true; break;
       case "--limit":
         limit = parseInt(args[++i] || "0", 10);
@@ -255,7 +284,7 @@ function parseArgs(): CliArgs {
     }
   }
 
-  return { mode, quiet, benchmark, includeUnattributed, allHistory, sources, limit, noWrite, scanSecrets };
+  return { mode, quiet, benchmark, includeUnattributed, allHistory, sources, limit, noWrite, consumerSessionsDryRun, scanSecrets };
 }
 
 // ── State file ─────────────────────────────────────────────────────────────
@@ -523,6 +552,11 @@ function* walkAllSources(ctx: WalkContext): Generator<{ path: string; type: Memo
   if (ctx.args.sources.has("transcript")) {
     yield* walkClaudeCodeProjects(ctx);
     yield* walkCodexSessions(ctx);
+  }
+  if (ctx.args.sources.has("consumer-session")) {
+    for (const path of walkConsumerSessionNormalizedFiles(GSTACK_HOME)) {
+      yield { path, type: "consumer-session" };
+    }
   }
   yield* walkGstackArtifacts(ctx);
 }
@@ -886,6 +920,15 @@ interface PreparedPage {
   /** Carry-through fields for state recording on success. */
   page_slug: string;
   partial: boolean;
+  consumer_session?: {
+    state_key: string;
+    content_sha256: string;
+    raw_path?: string;
+    export_path?: string;
+    provider: string;
+    conversation_id: string;
+    chunk_count: number;
+  };
 }
 
 interface StagingResult {
@@ -1030,6 +1073,74 @@ export function readNewFailures(
   return failed;
 }
 
+function recordPreparedSuccesses(
+  state: IngestState,
+  prepared: PreparedPage[],
+  failedSources: Set<string>,
+  nowIso: string,
+  quiet: boolean,
+): number {
+  let written = 0;
+  const consumerGroups = new Map<string, PreparedPage[]>();
+
+  for (const p of prepared) {
+    if (failedSources.has(p.source_path)) continue;
+    if (p.consumer_session) {
+      const group = consumerGroups.get(p.consumer_session.state_key) || [];
+      group.push(p);
+      consumerGroups.set(p.consumer_session.state_key, group);
+      written++;
+      if (!quiet) {
+        const tag = p.partial ? " [partial]" : "";
+        console.log(`[${written}] ${p.page_slug}${tag}`);
+      }
+      continue;
+    }
+
+    try {
+      state.sessions[p.source_path] = {
+        mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
+        sha256: fileSha256(p.source_path),
+        ingested_at: nowIso,
+        page_slug: p.page_slug,
+        partial: p.partial,
+      };
+      written++;
+      if (!quiet) {
+        const tag = p.partial ? " [partial]" : "";
+        console.log(`[${written}] ${p.page_slug}${tag}`);
+      }
+    } catch (err) {
+      // statSync can fail if the source file was removed mid-run; skip
+      // recording but don't fail the whole pass.
+      console.error(
+        `[state-record] ${p.source_path}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  if (consumerGroups.size > 0 && !state.consumer_sessions) {
+    state.consumer_sessions = {};
+  }
+  for (const [stateKey, group] of consumerGroups) {
+    const meta = group[0]?.consumer_session;
+    if (!meta || !state.consumer_sessions) continue;
+    state.consumer_sessions[stateKey] = {
+      content_sha256: meta.content_sha256,
+      ingested_at: nowIso,
+      page_slugs: group.map((p) => p.page_slug),
+      raw_path: meta.raw_path,
+      export_path: meta.export_path,
+      provider: meta.provider,
+      conversation_id: meta.conversation_id,
+      chunk_count: meta.chunk_count,
+      partial: group.some((p) => p.partial),
+    };
+  }
+
+  return written;
+}
+
 // ── Main ingest passes ─────────────────────────────────────────────────────
 
 async function probeMode(args: CliArgs): Promise<ProbeReport> {
@@ -1045,6 +1156,7 @@ async function probeMode(args: CliArgs): Promise<ProbeReport> {
     "design-doc": { count: 0, bytes: 0 },
     retro: { count: 0, bytes: 0 },
     "builder-profile-entry": { count: 0, bytes: 0 },
+    "consumer-session": { count: 0, bytes: 0 },
   };
 
   let totalFiles = 0;
@@ -1130,7 +1242,7 @@ function preparePages(
   for (const { path, type } of walkAllSources(ctx)) {
     if (args.limit !== null && prepared.length >= args.limit) break;
 
-    if (args.mode === "incremental" && !fileChangedSinceState(path, state)) {
+    if (type !== "consumer-session" && args.mode === "incremental" && !fileChangedSinceState(path, state)) {
       skippedDedup++;
       continue;
     }
@@ -1156,7 +1268,50 @@ function preparePages(
 
     let page: PageRecord;
     try {
-      if (type === "transcript") {
+      if (type === "consumer-session") {
+        const sessions = parseNormalizedConsumerSessionExport(path);
+        for (const session of sessions) {
+          const pages = renderConsumerSessionPages(session);
+          const stateKey = consumerSessionStateKey(session);
+          const existing = state.consumer_sessions?.[stateKey];
+          if (args.mode === "incremental" && existing?.content_sha256 === pages[0]?.content_sha256) {
+            skippedDedup++;
+            continue;
+          }
+          if (session.completeness.partial) partialPages++;
+          for (const rendered of pages) {
+            if (args.limit !== null && prepared.length >= args.limit) break;
+            prepared.push({
+              slug: rendered.slug,
+              source_path: path,
+              rendered_body: renderPageBody({
+                slug: rendered.slug,
+                title: rendered.title,
+                type: "consumer-session",
+                body: rendered.body,
+                tags: rendered.tags,
+                source_path: path,
+                session_id: rendered.session_id,
+                partial: rendered.partial,
+                size_bytes: statSync(path).size,
+                content_sha256: rendered.content_sha256,
+              }),
+              page_slug: rendered.slug,
+              partial: rendered.partial,
+              consumer_session: {
+                state_key: rendered.conversation_key,
+                content_sha256: rendered.content_sha256,
+                raw_path: session.source_receipt.raw_path,
+                export_path: session.source_receipt.export_path || path,
+                provider: session.provider,
+                conversation_id: session.conversation_id,
+                chunk_count: rendered.chunk_count,
+              },
+            });
+          }
+        }
+        continue;
+      } else if (type === "transcript") {
         const session = parseTranscriptJsonl(path);
         if (!session) {
           parseFailed++;
@@ -1475,20 +1630,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // the prior contract from --help: "Skip gbrain put calls (still
     // updates state file)".
     const nowIso = new Date().toISOString();
-    for (const p of prep.prepared) {
-      try {
-        state.sessions[p.source_path] = {
-          mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-          sha256: fileSha256(p.source_path),
-          ingested_at: nowIso,
-          page_slug: p.page_slug,
-          partial: p.partial,
-        };
-        written++;
-      } catch {
-        // best-effort state record
-      }
-    }
+    written = recordPreparedSuccesses(state, prep.prepared, new Set(), nowIso, true);
     state.last_full_walk = new Date().toISOString();
     state.last_writer = "gstack-memory-ingest";
     saveState(state);
@@ -1644,22 +1786,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // machine's perspective, the act of staging IS the write.
     if (remoteHttpMode) {
       const nowIso = new Date().toISOString();
-      for (const p of prep.prepared) {
-        try {
-          state.sessions[p.source_path] = {
-            mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-            sha256: fileSha256(p.source_path),
-            ingested_at: nowIso,
-            page_slug: p.page_slug,
-            partial: p.partial,
-          };
-          written++;
-        } catch (err) {
-          console.error(
-            `[state-record] ${p.source_path}: ${(err as Error).message}`,
-          );
-        }
-      }
+      written = recordPreparedSuccesses(state, prep.prepared, new Set(), nowIso, args.quiet);
       state.last_full_walk = nowIso;
       state.last_writer = "gstack-memory-ingest (remote-http mode)";
       saveState(state);
@@ -1787,29 +1914,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // left un-state'd so the next run re-prepares them and gbrain's
     // content_hash dedup short-circuits the import.
     const nowIso = new Date().toISOString();
-    for (const p of prep.prepared) {
-      if (failedSources.has(p.source_path)) continue;
-      try {
-        state.sessions[p.source_path] = {
-          mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-          sha256: fileSha256(p.source_path),
-          ingested_at: nowIso,
-          page_slug: p.page_slug,
-          partial: p.partial,
-        };
-        written++;
-        if (!args.quiet) {
-          const tag = p.partial ? " [partial]" : "";
-          console.log(`[${written}] ${p.page_slug}${tag}`);
-        }
-      } catch (err) {
-        // statSync can fail if the source file was removed mid-run; skip
-        // recording but don't fail the whole pass.
-        console.error(
-          `[state-record] ${p.source_path}: ${(err as Error).message}`,
-        );
-      }
-    }
+    written = recordPreparedSuccesses(state, prep.prepared, failedSources, nowIso, args.quiet);
 
     if (!args.quiet) {
       console.error(
@@ -1893,10 +1998,20 @@ function printBulkResult(r: BulkResult, args: CliArgs): void {
   }
 }
 
+function printConsumerSessionsDryRun(): void {
+  const report = discoverConsumerSessionFiles(GSTACK_HOME);
+  console.log(JSON.stringify(report, null, 2));
+}
+
 // ── Entry point ────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
   const args = parseArgs();
+
+  if (args.consumerSessionsDryRun) {
+    printConsumerSessionsDryRun();
+    return;
+  }
 
   // Engine tier detection — informational; routing happens in gbrain server-side.
   const engine = detectEngineTier();

--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -67,6 +67,7 @@ import {
 import { execGbrainText, spawnGbrainAsync } from "../lib/gbrain-exec";
 import { checkOwnedStagingDir, STAGING_MARKER } from "../lib/staging-guard";
 import {
+  consumerSessionContentHash,
   consumerSessionStateKey,
   discoverConsumerSessionFiles,
   parseNormalizedConsumerSessionExport,
@@ -202,6 +203,8 @@ const ALL_TYPES: MemoryType[] = [
   "consumer-session",
 ];
 
+const DEFAULT_TYPES: MemoryType[] = ALL_TYPES.filter((t) => t !== "consumer-session");
+
 // ── CLI ────────────────────────────────────────────────────────────────────
 
 function printUsage(): void {
@@ -218,6 +221,8 @@ Options:
   --include-unattributed  Ingest sessions with no resolvable git remote.
   --all-history        Walk transcripts older than 90 days too.
   --sources <list>     Comma-separated subset: ${ALL_TYPES.join(",")}
+                       Default excludes consumer-session; opt in explicitly
+                       with --sources consumer-session.
   --limit <N>          Stop after N pages written (smoke testing).
   --consumer-sessions-dry-run
                        Discover raw/normalized consumer session exports under
@@ -239,7 +244,7 @@ function parseArgs(): CliArgs {
   let includeUnattributed = false;
   let allHistory = false;
   let limit: number | null = null;
-  let sources: Set<MemoryType> = new Set(ALL_TYPES);
+  let sources: Set<MemoryType> = new Set(DEFAULT_TYPES);
   let noWrite = process.env.GSTACK_MEMORY_INGEST_NO_WRITE === "1";
   let consumerSessionsDryRun = false;
   let scanSecrets = process.env.GSTACK_MEMORY_INGEST_SCAN_SECRETS === "1";
@@ -1141,6 +1146,34 @@ function recordPreparedSuccesses(
   return written;
 }
 
+function consumerSessionProbeStatus(
+  path: string,
+  state: IngestState,
+): "new" | "updated" | "unchanged" {
+  let sessions;
+  try {
+    sessions = parseNormalizedConsumerSessionExport(path);
+  } catch {
+    return "new";
+  }
+
+  if (sessions.length === 0) return "new";
+  let sawExisting = false;
+  for (const session of sessions) {
+    const stateKey = consumerSessionStateKey(session);
+    const existing = state.consumer_sessions?.[stateKey];
+    if (!existing) return sawExisting ? "updated" : "new";
+    sawExisting = true;
+    if (existing.content_sha256 !== consumerSessionContentHash(session)) {
+      return "updated";
+    }
+    if (existing.page_slugs.length !== existing.chunk_count) {
+      return "updated";
+    }
+  }
+  return "unchanged";
+}
+
 // ── Main ingest passes ─────────────────────────────────────────────────────
 
 async function probeMode(args: CliArgs): Promise<ProbeReport> {
@@ -1177,10 +1210,17 @@ async function probeMode(args: CliArgs): Promise<ProbeReport> {
     byType[type].bytes += size;
     totalBytes += size;
 
-    const entry = state.sessions[path];
-    if (!entry) newCount++;
-    else if (fileChangedSinceState(path, state)) updatedCount++;
-    else unchangedCount++;
+    if (type === "consumer-session") {
+      const status = consumerSessionProbeStatus(path, state);
+      if (status === "new") newCount++;
+      else if (status === "updated") updatedCount++;
+      else unchangedCount++;
+    } else {
+      const entry = state.sessions[path];
+      if (!entry) newCount++;
+      else if (fileChangedSinceState(path, state)) updatedCount++;
+      else unchangedCount++;
+    }
   }
 
   // Per ED2: ~25-35 min for ~11.7K transcripts = ~150ms/page synchronous
@@ -1274,13 +1314,23 @@ function preparePages(
           const pages = renderConsumerSessionPages(session);
           const stateKey = consumerSessionStateKey(session);
           const existing = state.consumer_sessions?.[stateKey];
-          if (args.mode === "incremental" && existing?.content_sha256 === pages[0]?.content_sha256) {
+          if (
+            args.mode === "incremental"
+            && existing?.content_sha256 === pages[0]?.content_sha256
+            && existing.page_slugs.length === existing.chunk_count
+          ) {
             skippedDedup++;
             continue;
           }
+          const remainingLimit = args.limit === null
+            ? Number.POSITIVE_INFINITY
+            : args.limit - prepared.length;
+          if (pages.length > remainingLimit) {
+            skippedDedup++;
+            break;
+          }
           if (session.completeness.partial) partialPages++;
           for (const rendered of pages) {
-            if (args.limit !== null && prepared.length >= args.limit) break;
             prepared.push({
               slug: rendered.slug,
               source_path: path,

--- a/docs/consumer-session-gemini-takeout.md
+++ b/docs/consumer-session-gemini-takeout.md
@@ -1,0 +1,68 @@
+# Gemini Takeout consumer-session import
+
+`scripts/consumer-session-gemini-takeout-import.ts` normalizes sanitized Google
+Gemini Apps Takeout exports into MAT-14 `ConsumerSession` JSON.
+
+Default paths:
+
+```bash
+bun run scripts/consumer-session-gemini-takeout-import.ts
+```
+
+- Input: `~/.gstack/consumer-sessions/raw/gemini`
+- Output: `~/.gstack/consumer-sessions/normalized/gemini`
+
+Explicit extracted folders or archives are supported:
+
+```bash
+bun run scripts/consumer-session-gemini-takeout-import.ts --input /path/to/Takeout --dry-run
+bun run scripts/consumer-session-gemini-takeout-import.ts --input /path/to/takeout.zip
+bun run scripts/consumer-session-gemini-takeout-import.ts --input /path/to/takeout.tgz
+```
+
+Archive support shells out to system `unzip` or `tar`; no package dependency is
+added.
+
+## Supported shapes
+
+The importer only emits sessions from JSON records with actual conversation
+turn arrays. Supported synthetic shapes are:
+
+- `Gemini Apps/**.json` files containing `{ conversations: [...] }`,
+  `{ sessions: [...] }`, or an array of conversation objects.
+- Conversation objects with `turns` or `messages` arrays. Turn text is read from
+  `content`, `text`, `prompt`, `response`, `query`, `answer`, or text-bearing
+  `parts`.
+- `My Activity/Gemini Apps/MyActivity.json` entries are parsed for metadata.
+  Activity entries only become sessions when they contain an embedded
+  `conversation`, `turns`, or `messages` shape.
+- Gems files are metadata-only unless they contain the same explicit
+  conversation-turn shape.
+- Turn-level uploads and generated media are copied as attachment metadata only:
+  id, name, mime type, size, source kind, provider id, and sha256 where present.
+  Binary payload keys such as `data`, `base64`, `bytes`, `blob`, and
+  `inlineData` are not copied.
+
+Each normalized session includes:
+
+- `provider: "gemini"`
+- `source_receipt.provider_export_kind: "google-takeout"`
+- `source_receipt.raw_path`
+- `account_hash`
+- `host`
+- `completeness`
+
+Recurring exports are merged by stable `conversation_id`; duplicate turns are
+deduped by provider turn id, falling back to a deterministic hash of role, time,
+content, and attachment metadata.
+
+## Fail-closed behavior
+
+Unsupported JSON, activity-only entries, and Gems-only metadata do not create
+synthetic chats. They are counted in the import result and skipped. Invalid JSON
+is treated as unsupported. Missing optional activity fields such as title or time
+do not fail import; missing turn content marks the normalized session partial
+when any usable turn or attachment remains.
+
+`--dry-run` prints counts and planned output paths only. It does not print turn
+content, account identifiers, or conversation titles.

--- a/lib/consumer-session-gemini.ts
+++ b/lib/consumer-session-gemini.ts
@@ -1,0 +1,696 @@
+import { createHash } from "crypto";
+import { spawnSync } from "child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { homedir, hostname, platform, tmpdir } from "os";
+import { basename, dirname, join, relative } from "path";
+
+import {
+  consumerSessionRoots,
+  type NormalizedConsumerSession,
+  type NormalizedConsumerSessionAttachment,
+  type NormalizedConsumerSessionTurn,
+} from "./consumer-sessions";
+
+export interface GeminiTakeoutImportOptions {
+  inputPath?: string;
+  outputPath?: string;
+  gstackHome?: string;
+  dryRun?: boolean;
+  importedAt?: string;
+}
+
+export interface GeminiTakeoutPlannedOutput {
+  path: string;
+  conversation_id: string;
+  turn_count: number;
+  attachment_count: number;
+}
+
+export interface GeminiTakeoutImportResult {
+  provider: "gemini";
+  provider_export_kind: "google-takeout";
+  input_path: string;
+  output_path: string;
+  dry_run: boolean;
+  account_hash: string;
+  conversation_count: number;
+  turn_count: number;
+  attachment_count: number;
+  metadata_only_count: number;
+  unsupported_json_count: number;
+  planned_outputs: GeminiTakeoutPlannedOutput[];
+}
+
+interface SourceJson {
+  path: string;
+  relativePath: string;
+  value: unknown;
+}
+
+interface ActivityMetadata {
+  conversationId?: string;
+  title?: string;
+  titleUrl?: string;
+  time?: string;
+  products?: string[];
+}
+
+interface CandidateConversation {
+  conversationId: string;
+  title: string;
+  createdAt?: string;
+  updatedAt?: string;
+  turns: NormalizedConsumerSessionTurn[];
+  attachments: NormalizedConsumerSessionAttachment[];
+  rawPath: string;
+  sourceMetadata: Record<string, unknown>;
+  partialReasons: string[];
+  sourceComplete?: boolean;
+}
+
+const PROVIDER = "gemini";
+const PROVIDER_EXPORT_KIND = "google-takeout";
+const BINARY_KEYS = new Set([
+  "base64",
+  "base64data",
+  "binary",
+  "blob",
+  "bytes",
+  "data",
+  "datauri",
+  "inline",
+  "inlinedata",
+  "payload",
+]);
+
+export function importGeminiTakeout(options: GeminiTakeoutImportOptions = {}): GeminiTakeoutImportResult {
+  const gstackHome = options.gstackHome || process.env.GSTACK_HOME || join(homedir(), ".gstack");
+  const roots = consumerSessionRoots(gstackHome);
+  const inputPath = options.inputPath || join(roots.raw, PROVIDER);
+  const outputPath = options.outputPath || join(roots.normalized, PROVIDER);
+  const importedAt = options.importedAt;
+  const input = prepareInput(inputPath);
+
+  try {
+    const sources = loadJsonSources(input.root);
+    const accountHash = accountHashForSources(sources);
+    const activity = collectActivityMetadata(sources);
+    const candidates: CandidateConversation[] = [];
+    let metadataOnlyCount = 0;
+    let unsupportedJsonCount = 0;
+
+    for (const source of sources) {
+      const kind = sourceKind(source.relativePath);
+      const sourceCandidates = extractConversationsFromValue(source, activity);
+      if (kind === "activity") {
+        metadataOnlyCount += Math.max(0, arrayFromContainer(source.value).length - sourceCandidates.length);
+      } else if (kind === "gems" && sourceCandidates.length === 0) {
+        metadataOnlyCount++;
+      }
+      if (sourceCandidates.length === 0) {
+        if (kind !== "activity" && kind !== "gems") unsupportedJsonCount++;
+        continue;
+      }
+      candidates.push(...sourceCandidates);
+    }
+
+    const sessions = mergeCandidateConversations(candidates).map((candidate) =>
+      candidateToSession(candidate, accountHash, outputPath, importedAt),
+    );
+    sessions.sort((a, b) =>
+      (a.created_at || a.updated_at || a.conversation_id).localeCompare(b.created_at || b.updated_at || b.conversation_id)
+      || a.conversation_id.localeCompare(b.conversation_id)
+    );
+
+    const planned = sessions.map((session) => plannedOutputForSession(outputPath, session));
+    if (!options.dryRun) {
+      mkdirSync(outputPath, { recursive: true });
+      for (const session of sessions) {
+        const out = plannedOutputForSession(outputPath, session).path;
+        mkdirSync(dirname(out), { recursive: true });
+        writeFileSync(out, `${JSON.stringify(session, null, 2)}\n`, "utf-8");
+      }
+    }
+
+    return {
+      provider: PROVIDER,
+      provider_export_kind: PROVIDER_EXPORT_KIND,
+      input_path: inputPath,
+      output_path: outputPath,
+      dry_run: Boolean(options.dryRun),
+      account_hash: accountHash,
+      conversation_count: sessions.length,
+      turn_count: sessions.reduce((sum, session) => sum + session.turns.length, 0),
+      attachment_count: sessions.reduce((sum, session) =>
+        sum + (session.attachments?.length || 0) + session.turns.reduce((n, turn) => n + (turn.attachments?.length || 0), 0),
+      0),
+      metadata_only_count: metadataOnlyCount,
+      unsupported_json_count: unsupportedJsonCount,
+      planned_outputs: planned,
+    };
+  } finally {
+    input.cleanup();
+  }
+}
+
+function prepareInput(inputPath: string): { root: string; cleanup: () => void } {
+  const lower = inputPath.toLowerCase();
+  if (lower.endsWith(".zip")) {
+    const root = mkdtempSync(join(tmpdir(), "gstack-gemini-takeout-"));
+    assertArchiveEntriesSafe(inputPath, "zip");
+    const result = spawnSync("unzip", ["-q", inputPath, "-d", root], { encoding: "utf-8" });
+    if (result.status !== 0) {
+      rmSync(root, { recursive: true, force: true });
+      throw new Error(`failed_to_extract_zip:${result.stderr || result.stdout || "unzip failed"}`);
+    }
+    return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+  }
+  if (lower.endsWith(".tgz") || lower.endsWith(".tar.gz")) {
+    const root = mkdtempSync(join(tmpdir(), "gstack-gemini-takeout-"));
+    assertArchiveEntriesSafe(inputPath, "tgz");
+    const result = spawnSync("tar", ["-xzf", inputPath, "-C", root], { encoding: "utf-8" });
+    if (result.status !== 0) {
+      rmSync(root, { recursive: true, force: true });
+      throw new Error(`failed_to_extract_tgz:${result.stderr || result.stdout || "tar failed"}`);
+    }
+    return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+  }
+  return { root: inputPath, cleanup: () => undefined };
+}
+
+function assertArchiveEntriesSafe(inputPath: string, kind: "zip" | "tgz"): void {
+  const result = kind === "zip"
+    ? spawnSync("unzip", ["-Z1", inputPath], { encoding: "utf-8" })
+    : spawnSync("tar", ["-tzf", inputPath], { encoding: "utf-8" });
+  if (result.status !== 0) {
+    throw new Error(`failed_to_list_${kind}:${result.stderr || result.stdout || "archive listing failed"}`);
+  }
+  for (const entry of (result.stdout || "").split(/\r?\n/).filter(Boolean)) {
+    if (isUnsafeArchiveEntry(entry)) throw new Error(`unsafe_archive_entry:${entry}`);
+  }
+}
+
+function isUnsafeArchiveEntry(entry: string): boolean {
+  if (entry.startsWith("/") || /^[A-Za-z]:/.test(entry)) return true;
+  const parts = entry.split(/[\\/]+/).filter(Boolean);
+  return parts.includes("..");
+}
+
+function loadJsonSources(root: string): SourceJson[] {
+  if (!existsSync(root)) return [];
+  const out: SourceJson[] = [];
+  for (const path of walkFiles(root)) {
+    if (!basename(path).toLowerCase().endsWith(".json")) continue;
+    try {
+      out.push({
+        path,
+        relativePath: relative(root, path).split("\\").join("/"),
+        value: JSON.parse(readFileSync(path, "utf-8")),
+      });
+    } catch {
+      // Invalid JSON fails closed: it is reported as unsupported, never guessed.
+      out.push({ path, relativePath: relative(root, path).split("\\").join("/"), value: undefined });
+    }
+  }
+  out.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  return out;
+}
+
+function walkFiles(root: string): string[] {
+  const out: string[] = [];
+  function visit(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry);
+      let st;
+      try {
+        st = statSync(path);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) visit(path);
+      else if (st.isFile()) out.push(path);
+    }
+  }
+  visit(root);
+  out.sort();
+  return out;
+}
+
+function sourceKind(relativePath: string): "activity" | "gems" | "conversation" | "other" {
+  const lower = relativePath.toLowerCase();
+  if (lower.includes("my activity/gemini apps/")) return "activity";
+  if (/(^|\/)gems?(\.json|\/|$)/.test(lower)) return "gems";
+  if (lower.includes("conversation") || lower.includes("chat") || lower.includes("gemini apps/")) return "conversation";
+  return "other";
+}
+
+function accountHashForSources(sources: SourceJson[]): string {
+  const identifiers: string[] = [];
+  for (const source of sources) {
+    collectAccountIdentifiers(source.value, identifiers, 0);
+  }
+  const id = identifiers.map((value) => value.trim().toLowerCase()).filter(Boolean).sort()[0] || "unknown-account";
+  return sha256(`gemini:${id}`).slice(0, 32);
+}
+
+function collectAccountIdentifiers(value: unknown, out: string[], depth: number): void {
+  if (depth > 5 || !value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value.slice(0, 100)) collectAccountIdentifiers(item, out, depth + 1);
+    return;
+  }
+  const obj = value as Record<string, unknown>;
+  for (const key of ["email", "accountEmail", "account_email", "gaiaId", "gaia_id", "accountId", "account_id"]) {
+    const found = stringValue(obj[key]);
+    if (found) out.push(found);
+  }
+  for (const key of ["account", "user", "owner", "profile"]) {
+    collectAccountIdentifiers(obj[key], out, depth + 1);
+  }
+}
+
+function collectActivityMetadata(sources: SourceJson[]): Map<string, ActivityMetadata[]> {
+  const activity = new Map<string, ActivityMetadata[]>();
+  for (const source of sources) {
+    if (sourceKind(source.relativePath) !== "activity") continue;
+    for (const entry of arrayFromContainer(source.value)) {
+      const obj = asObject(entry);
+      if (!obj) continue;
+      const conversationId = conversationIdFromObject(obj);
+      const metadata: ActivityMetadata = {
+        conversationId,
+        title: stringValue(obj.title) || stringValue(obj.name),
+        titleUrl: stringValue(obj.titleUrl) || stringValue(obj.url),
+        time: normalizeTime(obj.time) || normalizeTime(obj.timestamp),
+        products: Array.isArray(obj.products) ? obj.products.map(String) : undefined,
+      };
+      if (conversationId) {
+        const list = activity.get(conversationId) || [];
+        list.push(metadata);
+        activity.set(conversationId, list);
+      }
+    }
+  }
+  return activity;
+}
+
+function extractConversationsFromValue(
+  source: SourceJson,
+  activity: Map<string, ActivityMetadata[]>,
+): CandidateConversation[] {
+  if (source.value === undefined) return [];
+  const candidates: CandidateConversation[] = [];
+  for (const item of arrayFromContainer(source.value)) {
+    const conversation = candidateFromObject(item, source.relativePath, activity);
+    if (conversation) candidates.push(conversation);
+  }
+  const direct = candidates.length === 0 ? candidateFromObject(source.value, source.relativePath, activity) : undefined;
+  if (direct) candidates.push(direct);
+  return candidates;
+}
+
+function arrayFromContainer(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  const obj = asObject(value);
+  if (!obj) return [];
+  for (const key of ["conversations", "conversation", "sessions", "items", "activity", "activities", "messages", "turns"]) {
+    const nested = obj[key];
+    if (Array.isArray(nested)) {
+      if ((key === "messages" || key === "turns") && hasTurnArray(obj)) return [obj];
+      return nested;
+    }
+  }
+  return [value];
+}
+
+function candidateFromObject(
+  value: unknown,
+  rawPath: string,
+  activity: Map<string, ActivityMetadata[]>,
+): CandidateConversation | undefined {
+  const obj = asObject(value);
+  if (!obj) return undefined;
+  const nested = asObject(obj.conversation);
+  if (nested && hasTurnArray(nested)) return candidateFromObject(nested, rawPath, activity);
+  if (!hasTurnArray(obj)) return undefined;
+
+  const rawTurns = turnArray(obj);
+  const turns: NormalizedConsumerSessionTurn[] = [];
+  const conversationId = conversationIdFromObject(obj)
+    || stableConversationId(rawPath, stringValue(obj.title) || stringValue(obj.name), rawTurns);
+  const partialReasons: string[] = [];
+
+  for (let i = 0; i < rawTurns.length; i++) {
+    const turn = turnFromObject(rawTurns[i], i, partialReasons);
+    if (turn && (turn.content.trim() || (turn.attachments && turn.attachments.length > 0))) {
+      turns.push(turn);
+    }
+  }
+  if (turns.length === 0) return undefined;
+
+  const activityMetadata = activity.get(conversationId) || [];
+  const attachments = dedupeAttachments(turns.flatMap((turn) => turn.attachments || []));
+  return {
+    conversationId,
+    title: stringValue(obj.title) || stringValue(obj.name) || activityMetadata[0]?.title || "Gemini conversation",
+    createdAt: normalizeTime(obj.created_at) || normalizeTime(obj.createdAt) || normalizeTime(obj.createTime) || turns[0]?.created_at,
+    updatedAt: normalizeTime(obj.updated_at) || normalizeTime(obj.updatedAt) || normalizeTime(obj.updateTime) || turns[turns.length - 1]?.created_at,
+    turns,
+    attachments,
+    rawPath,
+    sourceMetadata: {
+      source_file: rawPath,
+      activity_count: activityMetadata.length,
+      activity: activityMetadata.map((entry) => ({
+        title: entry.title,
+        title_url: entry.titleUrl,
+        time: entry.time,
+        products: entry.products,
+      })),
+    },
+    partialReasons,
+    sourceComplete: booleanValue(obj.complete) ?? booleanValue(obj.source_complete) ?? booleanValue(obj.sourceComplete),
+  };
+}
+
+function hasTurnArray(obj: Record<string, unknown>): boolean {
+  return Array.isArray(obj.turns) || Array.isArray(obj.messages);
+}
+
+function turnArray(obj: Record<string, unknown>): unknown[] {
+  if (Array.isArray(obj.turns)) return obj.turns;
+  if (Array.isArray(obj.messages)) return obj.messages;
+  return [];
+}
+
+function conversationIdFromObject(obj: Record<string, unknown>): string | undefined {
+  return safePathSegment(
+    stringValue(obj.conversation_id)
+      || stringValue(obj.conversationId)
+      || stringValue(obj.conversationUuid)
+      || stringValue(obj.chat_id)
+      || stringValue(obj.chatId)
+      || stringValue(obj.id)
+      || idFromUrl(stringValue(obj.titleUrl) || stringValue(obj.url)),
+  );
+}
+
+function stableConversationId(rawPath: string, title: string | undefined, turns: unknown[]): string {
+  const firstTurn = asObject(turns[0]);
+  const key = [
+    rawPath,
+    title || "",
+    normalizeTime(firstTurn?.created_at) || normalizeTime(firstTurn?.createdAt) || normalizeTime(firstTurn?.time) || "",
+    extractTurnContent(firstTurn || {}).slice(0, 200),
+  ].join("\n");
+  return `derived-${sha256(key).slice(0, 24)}`;
+}
+
+function turnFromObject(value: unknown, index: number, partialReasons: string[]): NormalizedConsumerSessionTurn | undefined {
+  const obj = asObject(value);
+  if (!obj) {
+    partialReasons.push(`turn_${index}_not_object`);
+    return undefined;
+  }
+  const content = extractTurnContent(obj);
+  const attachments = extractAttachments(obj);
+  if (!content && attachments.length === 0) {
+    partialReasons.push(`turn_${index}_missing_content`);
+  }
+  return {
+    index,
+    id: stringValue(obj.id) || stringValue(obj.turn_id) || stringValue(obj.message_id),
+    role: normalizeRole(stringValue(obj.role) || stringValue(obj.author) || stringValue(obj.sender)),
+    created_at: normalizeTime(obj.created_at) || normalizeTime(obj.createdAt) || normalizeTime(obj.time) || normalizeTime(obj.timestamp),
+    content,
+    attachments,
+    metadata: {
+      source_index: index,
+      generated_media_count: countArray(obj.generatedMedia) + countArray(obj.generated_media),
+      upload_count: countArray(obj.uploads) + countArray(obj.uploadedFiles) + countArray(obj.files),
+    },
+  };
+}
+
+function extractTurnContent(obj: Record<string, unknown>): string {
+  for (const key of ["content", "text", "prompt", "response", "query", "answer"]) {
+    const value = obj[key];
+    if (typeof value === "string") return value;
+    const fromObject = extractTextValue(value, 0);
+    if (fromObject) return fromObject;
+  }
+  const parts = obj.parts;
+  if (Array.isArray(parts)) {
+    return parts.map((part) => extractTextValue(part, 0)).filter(Boolean).join("\n\n");
+  }
+  return "";
+}
+
+function extractTextValue(value: unknown, depth: number): string {
+  if (depth > 5 || value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map((item) => extractTextValue(item, depth + 1)).filter(Boolean).join("\n\n");
+  const obj = asObject(value);
+  if (!obj) return "";
+  const direct = stringValue(obj.text) || stringValue(obj.markdown) || stringValue(obj.plainText) || stringValue(obj.value);
+  if (direct) return direct;
+  return Object.entries(obj)
+    .filter(([key]) => !BINARY_KEYS.has(key.toLowerCase()))
+    .map(([, child]) => extractTextValue(child, depth + 1))
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function extractAttachments(obj: Record<string, unknown>): NormalizedConsumerSessionAttachment[] {
+  const attachments: NormalizedConsumerSessionAttachment[] = [];
+  appendAttachments(attachments, obj.attachments, "attachment");
+  appendAttachments(attachments, obj.uploads, "upload");
+  appendAttachments(attachments, obj.uploadedFiles, "upload");
+  appendAttachments(attachments, obj.files, "upload");
+  appendAttachments(attachments, obj.generatedMedia, "generated_media");
+  appendAttachments(attachments, obj.generated_media, "generated_media");
+  return dedupeAttachments(attachments);
+}
+
+function appendAttachments(out: NormalizedConsumerSessionAttachment[], value: unknown, sourceKind: string): void {
+  const items = Array.isArray(value) ? value : value ? [value] : [];
+  for (const item of items) {
+    const obj = asObject(item);
+    if (!obj) continue;
+    const name = stringValue(obj.name) || stringValue(obj.fileName) || stringValue(obj.filename) || stringValue(obj.title);
+    const id = stringValue(obj.id) || stringValue(obj.mediaId) || stringValue(obj.fileId);
+    const mime = stringValue(obj.mime_type) || stringValue(obj.mimeType) || stringValue(obj.contentType);
+    const size = numberValue(obj.size_bytes) ?? numberValue(obj.sizeBytes) ?? numberValue(obj.size);
+    const sha = stringValue(obj.sha256) || stringValue(obj.sha_256) || stringValue(obj.digest);
+    if (!name && !id && !mime && size === undefined && !sha) continue;
+    out.push({
+      id,
+      name,
+      mime_type: mime,
+      size_bytes: size,
+      source_kind: sourceKind,
+      provider_attachment_id: id,
+      sha256: sha,
+    });
+  }
+}
+
+function mergeCandidateConversations(candidates: CandidateConversation[]): CandidateConversation[] {
+  const byId = new Map<string, CandidateConversation>();
+  for (const candidate of candidates) {
+    const existing = byId.get(candidate.conversationId);
+    if (!existing) {
+      byId.set(candidate.conversationId, { ...candidate, turns: reindexTurns(dedupeTurns(candidate.turns)) });
+      continue;
+    }
+    const mergedTurns = reindexTurns(dedupeTurns([...existing.turns, ...candidate.turns]));
+    existing.turns = mergedTurns;
+    existing.attachments = dedupeAttachments([...existing.attachments, ...candidate.attachments]);
+    existing.createdAt = minTime(existing.createdAt, candidate.createdAt);
+    existing.updatedAt = maxTime(existing.updatedAt, candidate.updatedAt);
+    existing.partialReasons = [...new Set([...existing.partialReasons, ...candidate.partialReasons])].sort();
+    existing.sourceMetadata = {
+      ...existing.sourceMetadata,
+      source_files: [...new Set([
+        ...arrayOfStrings(existing.sourceMetadata.source_files),
+        String(existing.sourceMetadata.source_file || ""),
+        candidate.rawPath,
+      ].filter(Boolean))].sort(),
+    };
+    existing.sourceComplete = existing.sourceComplete === false || candidate.sourceComplete === false ? false : existing.sourceComplete ?? candidate.sourceComplete;
+  }
+  return [...byId.values()];
+}
+
+function candidateToSession(
+  candidate: CandidateConversation,
+  accountHash: string,
+  outputPath: string,
+  importedAt: string | undefined,
+): NormalizedConsumerSession {
+  const partial = candidate.partialReasons.length > 0;
+  return {
+    schema_version: 1,
+    provider: PROVIDER,
+    account_hash: accountHash,
+    conversation_id: candidate.conversationId,
+    title: candidate.title,
+    created_at: candidate.createdAt,
+    updated_at: candidate.updatedAt,
+    turns: candidate.turns,
+    attachments: candidate.attachments,
+    source_receipt: {
+      raw_path: candidate.rawPath,
+      provider_export_kind: PROVIDER_EXPORT_KIND,
+      export_path: join(outputPath, outputFileName(accountHash, candidate.conversationId)),
+      imported_at: importedAt,
+      content_sha256: sha256(JSON.stringify({
+        conversation_id: candidate.conversationId,
+        turns: candidate.turns,
+        attachments: candidate.attachments,
+      })),
+    },
+    host: {
+      hostname: process.env.GSTACK_HOSTNAME || hostname(),
+      platform: platform(),
+    },
+    completeness: {
+      complete: !partial && candidate.sourceComplete !== false,
+      partial,
+      truncated: false,
+      missing_turns: partial || undefined,
+      source_complete: candidate.sourceComplete,
+      reason: partial ? candidate.partialReasons.join(",") : undefined,
+    },
+  };
+}
+
+function plannedOutputForSession(outputPath: string, session: NormalizedConsumerSession): GeminiTakeoutPlannedOutput {
+  const path = join(outputPath, outputFileName(session.account_hash, session.conversation_id));
+  return {
+    path,
+    conversation_id: session.conversation_id,
+    turn_count: session.turns.length,
+    attachment_count: (session.attachments?.length || 0) + session.turns.reduce((sum, turn) => sum + (turn.attachments?.length || 0), 0),
+  };
+}
+
+function outputFileName(accountHash: string, conversationId: string): string {
+  const conversationSlug = safePathSegment(conversationId) || sha256(conversationId).slice(0, 24);
+  return `${accountHash}/${conversationSlug}.json`;
+}
+
+function dedupeTurns(turns: NormalizedConsumerSessionTurn[]): NormalizedConsumerSessionTurn[] {
+  const seen = new Map<string, NormalizedConsumerSessionTurn>();
+  for (const turn of turns) {
+    const key = turn.id
+      ? `id:${turn.id}`
+      : sha256([turn.role, turn.created_at || "", turn.content, JSON.stringify(turn.attachments || [])].join("\n"));
+    if (!seen.has(key)) seen.set(key, turn);
+  }
+  return [...seen.values()].sort((a, b) =>
+    (a.created_at || "").localeCompare(b.created_at || "")
+    || a.index - b.index
+    || a.role.localeCompare(b.role)
+    || a.content.localeCompare(b.content)
+  );
+}
+
+function reindexTurns(turns: NormalizedConsumerSessionTurn[]): NormalizedConsumerSessionTurn[] {
+  return turns.map((turn, index) => ({ ...turn, index }));
+}
+
+function dedupeAttachments(attachments: NormalizedConsumerSessionAttachment[]): NormalizedConsumerSessionAttachment[] {
+  const seen = new Map<string, NormalizedConsumerSessionAttachment>();
+  for (const attachment of attachments) {
+    const key = attachment.id || attachment.sha256 || [attachment.name, attachment.mime_type, attachment.size_bytes, attachment.source_kind].join(":");
+    if (!seen.has(key)) seen.set(key, attachment);
+  }
+  return [...seen.values()].sort((a, b) =>
+    (a.source_kind || "").localeCompare(b.source_kind || "")
+    || (a.name || "").localeCompare(b.name || "")
+    || (a.id || "").localeCompare(b.id || "")
+  );
+}
+
+function normalizeRole(role: string | undefined): string {
+  const normalized = (role || "").toLowerCase();
+  if (["user", "human", "me"].includes(normalized)) return "user";
+  if (["assistant", "model", "gemini", "bard", "bot"].includes(normalized)) return "assistant";
+  if (["system", "tool"].includes(normalized)) return normalized;
+  return "other";
+}
+
+function normalizeTime(value: unknown): string | undefined {
+  const raw = stringValue(value);
+  if (!raw) return undefined;
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return undefined;
+  return d.toISOString();
+}
+
+function idFromUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  const match = url.match(/(?:conversation|chat|c)\/([A-Za-z0-9_-]+)/) || url.match(/[?&](?:conversation|chat|id)=([A-Za-z0-9_-]+)/);
+  return match?.[1];
+}
+
+function minTime(a: string | undefined, b: string | undefined): string | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return a < b ? a : b;
+}
+
+function maxTime(a: string | undefined, b: string | undefined): string | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return a > b ? a : b;
+}
+
+function safePathSegment(value: string | undefined): string {
+  const cleaned = (value || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned || "";
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function countArray(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function arrayOfStrings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}

--- a/lib/consumer-session-gemini.ts
+++ b/lib/consumer-session-gemini.ts
@@ -2,12 +2,14 @@ import { createHash } from "crypto";
 import { spawnSync } from "child_process";
 import {
   existsSync,
+  lstatSync,
   mkdtempSync,
   mkdirSync,
   readdirSync,
   readFileSync,
+  renameSync,
   rmSync,
-  statSync,
+  unlinkSync,
   writeFileSync,
 } from "fs";
 import { homedir, hostname, platform, tmpdir } from "os";
@@ -91,6 +93,21 @@ const BINARY_KEYS = new Set([
   "inlinedata",
   "payload",
 ]);
+const TEXT_CONTAINER_KEYS = new Set([
+  "answer",
+  "body",
+  "content",
+  "markdown",
+  "message",
+  "parts",
+  "plainText",
+  "prompt",
+  "query",
+  "response",
+  "segments",
+  "text",
+  "value",
+]);
 
 export function importGeminiTakeout(options: GeminiTakeoutImportOptions = {}): GeminiTakeoutImportResult {
   const gstackHome = options.gstackHome || process.env.GSTACK_HOME || join(homedir(), ".gstack");
@@ -134,11 +151,14 @@ export function importGeminiTakeout(options: GeminiTakeoutImportOptions = {}): G
     const planned = sessions.map((session) => plannedOutputForSession(outputPath, session));
     if (!options.dryRun) {
       mkdirSync(outputPath, { recursive: true });
-      for (const session of sessions) {
-        const out = plannedOutputForSession(outputPath, session).path;
+      for (let i = 0; i < sessions.length; i++) {
+        const out = planned[i].path;
         mkdirSync(dirname(out), { recursive: true });
-        writeFileSync(out, `${JSON.stringify(session, null, 2)}\n`, "utf-8");
+        writeFileAtomic(out, `${JSON.stringify(sessions[i], null, 2)}\n`);
       }
+      const nextFiles = planned.map((item) => relative(outputPath, item.path).split("\\").join("/"));
+      removeStaleManifestOutputs(outputPath, nextFiles);
+      writeManifest(outputPath, nextFiles);
     }
 
     return {
@@ -162,47 +182,41 @@ export function importGeminiTakeout(options: GeminiTakeoutImportOptions = {}): G
   }
 }
 
+export function displayGeminiTakeoutImportResult(result: GeminiTakeoutImportResult): GeminiTakeoutImportResult {
+  return {
+    ...result,
+    input_path: "<redacted-gemini-input>",
+    output_path: "consumer-sessions/normalized/gemini",
+    account_hash: "<redacted-account-hash>",
+    planned_outputs: result.planned_outputs.map((output, index) => ({
+      ...output,
+      path: `consumer-sessions/normalized/gemini/<redacted-output-${String(index + 1).padStart(3, "0")}.json>`,
+      conversation_id: `<redacted-conversation-${String(index + 1).padStart(3, "0")}>`,
+    })),
+  };
+}
+
 function prepareInput(inputPath: string): { root: string; cleanup: () => void } {
   const lower = inputPath.toLowerCase();
   if (lower.endsWith(".zip")) {
     const root = mkdtempSync(join(tmpdir(), "gstack-gemini-takeout-"));
-    assertArchiveEntriesSafe(inputPath, "zip");
-    const result = spawnSync("unzip", ["-q", inputPath, "-d", root], { encoding: "utf-8" });
-    if (result.status !== 0) {
+    const result = extractArchiveSafely(inputPath, root, "zip");
+    if (!result.ok) {
       rmSync(root, { recursive: true, force: true });
-      throw new Error(`failed_to_extract_zip:${result.stderr || result.stdout || "unzip failed"}`);
+      throw new Error(`failed_to_extract_zip:${result.reason}`);
     }
     return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
   }
   if (lower.endsWith(".tgz") || lower.endsWith(".tar.gz")) {
     const root = mkdtempSync(join(tmpdir(), "gstack-gemini-takeout-"));
-    assertArchiveEntriesSafe(inputPath, "tgz");
-    const result = spawnSync("tar", ["-xzf", inputPath, "-C", root], { encoding: "utf-8" });
-    if (result.status !== 0) {
+    const result = extractArchiveSafely(inputPath, root, "tgz");
+    if (!result.ok) {
       rmSync(root, { recursive: true, force: true });
-      throw new Error(`failed_to_extract_tgz:${result.stderr || result.stdout || "tar failed"}`);
+      throw new Error(`failed_to_extract_tgz:${result.reason}`);
     }
     return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
   }
   return { root: inputPath, cleanup: () => undefined };
-}
-
-function assertArchiveEntriesSafe(inputPath: string, kind: "zip" | "tgz"): void {
-  const result = kind === "zip"
-    ? spawnSync("unzip", ["-Z1", inputPath], { encoding: "utf-8" })
-    : spawnSync("tar", ["-tzf", inputPath], { encoding: "utf-8" });
-  if (result.status !== 0) {
-    throw new Error(`failed_to_list_${kind}:${result.stderr || result.stdout || "archive listing failed"}`);
-  }
-  for (const entry of (result.stdout || "").split(/\r?\n/).filter(Boolean)) {
-    if (isUnsafeArchiveEntry(entry)) throw new Error(`unsafe_archive_entry:${entry}`);
-  }
-}
-
-function isUnsafeArchiveEntry(entry: string): boolean {
-  if (entry.startsWith("/") || /^[A-Za-z]:/.test(entry)) return true;
-  const parts = entry.split(/[\\/]+/).filter(Boolean);
-  return parts.includes("..");
 }
 
 function loadJsonSources(root: string): SourceJson[] {
@@ -238,10 +252,11 @@ function walkFiles(root: string): string[] {
       const path = join(dir, entry);
       let st;
       try {
-        st = statSync(path);
+        st = lstatSync(path);
       } catch {
         continue;
       }
+      if (st.isSymbolicLink()) continue;
       if (st.isDirectory()) visit(path);
       else if (st.isFile()) out.push(path);
     }
@@ -399,15 +414,13 @@ function turnArray(obj: Record<string, unknown>): unknown[] {
 }
 
 function conversationIdFromObject(obj: Record<string, unknown>): string | undefined {
-  return safePathSegment(
-    stringValue(obj.conversation_id)
-      || stringValue(obj.conversationId)
-      || stringValue(obj.conversationUuid)
-      || stringValue(obj.chat_id)
-      || stringValue(obj.chatId)
-      || stringValue(obj.id)
-      || idFromUrl(stringValue(obj.titleUrl) || stringValue(obj.url)),
-  );
+  return stringValue(obj.conversation_id)
+    || stringValue(obj.conversationId)
+    || stringValue(obj.conversationUuid)
+    || stringValue(obj.chat_id)
+    || stringValue(obj.chatId)
+    || stringValue(obj.id)
+    || idFromUrl(stringValue(obj.titleUrl) || stringValue(obj.url));
 }
 
 function stableConversationId(rawPath: string, title: string | undefined, turns: unknown[]): string {
@@ -470,7 +483,10 @@ function extractTextValue(value: unknown, depth: number): string {
   const direct = stringValue(obj.text) || stringValue(obj.markdown) || stringValue(obj.plainText) || stringValue(obj.value);
   if (direct) return direct;
   return Object.entries(obj)
-    .filter(([key]) => !BINARY_KEYS.has(key.toLowerCase()))
+    .filter(([key]) => {
+      const lower = key.toLowerCase();
+      return TEXT_CONTAINER_KEYS.has(key) || TEXT_CONTAINER_KEYS.has(lower) || (!BINARY_KEYS.has(lower) && lower.endsWith("text"));
+    })
     .map(([, child]) => extractTextValue(child, depth + 1))
     .filter(Boolean)
     .join("\n\n");
@@ -592,7 +608,7 @@ function plannedOutputForSession(outputPath: string, session: NormalizedConsumer
 
 function outputFileName(accountHash: string, conversationId: string): string {
   const conversationSlug = safePathSegment(conversationId) || sha256(conversationId).slice(0, 24);
-  return `${accountHash}/${conversationSlug}.json`;
+  return `${accountHash}/${conversationSlug}-${sha256(conversationId).slice(0, 12)}.json`;
 }
 
 function dedupeTurns(turns: NormalizedConsumerSessionTurn[]): NormalizedConsumerSessionTurn[] {
@@ -693,4 +709,116 @@ function countArray(value: unknown): number {
 
 function arrayOfStrings(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function extractArchiveSafely(
+  inputPath: string,
+  dest: string,
+  kind: "zip" | "tgz",
+): { ok: true } | { ok: false; reason: string } {
+  const result = spawnSync("python3", ["-c", SAFE_ARCHIVE_EXTRACTOR, inputPath, dest, kind], {
+    encoding: "utf-8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.status === 0) return { ok: true };
+  const raw = (result.stderr || result.stdout || "python_archive_extract_failed").trim().split(/\r?\n/)[0] || "python_archive_extract_failed";
+  return { ok: false, reason: raw.replace(/[^a-z0-9_:-]/gi, "_").slice(0, 80) };
+}
+
+const SAFE_ARCHIVE_EXTRACTOR = String.raw`
+import os, shutil, stat, sys, tarfile, zipfile
+
+archive_path, dest, kind = sys.argv[1:4]
+dest_abs = os.path.abspath(dest)
+
+def fail(reason):
+    print(reason, file=sys.stderr)
+    sys.exit(1)
+
+def safe_target(raw_name):
+    norm = (raw_name or "").replace("\\", "/")
+    if not norm:
+        return None
+    parts = [part for part in norm.split("/") if part]
+    if norm.startswith("/") or (parts and ":" in parts[0]) or any(part == ".." for part in parts):
+        fail("unsafe_archive_path")
+    target = os.path.abspath(os.path.join(dest_abs, *parts))
+    if target != dest_abs and not target.startswith(dest_abs + os.sep):
+        fail("unsafe_archive_escape")
+    return target
+
+try:
+    if kind == "zip":
+        with zipfile.ZipFile(archive_path) as zf:
+            for info in zf.infolist():
+                target = safe_target(info.filename)
+                if target is None:
+                    continue
+                mode = (info.external_attr >> 16) & 0o170000
+                if mode == stat.S_IFLNK:
+                    fail("unsafe_archive_symlink")
+                if info.is_dir() or info.filename.endswith("/"):
+                    os.makedirs(target, mode=0o700, exist_ok=True)
+                    continue
+                os.makedirs(os.path.dirname(target), mode=0o700, exist_ok=True)
+                with zf.open(info) as src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                os.chmod(target, 0o600)
+    else:
+        with tarfile.open(archive_path, "r:gz") as tf:
+            for member in tf.getmembers():
+                target = safe_target(member.name)
+                if target is None:
+                    continue
+                if member.isdir():
+                    os.makedirs(target, mode=0o700, exist_ok=True)
+                    continue
+                if not member.isfile():
+                    fail("unsafe_archive_member")
+                src = tf.extractfile(member)
+                if src is None:
+                    fail("unsafe_archive_member")
+                os.makedirs(os.path.dirname(target), mode=0o700, exist_ok=True)
+                with src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                os.chmod(target, 0o600)
+except (zipfile.BadZipFile, tarfile.TarError):
+    fail("invalid_archive")
+except OSError:
+    fail("archive_extract_io_error")
+`;
+
+const MANIFEST_NAME = ".gemini-import-manifest";
+
+function writeFileAtomic(path: string, body: string): void {
+  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
+  writeFileSync(tmp, body, "utf-8");
+  renameSync(tmp, path);
+}
+
+function readManifest(outputPath: string): string[] {
+  try {
+    const parsed = JSON.parse(readFileSync(join(outputPath, MANIFEST_NAME), "utf-8"));
+    return Array.isArray(parsed?.files)
+      ? parsed.files.filter((file: unknown) => typeof file === "string" && !file.startsWith("/") && !file.split("/").includes(".."))
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeManifest(outputPath: string, files: string[]): void {
+  writeFileAtomic(join(outputPath, MANIFEST_NAME), `${JSON.stringify({ files: [...files].sort() }, null, 2)}\n`);
+}
+
+function removeStaleManifestOutputs(outputPath: string, nextFiles: string[]): void {
+  const keep = new Set(nextFiles);
+  for (const previous of readManifest(outputPath)) {
+    if (keep.has(previous)) continue;
+    try {
+      unlinkSync(join(outputPath, previous));
+    } catch {
+      // Missing stale outputs are already gone.
+    }
+  }
 }

--- a/lib/consumer-sessions.ts
+++ b/lib/consumer-sessions.ts
@@ -1,0 +1,547 @@
+import { createHash } from "crypto";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { hostname, platform } from "os";
+import { basename, join, relative } from "path";
+
+export const CONSUMER_SESSION_SCHEMA_VERSION = 1;
+export const DEFAULT_CONSUMER_SESSION_CHUNK_CHARS = 80_000;
+
+export type ConsumerSessionProvider = "chatgpt" | "claude-ai" | "gemini" | "grok" | string;
+
+export interface NormalizedConsumerSessionAttachment {
+  id?: string;
+  name?: string;
+  mime_type?: string;
+  size_bytes?: number;
+  source_kind?: string;
+  provider_attachment_id?: string;
+  sha256?: string;
+}
+
+export interface NormalizedConsumerSessionTurn {
+  index: number;
+  id?: string;
+  role: "system" | "user" | "assistant" | "tool" | "other" | string;
+  created_at?: string;
+  content: string;
+  attachments?: NormalizedConsumerSessionAttachment[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface NormalizedConsumerSessionReceipt {
+  raw_path?: string;
+  receipt_missing?: boolean;
+  provider_export_kind: string;
+  export_path?: string;
+  content_sha256?: string;
+  imported_at?: string;
+}
+
+export interface NormalizedConsumerSessionHost {
+  hostname: string;
+  platform?: string;
+}
+
+export interface NormalizedConsumerSessionCompleteness {
+  complete: boolean;
+  partial: boolean;
+  truncated: boolean;
+  missing_turns?: boolean;
+  source_complete?: boolean;
+  reason?: string;
+}
+
+export interface NormalizedConsumerSession {
+  schema_version: 1;
+  provider: ConsumerSessionProvider;
+  account_hash: string;
+  conversation_id: string;
+  title: string;
+  created_at?: string;
+  updated_at?: string;
+  turns: NormalizedConsumerSessionTurn[];
+  attachments?: NormalizedConsumerSessionAttachment[];
+  source_receipt: NormalizedConsumerSessionReceipt;
+  host: NormalizedConsumerSessionHost;
+  completeness: NormalizedConsumerSessionCompleteness;
+}
+
+export interface ConsumerSessionRoots {
+  root: string;
+  raw: string;
+  normalized: string;
+  rendered: string;
+}
+
+export interface ConsumerSessionDryRunFile {
+  path: string;
+  provider_kind: string;
+  provider_export_kind: string;
+  size_bytes: number;
+  mtime: string;
+  conversation_count: number;
+  turn_count: number;
+  attachment_count: number;
+  parser_status: "ok" | "unsupported_raw_pending_adapter" | "invalid_json" | "schema_error" | "unreadable";
+}
+
+export interface ConsumerSessionDryRunReport {
+  roots: ConsumerSessionRoots;
+  files: ConsumerSessionDryRunFile[];
+}
+
+export interface RenderedConsumerSessionPage {
+  slug: string;
+  title: string;
+  tags: string[];
+  body: string;
+  session_id: string;
+  conversation_key: string;
+  content_sha256: string;
+  chunk_index: number;
+  chunk_count: number;
+  partial: boolean;
+}
+
+export function consumerSessionRoots(gstackHome: string): ConsumerSessionRoots {
+  const root = process.env.GSTACK_CONSUMER_SESSIONS_ROOT || join(gstackHome, "consumer-sessions");
+  return {
+    root,
+    raw: join(root, "raw"),
+    normalized: join(root, "normalized"),
+    rendered: join(gstackHome, "sessions"),
+  };
+}
+
+export function walkConsumerSessionNormalizedFiles(gstackHome: string): string[] {
+  return walkFiles(consumerSessionRoots(gstackHome).normalized, (path) => {
+    const name = basename(path).toLowerCase();
+    return name.endsWith(".json");
+  });
+}
+
+export function discoverConsumerSessionFiles(gstackHome: string): ConsumerSessionDryRunReport {
+  const roots = consumerSessionRoots(gstackHome);
+  const files: ConsumerSessionDryRunFile[] = [];
+
+  for (const path of walkFiles(roots.raw, () => true)) {
+    files.push(buildRawDiscovery(path, roots.raw));
+  }
+
+  for (const path of walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"))) {
+    files.push(buildNormalizedDiscovery(path, roots.normalized));
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return { roots, files };
+}
+
+export function parseNormalizedConsumerSessionExport(path: string): NormalizedConsumerSession[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    throw new Error("invalid_json");
+  }
+
+  const rawSessions = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === "object" && Array.isArray((parsed as { sessions?: unknown }).sessions)
+      ? (parsed as { sessions: unknown[] }).sessions
+      : parsed && typeof parsed === "object"
+        ? [parsed]
+        : [];
+
+  if (rawSessions.length === 0) throw new Error("schema_error");
+  return rawSessions.map((value, index) => coerceSession(value, path, index));
+}
+
+export function consumerSessionContentHash(session: NormalizedConsumerSession): string {
+  return sha256(stableJson(normalizeForHash(session)));
+}
+
+export function consumerSessionStableId(session: NormalizedConsumerSession): string {
+  const key = `${session.provider}:${session.account_hash}:${session.conversation_id}`;
+  return sha256(key).slice(0, 32);
+}
+
+export function consumerSessionStateKey(session: NormalizedConsumerSession): string {
+  return `consumer:${safePathSegment(session.provider)}:${safePathSegment(session.account_hash)}:${consumerSessionStableId(session)}`;
+}
+
+export function renderConsumerSessionPages(
+  session: NormalizedConsumerSession,
+  options: { maxChunkChars?: number } = {},
+): RenderedConsumerSessionPage[] {
+  const maxChunkChars = options.maxChunkChars ?? DEFAULT_CONSUMER_SESSION_CHUNK_CHARS;
+  const sessionId = consumerSessionStableId(session);
+  const contentHash = consumerSessionContentHash(session);
+  const providerFolder = safePathSegment(session.provider);
+  const accountFolder = safePathSegment(session.account_hash);
+  const date = dateOnly(session.created_at || session.updated_at);
+  const titleSlug = safePathSegment(session.title || session.conversation_id).slice(0, 48) || "conversation";
+  const baseSlug = `sessions/${providerFolder}/${accountFolder}/${date}-${titleSlug}-${sessionId.slice(0, 12)}`;
+  const turnSections = renderTurnSections(session, maxChunkChars);
+  const chunks = chunkSections(turnSections, maxChunkChars);
+  const chunkCount = chunks.length;
+  const commonTags = [
+    "session",
+    "consumer-session",
+    `provider:${providerFolder}`,
+    `date:${date}`,
+  ];
+  if (session.completeness.partial) commonTags.push("partial:true");
+  if (session.completeness.truncated) commonTags.push("truncated:true");
+
+  return chunks.map((chunk, index) => {
+    const chunkIndex = index + 1;
+    const chunkSuffix = chunkCount > 1 ? `-part-${String(chunkIndex).padStart(4, "0")}-of-${String(chunkCount).padStart(4, "0")}` : "";
+    const slug = `${baseSlug}${chunkSuffix}`;
+    const pageTitle = chunkCount > 1
+      ? `${session.title || session.conversation_id} (${chunkIndex}/${chunkCount})`
+      : session.title || session.conversation_id;
+    const body = [
+      "---",
+      `provider: ${JSON.stringify(session.provider)}`,
+      `account_hash: ${JSON.stringify(session.account_hash)}`,
+      `conversation_id: ${JSON.stringify(session.conversation_id)}`,
+      `session_id: ${sessionId}`,
+      `provider_export_kind: ${JSON.stringify(session.source_receipt.provider_export_kind)}`,
+      `host: ${JSON.stringify(session.host.hostname)}`,
+      session.source_receipt.raw_path
+        ? `raw_path: ${JSON.stringify(session.source_receipt.raw_path)}`
+        : "receipt_missing: true",
+      `created_at: ${session.created_at || ""}`,
+      `updated_at: ${session.updated_at || ""}`,
+      `complete: ${session.completeness.complete ? "true" : "false"}`,
+      `partial: ${session.completeness.partial ? "true" : "false"}`,
+      `truncated: ${session.completeness.truncated ? "true" : "false"}`,
+      `chunk_index: ${chunkIndex}`,
+      `chunk_count: ${chunkCount}`,
+      `content_sha256: ${contentHash}`,
+      "---",
+      "",
+      chunk.join("\n\n"),
+      "",
+    ].join("\n");
+    return {
+      slug,
+      title: pageTitle,
+      tags: commonTags,
+      body,
+      session_id: sessionId,
+      conversation_key: consumerSessionStateKey(session),
+      content_sha256: contentHash,
+      chunk_index: chunkIndex,
+      chunk_count: chunkCount,
+      partial: session.completeness.partial,
+    };
+  });
+}
+
+function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRunFile {
+  const st = safeStat(path);
+  return {
+    path,
+    provider_kind: providerKindFromPath(path, rawRoot),
+    provider_export_kind: "raw-provider-export",
+    size_bytes: st.size,
+    mtime: st.mtime,
+    conversation_count: 0,
+    turn_count: 0,
+    attachment_count: 0,
+    parser_status: st.ok ? "unsupported_raw_pending_adapter" : "unreadable",
+  };
+}
+
+function buildNormalizedDiscovery(path: string, normalizedRoot: string): ConsumerSessionDryRunFile {
+  const st = safeStat(path);
+  if (!st.ok) {
+    return {
+      path,
+      provider_kind: providerKindFromPath(path, normalizedRoot),
+      provider_export_kind: "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: 0,
+      turn_count: 0,
+      attachment_count: 0,
+      parser_status: "unreadable",
+    };
+  }
+  try {
+    const sessions = parseNormalizedConsumerSessionExport(path);
+    return {
+      path,
+      provider_kind: providerKindFromSessionOrPath(sessions[0], path, normalizedRoot),
+      provider_export_kind: sessions[0]?.source_receipt.provider_export_kind || "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: sessions.length,
+      turn_count: sessions.reduce((sum, session) => sum + session.turns.length, 0),
+      attachment_count: sessions.reduce((sum, session) => sum + (session.attachments?.length || 0) + session.turns.reduce((n, turn) => n + (turn.attachments?.length || 0), 0), 0),
+      parser_status: "ok",
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+    return {
+      path,
+      provider_kind: providerKindFromPath(path, normalizedRoot),
+      provider_export_kind: "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: 0,
+      turn_count: 0,
+      attachment_count: 0,
+      parser_status: message === "invalid_json" ? "invalid_json" : "schema_error",
+    };
+  }
+}
+
+function coerceSession(value: unknown, path: string, index: number): NormalizedConsumerSession {
+  if (!value || typeof value !== "object") throw new Error("schema_error");
+  const obj = value as Record<string, unknown>;
+  const provider = requireString(obj.provider, "provider");
+  const accountHash = requireString(obj.account_hash, "account_hash");
+  const conversationId = requireString(obj.conversation_id, "conversation_id");
+  const turnsRaw = obj.turns;
+  if (!Array.isArray(turnsRaw)) throw new Error("schema_error");
+  const turns = turnsRaw.map((turn, turnIndex) => coerceTurn(turn, turnIndex));
+  const receipt = coerceReceipt(obj.source_receipt, path);
+  const host = coerceHost(obj.host);
+  const completeness = coerceCompleteness(obj.completeness);
+  return {
+    schema_version: CONSUMER_SESSION_SCHEMA_VERSION,
+    provider,
+    account_hash: accountHash,
+    conversation_id: conversationId,
+    title: typeof obj.title === "string" && obj.title.trim() ? obj.title : `Conversation ${index + 1}`,
+    created_at: optionalString(obj.created_at),
+    updated_at: optionalString(obj.updated_at),
+    turns,
+    attachments: Array.isArray(obj.attachments) ? obj.attachments.map(coerceAttachment) : [],
+    source_receipt: receipt,
+    host,
+    completeness,
+  };
+}
+
+function coerceTurn(value: unknown, index: number): NormalizedConsumerSessionTurn {
+  if (!value || typeof value !== "object") throw new Error("schema_error");
+  const obj = value as Record<string, unknown>;
+  return {
+    index: typeof obj.index === "number" ? obj.index : index,
+    id: optionalString(obj.id),
+    role: typeof obj.role === "string" ? obj.role : "other",
+    created_at: optionalString(obj.created_at),
+    content: typeof obj.content === "string" ? obj.content : "",
+    attachments: Array.isArray(obj.attachments) ? obj.attachments.map(coerceAttachment) : [],
+    metadata: obj.metadata && typeof obj.metadata === "object" && !Array.isArray(obj.metadata)
+      ? obj.metadata as Record<string, unknown>
+      : undefined,
+  };
+}
+
+function coerceAttachment(value: unknown): NormalizedConsumerSessionAttachment {
+  if (!value || typeof value !== "object") return {};
+  const obj = value as Record<string, unknown>;
+  return {
+    id: optionalString(obj.id),
+    name: optionalString(obj.name),
+    mime_type: optionalString(obj.mime_type),
+    size_bytes: typeof obj.size_bytes === "number" ? obj.size_bytes : undefined,
+    source_kind: optionalString(obj.source_kind),
+    provider_attachment_id: optionalString(obj.provider_attachment_id),
+    sha256: optionalString(obj.sha256),
+  };
+}
+
+function coerceReceipt(value: unknown, exportPath: string): NormalizedConsumerSessionReceipt {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  const rawPath = optionalString(obj.raw_path);
+  const receiptMissing = typeof obj.receipt_missing === "boolean" ? obj.receipt_missing : !rawPath;
+  return {
+    raw_path: rawPath,
+    receipt_missing: receiptMissing,
+    provider_export_kind: optionalString(obj.provider_export_kind) || "normalized-consumer-session",
+    export_path: optionalString(obj.export_path) || exportPath,
+    content_sha256: optionalString(obj.content_sha256),
+    imported_at: optionalString(obj.imported_at),
+  };
+}
+
+function coerceHost(value: unknown): NormalizedConsumerSessionHost {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  return {
+    hostname: optionalString(obj.hostname) || process.env.GSTACK_HOSTNAME || hostname(),
+    platform: optionalString(obj.platform) || platform(),
+  };
+}
+
+function coerceCompleteness(value: unknown): NormalizedConsumerSessionCompleteness {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  const partial = Boolean(obj.partial);
+  const truncated = Boolean(obj.truncated);
+  return {
+    complete: typeof obj.complete === "boolean" ? obj.complete : !partial && !truncated,
+    partial,
+    truncated,
+    missing_turns: typeof obj.missing_turns === "boolean" ? obj.missing_turns : undefined,
+    source_complete: typeof obj.source_complete === "boolean" ? obj.source_complete : undefined,
+    reason: optionalString(obj.reason),
+  };
+}
+
+function renderTurnSections(session: NormalizedConsumerSession, maxChunkChars: number): string[] {
+  const sorted = [...session.turns].sort((a, b) => a.index - b.index);
+  const sections: string[] = [];
+  for (const turn of sorted) {
+    const label = turn.role.charAt(0).toUpperCase() + turn.role.slice(1);
+    const head = [`## Turn ${turn.index + 1}: ${label}`];
+    if (turn.created_at) head.push(`Time: ${turn.created_at}`);
+    if (turn.attachments && turn.attachments.length > 0) {
+      head.push(`Attachments: ${turn.attachments.length}`);
+    }
+    const prefix = `${head.join("\n")}\n\n`;
+    const content = turn.content || "";
+    if (prefix.length + content.length <= maxChunkChars) {
+      sections.push(prefix + content);
+      continue;
+    }
+    const parts = splitStringByMax(content, Math.max(1, maxChunkChars - prefix.length - 80));
+    for (let i = 0; i < parts.length; i++) {
+      sections.push(`${prefix}_Continuation ${i + 1}/${parts.length}_\n\n${parts[i]}`);
+    }
+  }
+  return sections;
+}
+
+function chunkSections(sections: string[], maxChunkChars: number): string[][] {
+  const chunks: string[][] = [];
+  let current: string[] = [];
+  let currentSize = 0;
+  for (const section of sections) {
+    const nextSize = currentSize + (current.length > 0 ? 2 : 0) + section.length;
+    if (current.length > 0 && nextSize > maxChunkChars) {
+      chunks.push(current);
+      current = [];
+      currentSize = 0;
+    }
+    current.push(section);
+    currentSize += (current.length > 1 ? 2 : 0) + section.length;
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks.length > 0 ? chunks : [[""]];
+}
+
+function splitStringByMax(text: string, maxChars: number): string[] {
+  const parts: string[] = [];
+  for (let i = 0; i < text.length; i += maxChars) {
+    parts.push(text.slice(i, i + maxChars));
+  }
+  return parts.length > 0 ? parts : [""];
+}
+
+function walkFiles(root: string, predicate: (path: string) => boolean): string[] {
+  if (!existsSync(root)) return [];
+  const out: string[] = [];
+  function visit(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry);
+      let st;
+      try {
+        st = statSync(path);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) visit(path);
+      else if (st.isFile() && predicate(path)) out.push(path);
+    }
+  }
+  visit(root);
+  out.sort();
+  return out;
+}
+
+function safeStat(path: string): { ok: boolean; size: number; mtime: string } {
+  try {
+    const st = statSync(path);
+    return { ok: true, size: st.size, mtime: new Date(st.mtimeMs).toISOString() };
+  } catch {
+    return { ok: false, size: 0, mtime: "" };
+  }
+}
+
+function providerKindFromSessionOrPath(session: NormalizedConsumerSession | undefined, path: string, root: string): string {
+  return session?.provider ? safePathSegment(session.provider) : providerKindFromPath(path, root);
+}
+
+function providerKindFromPath(path: string, root: string): string {
+  const rel = relative(root, path).split(/[\\/]/).filter(Boolean);
+  return safePathSegment(rel[0] || "unknown");
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`schema_error:${field}`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function safePathSegment(value: string): string {
+  const cleaned = value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned || "unknown";
+}
+
+function dateOnly(ts: string | undefined): string {
+  if (!ts) return "undated";
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "undated";
+  return d.toISOString().slice(0, 10);
+}
+
+function normalizeForHash(session: NormalizedConsumerSession): unknown {
+  return {
+    schema_version: session.schema_version,
+    provider: session.provider,
+    account_hash: session.account_hash,
+    conversation_id: session.conversation_id,
+    title: session.title,
+    created_at: session.created_at,
+    updated_at: session.updated_at,
+    turns: [...session.turns].sort((a, b) => a.index - b.index),
+    attachments: session.attachments || [],
+    source_receipt: session.source_receipt,
+    host: session.host,
+    completeness: session.completeness,
+  };
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableJson(v)}`).join(",")}}`;
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}

--- a/lib/consumer-sessions.ts
+++ b/lib/consumer-sessions.ts
@@ -1,7 +1,7 @@
 import { createHash } from "crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { hostname, platform } from "os";
-import { basename, join, relative } from "path";
+import { basename, extname, join, relative } from "path";
 
 export const CONSUMER_SESSION_SCHEMA_VERSION = 1;
 export const DEFAULT_CONSUMER_SESSION_CHUNK_CHARS = 80_000;
@@ -109,7 +109,7 @@ export function consumerSessionRoots(gstackHome: string): ConsumerSessionRoots {
     root,
     raw: join(root, "raw"),
     normalized: join(root, "normalized"),
-    rendered: join(gstackHome, "sessions"),
+    rendered: join(root, "rendered"),
   };
 }
 
@@ -124,16 +124,22 @@ export function discoverConsumerSessionFiles(gstackHome: string): ConsumerSessio
   const roots = consumerSessionRoots(gstackHome);
   const files: ConsumerSessionDryRunFile[] = [];
 
-  for (const path of walkFiles(roots.raw, () => true)) {
-    files.push(buildRawDiscovery(path, roots.raw));
+  const rawFiles = walkFiles(roots.raw, () => true);
+  for (let i = 0; i < rawFiles.length; i++) {
+    files.push(buildRawDiscovery(rawFiles[i], roots.raw, displayConsumerSessionPath("raw", roots.raw, rawFiles[i], i + 1)));
   }
 
-  for (const path of walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"))) {
-    files.push(buildNormalizedDiscovery(path, roots.normalized));
+  const normalizedFiles = walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"));
+  for (let i = 0; i < normalizedFiles.length; i++) {
+    files.push(buildNormalizedDiscovery(
+      normalizedFiles[i],
+      roots.normalized,
+      displayConsumerSessionPath("normalized", roots.normalized, normalizedFiles[i], i + 1),
+    ));
   }
 
   files.sort((a, b) => a.path.localeCompare(b.path));
-  return { roots, files };
+  return { roots: displayConsumerSessionRoots(), files };
 }
 
 export function parseNormalizedConsumerSessionExport(path: string): NormalizedConsumerSession[] {
@@ -239,10 +245,10 @@ export function renderConsumerSessionPages(
   });
 }
 
-function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRunFile {
+function buildRawDiscovery(path: string, rawRoot: string, displayPath: string): ConsumerSessionDryRunFile {
   const st = safeStat(path);
   return {
-    path,
+    path: displayPath,
     provider_kind: providerKindFromPath(path, rawRoot),
     provider_export_kind: "raw-provider-export",
     size_bytes: st.size,
@@ -254,11 +260,11 @@ function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRun
   };
 }
 
-function buildNormalizedDiscovery(path: string, normalizedRoot: string): ConsumerSessionDryRunFile {
+function buildNormalizedDiscovery(path: string, normalizedRoot: string, displayPath: string): ConsumerSessionDryRunFile {
   const st = safeStat(path);
   if (!st.ok) {
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromPath(path, normalizedRoot),
       provider_export_kind: "normalized-consumer-session",
       size_bytes: st.size,
@@ -272,7 +278,7 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
   try {
     const sessions = parseNormalizedConsumerSessionExport(path);
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromSessionOrPath(sessions[0], path, normalizedRoot),
       provider_export_kind: sessions[0]?.source_receipt.provider_export_kind || "normalized-consumer-session",
       size_bytes: st.size,
@@ -285,7 +291,7 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
   } catch (err) {
     const message = err instanceof Error ? err.message : "";
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromPath(path, normalizedRoot),
       provider_export_kind: "normalized-consumer-session",
       size_bytes: st.size,
@@ -296,6 +302,23 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
       parser_status: message === "invalid_json" ? "invalid_json" : "schema_error",
     };
   }
+}
+
+function displayConsumerSessionRoots(): ConsumerSessionRoots {
+  return {
+    root: "consumer-sessions",
+    raw: "consumer-sessions/raw",
+    normalized: "consumer-sessions/normalized",
+    rendered: "consumer-sessions/rendered",
+  };
+}
+
+function displayConsumerSessionPath(kind: "raw" | "normalized", root: string, filePath: string, index: number): string {
+  const provider = providerKindFromPath(filePath, root);
+  const rawExt = extname(filePath).replace(/^\./, "");
+  const ext = rawExt ? safePathSegment(rawExt) : "";
+  const ordinal = String(index).padStart(3, "0");
+  return `consumer-sessions/${kind}/${provider}/<redacted-export-${ordinal}${ext ? `.${ext}` : ""}>`;
 }
 
 function coerceSession(value: unknown, path: string, index: number): NormalizedConsumerSession {

--- a/scripts/consumer-session-gemini-takeout-import.ts
+++ b/scripts/consumer-session-gemini-takeout-import.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { importGeminiTakeout } from "../lib/consumer-session-gemini";
+import { displayGeminiTakeoutImportResult, importGeminiTakeout } from "../lib/consumer-session-gemini";
 
 interface Args {
   inputPath?: string;
@@ -65,7 +65,7 @@ try {
     gstackHome: args.gstackHome,
     dryRun: args.dryRun,
   });
-  console.log(JSON.stringify(result, null, 2));
+  console.log(JSON.stringify(args.dryRun ? displayGeminiTakeoutImportResult(result) : result, null, 2));
 } catch (err) {
   console.error(err instanceof Error ? err.message : String(err));
   console.error(usage());

--- a/scripts/consumer-session-gemini-takeout-import.ts
+++ b/scripts/consumer-session-gemini-takeout-import.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env bun
+
+import { importGeminiTakeout } from "../lib/consumer-session-gemini";
+
+interface Args {
+  inputPath?: string;
+  outputPath?: string;
+  gstackHome?: string;
+  dryRun: boolean;
+}
+
+function usage(): string {
+  return `Usage: consumer-session-gemini-takeout-import [options]
+
+Options:
+  --input <path>       Extracted Google Takeout folder, .zip, .tgz, or .tar.gz.
+                       Default: ~/.gstack/consumer-sessions/raw/gemini
+  --output <path>      Normalized output folder.
+                       Default: ~/.gstack/consumer-sessions/normalized/gemini
+  --gstack-home <path> Override GSTACK_HOME for default input/output roots.
+  --dry-run           Print counts and planned output paths only; no chat text.
+  --help              Show this text.
+`;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--input":
+        args.inputPath = requireValue(argv, ++i, "--input");
+        break;
+      case "--output":
+        args.outputPath = requireValue(argv, ++i, "--output");
+        break;
+      case "--gstack-home":
+        args.gstackHome = requireValue(argv, ++i, "--gstack-home");
+        break;
+      case "--dry-run":
+        args.dryRun = true;
+        break;
+      case "--help":
+      case "-h":
+        console.log(usage());
+        process.exit(0);
+      default:
+        throw new Error(`unknown_arg:${arg}`);
+    }
+  }
+  return args;
+}
+
+function requireValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const result = importGeminiTakeout({
+    inputPath: args.inputPath,
+    outputPath: args.outputPath,
+    gstackHome: args.gstackHome,
+    dryRun: args.dryRun,
+  });
+  console.log(JSON.stringify(result, null, 2));
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  console.error(usage());
+  process.exit(1);
+}

--- a/test/consumer-session-gemini.test.ts
+++ b/test/consumer-session-gemini.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { spawnSync } from "child_process";
+
+import { importGeminiTakeout } from "../lib/consumer-session-gemini";
+import { parseNormalizedConsumerSessionExport, renderConsumerSessionPages } from "../lib/consumer-sessions";
+
+const SCRIPT = join(import.meta.dir, "..", "scripts", "consumer-session-gemini-takeout-import.ts");
+
+function makeHome(): string {
+  return mkdtempSync(join(tmpdir(), "gstack-gemini-takeout-"));
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+function writeConversation(root: string, rel: string, value: unknown): string {
+  const path = join(root, rel);
+  writeJson(path, value);
+  return path;
+}
+
+function readOnlySession(path: string) {
+  const sessions = parseNormalizedConsumerSessionExport(path);
+  expect(sessions.length).toBe(1);
+  return sessions[0];
+}
+
+describe("Gemini Takeout consumer-session normalizer", () => {
+  it("uses the default raw/normalized Gemini roots and dedupes recurring export overlap", () => {
+    const home = makeHome();
+    try {
+      const gstackHome = join(home, ".gstack");
+      const raw = join(gstackHome, "consumer-sessions", "raw", "gemini");
+      writeConversation(raw, "Gemini Apps/conversations-2026-06-01.json", {
+        account: { email: "synthetic@example.test" },
+        conversations: [{
+          id: "conv-stable-1",
+          title: "Planning notes",
+          createdAt: "2026-06-01T10:00:00Z",
+          messages: [
+            { id: "turn-1", role: "user", time: "2026-06-01T10:00:00Z", text: "First synthetic prompt" },
+            { id: "turn-2", role: "model", time: "2026-06-01T10:01:00Z", text: "First synthetic answer" },
+          ],
+        }],
+      });
+      writeConversation(raw, "Gemini Apps/conversations-2026-06-07.json", {
+        account: { email: "synthetic@example.test" },
+        conversations: [{
+          id: "conv-stable-1",
+          title: "Planning notes",
+          updatedAt: "2026-06-07T12:00:00Z",
+          messages: [
+            { id: "turn-2", role: "model", time: "2026-06-01T10:01:00Z", text: "First synthetic answer" },
+            { id: "turn-3", role: "user", time: "2026-06-07T12:00:00Z", text: "Recurring export follow-up" },
+          ],
+        }],
+      });
+
+      const result = importGeminiTakeout({ gstackHome });
+      expect(result.dry_run).toBe(false);
+      expect(result.conversation_count).toBe(1);
+      expect(result.turn_count).toBe(3);
+      expect(result.output_path).toBe(join(gstackHome, "consumer-sessions", "normalized", "gemini"));
+
+      const out = result.planned_outputs[0].path;
+      expect(existsSync(out)).toBe(true);
+      const session = readOnlySession(out);
+      expect(session.provider).toBe("gemini");
+      expect(session.source_receipt.provider_export_kind).toBe("google-takeout");
+      expect(session.source_receipt.raw_path).toBe("Gemini Apps/conversations-2026-06-01.json");
+      expect(session.account_hash).toMatch(/^[a-f0-9]{32}$/);
+      expect(session.host.hostname.length).toBeGreaterThan(0);
+      expect(session.completeness.complete).toBe(true);
+      expect(session.turns.map((turn) => turn.id)).toEqual(["turn-1", "turn-2", "turn-3"]);
+      expect(session.source_receipt.imported_at).toBeUndefined();
+      const firstNormalized = readFileSync(out, "utf-8");
+      importGeminiTakeout({ gstackHome });
+      expect(readFileSync(out, "utf-8")).toBe(firstNormalized);
+
+      const secondHome = makeHome();
+      try {
+        const secondRaw = join(secondHome, ".gstack", "consumer-sessions", "raw", "gemini");
+        writeConversation(secondRaw, "Takeout/Gemini Apps/conversations.json", {
+          account: { email: "synthetic@example.test" },
+          conversations: [{ id: "conv-stable-1", title: "Planning notes", messages: [{ id: "turn-1", role: "user", text: "First synthetic prompt" }] }],
+        });
+        const second = importGeminiTakeout({ gstackHome: join(secondHome, ".gstack"), dryRun: true });
+        expect(second.account_hash).toBe(result.account_hash);
+      } finally {
+        rmSync(secondHome, { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves generated media and upload metadata without copying binary payloads", () => {
+    const home = makeHome();
+    try {
+      const input = join(home, "takeout");
+      const output = join(home, "normalized");
+      writeConversation(input, "Gemini Apps/conversations.json", {
+        account: { email: "media@example.test" },
+        conversations: [{
+          conversationId: "media-conv",
+          title: "Media fixture",
+          turns: [
+            {
+              id: "u1",
+              role: "user",
+              text: "Please use this image.",
+              uploads: [{ id: "upload-1", fileName: "diagram.png", mimeType: "image/png", sizeBytes: 2048, data: "BINARY_UPLOAD_SHOULD_NOT_APPEAR" }],
+            },
+            {
+              id: "a1",
+              role: "assistant",
+              text: "Here is generated media metadata.",
+              generatedMedia: [{ id: "gen-1", name: "generated.png", mimeType: "image/png", sizeBytes: 4096, base64: "BINARY_MEDIA_SHOULD_NOT_APPEAR" }],
+            },
+          ],
+        }],
+      });
+
+      const result = importGeminiTakeout({ inputPath: input, outputPath: output });
+      const session = readOnlySession(result.planned_outputs[0].path);
+      expect(session.attachments?.map((attachment) => attachment.source_kind).sort()).toEqual(["generated_media", "upload"]);
+      expect(session.turns.flatMap((turn) => turn.attachments || []).map((attachment) => attachment.name).sort()).toEqual(["diagram.png", "generated.png"]);
+      const normalized = readFileSync(result.planned_outputs[0].path, "utf-8");
+      expect(normalized).not.toContain("BINARY_UPLOAD_SHOULD_NOT_APPEAR");
+      expect(normalized).not.toContain("BINARY_MEDIA_SHOULD_NOT_APPEAR");
+
+      const rendered = renderConsumerSessionPages(session).map((page) => page.body).join("\n");
+      expect(rendered).toContain("Attachments: 1");
+      expect(rendered).not.toContain("BINARY_UPLOAD_SHOULD_NOT_APPEAR");
+      expect(rendered).not.toContain("BINARY_MEDIA_SHOULD_NOT_APPEAR");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("handles Gemini Apps Activity with missing fields and treats Gems-only files as metadata", () => {
+    const home = makeHome();
+    try {
+      const input = join(home, "takeout");
+      const output = join(home, "normalized");
+      writeConversation(input, "My Activity/Gemini Apps/MyActivity.json", [
+        { products: ["Gemini Apps"], titleUrl: "https://gemini.google.com/app/activity-conv" },
+        {
+          products: ["Gemini Apps"],
+          conversation: {
+            id: "activity-conv",
+            messages: [
+              { role: "user", text: "Activity embedded prompt" },
+              { role: "model", text: "Activity embedded answer" },
+            ],
+          },
+        },
+        { products: ["Gemini Apps"] },
+      ]);
+      writeConversation(input, "Gemini Apps/Gems.json", {
+        gems: [{ id: "gem-1", name: "Synthetic Gem", instructions: "Metadata only" }],
+      });
+
+      const result = importGeminiTakeout({ inputPath: input, outputPath: output });
+      expect(result.conversation_count).toBe(1);
+      expect(result.metadata_only_count).toBe(3);
+      expect(result.unsupported_json_count).toBe(0);
+      const session = readOnlySession(result.planned_outputs[0].path);
+      expect(session.conversation_id).toBe("activity-conv");
+      expect(session.turns.length).toBe(2);
+      expect(session.completeness.partial).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("dry-run reports counts and planned output paths without chat text", () => {
+    const home = makeHome();
+    try {
+      const input = join(home, "takeout");
+      writeConversation(input, "Gemini Apps/conversations.json", {
+        account: { email: "dryrun@example.test" },
+        conversations: [{
+          id: "dry-run-conv",
+          title: "Dry run private title",
+          messages: [{ role: "user", text: "DRY_RUN_CHAT_TEXT_SHOULD_NOT_PRINT" }],
+        }],
+      });
+
+      const result = spawnSync("bun", [SCRIPT, "--input", input, "--dry-run"], { encoding: "utf-8" });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("conversation_count");
+      expect(result.stdout).toContain("planned_outputs");
+      expect(result.stdout).toContain("dry-run-conv");
+      expect(result.stdout).not.toContain("DRY_RUN_CHAT_TEXT_SHOULD_NOT_PRINT");
+      expect(result.stdout).not.toContain("dryrun@example.test");
+      expect(result.stdout).not.toContain("Dry run private title");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("can normalize a tgz Takeout archive using system tar when available", () => {
+    const probe = spawnSync("tar", ["--version"], { encoding: "utf-8" });
+    if (probe.status !== 0) return;
+
+    const home = makeHome();
+    try {
+      const input = join(home, "takeout");
+      const archive = join(home, "takeout.tgz");
+      const output = join(home, "normalized");
+      writeConversation(input, "Gemini Apps/conversations.json", {
+        account: { email: "archive@example.test" },
+        conversations: [{
+          id: "archive-conv",
+          title: "Archive fixture",
+          messages: [{ role: "user", text: "Archive synthetic prompt" }],
+        }],
+      });
+      const packed = spawnSync("tar", ["-czf", archive, "-C", input, "."], { encoding: "utf-8" });
+      expect(packed.status).toBe(0);
+
+      const result = importGeminiTakeout({ inputPath: archive, outputPath: output });
+      expect(result.conversation_count).toBe(1);
+      expect(existsSync(result.planned_outputs[0].path)).toBe(true);
+      const session = readOnlySession(result.planned_outputs[0].path);
+      expect(session.conversation_id).toBe("archive-conv");
+      expect(session.source_receipt.raw_path).toBe("Gemini Apps/conversations.json");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("produces normalized sessions compatible with MAT-14 long-conversation rendering", () => {
+    const home = makeHome();
+    try {
+      const input = join(home, "takeout");
+      const output = join(home, "normalized");
+      const longText = `start\n${"x".repeat(170_000)}\ntail-marker`;
+      writeConversation(input, "Gemini Apps/conversations.json", {
+        account: { email: "long@example.test" },
+        conversations: [{
+          id: "long-conv",
+          title: "Long Gemini conversation",
+          messages: [{ id: "long-turn", role: "user", time: "2026-06-02T12:00:00Z", text: longText }],
+        }],
+      });
+
+      const result = importGeminiTakeout({ inputPath: input, outputPath: output });
+      const session = readOnlySession(result.planned_outputs[0].path);
+      const pages = renderConsumerSessionPages(session);
+      expect(pages.length).toBeGreaterThan(1);
+      expect(pages.every((page) => page.slug.includes("sessions/gemini/"))).toBe(true);
+      expect(pages.map((page) => page.body).join("\n")).toContain("tail-marker");
+      expect(pages[0].body).toContain('provider_export_kind: "google-takeout"');
+      expect(pages[0].body).toContain("raw_path:");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/consumer-session-gemini.test.ts
+++ b/test/consumer-session-gemini.test.ts
@@ -113,7 +113,7 @@ describe("Gemini Takeout consumer-session normalizer", () => {
             {
               id: "u1",
               role: "user",
-              text: "Please use this image.",
+              parts: [{ text: "Please use this image.", inline_data: "INLINE_DATA_SHOULD_NOT_APPEAR" }],
               uploads: [{ id: "upload-1", fileName: "diagram.png", mimeType: "image/png", sizeBytes: 2048, data: "BINARY_UPLOAD_SHOULD_NOT_APPEAR" }],
             },
             {
@@ -133,11 +133,13 @@ describe("Gemini Takeout consumer-session normalizer", () => {
       const normalized = readFileSync(result.planned_outputs[0].path, "utf-8");
       expect(normalized).not.toContain("BINARY_UPLOAD_SHOULD_NOT_APPEAR");
       expect(normalized).not.toContain("BINARY_MEDIA_SHOULD_NOT_APPEAR");
+      expect(normalized).not.toContain("INLINE_DATA_SHOULD_NOT_APPEAR");
 
       const rendered = renderConsumerSessionPages(session).map((page) => page.body).join("\n");
       expect(rendered).toContain("Attachments: 1");
       expect(rendered).not.toContain("BINARY_UPLOAD_SHOULD_NOT_APPEAR");
       expect(rendered).not.toContain("BINARY_MEDIA_SHOULD_NOT_APPEAR");
+      expect(rendered).not.toContain("INLINE_DATA_SHOULD_NOT_APPEAR");
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
@@ -196,7 +198,10 @@ describe("Gemini Takeout consumer-session normalizer", () => {
       expect(result.status).toBe(0);
       expect(result.stdout).toContain("conversation_count");
       expect(result.stdout).toContain("planned_outputs");
-      expect(result.stdout).toContain("dry-run-conv");
+      expect(result.stdout).toContain("<redacted-conversation-001>");
+      expect(result.stdout).not.toContain("dry-run-conv");
+      expect(result.stdout).not.toContain(input);
+      expect(result.stdout).not.toContain(home);
       expect(result.stdout).not.toContain("DRY_RUN_CHAT_TEXT_SHOULD_NOT_PRINT");
       expect(result.stdout).not.toContain("dryrun@example.test");
       expect(result.stdout).not.toContain("Dry run private title");
@@ -205,7 +210,7 @@ describe("Gemini Takeout consumer-session normalizer", () => {
     }
   });
 
-  it("can normalize a tgz Takeout archive using system tar when available", () => {
+  it("can normalize a tgz Takeout archive using the safe extractor when tar is available for fixture creation", () => {
     const probe = spawnSync("tar", ["--version"], { encoding: "utf-8" });
     if (probe.status !== 0) return;
 
@@ -231,6 +236,86 @@ describe("Gemini Takeout consumer-session normalizer", () => {
       const session = readOnlySession(result.planned_outputs[0].path);
       expect(session.conversation_id).toBe("archive-conv");
       expect(session.source_receipt.raw_path).toBe("Gemini Apps/conversations.json");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects archive symlinks before extraction", () => {
+    const python = spawnSync("python3", ["--version"], { encoding: "utf-8" });
+    if ((python.status ?? 1) !== 0) return;
+
+    const home = makeHome();
+    try {
+      const archive = join(home, "malicious.tgz");
+      const makeArchive = spawnSync("python3", ["-c", `
+import os, tarfile
+archive = os.environ["ARCHIVE_PATH"]
+info = tarfile.TarInfo("linked-export")
+info.type = tarfile.SYMTYPE
+info.linkname = "/tmp"
+with tarfile.open(archive, "w:gz") as tf:
+    tf.addfile(info)
+`], {
+        env: { ...process.env, ARCHIVE_PATH: archive },
+        encoding: "utf-8",
+      });
+      expect(makeArchive.status).toBe(0);
+
+      expect(() => importGeminiTakeout({
+        inputPath: archive,
+        outputPath: join(home, "normalized"),
+      })).toThrow(/unsafe_archive_member/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps raw provider conversation ids distinct even when file slugs collide", () => {
+    const home = makeHome();
+    try {
+      const input = join(home, "takeout");
+      const output = join(home, "normalized");
+      writeConversation(input, "Gemini Apps/conversations.json", {
+        conversations: [
+          { id: "abc.def", messages: [{ role: "user", text: "dot id" }] },
+          { id: "abc/def", messages: [{ role: "user", text: "slash id" }] },
+        ],
+      });
+
+      const result = importGeminiTakeout({ inputPath: input, outputPath: output });
+      expect(result.conversation_count).toBe(2);
+      expect(new Set(result.planned_outputs.map((output) => output.path)).size).toBe(2);
+      const ids = result.planned_outputs
+        .map((output) => readOnlySession(output.path).conversation_id)
+        .sort();
+      expect(ids).toEqual(["abc.def", "abc/def"]);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("removes stale normalized outputs from the previous manifest", () => {
+    const home = makeHome();
+    try {
+      const input = join(home, "takeout");
+      const output = join(home, "normalized");
+      writeConversation(input, "Gemini Apps/conversations.json", {
+        conversations: [
+          { id: "conv-a", messages: [{ role: "user", text: "keep" }] },
+          { id: "conv-b", messages: [{ role: "user", text: "remove" }] },
+        ],
+      });
+      const first = importGeminiTakeout({ inputPath: input, outputPath: output });
+      const stalePath = first.planned_outputs.find((planned) => planned.conversation_id === "conv-b")?.path;
+      expect(stalePath).toBeTruthy();
+      expect(existsSync(stalePath!)).toBe(true);
+
+      writeConversation(input, "Gemini Apps/conversations.json", {
+        conversations: [{ id: "conv-a", messages: [{ role: "user", text: "keep" }] }],
+      });
+      importGeminiTakeout({ inputPath: input, outputPath: output });
+      expect(existsSync(stalePath!)).toBe(false);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -766,3 +766,189 @@ exit 0
     rmSync(home, { recursive: true, force: true });
   });
 });
+
+// ── Consumer session contract and synthetic normalized adapter ─────────────
+
+function makeConsumerSession(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    provider: "chatgpt",
+    account_hash: "acct_0123456789abcdef",
+    conversation_id: "conv-001",
+    title: "Synthetic planning session",
+    created_at: "2026-06-01T10:00:00Z",
+    updated_at: "2026-06-01T10:05:00Z",
+    turns: [
+      { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: "first prompt" },
+      { index: 1, role: "assistant", created_at: "2026-06-01T10:01:00Z", content: "first answer" },
+    ],
+    attachments: [
+      { id: "att-1", name: "context.txt", mime_type: "text/plain", size_bytes: 42, sha256: "a".repeat(64) },
+    ],
+    source_receipt: {
+      raw_path: "/exports/chatgpt/raw-export.json",
+      provider_export_kind: "synthetic-normalized-v1",
+    },
+    host: { hostname: "macbook-fixture", platform: "darwin" },
+    completeness: { complete: true, partial: false, truncated: false },
+    ...overrides,
+  };
+}
+
+function writeConsumerSessions(gstackHome: string, provider: string, fileName: string, sessions: Record<string, unknown>[]): string {
+  const dir = join(gstackHome, "consumer-sessions", "normalized", provider);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, fileName);
+  writeFileSync(file, JSON.stringify({ sessions }, null, 2), "utf-8");
+  return file;
+}
+
+describe("gstack-memory-ingest consumer-session normalized contract", () => {
+  it("dry-run discovery reports metadata only and never prints chat/storage values", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    const rawDir = join(gstackHome, "consumer-sessions", "raw", "chatgpt");
+    mkdirSync(rawDir, { recursive: true });
+    writeFileSync(
+      join(rawDir, "export.json"),
+      JSON.stringify({
+        text: "DO NOT LEAK CHAT TEXT",
+        cookie: "cookie-secret-value",
+        localStorage: { auth: "local-storage-secret" },
+        indexedDB: { auth: "indexed-db-secret" },
+      }),
+      "utf-8",
+    );
+    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+      makeConsumerSession({
+        turns: [{ index: 0, role: "user", content: "NORMALIZED CHAT SECRET" }],
+      }),
+    ]);
+
+    const r = runScript(["--consumer-sessions-dry-run"], { HOME: home, GSTACK_HOME: gstackHome });
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.files.length).toBe(2);
+    expect(r.stdout).toContain("provider_kind");
+    expect(r.stdout).toContain("provider_export_kind");
+    expect(r.stdout).toContain("parser_status");
+    expect(r.stdout).toContain("conversation_count");
+    expect(r.stdout).not.toContain("DO NOT LEAK CHAT TEXT");
+    expect(r.stdout).not.toContain("cookie-secret-value");
+    expect(r.stdout).not.toContain("local-storage-secret");
+    expect(r.stdout).not.toContain("indexed-db-secret");
+    expect(r.stdout).not.toContain("NORMALIZED CHAT SECRET");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("renders synthetic normalized sessions under sessions/<provider> and chunks long conversations", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const stagingCopy = join(home, "consumer-staging-copy");
+    const binDir = join(home, "fake-bin");
+    mkdirSync(binDir, { recursive: true });
+    const fake = `#!/usr/bin/env bash
+case "\${1:-}" in
+  --help|-h) echo "Usage: gbrain"; echo "Commands:"; echo "  import <dir>   Import"; exit 0 ;;
+  import)
+    DIR="\${2:-}"
+    cp -R "\$DIR" "${stagingCopy}" 2>/dev/null || true
+    TOTAL=\$(find "\$DIR" -name "*.md" -type f | wc -l | tr -d ' ')
+    echo "{\\"status\\":\\"success\\",\\"duration_s\\":0.1,\\"imported\\":\$TOTAL,\\"skipped\\":0,\\"errors\\":0,\\"chunks\\":\$TOTAL,\\"total_files\\":\$TOTAL}"
+    exit 0 ;;
+  *) exit 2 ;;
+esac
+`;
+    const fakePath = join(binDir, "gbrain");
+    writeFileSync(fakePath, fake, "utf-8");
+    chmodSync(fakePath, 0o755);
+
+    const longContent = `start\n${"x".repeat(170_000)}\ntail-marker`;
+    writeConsumerSessions(gstackHome, "chatgpt", "long.json", [
+      makeConsumerSession({
+        turns: [
+          { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: longContent },
+        ],
+      }),
+    ]);
+
+    const r = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(r.exitCode).toBe(0);
+
+    const findMd = spawnSync("find", [stagingCopy, "-name", "*.md", "-type", "f"], { encoding: "utf-8" });
+    const mdPaths = (findMd.stdout || "").trim().split("\n").filter(Boolean).sort();
+    expect(mdPaths.length).toBeGreaterThan(1);
+    for (const mdPath of mdPaths) {
+      expect(mdPath).toContain("/sessions/chatgpt/");
+    }
+    const bodies = mdPaths.map((p) => readFileSync(p, "utf-8"));
+    expect(bodies[0]).toContain("type: consumer-session");
+    expect(bodies[0]).toContain("raw_path: \"/exports/chatgpt/raw-export.json\"");
+    expect(bodies[0]).toContain("provider_export_kind: \"synthetic-normalized-v1\"");
+    expect(bodies[0]).toContain("host: \"macbook-fixture\"");
+    expect(bodies[0]).toMatch(/session_id: [a-f0-9]{32}/);
+    expect(bodies[0]).toContain("consumer-session");
+    expect(bodies.join("\n")).toContain("tail-marker");
+
+    const state = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    const entries = Object.values(state.consumer_sessions || {}) as Array<{ page_slugs: string[]; content_sha256: string; chunk_count: number }>;
+    expect(entries.length).toBe(1);
+    expect(entries[0].page_slugs.length).toBe(mdPaths.length);
+    expect(entries[0].content_sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(entries[0].chunk_count).toBe(mdPaths.length);
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("incremental state is per normalized conversation content hash, not export-file mtime only", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir, stagingListFile } = installFakeGbrain(home);
+
+    const sessionA = makeConsumerSession({
+      conversation_id: "conv-a",
+      title: "Conversation A",
+      turns: [{ index: 0, role: "user", content: "unchanged A" }],
+    });
+    const sessionB = makeConsumerSession({
+      conversation_id: "conv-b",
+      title: "Conversation B",
+      turns: [{ index: 0, role: "user", content: "before B" }],
+    });
+    const exportPath = writeConsumerSessions(gstackHome, "chatgpt", "bundle.json", [sessionA, sessionB]);
+
+    const first = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(first.exitCode).toBe(0);
+    expect(readFileSync(stagingListFile, "utf-8").match(/\.md/g)?.length).toBe(2);
+
+    writeFileSync(
+      exportPath,
+      JSON.stringify({ sessions: [sessionA, { ...sessionB, turns: [{ index: 0, role: "user", content: "after B" }] }] }, null, 2),
+      "utf-8",
+    );
+
+    const second = runScript(["--incremental", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(second.exitCode).toBe(0);
+    const stagedList = readFileSync(stagingListFile, "utf-8");
+    expect(stagedList.match(/\.md/g)?.length).toBe(1);
+    expect(stagedList).toContain("conversation-b");
+    expect(stagedList).not.toContain("conversation-a");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+});

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -804,13 +804,29 @@ function writeConsumerSessions(gstackHome: string, provider: string, fileName: s
 }
 
 describe("gstack-memory-ingest consumer-session normalized contract", () => {
+  it("does not include consumer sessions in the default source set", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+      makeConsumerSession(),
+    ]);
+
+    const r = runScript(["--probe"], { HOME: home, GSTACK_HOME: gstackHome });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("Total files in window: 0");
+    expect(r.stdout).not.toContain("consumer-session");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
   it("dry-run discovery reports metadata only and never prints chat/storage values", () => {
     const home = makeTestHome();
     const gstackHome = join(home, ".gstack");
     const rawDir = join(gstackHome, "consumer-sessions", "raw", "chatgpt");
     mkdirSync(rawDir, { recursive: true });
     writeFileSync(
-      join(rawDir, "export.json"),
+      join(rawDir, "matt@example.com salary chat export.json"),
       JSON.stringify({
         text: "DO NOT LEAK CHAT TEXT",
         cookie: "cookie-secret-value",
@@ -819,7 +835,7 @@ describe("gstack-memory-ingest consumer-session normalized contract", () => {
       }),
       "utf-8",
     );
-    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+    writeConsumerSessions(gstackHome, "chatgpt", "private conversation title.json", [
       makeConsumerSession({
         turns: [{ index: 0, role: "user", content: "NORMALIZED CHAT SECRET" }],
       }),
@@ -838,6 +854,12 @@ describe("gstack-memory-ingest consumer-session normalized contract", () => {
     expect(r.stdout).not.toContain("local-storage-secret");
     expect(r.stdout).not.toContain("indexed-db-secret");
     expect(r.stdout).not.toContain("NORMALIZED CHAT SECRET");
+    expect(r.stdout).not.toContain("matt@example.com");
+    expect(r.stdout).not.toContain("salary chat");
+    expect(r.stdout).not.toContain("private conversation title");
+    expect(r.stdout).toContain("consumer-sessions/raw/chatgpt/<redacted-export-001.json>");
+    expect(r.stdout).toContain("consumer-sessions/normalized/chatgpt/<redacted-export-001.json>");
+    expect(parsed.roots.root).toBe("consumer-sessions");
 
     rmSync(home, { recursive: true, force: true });
   });
@@ -948,6 +970,75 @@ esac
     expect(stagedList.match(/\.md/g)?.length).toBe(1);
     expect(stagedList).toContain("conversation-b");
     expect(stagedList).not.toContain("conversation-a");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("probe treats unchanged consumer sessions as unchanged after ingest", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir } = installFakeGbrain(home);
+
+    writeConsumerSessions(gstackHome, "chatgpt", "bundle.json", [
+      makeConsumerSession(),
+    ]);
+
+    const first = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(first.exitCode).toBe(0);
+
+    const probe = runScript(["--probe", "--sources", "consumer-session"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+    });
+    expect(probe.exitCode).toBe(0);
+    expect(probe.stdout).toContain("Total files in window: 1");
+    expect(probe.stdout).toContain("New (never ingested):  0");
+    expect(probe.stdout).toContain("Updated (mtime/hash):  0");
+    expect(probe.stdout).toContain("Unchanged:             1");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("--limit does not mark an incomplete multi-chunk consumer session as ingested", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir } = installFakeGbrain(home);
+
+    const longContent = `start\n${"x".repeat(170_000)}\ntail-marker`;
+    writeConsumerSessions(gstackHome, "chatgpt", "long.json", [
+      makeConsumerSession({
+        turns: [
+          { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: longContent },
+        ],
+      }),
+    ]);
+
+    const limited = runScript(["--bulk", "--sources", "consumer-session", "--limit", "1", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(limited.exitCode).toBe(0);
+    const limitedState = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    expect(Object.keys(limitedState.consumer_sessions || {}).length).toBe(0);
+
+    const full = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(full.exitCode).toBe(0);
+    const fullState = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    const entries = Object.values(fullState.consumer_sessions || {}) as Array<{ page_slugs: string[]; chunk_count: number }>;
+    expect(entries.length).toBe(1);
+    expect(entries[0].page_slugs.length).toBe(entries[0].chunk_count);
+    expect(entries[0].chunk_count).toBeGreaterThan(1);
 
     rmSync(home, { recursive: true, force: true });
   });


### PR DESCRIPTION
Linear: MAT-17

Depends on: #2071 / MAT-14. This branch is stacked on the consumer-session contract and should not merge before #2071. The diff will shrink after #2071 lands.

## Summary
- Adds a Gemini Apps Google Takeout normalizer.
- Supports extracted folders plus ZIP/TGZ/TAR.GZ archives through a safe extractor.
- Handles synthetic Gemini Apps conversation JSON, embedded My Activity conversations, Gems metadata, uploads/generated-media metadata, recurring export overlap, and MAT-14 renderer compatibility.

## Adversarial review hardening
- Safe archive extraction rejects symlinks, hardlinks, special files, absolute paths, and path escapes.
- Keeps raw provider conversation IDs distinct and uses hashed filename suffixes to avoid slug collisions.
- CLI dry-run output redacts paths, account hash, and conversation IDs.
- Writes normalized outputs atomically and removes stale outputs via a manifest.
- Tightened text extraction so unknown payload-like fields such as inline data are not copied into turn text.

## Verification
- `bun test test/consumer-session-gemini.test.ts test/gstack-memory-ingest.test.ts` - pass, 38 tests.
- `git diff --check` - pass.
