### PR TITLE
fix(learnings-log): bun -e import fails on Windows Git Bash (MSYS path mangling)

### DIFF
--- a/bin/gstack-learnings-log
+++ b/bin/gstack-learnings-log
@@ -7,6 +7,19 @@
 # by gstack-learnings-search ("latest winner" per key+type).
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# bun is a native binary. On Git Bash (Windows) MSYS unreliably mangles an
+# absolute /c/... path embedded inside the `bun -e` script string, breaking
+# the static import ("Cannot find module"). Resolve the lib to a file:// URL
+# and hand it to bun via an env var (env values are NOT path-mangled), then
+# dynamic-import it. cygpath -m yields a Windows path on MSYS; on POSIX the
+# canonical absolute path is used directly.
+LIB_TS="$(cd "$SCRIPT_DIR/../lib" && pwd)/jsonl-store.ts"
+if command -v cygpath >/dev/null 2>&1; then
+  GSTACK_LIB_URL="file://$(cygpath -m "$LIB_TS")"
+else
+  GSTACK_LIB_URL="file://$LIB_TS"
+fi
+export GSTACK_LIB_URL
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null)"
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"
@@ -15,7 +28,7 @@ INPUT="$1"
 
 # Validate and sanitize input
 VALIDATED=$(printf '%s' "$INPUT" | bun -e "
-import { hasInjection } from '$SCRIPT_DIR/../lib/jsonl-store.ts';
+const { hasInjection } = await import(process.env.GSTACK_LIB_URL);
 const raw = await Bun.stdin.text();
 let j;
 try { j = JSON.parse(raw); } catch { process.stderr.write('gstack-learnings-log: invalid JSON, skipping\n'); process.exit(1); }


### PR DESCRIPTION
## Problem

On **Windows Git Bash (MSYS)**, `bin/gstack-learnings-log` exits 1 with no output, so `/learn` cannot append learnings — they have to be hand-appended to `learnings.jsonl`.

## Root cause

bun is a **native Windows binary**. The script runs:
```bash
bun -e "import { hasInjection } from '$SCRIPT_DIR/../lib/jsonl-store.ts'; ..."
```
MSYS unreliably mangles the absolute `/c/Users/...` import path embedded inside the `bun -e` script string, so the static import fails with `Cannot find module ... from 'C:\...\[eval]'` → empty stdout → `exit 1`, no write. (Confirmed via `bash -x` trace + isolating the snippet.)

It is **not** the bun-shim PATH issue — the shim resolves fine.

## Fix

Resolve the lib to a `file://` URL (`cygpath -m` on MSYS, plain absolute path on POSIX), pass it via env var `GSTACK_LIB_URL` (env values are **not** path-mangled), and `await import()` it dynamically (the script already uses top-level await). One-file change in `bin/gstack-learnings-log`.

POSIX/macOS/Linux are unaffected (no `cygpath`; `file://` + absolute path resolves correctly).

## Verification (Windows Git Bash)

- Probe entry logged → `exit=0`, written to `learnings.jsonl` with auto-injected `ts` and `trusted:false`.
- Reject paths intact: invalid `type` and invalid `key` both exit 1 and write nothing.
- `gstack-learnings-search` reads the file cleanly.

Only `gstack-learnings-log` used this inline-absolute-path-in-`-e`-string pattern; other bin scripts use relative imports (`from "../lib/..."`) which bun resolves from the module location regardless of MSYS.