### PR TITLE
Add email & Outlook skills

### DIFF
--- a/bin/gstack-email
+++ b/bin/gstack-email
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: gstack-email send --to RECIPIENT [--subject SUBJECT] [--body TEXT | --body-file PATH] [--from FROM_EMAIL] [--html] [--dry-run]
+
+Environment:
+  SENDGRID_API_KEY     If set, SendGrid API is used. Otherwise falls back to local sendmail/MSMTP.
+  EMAIL_FROM           Default From address if --from not provided.
+
+Examples:
+  gstack-email send --to alice@example.com --subject "Hi" --body "Hello"
+  gstack-email send --to alice@example.com --body-file ./msg.txt --from you@org.com --dry-run
+EOF
+  exit 1
+}
+
+command=""
+if [[ $# -lt 1 ]]; then usage; fi
+command="$1"; shift
+if [[ "$command" != "send" ]]; then usage; fi
+
+TO=""; SUBJECT=""; BODY=""; BODY_FILE=""; FROM="${EMAIL_FROM:-}"; HTML=false; DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --to) TO="$2"; shift 2;;
+    --subject) SUBJECT="$2"; shift 2;;
+    --body) BODY="$2"; shift 2;;
+    --body-file) BODY_FILE="$2"; shift 2;;
+    --from) FROM="$2"; shift 2;;
+    --html) HTML=true; shift;;
+    --dry-run) DRY_RUN=true; shift;;
+    -h|--help) usage;;
+    *) echo "Unknown arg: $1"; usage;;
+  esac
+done
+
+if [[ -z "$TO" ]]; then echo "--to is required" >&2; usage; fi
+if [[ -n "$BODY_FILE" ]]; then
+  if [[ ! -f "$BODY_FILE" ]]; then echo "body-file not found: $BODY_FILE" >&2; exit 2; fi
+  BODY=$(cat "$BODY_FILE")
+fi
+if [[ -z "$BODY" ]]; then echo "Either --body or --body-file must provide a message body" >&2; usage; fi
+if [[ -z "$FROM" ]]; then echo "From address not provided; set EMAIL_FROM env or pass --from" >&2; exit 2; fi
+
+# Prepare MIME body
+boundary="ZZ_BOUNDARY_$(date +%s)"
+if [[ "$HTML" == "true" ]]; then
+  mime_body="--$boundary\nContent-Type: text/html; charset=us-ascii\n\n$BODY\n--$boundary--"
+  content_type="multipart/alternative; boundary=$boundary"
+else
+  mime_body="$BODY"
+  content_type="text/plain; charset=us-ascii"
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "--- DRY RUN: email payload ---"
+  echo "From: $FROM"
+  echo "To: $TO"
+  echo "Subject: $SUBJECT"
+  echo "Content-Type: $content_type"
+  echo
+  echo "$mime_body"
+  echo "--- end ---"
+  exit 0
+fi
+
+# Prefer SendGrid if API key present
+if [[ -n "${SENDGRID_API_KEY:-}" ]]; then
+  # Build content type safely
+  if [[ "$HTML" == "true" ]]; then
+    ctype="text/html"
+  else
+    ctype="text/plain"
+  fi
+  # Pass values via environment to a small python helper to produce safe JSON
+  export _GSTACK_TO="$TO" _GSTACK_FROM="$FROM" _GSTACK_SUBJECT="$SUBJECT" _GSTACK_BODY="$BODY" _GSTACK_CTYPE="$ctype"
+  payload=$(python3 - <<PY
+import os, json
+payload = {
+  "personalizations": [{"to": [{"email": os.environ.get('_GSTACK_TO','')}]}],
+  "from": {"email": os.environ.get('_GSTACK_FROM','')},
+  "subject": os.environ.get('_GSTACK_SUBJECT',''),
+  "content": [{"type": os.environ.get('_GSTACK_CTYPE','text/plain'), "value": os.environ.get('_GSTACK_BODY','')}]
+}
+print(json.dumps(payload))
+PY
+)
+  # Unset the temporary env vars
+  unset _GSTACK_TO _GSTACK_FROM _GSTACK_SUBJECT _GSTACK_BODY _GSTACK_CTYPE
+  # Note: keep payload simple; users can extend for attachments
+  curl -sS --fail -X POST "https://api.sendgrid.com/v3/mail/send" \
+    -H "Authorization: Bearer ${SENDGRID_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "$payload"
+  rc=$?
+  if [[ $rc -ne 0 ]]; then echo "SendGrid send failed (curl rc=$rc)" >&2; exit $rc; fi
+  echo "Email sent via SendGrid to $TO"
+  exit 0
+fi
+
+# Fallback: use sendmail (or msmtp if sendmail not present)
+if command -v /usr/sbin/sendmail >/dev/null 2>&1 || command -v sendmail >/dev/null 2>&1; then
+  SENDMAIL_BIN=$(command -v /usr/sbin/sendmail || command -v sendmail)
+  tmpfile=$(mktemp /tmp/gstack-email.XXXX)
+  {
+    echo "From: $FROM"
+    echo "To: $TO"
+    echo "Subject: $SUBJECT"
+    if [[ "$HTML" == "true" ]]; then
+      echo "MIME-Version: 1.0"
+      echo "Content-Type: $content_type"
+      echo
+      echo "$mime_body"
+    else
+      echo
+      echo "$mime_body"
+    fi
+  } > "$tmpfile"
+  "$SENDMAIL_BIN" -t < "$tmpfile"
+  rc=$?
+  rm -f "$tmpfile"
+  if [[ $rc -ne 0 ]]; then echo "sendmail failed (rc=$rc)" >&2; exit $rc; fi
+  echo "Email sent via sendmail to $TO"
+  exit 0
+fi
+
+echo "No SendGrid key and no sendmail found. To use SendGrid, set SENDGRID_API_KEY. To use SMTP, install/configure sendmail or msmtp and ensure sendmail is on PATH." >&2
+exit 2

