### PR TITLE
[codex] Add consumer export bridge inbox sync

### DIFF
--- a/bin/gstack-artifacts-init
+++ b/bin/gstack-artifacts-init
@@ -249,6 +249,13 @@ builder-profile.jsonl
 # is skipped; brain admin pulls + indexes into the remote brain.
 transcripts/run-*/*.md
 transcripts/run-*/**/*.md
+# Consumer AI export bridge inboxes. Raw exports are synced only when the
+# user explicitly places them under:
+#   consumer-sessions/raw/<provider>/<account>/<device>/inbox/
+# The per-device freshness marker lets the receiving machine distinguish
+# "device reported no new exports" from "device has not reported".
+consumer-sessions/raw/*/*/*/freshness.json
+consumer-sessions/raw/*/*/*/inbox/**
 # NOT synced (machine-local UX state):
 #   projects/*/question-preferences.json (per-machine UX preferences)
 #   projects/*/question-log.jsonl (audit/derivation log stays with preferences)
@@ -273,7 +280,9 @@ cat > "$GSTACK_HOME/.brain-privacy-map.json" <<'EOF'
   {"pattern": "developer-profile.json", "class": "behavioral"},
   {"pattern": "builder-profile.jsonl", "class": "behavioral"},
   {"pattern": "transcripts/run-*/*.md", "class": "behavioral"},
-  {"pattern": "transcripts/run-*/**/*.md", "class": "behavioral"}
+  {"pattern": "transcripts/run-*/**/*.md", "class": "behavioral"},
+  {"pattern": "consumer-sessions/raw/*/*/*/freshness.json", "class": "behavioral"},
+  {"pattern": "consumer-sessions/raw/*/*/*/inbox/**", "class": "behavioral"}
 ]
 EOF
 

--- a/bin/gstack-brain-sync
+++ b/bin/gstack-brain-sync
@@ -7,6 +7,8 @@
 #   gstack-brain-sync --skip-file <p>  add <p> to ~/.gstack/.brain-skip.txt
 #   gstack-brain-sync --drop-queue --yes   clear queue without committing
 #   gstack-brain-sync --discover-new   scan allowlist dirs, enqueue changed files
+#   gstack-brain-sync --discover-new --dry-run
+#                                      print paths/metadata that would enqueue
 #
 # Invoked by the preamble at skill START and END boundaries. No persistent
 # daemon. Typical run <1s when queue empty; ~200-800ms with network push.
@@ -378,17 +380,38 @@ subcmd_drop_queue() {
 }
 
 subcmd_discover_new() {
+  local dry_run="${1:-}"
+  if [ -n "$dry_run" ] && [ "$dry_run" != "--dry-run" ]; then
+    echo "Usage: gstack-brain-sync --discover-new [--dry-run]" >&2
+    exit 1
+  fi
   if ! sync_active; then
     exit 0
   fi
   # Walk allowlist globs; enqueue any file where mtime+size differs from cursor.
-  python3 - "$GSTACK_HOME" "$ALLOWLIST" "$DISCOVER_CURSOR" <<'PYEOF' 2>/dev/null || true
+  python3 - "$GSTACK_HOME" "$ALLOWLIST" "$DISCOVER_CURSOR" "$dry_run" <<'PYEOF' 2>/dev/null || true
 import sys, os, json, fnmatch
 from datetime import datetime, timezone
 
-gstack_home, allowlist_path, cursor_path = sys.argv[1:4]
+gstack_home, allowlist_path, cursor_path, dry_run_arg = sys.argv[1:5]
+dry_run = dry_run_arg == "--dry-run"
 queue_path = os.path.join(gstack_home, ".brain-queue.jsonl")
 skip_path = os.path.join(gstack_home, ".brain-skip.txt")
+TEMP_SUFFIXES = (
+    ".tmp",
+    ".temp",
+    ".part",
+    ".partial",
+    ".download",
+    ".crdownload",
+    ".inprogress",
+)
+ARCHIVE_SUFFIXES = (
+    ".zip",
+    ".tgz",
+    ".tar",
+    ".tar.gz",
+)
 
 def load_lines(path):
     try:
@@ -410,6 +433,79 @@ def save_cursor(path, data):
             json.dump(data, f)
     except OSError:
         pass
+
+def is_consumer_export_path(rel):
+    parts = rel.split("/")
+    return (
+        len(parts) >= 7
+        and parts[0] == "consumer-sessions"
+        and parts[1] == "raw"
+        and parts[5] == "inbox"
+    )
+
+def is_consumer_freshness_marker(rel):
+    parts = rel.split("/")
+    return (
+        len(parts) == 6
+        and parts[0] == "consumer-sessions"
+        and parts[1] == "raw"
+        and parts[5] == "freshness.json"
+    )
+
+def is_temp_transfer_name(rel):
+    lower = rel.lower()
+    return lower.endswith(TEMP_SUFFIXES) or ".tmp." in lower or ".partial." in lower
+
+def is_archive_export(rel):
+    lower = rel.lower()
+    return lower.endswith(ARCHIVE_SUFFIXES)
+
+def completion_marker_for(full):
+    return full + ".complete"
+
+def archive_has_completion_marker(full):
+    marker = completion_marker_for(full)
+    try:
+        export_st = os.stat(full)
+        marker_st = os.stat(marker)
+    except OSError:
+        return False
+    # The marker must be written after the archive payload. If the archive is
+    # changed later, skip until the writer refreshes the marker.
+    return marker_st.st_mtime_ns >= export_st.st_mtime_ns
+
+def protect_consumer_path(full, rel):
+    if not (is_consumer_export_path(rel) or is_consumer_freshness_marker(rel)):
+        return
+    current = os.path.dirname(full)
+    stop = os.path.abspath(gstack_home)
+    dirs = []
+    while os.path.abspath(current).startswith(stop) and os.path.abspath(current) != stop:
+        dirs.append(current)
+        current = os.path.dirname(current)
+    for d in reversed(dirs):
+        try:
+            os.chmod(d, 0o700)
+        except OSError:
+            pass
+    try:
+        os.chmod(full, 0o600)
+    except OSError:
+        pass
+
+def include_allowlisted_file(full, rel):
+    if is_consumer_freshness_marker(rel):
+        return True
+    if is_consumer_export_path(rel):
+        if is_temp_transfer_name(rel):
+            return False
+        if rel.endswith(".complete"):
+            target = full[:-len(".complete")]
+            return os.path.exists(target)
+        if is_archive_export(rel) and not archive_has_completion_marker(full):
+            return False
+        return True
+    return True
 
 allowlist = load_lines(allowlist_path)
 # Normalize skip entries to the same POSIX form as `rel` below, so a
@@ -437,13 +533,31 @@ for root, dirs, files in os.walk(gstack_home):
             continue
         if rel in skip:
             continue
+        if not include_allowlisted_file(full, rel):
+            continue
+        if not dry_run:
+            protect_consumer_path(full, rel)
         try:
             st = os.stat(full)
             key = f"{int(st.st_mtime)}:{st.st_size}"
         except OSError:
             continue
         if cursor.get(rel) != key:
-            to_enqueue.append((rel, key))
+            to_enqueue.append((rel, key, st.st_size, int(st.st_mtime), is_consumer_export_path(rel), is_consumer_freshness_marker(rel)))
+
+if dry_run:
+    files = []
+    for rel, key, size, mtime, is_export, is_freshness in to_enqueue:
+        kind = "consumer-export" if is_export else "consumer-freshness" if is_freshness else "artifact"
+        files.append({
+            "path": rel,
+            "kind": kind,
+            "size_bytes": size,
+            "mtime": datetime.fromtimestamp(mtime, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "archive_complete": bool(is_archive_export(rel) and not rel.endswith(".complete")),
+        })
+    print(json.dumps({"root": gstack_home, "files": files}, indent=2, sort_keys=True))
+    sys.exit(0)
 
 # Append to the queue directly. The previous implementation shelled out to
 # gstack-brain-enqueue once per file, but Windows Python cannot exec a
@@ -460,7 +574,7 @@ if to_enqueue:
         # don't guarantee that. Compact separators match the shim's JSON shape.
         fd = os.open(queue_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
         try:
-            for rel, key in to_enqueue:
+            for rel, key, *_ in to_enqueue:
                 rec = json.dumps({"file": rel, "ts": ts}, separators=(",", ":"))
                 os.write(fd, (rec + "\n").encode("utf-8"))
         finally:
@@ -472,10 +586,11 @@ if to_enqueue:
         # file next changes).
         to_enqueue = []
     # Advance the cursor only for records actually written.
-    for rel, key in to_enqueue:
+    for rel, key, *_ in to_enqueue:
         new_cursor[rel] = key
 
-save_cursor(cursor_path, new_cursor)
+if not dry_run:
+    save_cursor(cursor_path, new_cursor)
 PYEOF
 }
 
@@ -485,7 +600,7 @@ case "${1:-}" in
   --status) subcmd_status ;;
   --skip-file) shift; subcmd_skip_file "${1:-}" ;;
   --drop-queue) shift; subcmd_drop_queue "${1:-}" ;;
-  --discover-new) subcmd_discover_new ;;
+  --discover-new) shift; subcmd_discover_new "${1:-}" ;;
   --help|-h)
     sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
     ;;

--- a/bin/gstack-brain-sync
+++ b/bin/gstack-brain-sync
@@ -185,6 +185,74 @@ def mode_allows(cls, mode):
         return cls == "artifact"
     return True  # full
 
+TEMP_SUFFIXES = (
+    ".tmp",
+    ".temp",
+    ".part",
+    ".partial",
+    ".download",
+    ".crdownload",
+    ".inprogress",
+)
+ARCHIVE_SUFFIXES = (
+    ".zip",
+    ".tgz",
+    ".tar",
+    ".tar.gz",
+)
+
+def is_consumer_raw_path(rel):
+    parts = rel.split("/")
+    return len(parts) >= 2 and parts[0] == "consumer-sessions" and parts[1] == "raw"
+
+def is_consumer_export_path(rel):
+    parts = rel.split("/")
+    return (
+        len(parts) >= 7
+        and parts[0] == "consumer-sessions"
+        and parts[1] == "raw"
+        and parts[5] == "inbox"
+    )
+
+def is_consumer_freshness_marker(rel):
+    parts = rel.split("/")
+    return (
+        len(parts) == 6
+        and parts[0] == "consumer-sessions"
+        and parts[1] == "raw"
+        and parts[5] == "freshness.json"
+    )
+
+def is_temp_transfer_name(rel):
+    lower = rel.lower()
+    return lower.endswith(TEMP_SUFFIXES) or ".tmp." in lower or ".partial." in lower
+
+def is_archive_export(rel):
+    lower = rel.lower()
+    return lower.endswith(ARCHIVE_SUFFIXES)
+
+def archive_has_completion_marker(full):
+    try:
+        export_st = os.stat(full)
+        marker_st = os.stat(full + ".complete")
+    except OSError:
+        return False
+    return marker_st.st_mtime_ns >= export_st.st_mtime_ns
+
+def include_consumer_path(full, rel):
+    if is_consumer_freshness_marker(rel):
+        return True
+    if not is_consumer_export_path(rel):
+        return False
+    if is_temp_transfer_name(rel):
+        return False
+    if rel.endswith(".complete"):
+        target = full[:-len(".complete")]
+        return os.path.exists(target)
+    if is_archive_export(rel) and not archive_has_completion_marker(full):
+        return False
+    return True
+
 final = []
 for p in sorted(queue_paths):
     if p in skip_lines:
