### PR TITLE
Fix Codex runtime sidecars for gstack binaries

### DIFF
--- a/hosts/codex.ts
+++ b/hosts/codex.ts
@@ -42,14 +42,14 @@ const codex: HostConfig = {
   ],
 
   runtimeRoot: {
-    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'design/dist', 'make-pdf/dist', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
       'review': ['checklist.md', 'TODOS-format.md'],
     },
   },
   sidecar: {
     path: '.agents/skills/gstack',
-    symlinks: ['bin', 'browse', 'review', 'qa', 'ETHOS.md'],
+    symlinks: ['bin', 'browse', 'design', 'make-pdf', 'review', 'qa', 'ETHOS.md'],
   },
 
   install: {

--- a/scripts/resolvers/browse.ts
+++ b/scripts/resolvers/browse.ts
@@ -1,4 +1,4 @@
-import type { TemplateContext } from './types';
+import { shellRuntimePath, type TemplateContext } from './types';
 import { COMMAND_DESCRIPTIONS } from '../../browse/src/commands';
 import { SNAPSHOT_FLAGS } from '../../browse/src/snapshot';
 
@@ -106,7 +106,7 @@ export function generateBrowseSetup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse" ] && B="$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse"
-[ -z "$B" ] && B="$HOME${ctx.paths.browseDir.replace(/^~/, '')}/browse"
+[ -z "$B" ] && B="${shellRuntimePath(ctx.paths.browseDir)}/browse"
 if [ -x "$B" ]; then
   echo "READY: $B"
 else

--- a/scripts/resolvers/design.ts
+++ b/scripts/resolvers/design.ts
@@ -1,4 +1,4 @@
-import type { TemplateContext } from './types';
+import { shellRuntimePath, type TemplateContext } from './types';
 import { AI_SLOP_BLACKLIST, OPENAI_HARD_REJECTIONS, OPENAI_LITMUS_CHECKS } from './constants';
 
 export function generateDesignReviewLite(ctx: TemplateContext): string {
@@ -792,7 +792,7 @@ export function generateDesignSetup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 D=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design" ] && D="$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design"
-[ -z "$D" ] && D="$HOME${ctx.paths.designDir.replace(/^~/, '')}/design"
+[ -z "$D" ] && D="${shellRuntimePath(ctx.paths.designDir)}/design"
 if [ -x "$D" ]; then
   echo "DESIGN_READY: $D"
 else
@@ -800,7 +800,7 @@ else
 fi
 B=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse" ] && B="$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse"
-[ -z "$B" ] && B="$HOME${ctx.paths.browseDir.replace(/^~/, '')}/browse"
+[ -z "$B" ] && B="${shellRuntimePath(ctx.paths.browseDir)}/browse"
 if [ -x "$B" ]; then
   echo "BROWSE_READY: $B"
 else
@@ -837,7 +837,7 @@ export function generateDesignMockup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 D=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design" ] && D="$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design"
-[ -z "$D" ] && D="$HOME${ctx.paths.designDir.replace(/^~/, '')}/design"
+[ -z "$D" ] && D="${shellRuntimePath(ctx.paths.designDir)}/design"
 [ -x "$D" ] && echo "DESIGN_READY" || echo "DESIGN_NOT_AVAILABLE"
 \`\`\`
 
@@ -1154,4 +1154,3 @@ Flat design can strip away useful visual information that signals interactivity.
 Prioritize ruthlessly: things needed in a hurry go close at hand, everything
 else a few taps away with an obvious path to get there.`;
 }
-

--- a/scripts/resolvers/make-pdf.ts
+++ b/scripts/resolvers/make-pdf.ts
@@ -1,4 +1,4 @@
-import type { TemplateContext } from './types';
+import { shellRuntimePath, type TemplateContext } from './types';
 
 /**
  * {{MAKE_PDF_SETUP}} — emits the shell preamble that resolves $P to the
@@ -19,7 +19,7 @@ _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 P=""
 [ -n "$MAKE_PDF_BIN" ] && [ -x "$MAKE_PDF_BIN" ] && P="$MAKE_PDF_BIN"
 [ -z "$P" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf" ] && P="$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf"
-[ -z "$P" ] && P="$HOME${ctx.paths.makePdfDir.replace(/^~/, '')}/pdf"
+[ -z "$P" ] && P="${shellRuntimePath(ctx.paths.makePdfDir)}/pdf"
 if [ -x "$P" ]; then
   echo "MAKE_PDF_READY: $P"
   alias _p_="$P"   # shellcheck alias helper (not exported)

--- a/scripts/resolvers/types.ts
+++ b/scripts/resolvers/types.ts
@@ -50,6 +50,10 @@ function buildHostPaths(): Record<string, HostPaths> {
 
 export const HOST_PATHS: Record<string, HostPaths> = buildHostPaths();
 
+export function shellRuntimePath(path: string): string {
+  return path.startsWith('$') ? path : `$HOME${path.replace(/^~/, '')}`;
+}
+
 import type { Model } from '../models';
 export type { Model } from '../models';
 

--- a/setup
+++ b/setup
@@ -749,7 +749,7 @@ create_agents_sidecar() {
   mkdir -p "$agents_gstack"
 
   # Sidecar directories that skills reference at runtime
-  for asset in bin browse review qa; do
+  for asset in bin browse design make-pdf review qa; do
     local src="$SOURCE_GSTACK_DIR/$asset"
     local dst="$agents_gstack/$asset"
     if [ -d "$src" ] || [ -f "$src" ]; then
@@ -788,7 +788,7 @@ create_codex_runtime_root() {
     rm -rf "$codex_gstack"
   fi
 
-  mkdir -p "$codex_gstack" "$codex_gstack/browse" "$codex_gstack/gstack-upgrade" "$codex_gstack/review"
+  mkdir -p "$codex_gstack" "$codex_gstack/browse" "$codex_gstack/design" "$codex_gstack/make-pdf" "$codex_gstack/gstack-upgrade" "$codex_gstack/review"
 
   if [ -f "$agents_dir/gstack/SKILL.md" ]; then
     _link_or_copy "$agents_dir/gstack/SKILL.md" "$codex_gstack/SKILL.md"
@@ -801,6 +801,12 @@ create_codex_runtime_root() {
   fi
   if [ -d "$gstack_dir/browse/bin" ]; then
     _link_or_copy "$gstack_dir/browse/bin" "$codex_gstack/browse/bin"
+  fi
+  if [ -d "$gstack_dir/design/dist" ]; then
+    _link_or_copy "$gstack_dir/design/dist" "$codex_gstack/design/dist"
+  fi
+  if [ -d "$gstack_dir/make-pdf/dist" ]; then
+    _link_or_copy "$gstack_dir/make-pdf/dist" "$codex_gstack/make-pdf/dist"
   fi
   if [ -f "$agents_dir/gstack-upgrade/SKILL.md" ]; then
     _link_or_copy "$agents_dir/gstack-upgrade/SKILL.md" "$codex_gstack/gstack-upgrade/SKILL.md"

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -23,7 +23,7 @@ import {
   cursor,
   openclaw,
 } from '../hosts/index';
-import { HOST_PATHS } from '../scripts/resolvers/types';
+import { HOST_PATHS, shellRuntimePath } from '../scripts/resolvers/types';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 
@@ -255,6 +255,13 @@ describe('HOST_PATHS derivation from configs', () => {
     expect(HOST_PATHS.codex.binDir).toBe('$GSTACK_BIN');
     expect(HOST_PATHS.codex.browseDir).toBe('$GSTACK_BROWSE');
     expect(HOST_PATHS.codex.designDir).toBe('$GSTACK_DESIGN');
+  });
+
+  test('shellRuntimePath does not prepend $HOME to env var paths', () => {
+    expect(shellRuntimePath('$GSTACK_BROWSE')).toBe('$GSTACK_BROWSE');
+    expect(shellRuntimePath('$GSTACK_DESIGN')).toBe('$GSTACK_DESIGN');
+    expect(shellRuntimePath('$GSTACK_MAKE_PDF')).toBe('$GSTACK_MAKE_PDF');
+    expect(shellRuntimePath('~/.codex/skills/gstack/browse/dist')).toBe('$HOME/.codex/skills/gstack/browse/dist');
   });
 
   test('every host with usesEnvVars=true gets env var paths', () => {
@@ -534,5 +541,14 @@ describe('host config correctness', () => {
       expect(config.runtimeRoot.globalSymlinks).toContain('bin');
       expect(config.runtimeRoot.globalSymlinks).toContain('ETHOS.md');
     }
+  });
+
+  test('Codex runtime exposes binary sidecars used by generated skills', () => {
+    expect(codex.runtimeRoot.globalSymlinks).toContain('browse/dist');
+    expect(codex.runtimeRoot.globalSymlinks).toContain('design/dist');
+    expect(codex.runtimeRoot.globalSymlinks).toContain('make-pdf/dist');
+    expect(codex.sidecar?.symlinks).toContain('browse');
+    expect(codex.sidecar?.symlinks).toContain('design');
+    expect(codex.sidecar?.symlinks).toContain('make-pdf');
   });
 });


### PR DESCRIPTION
## Summary
- Preserve env-var runtime paths like `` instead of generating broken `/Users/brocgustafson` fallbacks.
- Expose `design/dist` and `make-pdf/dist` in the Codex runtime root and repo sidecar so generated skills can resolve their binaries.
- Add host-config coverage for the env-var path helper and Codex sidecar assets.

## Verification
- `git diff --check -- hosts/codex.ts scripts/resolvers/browse.ts scripts/resolvers/design.ts scripts/resolvers/make-pdf.ts scripts/resolvers/types.ts setup test/host-config.test.ts`
- `bun run gen:skill-docs --host codex --dry-run`
- `bun test test/host-config.test.ts` passes the new assertions, but this local Codex session still fails the pre-existing assertion `detect finds claude (since we are running in claude)` because detection returns `codex\nhermes` here.