--- a/bin/gstack-email-outlook
+++ b/bin/gstack-email-outlook
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: gstack-email-outlook send --to RECIPIENT [--subject SUBJECT] [--body TEXT | --body-file PATH] [--from FROM_EMAIL] [--dry-run]
+
+This uses the Microsoft Outlook desktop app via AppleScript to send from the logged-in Outlook account.
+EOF
+  exit 1
+}
+
+if [[ $# -lt 1 ]]; then usage; fi
+cmd="$1"; shift
+if [[ "$cmd" != "send" ]]; then usage; fi
+
+TO=""; SUBJECT=""; BODY=""; BODY_FILE=""; FROM="${EMAIL_FROM:-}"; DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --to) TO="$2"; shift 2;;
+    --subject) SUBJECT="$2"; shift 2;;
+    --body) BODY="$2"; shift 2;;
+    --body-file) BODY_FILE="$2"; shift 2;;
+    --from) FROM="$2"; shift 2;;
+    --dry-run) DRY_RUN=true; shift;;
+    -h|--help) usage;;
+    *) echo "Unknown arg: $1"; usage;;
+  esac
+done
+
+if [[ -z "$TO" ]]; then echo "--to is required" >&2; usage; fi
+if [[ -n "$BODY_FILE" ]]; then
+  if [[ ! -f "$BODY_FILE" ]]; then echo "body-file not found: $BODY_FILE" >&2; exit 2; fi
+  BODY=$(cat "$BODY_FILE")
+fi
+if [[ -z "$BODY" ]]; then echo "--body is required" >&2; usage; fi
+if [[ -z "$FROM" ]]; then FROM=""; fi
+
+# Escape double quotes for AppleScript literal
+esc_subject=${SUBJECT//\"/\\\"}
+esc_body=${BODY//\"/\\\"}
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "--- DRY RUN: Outlook email ---"
+  echo "To: $TO"
+  echo "From (Outlook account): $FROM"
+  echo "Subject: $SUBJECT"
+  echo
+  echo "$BODY"
+  exit 0
+fi
+
+# Build and run AppleScript to create and send the message
+osascript -e 'tell application "Microsoft Outlook"' \
+          -e "set newMessage to make new outgoing message with properties {subject:\"$esc_subject\", content:\"$esc_body\"}" \
+          -e "make new recipient at newMessage with properties {email address:{address:\"$TO\"}}" \
+          -e "send newMessage" \
+          -e 'end tell'
+
+rc=$?
+if [[ $rc -ne 0 ]]; then echo "Outlook send failed (osascript rc=$rc)" >&2; exit $rc; fi
+
+echo "Email sent via Microsoft Outlook to $TO"

--- a/bin/gstack-graph-setup
+++ b/bin/gstack-graph-setup
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gstack-graph-setup
+# Small helper to scaffold a Microsoft Graph app-registration config and open the
+# Azure App Registrations page. It DOES NOT store secrets remotely.
+
+ROOT_DIR="$(dirname "$0")/.."
+SKILL_DIR="/Users/briankennedyjrm.ed/.claude/skills/gstack"
+CONFIG_PATH="$SKILL_DIR/email/graph-config.example.json"
+
+echo "Scaffolding example Graph config at: $CONFIG_PATH"
+mkdir -p "$(dirname "$CONFIG_PATH")"
+cat > "$CONFIG_PATH" <<'JSON'
+{
+  "client_id": "<PASTE_CLIENT_ID_HERE>",
+  "client_secret": "<PASTE_CLIENT_SECRET_HERE>",
+  "tenant_id": "<PASTE_TENANT_ID_OR_COMMON>",
+  "redirect_uri": "http://localhost:8080/callback",
+  "scopes": ["offline_access","openid","profile","Mail.ReadWrite","Mail.Send","User.Read"]
+}
+JSON
+
+cat <<EOF
+Example config created: $CONFIG_PATH
+
+Next steps (quick):
+  1) In the Azure portal you will register a new app (App registrations → New registration).
+     - Name: gstack-email-agent (or choose your own)
+     - Redirect URI: Web -> http://localhost:8080/callback
+  2) Add API permissions: Microsoft Graph -> Delegated permissions: Mail.Send, Mail.ReadWrite, User.Read, openid, offline_access
+  3) Grant admin consent (if needed for your tenant) or consent during sign-in for personal accounts.
+  4) Create a client secret (Certificates & secrets) and copy Client ID, Tenant ID, and Secret into the example JSON above.
+
+After registration, run this script again with the --validate flag to perform a quick validation (it will attempt a device-code or instruct how to run a local OAuth flow).
+
+Security note: Do NOT commit client_secret to git. Keep it in a local secret store or environment variables.
+
+Opening the Azure App Registrations page in your browser now...
+EOF
+
+# Open Azure App Registrations blade
+open "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade"
+
+exit 0