@@ -195,12 +263,15 @@ for p in sorted(queue_paths):
     # Must match at least one allowlist glob.
     if not path_matches_any(p, allowlist_globs):
         continue
+    full_path = os.path.join(gstack_home, p)
+    if is_consumer_raw_path(p) and not include_consumer_path(full_path, p):
+        continue
     # Must survive privacy mode filter.
     cls = privacy_class(p, privacy_map)
     if not mode_allows(cls, mode):
         continue
     # Must exist on disk — can't stage what isn't there.
-    if not os.path.exists(os.path.join(gstack_home, p)):
+    if not os.path.exists(full_path):
         continue
     final.append(p)
 
@@ -388,12 +459,14 @@ subcmd_discover_new() {
   if ! sync_active; then
     exit 0
   fi
+  local mode
+  mode=$("$CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
   # Walk allowlist globs; enqueue any file where mtime+size differs from cursor.
-  python3 - "$GSTACK_HOME" "$ALLOWLIST" "$DISCOVER_CURSOR" "$dry_run" <<'PYEOF' 2>/dev/null || true
+  python3 - "$GSTACK_HOME" "$ALLOWLIST" "$DISCOVER_CURSOR" "$dry_run" "$PRIVACY_MAP" "$mode" <<'PYEOF' 2>/dev/null || true
 import sys, os, json, fnmatch
 from datetime import datetime, timezone
 
-gstack_home, allowlist_path, cursor_path, dry_run_arg = sys.argv[1:5]
+gstack_home, allowlist_path, cursor_path, dry_run_arg, privacy_path, mode = sys.argv[1:7]
 dry_run = dry_run_arg == "--dry-run"
 queue_path = os.path.join(gstack_home, ".brain-queue.jsonl")
 skip_path = os.path.join(gstack_home, ".brain-skip.txt")
@@ -427,12 +500,24 @@ def load_cursor(path):
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
 
+def load_privacy_map(path):
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return data if isinstance(data, list) else []
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
+
 def save_cursor(path, data):
     try:
         with open(path, "w") as f:
             json.dump(data, f)
     except OSError:
         pass
+
+def is_consumer_raw_path(rel):
+    parts = rel.split("/")
+    return len(parts) >= 2 and parts[0] == "consumer-sessions" and parts[1] == "raw"
 
 def is_consumer_export_path(rel):
     parts = rel.split("/")
@@ -494,6 +579,8 @@ def protect_consumer_path(full, rel):
         pass
 
 def include_allowlisted_file(full, rel):
+    if is_consumer_raw_path(rel) and not (is_consumer_export_path(rel) or is_consumer_freshness_marker(rel)):
+        return False
     if is_consumer_freshness_marker(rel):
         return True
     if is_consumer_export_path(rel):
@@ -507,7 +594,46 @@ def include_allowlisted_file(full, rel):
         return True
     return True
 
+def privacy_class(path, mapping):
+    for entry in mapping:
+        pat = entry.get("pattern")
+        if pat and fnmatch.fnmatchcase(path, pat):
+            return entry.get("class", "artifact")
+    return "artifact"
+
+def mode_allows(cls):
+    if mode == "off":
+        return False
+    if mode == "artifacts-only":
+        return cls == "artifact"
+    return True
+
+def display_path(rel):
+    if is_consumer_export_path(rel):
+        parts = rel.split("/")
+        return "/".join([
+            "consumer-sessions",
+            "raw",
+            parts[2],
+            "<redacted-account>",
+            "<redacted-device>",
+            "inbox",
+            "<redacted-export-file>",
+        ])
+    if is_consumer_freshness_marker(rel):
+        parts = rel.split("/")
+        return "/".join([
+            "consumer-sessions",
+            "raw",
+            parts[2],
+            "<redacted-account>",
+            "<redacted-device>",
+            "freshness.json",
+        ])
+    return rel
+
 allowlist = load_lines(allowlist_path)
+privacy_map = load_privacy_map(privacy_path)
 # Normalize skip entries to the same POSIX form as `rel` below, so a
 # backslash entry in .brain-skip.txt still matches a normalized path on Windows.
 skip = {s.replace(os.sep, "/") for s in load_lines(skip_path)}
@@ -535,6 +661,8 @@ for root, dirs, files in os.walk(gstack_home):
             continue
         if not include_allowlisted_file(full, rel):
             continue
+        if not mode_allows(privacy_class(rel, privacy_map)):
+            continue
         if not dry_run:
             protect_consumer_path(full, rel)
         try:
@@ -550,13 +678,13 @@ if dry_run:
     for rel, key, size, mtime, is_export, is_freshness in to_enqueue:
         kind = "consumer-export" if is_export else "consumer-freshness" if is_freshness else "artifact"
         files.append({
-            "path": rel,
+            "path": display_path(rel),
             "kind": kind,
             "size_bytes": size,
             "mtime": datetime.fromtimestamp(mtime, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "archive_complete": bool(is_archive_export(rel) and not rel.endswith(".complete")),
         })
-    print(json.dumps({"root": gstack_home, "files": files}, indent=2, sort_keys=True))
+    print(json.dumps({"root": "<gstack-home>", "files": files}, indent=2, sort_keys=True))
     sys.exit(0)
 
 # Append to the queue directly. The previous implementation shelled out to

--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -66,6 +66,13 @@ import {
 } from "../lib/gstack-memory-helpers";
 import { execGbrainText, spawnGbrainAsync } from "../lib/gbrain-exec";
 import { checkOwnedStagingDir, STAGING_MARKER } from "../lib/staging-guard";
+import {
+  consumerSessionStateKey,
+  discoverConsumerSessionFiles,
+  parseNormalizedConsumerSessionExport,
+  renderConsumerSessionPages,
+  walkConsumerSessionNormalizedFiles,
+} from "../lib/consumer-sessions";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -80,6 +87,7 @@ interface CliArgs {
   sources: Set<MemoryType>;
   limit: number | null;
   noWrite: boolean;
+  consumerSessionsDryRun: boolean;
   /**
    * Opt-in per-file gitleaks scan during the prepare phase. Off by
    * default — the cross-machine boundary (gstack-brain-sync, git push)
@@ -96,7 +104,8 @@ type MemoryType =
   | "ceo-plan"
   | "design-doc"
   | "retro"
-  | "builder-profile-entry";
+  | "builder-profile-entry"
+  | "consumer-session";
 
 interface PageRecord {
   slug: string;
@@ -127,6 +136,20 @@ interface IngestState {
       sha256: string;
       ingested_at: string;
       page_slug: string;
+      partial?: boolean;
+    }
+  >;
+  consumer_sessions?: Record<
+    string,
+    {
+      content_sha256: string;
+      ingested_at: string;
+      page_slugs: string[];
+      raw_path?: string;
+      export_path?: string;
+      provider: string;
+      conversation_id: string;
+      chunk_count: number;
       partial?: boolean;
     }
   >;
@@ -176,6 +199,7 @@ const ALL_TYPES: MemoryType[] = [
   "design-doc",
   "retro",
   "builder-profile-entry",
+  "consumer-session",
 ];
 
 // ── CLI ────────────────────────────────────────────────────────────────────
@@ -195,6 +219,9 @@ Options:
   --all-history        Walk transcripts older than 90 days too.
   --sources <list>     Comma-separated subset: ${ALL_TYPES.join(",")}
   --limit <N>          Stop after N pages written (smoke testing).
+  --consumer-sessions-dry-run
+                       Discover raw/normalized consumer session exports under
+                       the local inbox without printing chat text or raw values.
   --no-write           Skip gbrain put calls (still updates state file).
                        Used by tests + dry runs without actual ingest.
   --scan-secrets       Opt-in per-file gitleaks scan during prepare. Off by
@@ -214,6 +241,7 @@ function parseArgs(): CliArgs {
   let limit: number | null = null;
   let sources: Set<MemoryType> = new Set(ALL_TYPES);
   let noWrite = process.env.GSTACK_MEMORY_INGEST_NO_WRITE === "1";
+  let consumerSessionsDryRun = false;
   let scanSecrets = process.env.GSTACK_MEMORY_INGEST_SCAN_SECRETS === "1";
 
   for (let i = 0; i < args.length; i++) {
@@ -227,6 +255,7 @@ function parseArgs(): CliArgs {
       case "--include-unattributed": includeUnattributed = true; break;
       case "--all-history": allHistory = true; break;
       case "--no-write": noWrite = true; break;
+      case "--consumer-sessions-dry-run": consumerSessionsDryRun = true; break;
       case "--scan-secrets": scanSecrets = true; break;
       case "--limit":
         limit = parseInt(args[++i] || "0", 10);
@@ -255,7 +284,7 @@ function parseArgs(): CliArgs {
     }
   }
 
-  return { mode, quiet, benchmark, includeUnattributed, allHistory, sources, limit, noWrite, scanSecrets };
+  return { mode, quiet, benchmark, includeUnattributed, allHistory, sources, limit, noWrite, consumerSessionsDryRun, scanSecrets };
 }
 
 // ── State file ─────────────────────────────────────────────────────────────
@@ -523,6 +552,11 @@ function* walkAllSources(ctx: WalkContext): Generator<{ path: string; type: Memo
   if (ctx.args.sources.has("transcript")) {
     yield* walkClaudeCodeProjects(ctx);
     yield* walkCodexSessions(ctx);
+  }
+  if (ctx.args.sources.has("consumer-session")) {
+    for (const path of walkConsumerSessionNormalizedFiles(GSTACK_HOME)) {
+      yield { path, type: "consumer-session" };
+    }
   }
   yield* walkGstackArtifacts(ctx);
 }
@@ -886,6 +920,15 @@ interface PreparedPage {
   /** Carry-through fields for state recording on success. */
   page_slug: string;
   partial: boolean;
+  consumer_session?: {
+    state_key: string;
+    content_sha256: string;
+    raw_path?: string;
+    export_path?: string;
+    provider: string;
+    conversation_id: string;
+    chunk_count: number;
+  };
 }
 
 interface StagingResult {
@@ -1030,6 +1073,74 @@ export function readNewFailures(
   return failed;
 }
 
+function recordPreparedSuccesses(
+  state: IngestState,
+  prepared: PreparedPage[],
+  failedSources: Set<string>,
+  nowIso: string,
+  quiet: boolean,
+): number {
+  let written = 0;
+  const consumerGroups = new Map<string, PreparedPage[]>();
+
+  for (const p of prepared) {
+    if (failedSources.has(p.source_path)) continue;
+    if (p.consumer_session) {
+      const group = consumerGroups.get(p.consumer_session.state_key) || [];
+      group.push(p);
+      consumerGroups.set(p.consumer_session.state_key, group);
+      written++;
+      if (!quiet) {
+        const tag = p.partial ? " [partial]" : "";
+        console.log(`[${written}] ${p.page_slug}${tag}`);
+      }
+      continue;
+    }
+
+    try {
+      state.sessions[p.source_path] = {
+        mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
+        sha256: fileSha256(p.source_path),
+        ingested_at: nowIso,
+        page_slug: p.page_slug,
+        partial: p.partial,
+      };
+      written++;
+      if (!quiet) {
+        const tag = p.partial ? " [partial]" : "";
+        console.log(`[${written}] ${p.page_slug}${tag}`);
+      }
+    } catch (err) {
+      // statSync can fail if the source file was removed mid-run; skip
+      // recording but don't fail the whole pass.
+      console.error(
+        `[state-record] ${p.source_path}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  if (consumerGroups.size > 0 && !state.consumer_sessions) {
+    state.consumer_sessions = {};
+  }
+  for (const [stateKey, group] of consumerGroups) {
+    const meta = group[0]?.consumer_session;
+    if (!meta || !state.consumer_sessions) continue;
+    state.consumer_sessions[stateKey] = {
+      content_sha256: meta.content_sha256,
+      ingested_at: nowIso,
+      page_slugs: group.map((p) => p.page_slug),
+      raw_path: meta.raw_path,
+      export_path: meta.export_path,
+      provider: meta.provider,
+      conversation_id: meta.conversation_id,
+      chunk_count: meta.chunk_count,
+      partial: group.some((p) => p.partial),
+    };
+  }
+
+  return written;
+}
+
 // ── Main ingest passes ─────────────────────────────────────────────────────
 
 async function probeMode(args: CliArgs): Promise<ProbeReport> {
@@ -1045,6 +1156,7 @@ async function probeMode(args: CliArgs): Promise<ProbeReport> {
     "design-doc": { count: 0, bytes: 0 },
     retro: { count: 0, bytes: 0 },
     "builder-profile-entry": { count: 0, bytes: 0 },
+    "consumer-session": { count: 0, bytes: 0 },
   };
 
   let totalFiles = 0;
@@ -1130,7 +1242,7 @@ function preparePages(
   for (const { path, type } of walkAllSources(ctx)) {
     if (args.limit !== null && prepared.length >= args.limit) break;
 
-    if (args.mode === "incremental" && !fileChangedSinceState(path, state)) {
+    if (type !== "consumer-session" && args.mode === "incremental" && !fileChangedSinceState(path, state)) {
       skippedDedup++;
       continue;
     }
@@ -1156,7 +1268,50 @@ function preparePages(
 
     let page: PageRecord;
     try {
-      if (type === "transcript") {
+      if (type === "consumer-session") {
+        const sessions = parseNormalizedConsumerSessionExport(path);
+        for (const session of sessions) {
+          const pages = renderConsumerSessionPages(session);
+          const stateKey = consumerSessionStateKey(session);
+          const existing = state.consumer_sessions?.[stateKey];
+          if (args.mode === "incremental" && existing?.content_sha256 === pages[0]?.content_sha256) {
+            skippedDedup++;
+            continue;
+          }
+          if (session.completeness.partial) partialPages++;
+          for (const rendered of pages) {
+            if (args.limit !== null && prepared.length >= args.limit) break;
+            prepared.push({
+              slug: rendered.slug,
+              source_path: path,
+              rendered_body: renderPageBody({
+                slug: rendered.slug,
+                title: rendered.title,
+                type: "consumer-session",
+                body: rendered.body,
+                tags: rendered.tags,
+                source_path: path,
+                session_id: rendered.session_id,
+                partial: rendered.partial,
+                size_bytes: statSync(path).size,
+                content_sha256: rendered.content_sha256,
+              }),
+              page_slug: rendered.slug,
+              partial: rendered.partial,
+              consumer_session: {
+                state_key: rendered.conversation_key,
+                content_sha256: rendered.content_sha256,
+                raw_path: session.source_receipt.raw_path,
+                export_path: session.source_receipt.export_path || path,
+                provider: session.provider,
+                conversation_id: session.conversation_id,
+                chunk_count: rendered.chunk_count,
+              },
+            });
+          }
+        }
+        continue;
+      } else if (type === "transcript") {
         const session = parseTranscriptJsonl(path);
         if (!session) {
           parseFailed++;
@@ -1475,20 +1630,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // the prior contract from --help: "Skip gbrain put calls (still
     // updates state file)".
     const nowIso = new Date().toISOString();
-    for (const p of prep.prepared) {
-      try {
-        state.sessions[p.source_path] = {
-          mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-          sha256: fileSha256(p.source_path),
-          ingested_at: nowIso,
-          page_slug: p.page_slug,
-          partial: p.partial,
-        };
-        written++;
-      } catch {
-        // best-effort state record
-      }
-    }
+    written = recordPreparedSuccesses(state, prep.prepared, new Set(), nowIso, true);
     state.last_full_walk = new Date().toISOString();
     state.last_writer = "gstack-memory-ingest";
     saveState(state);
@@ -1644,22 +1786,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // machine's perspective, the act of staging IS the write.
     if (remoteHttpMode) {
       const nowIso = new Date().toISOString();
-      for (const p of prep.prepared) {
-        try {
-          state.sessions[p.source_path] = {
-            mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-            sha256: fileSha256(p.source_path),
-            ingested_at: nowIso,
-            page_slug: p.page_slug,
-            partial: p.partial,
-          };
-          written++;
-        } catch (err) {
-          console.error(
-            `[state-record] ${p.source_path}: ${(err as Error).message}`,
-          );
-        }
-      }
+      written = recordPreparedSuccesses(state, prep.prepared, new Set(), nowIso, args.quiet);
       state.last_full_walk = nowIso;
       state.last_writer = "gstack-memory-ingest (remote-http mode)";
       saveState(state);
@@ -1787,29 +1914,7 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     // left un-state'd so the next run re-prepares them and gbrain's
     // content_hash dedup short-circuits the import.
     const nowIso = new Date().toISOString();
-    for (const p of prep.prepared) {
-      if (failedSources.has(p.source_path)) continue;
-      try {
-        state.sessions[p.source_path] = {
-          mtime_ns: Math.floor(statSync(p.source_path).mtimeMs * 1e6),
-          sha256: fileSha256(p.source_path),
-          ingested_at: nowIso,
-          page_slug: p.page_slug,
-          partial: p.partial,
-        };
-        written++;
-        if (!args.quiet) {
-          const tag = p.partial ? " [partial]" : "";
-          console.log(`[${written}] ${p.page_slug}${tag}`);
-        }
-      } catch (err) {
-        // statSync can fail if the source file was removed mid-run; skip
-        // recording but don't fail the whole pass.
-        console.error(
-          `[state-record] ${p.source_path}: ${(err as Error).message}`,
-        );
-      }
-    }
+    written = recordPreparedSuccesses(state, prep.prepared, failedSources, nowIso, args.quiet);
 
     if (!args.quiet) {
       console.error(
@@ -1893,10 +1998,20 @@ function printBulkResult(r: BulkResult, args: CliArgs): void {
   }
 }
 
+function printConsumerSessionsDryRun(): void {
+  const report = discoverConsumerSessionFiles(GSTACK_HOME);
+  console.log(JSON.stringify(report, null, 2));
+}
+
 // ── Entry point ────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
   const args = parseArgs();
+
+  if (args.consumerSessionsDryRun) {
+    printConsumerSessionsDryRun();
+    return;
+  }
 
   // Engine tier detection — informational; routing happens in gbrain server-side.
   const engine = detectEngineTier();

--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -67,6 +67,7 @@ import {
 import { execGbrainText, spawnGbrainAsync } from "../lib/gbrain-exec";
 import { checkOwnedStagingDir, STAGING_MARKER } from "../lib/staging-guard";
 import {
+  consumerSessionContentHash,
   consumerSessionStateKey,
   discoverConsumerSessionFiles,
   parseNormalizedConsumerSessionExport,
@@ -202,6 +203,8 @@ const ALL_TYPES: MemoryType[] = [
   "consumer-session",
 ];
 
+const DEFAULT_TYPES: MemoryType[] = ALL_TYPES.filter((t) => t !== "consumer-session");
+
 // ── CLI ────────────────────────────────────────────────────────────────────
 
 function printUsage(): void {
@@ -218,6 +221,8 @@ Options:
   --include-unattributed  Ingest sessions with no resolvable git remote.
   --all-history        Walk transcripts older than 90 days too.
   --sources <list>     Comma-separated subset: ${ALL_TYPES.join(",")}
+                       Default excludes consumer-session; opt in explicitly
+                       with --sources consumer-session.
   --limit <N>          Stop after N pages written (smoke testing).
   --consumer-sessions-dry-run
                        Discover raw/normalized consumer session exports under
@@ -239,7 +244,7 @@ function parseArgs(): CliArgs {
   let includeUnattributed = false;
   let allHistory = false;
   let limit: number | null = null;
-  let sources: Set<MemoryType> = new Set(ALL_TYPES);
+  let sources: Set<MemoryType> = new Set(DEFAULT_TYPES);
   let noWrite = process.env.GSTACK_MEMORY_INGEST_NO_WRITE === "1";
   let consumerSessionsDryRun = false;
   let scanSecrets = process.env.GSTACK_MEMORY_INGEST_SCAN_SECRETS === "1";
@@ -1141,6 +1146,34 @@ function recordPreparedSuccesses(
   return written;
 }
 
+function consumerSessionProbeStatus(
+  path: string,
+  state: IngestState,
+): "new" | "updated" | "unchanged" {
+  let sessions;
+  try {
+    sessions = parseNormalizedConsumerSessionExport(path);
+  } catch {
+    return "new";
+  }
+
+  if (sessions.length === 0) return "new";
+  let sawExisting = false;
+  for (const session of sessions) {
+    const stateKey = consumerSessionStateKey(session);
+    const existing = state.consumer_sessions?.[stateKey];
+    if (!existing) return sawExisting ? "updated" : "new";
+    sawExisting = true;
+    if (existing.content_sha256 !== consumerSessionContentHash(session)) {
+      return "updated";
+    }
+    if (existing.page_slugs.length !== existing.chunk_count) {
+      return "updated";
+    }
+  }
+  return "unchanged";
+}
+
 // ── Main ingest passes ─────────────────────────────────────────────────────
 
 async function probeMode(args: CliArgs): Promise<ProbeReport> {
@@ -1177,10 +1210,17 @@ async function probeMode(args: CliArgs): Promise<ProbeReport> {
     byType[type].bytes += size;
     totalBytes += size;
 
-    const entry = state.sessions[path];
-    if (!entry) newCount++;
-    else if (fileChangedSinceState(path, state)) updatedCount++;
-    else unchangedCount++;
+    if (type === "consumer-session") {
+      const status = consumerSessionProbeStatus(path, state);
+      if (status === "new") newCount++;
+      else if (status === "updated") updatedCount++;
+      else unchangedCount++;
+    } else {
+      const entry = state.sessions[path];
+      if (!entry) newCount++;
+      else if (fileChangedSinceState(path, state)) updatedCount++;
+      else unchangedCount++;
+    }
   }
 
   // Per ED2: ~25-35 min for ~11.7K transcripts = ~150ms/page synchronous
@@ -1274,13 +1314,23 @@ function preparePages(
           const pages = renderConsumerSessionPages(session);
           const stateKey = consumerSessionStateKey(session);
           const existing = state.consumer_sessions?.[stateKey];
-          if (args.mode === "incremental" && existing?.content_sha256 === pages[0]?.content_sha256) {
+          if (
+            args.mode === "incremental"
+            && existing?.content_sha256 === pages[0]?.content_sha256
+            && existing.page_slugs.length === existing.chunk_count
+          ) {
             skippedDedup++;
             continue;
           }
+          const remainingLimit = args.limit === null
+            ? Number.POSITIVE_INFINITY
+            : args.limit - prepared.length;
+          if (pages.length > remainingLimit) {
+            skippedDedup++;
+            break;
+          }
           if (session.completeness.partial) partialPages++;
           for (const rendered of pages) {
-            if (args.limit !== null && prepared.length >= args.limit) break;
             prepared.push({
               slug: rendered.slug,
               source_path: path,

--- a/docs/gbrain-sync.md
+++ b/docs/gbrain-sync.md
@@ -24,6 +24,9 @@ By design, these stay local even when sync is on:
   (`.welcome-seen`, `.telemetry-prompted`, `.vendoring-warned-*`, etc.)
 - Question-preferences: per-machine UX preferences
   (`question-preferences.json`, `question-log.jsonl`, `question-events.jsonl`).
+- Consumer AI raw exports, unless you explicitly place them in the export
+  inbox described below. Raw exports stay under `~/.gstack/consumer-sessions/`,
+  outside your Obsidian vault and outside default GBrain search.
 
 The exact allowlist lives in `~/.gstack/.brain-allowlist`. The CLI manages
 it; you can append your own entries below the marker line.
@@ -97,19 +100,77 @@ current privacy mode.
 Every skill run prints a `BRAIN_SYNC:` line near the top of the preamble
 output. Scan it for problems.
 
+For a metadata-only preview of newly discovered sync candidates:
+
+```bash
+gstack-brain-sync --discover-new --dry-run
+```
+
+The dry-run prints paths, size, mtime, and file kind. It does not print export
+archive contents or chat text.
+
 ## Privacy modes in detail
 
 | Mode | What syncs |
 |------|------------|
 | `off` | Nothing (default). |
 | `artifacts-only` | Plans, designs, retros, learnings, reviews. Skips timelines + developer-profile. |
-| `full` | Everything in the allowlist, including behavioral state. |
+| `full` | Everything in the allowlist, including behavioral state and explicitly staged consumer export inboxes. |
 
 Change anytime with:
 ```bash
 gstack-config set artifacts_sync_mode full
 gstack-config set artifacts_sync_mode off
 ```
+
+## Consumer AI export inboxes
+
+Use this when you want a MacBook to hand raw ChatGPT / Claude.ai / Gemini /
+Grok exports to another Mac through the existing private artifact bridge.
+
+The only synced raw-export location is:
+
+```text
+~/.gstack/consumer-sessions/raw/<provider>/<account>/<device>/inbox/
+```
+
+Write a freshness marker beside the inbox:
+
+```text
+~/.gstack/consumer-sessions/raw/<provider>/<account>/<device>/freshness.json
+```
+
+That marker is intentionally separate from the files. The receiving Mac can
+distinguish "this source device checked in and had no new exports" from "this
+source device has not reported." A minimal marker is:
+
+```json
+{"schema_version":1,"device":"macbook","last_reported_at":"2026-06-21T10:00:00Z","export_count":0}
+```
+
+Discovery is additive. `gstack-brain-sync` stages explicit existing files; it
+does not stage deletes for disappeared local exports, so a transient cleanup on
+one Mac does not unexpectedly remove the copy already pushed to the private
+repo.
+
+Large archive exports (`.zip`, `.tgz`, `.tar`, `.tar.gz`) are ignored until a
+newer sibling completion marker exists:
+
+```text
+chatgpt-export.zip
+chatgpt-export.zip.complete
+```
+
+Copy archives with a temporary name such as `.partial`, `.tmp`, `.download`, or
+`.crdownload`, rename to the final name when the copy is complete, then write
+the `.complete` marker last. The discovery step also best-effort hardens raw
+export files and inbox directories to `0600` / `0700` on macOS-style
+filesystems.
+
+Consumer session ingestion is still opt-in. Default `gstack-memory-ingest`
+sources exclude `consumer-session`; use `--sources consumer-session` when you
+want normalized consumer sessions indexed. Raw exports should remain in
+`~/.gstack/consumer-sessions/raw`, not in your Obsidian vault.
 
 ## Secret protection
 

--- a/lib/consumer-sessions.ts
+++ b/lib/consumer-sessions.ts
@@ -1,0 +1,547 @@
+import { createHash } from "crypto";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { hostname, platform } from "os";
+import { basename, join, relative } from "path";
+
+export const CONSUMER_SESSION_SCHEMA_VERSION = 1;
+export const DEFAULT_CONSUMER_SESSION_CHUNK_CHARS = 80_000;
+
+export type ConsumerSessionProvider = "chatgpt" | "claude-ai" | "gemini" | "grok" | string;
+
+export interface NormalizedConsumerSessionAttachment {
+  id?: string;
+  name?: string;
+  mime_type?: string;
+  size_bytes?: number;
+  source_kind?: string;
+  provider_attachment_id?: string;
+  sha256?: string;
+}
+
+export interface NormalizedConsumerSessionTurn {
+  index: number;
+  id?: string;
+  role: "system" | "user" | "assistant" | "tool" | "other" | string;
+  created_at?: string;
+  content: string;
+  attachments?: NormalizedConsumerSessionAttachment[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface NormalizedConsumerSessionReceipt {
+  raw_path?: string;
+  receipt_missing?: boolean;
+  provider_export_kind: string;
+  export_path?: string;
+  content_sha256?: string;
+  imported_at?: string;
+}
+
+export interface NormalizedConsumerSessionHost {
+  hostname: string;
+  platform?: string;
+}
+
+export interface NormalizedConsumerSessionCompleteness {
+  complete: boolean;
+  partial: boolean;
+  truncated: boolean;
+  missing_turns?: boolean;
+  source_complete?: boolean;
+  reason?: string;
+}
+
+export interface NormalizedConsumerSession {
+  schema_version: 1;
+  provider: ConsumerSessionProvider;
+  account_hash: string;
+  conversation_id: string;
+  title: string;
+  created_at?: string;
+  updated_at?: string;
+  turns: NormalizedConsumerSessionTurn[];
+  attachments?: NormalizedConsumerSessionAttachment[];
+  source_receipt: NormalizedConsumerSessionReceipt;
+  host: NormalizedConsumerSessionHost;
+  completeness: NormalizedConsumerSessionCompleteness;
+}
+
+export interface ConsumerSessionRoots {
+  root: string;
+  raw: string;
+  normalized: string;
+  rendered: string;
+}
+
+export interface ConsumerSessionDryRunFile {
+  path: string;
+  provider_kind: string;
+  provider_export_kind: string;
+  size_bytes: number;
+  mtime: string;
+  conversation_count: number;
+  turn_count: number;
+  attachment_count: number;
+  parser_status: "ok" | "unsupported_raw_pending_adapter" | "invalid_json" | "schema_error" | "unreadable";
+}
+
+export interface ConsumerSessionDryRunReport {
+  roots: ConsumerSessionRoots;
+  files: ConsumerSessionDryRunFile[];
+}
+
+export interface RenderedConsumerSessionPage {
+  slug: string;
+  title: string;
+  tags: string[];
+  body: string;
+  session_id: string;
+  conversation_key: string;
+  content_sha256: string;
+  chunk_index: number;
+  chunk_count: number;
+  partial: boolean;
+}
+
+export function consumerSessionRoots(gstackHome: string): ConsumerSessionRoots {
+  const root = process.env.GSTACK_CONSUMER_SESSIONS_ROOT || join(gstackHome, "consumer-sessions");
+  return {
+    root,
+    raw: join(root, "raw"),
+    normalized: join(root, "normalized"),
+    rendered: join(gstackHome, "sessions"),
+  };
+}
+
+export function walkConsumerSessionNormalizedFiles(gstackHome: string): string[] {
+  return walkFiles(consumerSessionRoots(gstackHome).normalized, (path) => {
+    const name = basename(path).toLowerCase();
+    return name.endsWith(".json");
+  });
+}
+
+export function discoverConsumerSessionFiles(gstackHome: string): ConsumerSessionDryRunReport {
+  const roots = consumerSessionRoots(gstackHome);
+  const files: ConsumerSessionDryRunFile[] = [];
+
+  for (const path of walkFiles(roots.raw, () => true)) {
+    files.push(buildRawDiscovery(path, roots.raw));
+  }
+
+  for (const path of walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"))) {
+    files.push(buildNormalizedDiscovery(path, roots.normalized));
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return { roots, files };
+}
+
+export function parseNormalizedConsumerSessionExport(path: string): NormalizedConsumerSession[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    throw new Error("invalid_json");
+  }
+
+  const rawSessions = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === "object" && Array.isArray((parsed as { sessions?: unknown }).sessions)
+      ? (parsed as { sessions: unknown[] }).sessions
+      : parsed && typeof parsed === "object"
+        ? [parsed]
+        : [];
+
+  if (rawSessions.length === 0) throw new Error("schema_error");
+  return rawSessions.map((value, index) => coerceSession(value, path, index));
+}
+
+export function consumerSessionContentHash(session: NormalizedConsumerSession): string {
+  return sha256(stableJson(normalizeForHash(session)));
+}
+
+export function consumerSessionStableId(session: NormalizedConsumerSession): string {
+  const key = `${session.provider}:${session.account_hash}:${session.conversation_id}`;
+  return sha256(key).slice(0, 32);
+}
+
+export function consumerSessionStateKey(session: NormalizedConsumerSession): string {
+  return `consumer:${safePathSegment(session.provider)}:${safePathSegment(session.account_hash)}:${consumerSessionStableId(session)}`;
+}
+
+export function renderConsumerSessionPages(
+  session: NormalizedConsumerSession,
+  options: { maxChunkChars?: number } = {},
+): RenderedConsumerSessionPage[] {
+  const maxChunkChars = options.maxChunkChars ?? DEFAULT_CONSUMER_SESSION_CHUNK_CHARS;
+  const sessionId = consumerSessionStableId(session);
+  const contentHash = consumerSessionContentHash(session);
+  const providerFolder = safePathSegment(session.provider);
+  const accountFolder = safePathSegment(session.account_hash);
+  const date = dateOnly(session.created_at || session.updated_at);
+  const titleSlug = safePathSegment(session.title || session.conversation_id).slice(0, 48) || "conversation";
+  const baseSlug = `sessions/${providerFolder}/${accountFolder}/${date}-${titleSlug}-${sessionId.slice(0, 12)}`;
+  const turnSections = renderTurnSections(session, maxChunkChars);
+  const chunks = chunkSections(turnSections, maxChunkChars);
+  const chunkCount = chunks.length;
+  const commonTags = [
+    "session",
+    "consumer-session",
+    `provider:${providerFolder}`,
+    `date:${date}`,
+  ];
+  if (session.completeness.partial) commonTags.push("partial:true");
+  if (session.completeness.truncated) commonTags.push("truncated:true");
+
+  return chunks.map((chunk, index) => {
+    const chunkIndex = index + 1;
+    const chunkSuffix = chunkCount > 1 ? `-part-${String(chunkIndex).padStart(4, "0")}-of-${String(chunkCount).padStart(4, "0")}` : "";
+    const slug = `${baseSlug}${chunkSuffix}`;
+    const pageTitle = chunkCount > 1
+      ? `${session.title || session.conversation_id} (${chunkIndex}/${chunkCount})`
+      : session.title || session.conversation_id;
+    const body = [
+      "---",
+      `provider: ${JSON.stringify(session.provider)}`,
+      `account_hash: ${JSON.stringify(session.account_hash)}`,
+      `conversation_id: ${JSON.stringify(session.conversation_id)}`,
+      `session_id: ${sessionId}`,
+      `provider_export_kind: ${JSON.stringify(session.source_receipt.provider_export_kind)}`,
+      `host: ${JSON.stringify(session.host.hostname)}`,
+      session.source_receipt.raw_path
+        ? `raw_path: ${JSON.stringify(session.source_receipt.raw_path)}`
+        : "receipt_missing: true",
+      `created_at: ${session.created_at || ""}`,
+      `updated_at: ${session.updated_at || ""}`,
+      `complete: ${session.completeness.complete ? "true" : "false"}`,
+      `partial: ${session.completeness.partial ? "true" : "false"}`,
+      `truncated: ${session.completeness.truncated ? "true" : "false"}`,
+      `chunk_index: ${chunkIndex}`,
+      `chunk_count: ${chunkCount}`,
+      `content_sha256: ${contentHash}`,
+      "---",
+      "",
+      chunk.join("\n\n"),
+      "",
+    ].join("\n");
+    return {
+      slug,
+      title: pageTitle,
+      tags: commonTags,
+      body,
+      session_id: sessionId,
+      conversation_key: consumerSessionStateKey(session),
+      content_sha256: contentHash,
+      chunk_index: chunkIndex,
+      chunk_count: chunkCount,
+      partial: session.completeness.partial,
+    };
+  });
+}
+
+function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRunFile {
+  const st = safeStat(path);
+  return {
+    path,
+    provider_kind: providerKindFromPath(path, rawRoot),
+    provider_export_kind: "raw-provider-export",
+    size_bytes: st.size,
+    mtime: st.mtime,
+    conversation_count: 0,
+    turn_count: 0,
+    attachment_count: 0,
+    parser_status: st.ok ? "unsupported_raw_pending_adapter" : "unreadable",
+  };
+}
+
+function buildNormalizedDiscovery(path: string, normalizedRoot: string): ConsumerSessionDryRunFile {
+  const st = safeStat(path);
+  if (!st.ok) {
+    return {
+      path,
+      provider_kind: providerKindFromPath(path, normalizedRoot),
+      provider_export_kind: "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: 0,
+      turn_count: 0,
+      attachment_count: 0,
+      parser_status: "unreadable",
+    };
+  }
+  try {
+    const sessions = parseNormalizedConsumerSessionExport(path);
+    return {
+      path,
+      provider_kind: providerKindFromSessionOrPath(sessions[0], path, normalizedRoot),
+      provider_export_kind: sessions[0]?.source_receipt.provider_export_kind || "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: sessions.length,
+      turn_count: sessions.reduce((sum, session) => sum + session.turns.length, 0),
+      attachment_count: sessions.reduce((sum, session) => sum + (session.attachments?.length || 0) + session.turns.reduce((n, turn) => n + (turn.attachments?.length || 0), 0), 0),
+      parser_status: "ok",
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+    return {
+      path,
+      provider_kind: providerKindFromPath(path, normalizedRoot),
+      provider_export_kind: "normalized-consumer-session",
+      size_bytes: st.size,
+      mtime: st.mtime,
+      conversation_count: 0,
+      turn_count: 0,
+      attachment_count: 0,
+      parser_status: message === "invalid_json" ? "invalid_json" : "schema_error",
+    };
+  }
+}
+
+function coerceSession(value: unknown, path: string, index: number): NormalizedConsumerSession {
+  if (!value || typeof value !== "object") throw new Error("schema_error");
+  const obj = value as Record<string, unknown>;
+  const provider = requireString(obj.provider, "provider");
+  const accountHash = requireString(obj.account_hash, "account_hash");
+  const conversationId = requireString(obj.conversation_id, "conversation_id");
+  const turnsRaw = obj.turns;
+  if (!Array.isArray(turnsRaw)) throw new Error("schema_error");
+  const turns = turnsRaw.map((turn, turnIndex) => coerceTurn(turn, turnIndex));
+  const receipt = coerceReceipt(obj.source_receipt, path);
+  const host = coerceHost(obj.host);
+  const completeness = coerceCompleteness(obj.completeness);
+  return {
+    schema_version: CONSUMER_SESSION_SCHEMA_VERSION,
+    provider,
+    account_hash: accountHash,
+    conversation_id: conversationId,
+    title: typeof obj.title === "string" && obj.title.trim() ? obj.title : `Conversation ${index + 1}`,
+    created_at: optionalString(obj.created_at),
+    updated_at: optionalString(obj.updated_at),
+    turns,
+    attachments: Array.isArray(obj.attachments) ? obj.attachments.map(coerceAttachment) : [],
+    source_receipt: receipt,
+    host,
+    completeness,
+  };
+}
+
+function coerceTurn(value: unknown, index: number): NormalizedConsumerSessionTurn {
+  if (!value || typeof value !== "object") throw new Error("schema_error");
+  const obj = value as Record<string, unknown>;
+  return {
+    index: typeof obj.index === "number" ? obj.index : index,
+    id: optionalString(obj.id),
+    role: typeof obj.role === "string" ? obj.role : "other",
+    created_at: optionalString(obj.created_at),
+    content: typeof obj.content === "string" ? obj.content : "",
+    attachments: Array.isArray(obj.attachments) ? obj.attachments.map(coerceAttachment) : [],
+    metadata: obj.metadata && typeof obj.metadata === "object" && !Array.isArray(obj.metadata)
+      ? obj.metadata as Record<string, unknown>
+      : undefined,
+  };
+}
+
+function coerceAttachment(value: unknown): NormalizedConsumerSessionAttachment {
+  if (!value || typeof value !== "object") return {};
+  const obj = value as Record<string, unknown>;
+  return {
+    id: optionalString(obj.id),
+    name: optionalString(obj.name),
+    mime_type: optionalString(obj.mime_type),
+    size_bytes: typeof obj.size_bytes === "number" ? obj.size_bytes : undefined,
+    source_kind: optionalString(obj.source_kind),
+    provider_attachment_id: optionalString(obj.provider_attachment_id),
+    sha256: optionalString(obj.sha256),
+  };
+}
+
+function coerceReceipt(value: unknown, exportPath: string): NormalizedConsumerSessionReceipt {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  const rawPath = optionalString(obj.raw_path);
+  const receiptMissing = typeof obj.receipt_missing === "boolean" ? obj.receipt_missing : !rawPath;
+  return {
+    raw_path: rawPath,
+    receipt_missing: receiptMissing,
+    provider_export_kind: optionalString(obj.provider_export_kind) || "normalized-consumer-session",
+    export_path: optionalString(obj.export_path) || exportPath,
+    content_sha256: optionalString(obj.content_sha256),
+    imported_at: optionalString(obj.imported_at),
+  };
+}
+
+function coerceHost(value: unknown): NormalizedConsumerSessionHost {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  return {
+    hostname: optionalString(obj.hostname) || process.env.GSTACK_HOSTNAME || hostname(),
+    platform: optionalString(obj.platform) || platform(),
+  };
+}
+
+function coerceCompleteness(value: unknown): NormalizedConsumerSessionCompleteness {
+  const obj = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  const partial = Boolean(obj.partial);
+  const truncated = Boolean(obj.truncated);
+  return {
+    complete: typeof obj.complete === "boolean" ? obj.complete : !partial && !truncated,
+    partial,
+    truncated,
+    missing_turns: typeof obj.missing_turns === "boolean" ? obj.missing_turns : undefined,
+    source_complete: typeof obj.source_complete === "boolean" ? obj.source_complete : undefined,
+    reason: optionalString(obj.reason),
+  };
+}
+
+function renderTurnSections(session: NormalizedConsumerSession, maxChunkChars: number): string[] {
+  const sorted = [...session.turns].sort((a, b) => a.index - b.index);
+  const sections: string[] = [];
+  for (const turn of sorted) {
+    const label = turn.role.charAt(0).toUpperCase() + turn.role.slice(1);
+    const head = [`## Turn ${turn.index + 1}: ${label}`];
+    if (turn.created_at) head.push(`Time: ${turn.created_at}`);
+    if (turn.attachments && turn.attachments.length > 0) {
+      head.push(`Attachments: ${turn.attachments.length}`);
+    }
+    const prefix = `${head.join("\n")}\n\n`;
+    const content = turn.content || "";
+    if (prefix.length + content.length <= maxChunkChars) {
+      sections.push(prefix + content);
+      continue;
+    }
+    const parts = splitStringByMax(content, Math.max(1, maxChunkChars - prefix.length - 80));
+    for (let i = 0; i < parts.length; i++) {
+      sections.push(`${prefix}_Continuation ${i + 1}/${parts.length}_\n\n${parts[i]}`);
+    }
+  }
+  return sections;
+}
+
+function chunkSections(sections: string[], maxChunkChars: number): string[][] {
+  const chunks: string[][] = [];
+  let current: string[] = [];
+  let currentSize = 0;
+  for (const section of sections) {
+    const nextSize = currentSize + (current.length > 0 ? 2 : 0) + section.length;
+    if (current.length > 0 && nextSize > maxChunkChars) {
+      chunks.push(current);
+      current = [];
+      currentSize = 0;
+    }
+    current.push(section);
+    currentSize += (current.length > 1 ? 2 : 0) + section.length;
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks.length > 0 ? chunks : [[""]];
+}
+
+function splitStringByMax(text: string, maxChars: number): string[] {
+  const parts: string[] = [];
+  for (let i = 0; i < text.length; i += maxChars) {
+    parts.push(text.slice(i, i + maxChars));
+  }
+  return parts.length > 0 ? parts : [""];
+}
+
+function walkFiles(root: string, predicate: (path: string) => boolean): string[] {
+  if (!existsSync(root)) return [];
+  const out: string[] = [];
+  function visit(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry);
+      let st;
+      try {
+        st = statSync(path);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) visit(path);
+      else if (st.isFile() && predicate(path)) out.push(path);
+    }
+  }
+  visit(root);
+  out.sort();
+  return out;
+}
+
+function safeStat(path: string): { ok: boolean; size: number; mtime: string } {
+  try {
+    const st = statSync(path);
+    return { ok: true, size: st.size, mtime: new Date(st.mtimeMs).toISOString() };
+  } catch {
+    return { ok: false, size: 0, mtime: "" };
+  }
+}
+
+function providerKindFromSessionOrPath(session: NormalizedConsumerSession | undefined, path: string, root: string): string {
+  return session?.provider ? safePathSegment(session.provider) : providerKindFromPath(path, root);
+}
+
+function providerKindFromPath(path: string, root: string): string {
+  const rel = relative(root, path).split(/[\\/]/).filter(Boolean);
+  return safePathSegment(rel[0] || "unknown");
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`schema_error:${field}`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function safePathSegment(value: string): string {
+  const cleaned = value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned || "unknown";
+}
+
+function dateOnly(ts: string | undefined): string {
+  if (!ts) return "undated";
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "undated";
+  return d.toISOString().slice(0, 10);
+}
+
+function normalizeForHash(session: NormalizedConsumerSession): unknown {
+  return {
+    schema_version: session.schema_version,
+    provider: session.provider,
+    account_hash: session.account_hash,
+    conversation_id: session.conversation_id,
+    title: session.title,
+    created_at: session.created_at,
+    updated_at: session.updated_at,
+    turns: [...session.turns].sort((a, b) => a.index - b.index),
+    attachments: session.attachments || [],
+    source_receipt: session.source_receipt,
+    host: session.host,
+    completeness: session.completeness,
+  };
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableJson(v)}`).join(",")}}`;
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}

--- a/lib/consumer-sessions.ts
+++ b/lib/consumer-sessions.ts
@@ -1,7 +1,7 @@
 import { createHash } from "crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { hostname, platform } from "os";
-import { basename, join, relative } from "path";
+import { basename, extname, join, relative } from "path";
 
 export const CONSUMER_SESSION_SCHEMA_VERSION = 1;
 export const DEFAULT_CONSUMER_SESSION_CHUNK_CHARS = 80_000;
@@ -109,7 +109,7 @@ export function consumerSessionRoots(gstackHome: string): ConsumerSessionRoots {
     root,
     raw: join(root, "raw"),
     normalized: join(root, "normalized"),
-    rendered: join(gstackHome, "sessions"),
+    rendered: join(root, "rendered"),
   };
 }
 
@@ -124,16 +124,22 @@ export function discoverConsumerSessionFiles(gstackHome: string): ConsumerSessio
   const roots = consumerSessionRoots(gstackHome);
   const files: ConsumerSessionDryRunFile[] = [];
 
-  for (const path of walkFiles(roots.raw, () => true)) {
-    files.push(buildRawDiscovery(path, roots.raw));
+  const rawFiles = walkFiles(roots.raw, () => true);
+  for (let i = 0; i < rawFiles.length; i++) {
+    files.push(buildRawDiscovery(rawFiles[i], roots.raw, displayConsumerSessionPath("raw", roots.raw, rawFiles[i], i + 1)));
   }
 
-  for (const path of walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"))) {
-    files.push(buildNormalizedDiscovery(path, roots.normalized));
+  const normalizedFiles = walkFiles(roots.normalized, (p) => basename(p).toLowerCase().endsWith(".json"));
+  for (let i = 0; i < normalizedFiles.length; i++) {
+    files.push(buildNormalizedDiscovery(
+      normalizedFiles[i],
+      roots.normalized,
+      displayConsumerSessionPath("normalized", roots.normalized, normalizedFiles[i], i + 1),
+    ));
   }
 
   files.sort((a, b) => a.path.localeCompare(b.path));
-  return { roots, files };
+  return { roots: displayConsumerSessionRoots(), files };
 }
 
 export function parseNormalizedConsumerSessionExport(path: string): NormalizedConsumerSession[] {
@@ -239,10 +245,10 @@ export function renderConsumerSessionPages(
   });
 }
 
-function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRunFile {
+function buildRawDiscovery(path: string, rawRoot: string, displayPath: string): ConsumerSessionDryRunFile {
   const st = safeStat(path);
   return {
-    path,
+    path: displayPath,
     provider_kind: providerKindFromPath(path, rawRoot),
     provider_export_kind: "raw-provider-export",
     size_bytes: st.size,
@@ -254,11 +260,11 @@ function buildRawDiscovery(path: string, rawRoot: string): ConsumerSessionDryRun
   };
 }
 
-function buildNormalizedDiscovery(path: string, normalizedRoot: string): ConsumerSessionDryRunFile {
+function buildNormalizedDiscovery(path: string, normalizedRoot: string, displayPath: string): ConsumerSessionDryRunFile {
   const st = safeStat(path);
   if (!st.ok) {
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromPath(path, normalizedRoot),
       provider_export_kind: "normalized-consumer-session",
       size_bytes: st.size,
@@ -272,7 +278,7 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
   try {
     const sessions = parseNormalizedConsumerSessionExport(path);
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromSessionOrPath(sessions[0], path, normalizedRoot),
       provider_export_kind: sessions[0]?.source_receipt.provider_export_kind || "normalized-consumer-session",
       size_bytes: st.size,
@@ -285,7 +291,7 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
   } catch (err) {
     const message = err instanceof Error ? err.message : "";
     return {
-      path,
+      path: displayPath,
       provider_kind: providerKindFromPath(path, normalizedRoot),
       provider_export_kind: "normalized-consumer-session",
       size_bytes: st.size,
@@ -296,6 +302,23 @@ function buildNormalizedDiscovery(path: string, normalizedRoot: string): Consume
       parser_status: message === "invalid_json" ? "invalid_json" : "schema_error",
     };
   }
+}
+
+function displayConsumerSessionRoots(): ConsumerSessionRoots {
+  return {
+    root: "consumer-sessions",
+    raw: "consumer-sessions/raw",
+    normalized: "consumer-sessions/normalized",
+    rendered: "consumer-sessions/rendered",
+  };
+}
+
+function displayConsumerSessionPath(kind: "raw" | "normalized", root: string, filePath: string, index: number): string {
+  const provider = providerKindFromPath(filePath, root);
+  const rawExt = extname(filePath).replace(/^\./, "");
+  const ext = rawExt ? safePathSegment(rawExt) : "";
+  const ordinal = String(index).padStart(3, "0");
+  return `consumer-sessions/${kind}/${provider}/<redacted-export-${ordinal}${ext ? `.${ext}` : ""}>`;
 }
 
 function coerceSession(value: unknown, path: string, index: number): NormalizedConsumerSession {

--- a/test/brain-sync.test.ts
+++ b/test/brain-sync.test.ts
@@ -385,12 +385,16 @@ describe('gstack-brain-sync --discover-new', () => {
       '{"schema_version":1,"device":"macbook","last_reported_at":"2026-06-21T10:00:00Z","export_count":1}\n');
     fs.writeFileSync(path.join(inboxDir, 'chatgpt-export.json'), '{"conversation":"synthetic"}\n');
     fs.writeFileSync(path.join(cacheDir, 'unsafe-cache.json'), '{"cookie":"do-not-sync"}\n');
+    const nestedCacheInbox = path.join(cacheDir, 'inbox');
+    fs.mkdirSync(nestedCacheInbox, { recursive: true });
+    fs.writeFileSync(path.join(nestedCacheInbox, 'unsafe-nested-cache.json'), '{"cookie":"do-not-sync"}\n');
 
     run(['gstack-brain-sync', '--discover-new']);
     const queue = fs.readFileSync(path.join(tmpHome, '.brain-queue.jsonl'), 'utf-8');
     expect(queue).toContain('consumer-sessions/raw/chatgpt/acct-1/macbook/freshness.json');
     expect(queue).toContain('consumer-sessions/raw/chatgpt/acct-1/macbook/inbox/chatgpt-export.json');
     expect(queue).not.toContain('unsafe-cache.json');
+    expect(queue).not.toContain('unsafe-nested-cache.json');
 
     const mode = fs.statSync(path.join(inboxDir, 'chatgpt-export.json')).mode & 0o777;
     expect(mode).toBe(0o600);
@@ -422,6 +426,56 @@ describe('gstack-brain-sync --discover-new', () => {
     expect(queue).toContain('consumer-sessions/raw/claude-ai/acct-1/macbook/inbox/claude-export.zip.complete');
   });
 
+  test('consumer archive completion guard is enforced during direct queue drain', () => {
+    run(['gstack-artifacts-init', '--remote', bareRemote]);
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
+
+    const inboxDir = path.join(tmpHome, 'consumer-sessions/raw/chatgpt/acct-1/macbook/inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    const rel = 'consumer-sessions/raw/chatgpt/acct-1/macbook/inbox/chatgpt-export.zip';
+    fs.writeFileSync(path.join(tmpHome, rel), 'partial zip bytes');
+    fs.writeFileSync(path.join(tmpHome, '.brain-queue.jsonl'), JSON.stringify({ file: rel, ts: '2026-06-21T10:00:00Z' }) + '\n');
+
+    run(['gstack-brain-sync', '--once']);
+    let tree = spawnSync('git', ['--git-dir=' + bareRemote, 'ls-tree', '-r', '--name-only', 'main'], { encoding: 'utf-8' });
+    expect(tree.stdout).not.toContain('chatgpt-export.zip');
+
+    const marker = path.join(tmpHome, `${rel}.complete`);
+    fs.writeFileSync(marker, '{"completed_at":"2026-06-21T10:05:00Z"}\n');
+    fs.utimesSync(path.join(tmpHome, rel), new Date('2026-06-21T10:00:00Z'), new Date('2026-06-21T10:00:00Z'));
+    fs.utimesSync(marker, new Date('2026-06-21T10:05:00Z'), new Date('2026-06-21T10:05:00Z'));
+    fs.writeFileSync(path.join(tmpHome, '.brain-queue.jsonl'), JSON.stringify({ file: rel, ts: '2026-06-21T10:06:00Z' }) + '\n');
+
+    run(['gstack-brain-sync', '--once']);
+    tree = spawnSync('git', ['--git-dir=' + bareRemote, 'ls-tree', '-r', '--name-only', 'main'], { encoding: 'utf-8' });
+    expect(tree.stdout).toContain(rel);
+  });
+
+  test('consumer export discovery does not advance cursor while artifacts-only hides behavioral exports', () => {
+    run(['gstack-artifacts-init', '--remote', bareRemote]);
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'artifacts-only']);
+
+    const inboxDir = path.join(tmpHome, 'consumer-sessions/raw/perplexity/acct-1/macbook/inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    const rel = 'consumer-sessions/raw/perplexity/acct-1/macbook/inbox/perplexity-export.json';
+    fs.writeFileSync(path.join(tmpHome, rel), '{"conversation":"sync later"}\n');
+
+    run(['gstack-brain-sync', '--discover-new']);
+    let queue = fs.existsSync(path.join(tmpHome, '.brain-queue.jsonl'))
+      ? fs.readFileSync(path.join(tmpHome, '.brain-queue.jsonl'), 'utf-8')
+      : '';
+    expect(queue).not.toContain('perplexity-export.json');
+    const cursor = fs.existsSync(path.join(tmpHome, '.brain-discover-cursor'))
+      ? fs.readFileSync(path.join(tmpHome, '.brain-discover-cursor'), 'utf-8')
+      : '';
+    expect(cursor).not.toContain('perplexity-export.json');
+
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
+    run(['gstack-brain-sync', '--discover-new']);
+    queue = fs.readFileSync(path.join(tmpHome, '.brain-queue.jsonl'), 'utf-8');
+    expect(queue).toContain(rel);
+  });
+
   test('consumer export dry-run prints metadata only and does not advance queue or cursor', () => {
     run(['gstack-artifacts-init', '--remote', bareRemote]);
     run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
@@ -435,13 +489,17 @@ describe('gstack-brain-sync --discover-new', () => {
     const parsed = JSON.parse(r.stdout);
     expect(parsed.files).toEqual(expect.arrayContaining([
       expect.objectContaining({
-        path: 'consumer-sessions/raw/gemini/acct-1/macbook/inbox/gemini-export.json',
+        path: 'consumer-sessions/raw/gemini/<redacted-account>/<redacted-device>/inbox/<redacted-export-file>',
         kind: 'consumer-export',
         size_bytes: expect.any(Number),
         mtime: expect.any(String),
       }),
     ]));
     expect(r.stdout).not.toContain('DO NOT PRINT CHAT TEXT');
+    expect(r.stdout).not.toContain(tmpHome);
+    expect(r.stdout).not.toContain('acct-1');
+    expect(r.stdout).not.toContain('macbook');
+    expect(r.stdout).not.toContain('gemini-export.json');
     expect(fs.existsSync(path.join(tmpHome, '.brain-queue.jsonl'))).toBe(false);
     expect(fs.existsSync(path.join(tmpHome, '.brain-discover-cursor'))).toBe(false);
   });

--- a/test/brain-sync.test.ts
+++ b/test/brain-sync.test.ts
@@ -372,4 +372,97 @@ describe('gstack-brain-sync --discover-new', () => {
     queue = fs.readFileSync(path.join(tmpHome, '.brain-queue.jsonl'), 'utf-8');
     expect(queue.trim()).toBe('');
   });
+
+  test('consumer export bridge discovers only explicit provider/account/device inbox plus freshness marker', () => {
+    run(['gstack-artifacts-init', '--remote', bareRemote]);
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
+
+    const inboxDir = path.join(tmpHome, 'consumer-sessions/raw/chatgpt/acct-1/macbook/inbox');
+    const cacheDir = path.join(tmpHome, 'consumer-sessions/raw/chatgpt/acct-1/macbook/cache');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpHome, 'consumer-sessions/raw/chatgpt/acct-1/macbook/freshness.json'),
+      '{"schema_version":1,"device":"macbook","last_reported_at":"2026-06-21T10:00:00Z","export_count":1}\n');
+    fs.writeFileSync(path.join(inboxDir, 'chatgpt-export.json'), '{"conversation":"synthetic"}\n');
+    fs.writeFileSync(path.join(cacheDir, 'unsafe-cache.json'), '{"cookie":"do-not-sync"}\n');
+
+    run(['gstack-brain-sync', '--discover-new']);
+    const queue = fs.readFileSync(path.join(tmpHome, '.brain-queue.jsonl'), 'utf-8');
+    expect(queue).toContain('consumer-sessions/raw/chatgpt/acct-1/macbook/freshness.json');
+    expect(queue).toContain('consumer-sessions/raw/chatgpt/acct-1/macbook/inbox/chatgpt-export.json');
+    expect(queue).not.toContain('unsafe-cache.json');
+
+    const mode = fs.statSync(path.join(inboxDir, 'chatgpt-export.json')).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test('consumer archive exports require completion markers before enqueue', () => {
+    run(['gstack-artifacts-init', '--remote', bareRemote]);
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
+
+    const inboxDir = path.join(tmpHome, 'consumer-sessions/raw/claude-ai/acct-1/macbook/inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    const archive = path.join(inboxDir, 'claude-export.zip');
+    fs.writeFileSync(archive, 'partial zip bytes');
+
+    run(['gstack-brain-sync', '--discover-new']);
+    let queue = fs.existsSync(path.join(tmpHome, '.brain-queue.jsonl'))
+      ? fs.readFileSync(path.join(tmpHome, '.brain-queue.jsonl'), 'utf-8')
+      : '';
+    expect(queue).not.toContain('claude-export.zip');
+
+    const marker = `${archive}.complete`;
+    fs.writeFileSync(marker, '{"completed_at":"2026-06-21T10:05:00Z"}\n');
+    fs.utimesSync(archive, new Date('2026-06-21T10:00:00Z'), new Date('2026-06-21T10:00:00Z'));
+    fs.utimesSync(marker, new Date('2026-06-21T10:05:00Z'), new Date('2026-06-21T10:05:00Z'));
+
+    run(['gstack-brain-sync', '--discover-new']);
+    queue = fs.readFileSync(path.join(tmpHome, '.brain-queue.jsonl'), 'utf-8');
+    expect(queue).toContain('consumer-sessions/raw/claude-ai/acct-1/macbook/inbox/claude-export.zip');
+    expect(queue).toContain('consumer-sessions/raw/claude-ai/acct-1/macbook/inbox/claude-export.zip.complete');
+  });
+
+  test('consumer export dry-run prints metadata only and does not advance queue or cursor', () => {
+    run(['gstack-artifacts-init', '--remote', bareRemote]);
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
+
+    const inboxDir = path.join(tmpHome, 'consumer-sessions/raw/gemini/acct-1/macbook/inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    fs.writeFileSync(path.join(inboxDir, 'gemini-export.json'), '{"secret":"DO NOT PRINT CHAT TEXT"}\n');
+
+    const r = run(['gstack-brain-sync', '--discover-new', '--dry-run']);
+    expect(r.status).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.files).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: 'consumer-sessions/raw/gemini/acct-1/macbook/inbox/gemini-export.json',
+        kind: 'consumer-export',
+        size_bytes: expect.any(Number),
+        mtime: expect.any(String),
+      }),
+    ]));
+    expect(r.stdout).not.toContain('DO NOT PRINT CHAT TEXT');
+    expect(fs.existsSync(path.join(tmpHome, '.brain-queue.jsonl'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpHome, '.brain-discover-cursor'))).toBe(false);
+  });
+
+  test('consumer export sync is additive and does not delete remote files after local removal', () => {
+    run(['gstack-artifacts-init', '--remote', bareRemote]);
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
+
+    const inboxDir = path.join(tmpHome, 'consumer-sessions/raw/grok/acct-1/macbook/inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    const rel = 'consumer-sessions/raw/grok/acct-1/macbook/inbox/grok-export.json';
+    const full = path.join(tmpHome, rel);
+    fs.writeFileSync(full, '{"conversation":"keep me remotely"}\n');
+
+    run(['gstack-brain-sync', '--discover-new']);
+    run(['gstack-brain-sync', '--once']);
+    fs.unlinkSync(full);
+    run(['gstack-brain-sync', '--discover-new']);
+    run(['gstack-brain-sync', '--once']);
+
+    const tree = spawnSync('git', ['--git-dir=' + bareRemote, 'ls-tree', '-r', '--name-only', 'main'], { encoding: 'utf-8' });
+    expect(tree.stdout).toContain(rel);
+  });
 });

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -766,3 +766,189 @@ exit 0
     rmSync(home, { recursive: true, force: true });
   });
 });
+
+// ── Consumer session contract and synthetic normalized adapter ─────────────
+
+function makeConsumerSession(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    provider: "chatgpt",
+    account_hash: "acct_0123456789abcdef",
+    conversation_id: "conv-001",
+    title: "Synthetic planning session",
+    created_at: "2026-06-01T10:00:00Z",
+    updated_at: "2026-06-01T10:05:00Z",
+    turns: [
+      { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: "first prompt" },
+      { index: 1, role: "assistant", created_at: "2026-06-01T10:01:00Z", content: "first answer" },
+    ],
+    attachments: [
+      { id: "att-1", name: "context.txt", mime_type: "text/plain", size_bytes: 42, sha256: "a".repeat(64) },
+    ],
+    source_receipt: {
+      raw_path: "/exports/chatgpt/raw-export.json",
+      provider_export_kind: "synthetic-normalized-v1",
+    },
+    host: { hostname: "macbook-fixture", platform: "darwin" },
+    completeness: { complete: true, partial: false, truncated: false },
+    ...overrides,
+  };
+}
+
+function writeConsumerSessions(gstackHome: string, provider: string, fileName: string, sessions: Record<string, unknown>[]): string {
+  const dir = join(gstackHome, "consumer-sessions", "normalized", provider);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, fileName);
+  writeFileSync(file, JSON.stringify({ sessions }, null, 2), "utf-8");
+  return file;
+}
+
+describe("gstack-memory-ingest consumer-session normalized contract", () => {
+  it("dry-run discovery reports metadata only and never prints chat/storage values", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    const rawDir = join(gstackHome, "consumer-sessions", "raw", "chatgpt");
+    mkdirSync(rawDir, { recursive: true });
+    writeFileSync(
+      join(rawDir, "export.json"),
+      JSON.stringify({
+        text: "DO NOT LEAK CHAT TEXT",
+        cookie: "cookie-secret-value",
+        localStorage: { auth: "local-storage-secret" },
+        indexedDB: { auth: "indexed-db-secret" },
+      }),
+      "utf-8",
+    );
+    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+      makeConsumerSession({
+        turns: [{ index: 0, role: "user", content: "NORMALIZED CHAT SECRET" }],
+      }),
+    ]);
+
+    const r = runScript(["--consumer-sessions-dry-run"], { HOME: home, GSTACK_HOME: gstackHome });
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.files.length).toBe(2);
+    expect(r.stdout).toContain("provider_kind");
+    expect(r.stdout).toContain("provider_export_kind");
+    expect(r.stdout).toContain("parser_status");
+    expect(r.stdout).toContain("conversation_count");
+    expect(r.stdout).not.toContain("DO NOT LEAK CHAT TEXT");
+    expect(r.stdout).not.toContain("cookie-secret-value");
+    expect(r.stdout).not.toContain("local-storage-secret");
+    expect(r.stdout).not.toContain("indexed-db-secret");
+    expect(r.stdout).not.toContain("NORMALIZED CHAT SECRET");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("renders synthetic normalized sessions under sessions/<provider> and chunks long conversations", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const stagingCopy = join(home, "consumer-staging-copy");
+    const binDir = join(home, "fake-bin");
+    mkdirSync(binDir, { recursive: true });
+    const fake = `#!/usr/bin/env bash
+case "\${1:-}" in
+  --help|-h) echo "Usage: gbrain"; echo "Commands:"; echo "  import <dir>   Import"; exit 0 ;;
+  import)
+    DIR="\${2:-}"
+    cp -R "\$DIR" "${stagingCopy}" 2>/dev/null || true
+    TOTAL=\$(find "\$DIR" -name "*.md" -type f | wc -l | tr -d ' ')
+    echo "{\\"status\\":\\"success\\",\\"duration_s\\":0.1,\\"imported\\":\$TOTAL,\\"skipped\\":0,\\"errors\\":0,\\"chunks\\":\$TOTAL,\\"total_files\\":\$TOTAL}"
+    exit 0 ;;
+  *) exit 2 ;;
+esac
+`;
+    const fakePath = join(binDir, "gbrain");
+    writeFileSync(fakePath, fake, "utf-8");
+    chmodSync(fakePath, 0o755);
+
+    const longContent = `start\n${"x".repeat(170_000)}\ntail-marker`;
+    writeConsumerSessions(gstackHome, "chatgpt", "long.json", [
+      makeConsumerSession({
+        turns: [
+          { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: longContent },
+        ],
+      }),
+    ]);
+
+    const r = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(r.exitCode).toBe(0);
+
+    const findMd = spawnSync("find", [stagingCopy, "-name", "*.md", "-type", "f"], { encoding: "utf-8" });
+    const mdPaths = (findMd.stdout || "").trim().split("\n").filter(Boolean).sort();
+    expect(mdPaths.length).toBeGreaterThan(1);
+    for (const mdPath of mdPaths) {
+      expect(mdPath).toContain("/sessions/chatgpt/");
+    }
+    const bodies = mdPaths.map((p) => readFileSync(p, "utf-8"));
+    expect(bodies[0]).toContain("type: consumer-session");
+    expect(bodies[0]).toContain("raw_path: \"/exports/chatgpt/raw-export.json\"");
+    expect(bodies[0]).toContain("provider_export_kind: \"synthetic-normalized-v1\"");
+    expect(bodies[0]).toContain("host: \"macbook-fixture\"");
+    expect(bodies[0]).toMatch(/session_id: [a-f0-9]{32}/);
+    expect(bodies[0]).toContain("consumer-session");
+    expect(bodies.join("\n")).toContain("tail-marker");
+
+    const state = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    const entries = Object.values(state.consumer_sessions || {}) as Array<{ page_slugs: string[]; content_sha256: string; chunk_count: number }>;
+    expect(entries.length).toBe(1);
+    expect(entries[0].page_slugs.length).toBe(mdPaths.length);
+    expect(entries[0].content_sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(entries[0].chunk_count).toBe(mdPaths.length);
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("incremental state is per normalized conversation content hash, not export-file mtime only", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir, stagingListFile } = installFakeGbrain(home);
+
+    const sessionA = makeConsumerSession({
+      conversation_id: "conv-a",
+      title: "Conversation A",
+      turns: [{ index: 0, role: "user", content: "unchanged A" }],
+    });
+    const sessionB = makeConsumerSession({
+      conversation_id: "conv-b",
+      title: "Conversation B",
+      turns: [{ index: 0, role: "user", content: "before B" }],
+    });
+    const exportPath = writeConsumerSessions(gstackHome, "chatgpt", "bundle.json", [sessionA, sessionB]);
+
+    const first = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(first.exitCode).toBe(0);
+    expect(readFileSync(stagingListFile, "utf-8").match(/\.md/g)?.length).toBe(2);
+
+    writeFileSync(
+      exportPath,
+      JSON.stringify({ sessions: [sessionA, { ...sessionB, turns: [{ index: 0, role: "user", content: "after B" }] }] }, null, 2),
+      "utf-8",
+    );
+
+    const second = runScript(["--incremental", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(second.exitCode).toBe(0);
+    const stagedList = readFileSync(stagingListFile, "utf-8");
+    expect(stagedList.match(/\.md/g)?.length).toBe(1);
+    expect(stagedList).toContain("conversation-b");
+    expect(stagedList).not.toContain("conversation-a");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+});

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -804,13 +804,29 @@ function writeConsumerSessions(gstackHome: string, provider: string, fileName: s
 }
 
 describe("gstack-memory-ingest consumer-session normalized contract", () => {
+  it("does not include consumer sessions in the default source set", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+      makeConsumerSession(),
+    ]);
+
+    const r = runScript(["--probe"], { HOME: home, GSTACK_HOME: gstackHome });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("Total files in window: 0");
+    expect(r.stdout).not.toContain("consumer-session");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
   it("dry-run discovery reports metadata only and never prints chat/storage values", () => {
     const home = makeTestHome();
     const gstackHome = join(home, ".gstack");
     const rawDir = join(gstackHome, "consumer-sessions", "raw", "chatgpt");
     mkdirSync(rawDir, { recursive: true });
     writeFileSync(
-      join(rawDir, "export.json"),
+      join(rawDir, "matt@example.com salary chat export.json"),
       JSON.stringify({
         text: "DO NOT LEAK CHAT TEXT",
         cookie: "cookie-secret-value",
@@ -819,7 +835,7 @@ describe("gstack-memory-ingest consumer-session normalized contract", () => {
       }),
       "utf-8",
     );
-    writeConsumerSessions(gstackHome, "chatgpt", "normalized.json", [
+    writeConsumerSessions(gstackHome, "chatgpt", "private conversation title.json", [
       makeConsumerSession({
         turns: [{ index: 0, role: "user", content: "NORMALIZED CHAT SECRET" }],
       }),
@@ -838,6 +854,12 @@ describe("gstack-memory-ingest consumer-session normalized contract", () => {
     expect(r.stdout).not.toContain("local-storage-secret");
     expect(r.stdout).not.toContain("indexed-db-secret");
     expect(r.stdout).not.toContain("NORMALIZED CHAT SECRET");
+    expect(r.stdout).not.toContain("matt@example.com");
+    expect(r.stdout).not.toContain("salary chat");
+    expect(r.stdout).not.toContain("private conversation title");
+    expect(r.stdout).toContain("consumer-sessions/raw/chatgpt/<redacted-export-001.json>");
+    expect(r.stdout).toContain("consumer-sessions/normalized/chatgpt/<redacted-export-001.json>");
+    expect(parsed.roots.root).toBe("consumer-sessions");
 
     rmSync(home, { recursive: true, force: true });
   });
@@ -948,6 +970,75 @@ esac
     expect(stagedList.match(/\.md/g)?.length).toBe(1);
     expect(stagedList).toContain("conversation-b");
     expect(stagedList).not.toContain("conversation-a");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("probe treats unchanged consumer sessions as unchanged after ingest", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir } = installFakeGbrain(home);
+
+    writeConsumerSessions(gstackHome, "chatgpt", "bundle.json", [
+      makeConsumerSession(),
+    ]);
+
+    const first = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(first.exitCode).toBe(0);
+
+    const probe = runScript(["--probe", "--sources", "consumer-session"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+    });
+    expect(probe.exitCode).toBe(0);
+    expect(probe.stdout).toContain("Total files in window: 1");
+    expect(probe.stdout).toContain("New (never ingested):  0");
+    expect(probe.stdout).toContain("Updated (mtime/hash):  0");
+    expect(probe.stdout).toContain("Unchanged:             1");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("--limit does not mark an incomplete multi-chunk consumer session as ingested", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir } = installFakeGbrain(home);
+
+    const longContent = `start\n${"x".repeat(170_000)}\ntail-marker`;
+    writeConsumerSessions(gstackHome, "chatgpt", "long.json", [
+      makeConsumerSession({
+        turns: [
+          { index: 0, role: "user", created_at: "2026-06-01T10:00:00Z", content: longContent },
+        ],
+      }),
+    ]);
+
+    const limited = runScript(["--bulk", "--sources", "consumer-session", "--limit", "1", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(limited.exitCode).toBe(0);
+    const limitedState = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    expect(Object.keys(limitedState.consumer_sessions || {}).length).toBe(0);
+
+    const full = runScript(["--bulk", "--sources", "consumer-session", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+    expect(full.exitCode).toBe(0);
+    const fullState = JSON.parse(readFileSync(join(gstackHome, ".transcript-ingest-state.json"), "utf-8"));
+    const entries = Object.values(fullState.consumer_sessions || {}) as Array<{ page_slugs: string[]; chunk_count: number }>;
+    expect(entries.length).toBe(1);
+    expect(entries[0].page_slugs.length).toBe(entries[0].chunk_count);
+    expect(entries[0].chunk_count).toBeGreaterThan(1);
 
     rmSync(home, { recursive: true, force: true });
   });


### PR DESCRIPTION
Linear: MAT-20

Depends on: #2071 / MAT-14. This branch is stacked on the consumer-session contract and should not merge before #2071. The diff will shrink after #2071 lands.

## Summary
- Extends the artifacts bridge for explicit consumer AI export inboxes:
  `consumer-sessions/raw/<provider>/<account>/<device>/inbox/`.
- Adds per-device `freshness.json`, additive discovery/sync, archive `.complete` handoff guards, dry-run discovery, and best-effort local permission hardening.
- Documents that raw exports stay outside Obsidian and outside default GBrain search.

## Adversarial review hardening
- Drain-time staging now enforces the same temp-name and archive completion-marker checks as discovery.
- Consumer raw paths are validated by exact path shape, not just broad `fnmatch` globs.
- Discovery is privacy-mode aware and does not advance the cursor for behavioral exports hidden by `artifacts-only`.
- Dry-run output redacts root, account, device, and export filenames.

## Verification
- `bash -n bin/gstack-brain-sync`
- `bash -n bin/gstack-artifacts-init`
- `HOME=/private/tmp/gstack-mat20-test-home bun test test/brain-sync.test.ts` - pass, 33 tests.
- `git diff --check` - pass.

Note: running `bun test test/brain-sync.test.ts` with the real sandboxed `HOME` fails because the test path writes `~/.gstack-artifacts-remote.txt`; isolating `HOME` exercises the intended behavior.