--- a/email/GRAPH-SETUP.md
+++ b/email/GRAPH-SETUP.md
@@ -1,0 +1,25 @@
+Microsoft Graph setup helper (gstack-graph-setup)
+
+Purpose
+
+This helper scaffolds a local example config for Microsoft Graph app registration and opens the Azure App Registrations page so you can create an app quickly. It does NOT send secrets anywhere.
+
+Quick run
+
+  chmod +x ~/.claude/skills/gstack/bin/gstack-graph-setup
+  ~/.claude/skills/gstack/bin/gstack-graph-setup
+
+What it creates
+
+  ~/.claude/skills/gstack/email/graph-config.example.json — fill in client_id, tenant_id, client_secret after registering the app.
+
+Recommended app registration settings
+
+  - Redirect URI: http://localhost:8080/callback
+  - Delegated scopes: Mail.Send, Mail.ReadWrite, User.Read, openid, offline_access
+  - Create a client secret under Certificates & secrets
+
+Security
+
+  - Never commit client_secret. Use macOS Keychain, ~/.netrc, or env vars for runtime secrets.
+  - The helper is intentionally simple; for automated OAuth flows use the Microsoft Authentication Library (MSAL) in a small script.

--- a/email/OUTLOOK.md
+++ b/email/OUTLOOK.md
@@ -1,0 +1,25 @@
+Outlook desktop integration
+
+This document describes gstack-email-outlook, a small script that sends email via the Microsoft Outlook desktop app using AppleScript.
+
+Usage
+
+1. Make executable:
+   chmod +x ~/.claude/skills/gstack/bin/gstack-email-outlook
+
+2. Send an email:
+   ~/.claude/skills/gstack/bin/gstack-email-outlook send --to recipient@example.com --subject "Hi" --body "Hello"
+
+3. Dry-run to preview:
+   ~/.claude/skills/gstack/bin/gstack-email-outlook send --to recipient@example.com --subject "Hi" --body "Hello" --dry-run
+
+Notes and permissions
+
+- macOS will prompt for automation permission the first time the script controls Outlook.
+- The script uses the logged-in Outlook account to send; the --from flag is informational only (Outlook picks the sending account).
+- For richer HTML messages or attachments, extend the script to use Outlook AppleScript APIs or the Outlook Web API.
+
+Security
+
+- The script does not store credentials. AppleScript uses the Outlook process and the signed-in account.
+- Respect PII: run gstack-redact on message content if it contains sensitive information before sending.

--- a/email/SKILL.md
+++ b/email/SKILL.md
@@ -1,0 +1,36 @@
+gstack email skill
+
+What it does
+
+This skill provides a small CLI (bin/gstack-email) to send one-off emails from the host machine. It prefers the SendGrid API when SENDGRID_API_KEY is set; otherwise it falls back to the local sendmail/msmtp binary (SMTP).
+
+Installation / permission
+
+1. Make the script executable: chmod +x ~/.claude/skills/gstack/bin/gstack-email
+2. Add ~/.claude/skills/gstack/bin to PATH or invoke the script by absolute path.
+
+Usage
+
+  gstack-email send --to RECIPIENT --subject "..." --body "..."
+  gstack-email send --to RECIPIENT --body-file ./message.txt --from you@org.com
+  gstack-email send --to RECIPIENT --subject "Hi" --body "<b>HTML</b>" --html
+  gstack-email send --to RECIPIENT --body "..." --dry-run  # show payload
+
+Environment configuration
+
+  SENDGRID_API_KEY  If set, SendGrid API is used (recommended for reliability).
+  EMAIL_FROM        Default From address if --from not supplied.
+
+Security and redaction
+
+- The skill reads credentials from environment variables; do not commit them.
+- When sending email content that may contain secrets or PII, run bin/gstack-redact on the message first.
+
+Extensibility
+
+- The script is intentionally small and portable. It can be extended to support attachments, multiple recipients, or other providers (SES, Mailgun).
+- For long-running automation or structured templates, prefer writing a small Node/Python tool that reuses this logic or calls an API directly.
+
+Support
+
+Open an issue against the gstack install or ask here for changes (attachment support, OAuth, templates).

--- a/email/graph-config.example.json
+++ b/email/graph-config.example.json
@@ -1,0 +1,7 @@
+{
+  "client_id": "<PASTE_CLIENT_ID_HERE>",
+  "client_secret": "<PASTE_CLIENT_SECRET_HERE>",
+  "tenant_id": "<PASTE_TENANT_ID_OR_COMMON>",
+  "redirect_uri": "http://localhost:8080/callback",
+  "scopes": ["offline_access","openid","profile","Mail.ReadWrite","Mail.Send","User.Read"]
+}


### PR DESCRIPTION
Adds a small email skill (SendGrid fallback), an Outlook AppleScript sender, and a Microsoft Graph setup helper.\n\nSee email/SKILL.md and email/OUTLOOK.md for usage.\n\nThis change was scaffolded locally and includes example configs; client secrets must be added by the operator.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>