### PR TITLE
feat(autoplan): unattended-mode gates + confidence-gated escalation

### DIFF
--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -886,7 +886,8 @@ Examples: run codex (always yes), run evals (always yes), reduce scope on a comp
 **User Challenge** — both models agree the user's stated direction should change.
 This is qualitatively different from taste decisions. When Claude and Codex both
 recommend merging, splitting, adding, or removing features/skills/workflows that
-the user specified, this is a User Challenge. It is NEVER auto-decided.
+the user specified, this is a User Challenge. It is NEVER auto-decided. (In unattended
+runs it is parked, not silently accepted — see Unattended Mode.)
 
 User Challenges go to the final approval gate with richer context than taste
 decisions:
@@ -904,6 +905,25 @@ change, not the other way around.
 feasibility blocker (not a preference), the AskUserQuestion framing explicitly
 warns: "Both models believe this is a security/feasibility risk, not just a
 preference." The user still decides, but the framing is appropriately urgent.
+
+---
+
+## Decision Confidence — escalate the coin-flips
+
+Every auto-decision carries a confidence score (1-10), using the same rubric as finding
+confidence: 9-10 verified by reading specific code; 7-8 high-confidence pattern; 5-6 moderate,
+could go either way; 3-4 low; 1-2 speculation.
+
+**Escalation rule:** a **Taste** decision scored **below the threshold** (default 6; override
+with `gstack-config get autoplan_escalate_below`) is escalated instead of silently
+auto-decided — to the Final Approval Gate when a human is present, or to the Unattended Mode
+pending-queue when not. A near-coin-flip is not a call the 6 principles should make alone.
+Mechanical decisions and Taste decisions at or above the threshold auto-decide as before. This
+rule never downgrades a User Challenge (those are always surfaced) and never overrides the
+two hard gates.
+
+Record the score in the Decision Audit Trail `Confidence` column. When a decision is escalated
+for low confidence, set its Rationale to `escalated: confidence N/10 < threshold`.
 
 ---
 
@@ -949,6 +969,57 @@ AskUserQuestion: you do, using the 6 principles, instead of the user.
 "No issues found" is a valid output for a section — but only after doing the analysis.
 State what you examined and why nothing was flagged (1-2 sentences minimum).
 "Skipped" is never valid for a non-skip-listed section.
+
+---
+
+## Unattended Mode — the two gates when no human is watching
+
+`/autoplan` is built to run unattended: spawned by an orchestrator (OpenClaw sets
+`OPENCLAW_SESSION`, surfaced as `SPAWNED_SESSION: true` in the preamble echo), batched
+across parallel sprints, or in a host that disables interactive prompts (Conductor runs
+`--disallowedTools AskUserQuestion`). Treat the run as unattended when ANY of these hold:
+`SPAWNED_SESSION: true` in the preamble echo, no AskUserQuestion variant is callable, or
+`gstack-config get autoplan_unattended` returns `true`.
+
+The generic preamble tells spawned sessions to "auto-choose the recommended option." That
+rule is correct for **Mechanical** and **Taste** decisions. **It does NOT apply to the two
+hard gates** — premise confirmation (Phase 1) and User Challenges. Silently accepting the
+default on those is exactly the high-stakes judgment the rest of this skill refuses to
+automate. When unattended, PARK them instead of auto-accepting:
+
+**1. Park, don't silently accept.** Append one row per gate to a durable queue artifact
+(create the project dir first):
+
+```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)" && mkdir -p ~/.gstack/projects/$SLUG
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-')
+PENDING="$HOME/.gstack/projects/$SLUG/$BRANCH-autoplan-pending-$(date +%Y%m%d-%H%M%S).jsonl"
+```
+
+Write each row with `jq -nc` (never hand-rolled echo), one JSON object per line:
+`{"kind":"premise|user_challenge","phase":"ceo|design|eng|dx","default":"<documented default>","context":"<full gate context: what the user said, what both models recommend, why, blind spots, cost-if-wrong>","security_flag":false,"resolved":false}`
+
+**2. Parking policy by kind:**
+- **Premise gate** → proceed on the user's stated premises (the documented default) and tag
+  the run `PENDING_PREMISE_REVIEW`. Do not invent or "improve" premises unattended.
+- **User Challenge** → keep the user's original direction (already the default) and tag
+  `PENDING_CHALLENGE`. Two models agreeing does not let them silently overrule an absent human.
+- **Security/feasibility-flagged challenge** (both models call it a risk, not a preference)
+  → **HALT.** Write the row with `"security_flag":true`, report
+  `BLOCKED — security/feasibility challenge requires human review`, and stop. Never proceed
+  unattended past a flagged security risk. This is the one sanctioned stop (see Important Rules).
+
+**3. Notify (optional).** If `gstack-config get notify_webhook` returns a URL, POST a
+one-line summary to it (parked-decision count + the resume command). No webhook configured →
+no-op, zero cost.
+
+**4. Resume.** When a human returns, `/autoplan --resume` reads the newest
+`*-autoplan-pending-*.jsonl`, replays each unresolved row as a real AskUserQuestion using its
+stored context, applies the answers, marks rows `"resolved":true`, and continues to the Final
+Approval Gate.
+
+When AskUserQuestion IS available (a normal interactive run), Unattended Mode changes nothing —
+the two gates behave exactly as specified elsewhere in this skill.
 
 ---
 
@@ -1081,7 +1152,8 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 - Mode selection: SELECTIVE EXPANSION
 - Premises: accept reasonable ones (P6), challenge only clearly wrong ones
 - **GATE: Present premises to user for confirmation** — this is the ONE AskUserQuestion
-  that is NOT auto-decided. Premises require human judgment.
+  that is NOT auto-decided. Premises require human judgment. In an unattended run, park this
+  gate per Unattended Mode (proceed on the stated premises, tag `PENDING_PREMISE_REVIEW`).
 - Alternatives: pick highest completeness (P1). If tied, pick simplest (P5).
   If top 2 are close → mark TASTE DECISION.
 - Scope expansion: in blast radius + <1d CC → approve (P2). Outside → defer to TODOS.md (P3).
@@ -1507,8 +1579,8 @@ After each auto-decision, append a row to the plan file using Edit:
 <!-- AUTONOMOUS DECISION LOG -->
 ## Decision Audit Trail
 
-| # | Phase | Decision | Classification | Principle | Rationale | Rejected |
-|---|-------|----------|-----------|-----------|----------|
+| # | Phase | Decision | Classification | Confidence | Principle | Rationale | Rejected |
+|---|-------|----------|----------------|-----------|-----------|----------|----------|
 ```
 
 Write one row per decision incrementally (via Edit). This keeps the audit on disk,
@@ -1779,8 +1851,9 @@ Suggest next step: `/ship` when ready to create the PR.
 
 ## Important Rules
 
-- **Never abort.** The user chose /autoplan. Respect that choice. Surface all taste decisions, never redirect to interactive review.
-- **Two gates.** The non-auto-decided AskUserQuestions are: (1) premise confirmation in Phase 1, and (2) User Challenges — when both models agree the user's stated direction should change. Everything else is auto-decided using the 6 principles.
+- **Never abort.** The user chose /autoplan. Respect that choice. Surface all taste decisions, never redirect to interactive review. (One sanctioned stop: a security/feasibility-flagged User Challenge in an unattended run HALTS with `BLOCKED` — see Unattended Mode.)
+- **Two gates.** The non-auto-decided AskUserQuestions are: (1) premise confirmation in Phase 1, and (2) User Challenges — when both models agree the user's stated direction should change. Everything else is auto-decided using the 6 principles. In unattended/spawned runs these two gates are parked to a pending-decisions queue and resumed with `/autoplan --resume`, never silently auto-accepted (see Unattended Mode).
+- **Confidence-gated escalation.** Every auto-decision carries a 1-10 confidence score. A Taste decision below the threshold (default 6, `autoplan_escalate_below`) is escalated, not silently auto-decided (see Decision Confidence).
 - **Log every decision.** No silent auto-decisions. Every choice gets a row in the audit trail.
 - **Full depth means full depth.** Do not compress or skip sections from the loaded skill files (except the skip list in Phase 0). "Full depth" means: read the code the section asks you to read, produce the outputs the section requires, identify every issue, and decide each one. A one-sentence summary of a section is not "full depth" — it is a skip. If you catch yourself writing fewer than 3 sentences for any review section, you are likely compressing.
 - **Artifacts are deliverables.** Test plan artifact, failure modes registry, error/rescue table, ASCII diagrams — these must exist on disk or in the plan file when the review completes. If they don't exist, the review is incomplete.

--- a/autoplan/SKILL.md.tmpl
+++ b/autoplan/SKILL.md.tmpl
@@ -81,7 +81,8 @@ Examples: run codex (always yes), run evals (always yes), reduce scope on a comp
 **User Challenge** — both models agree the user's stated direction should change.
 This is qualitatively different from taste decisions. When Claude and Codex both
 recommend merging, splitting, adding, or removing features/skills/workflows that
-the user specified, this is a User Challenge. It is NEVER auto-decided.
+the user specified, this is a User Challenge. It is NEVER auto-decided. (In unattended
+runs it is parked, not silently accepted — see Unattended Mode.)
 
 User Challenges go to the final approval gate with richer context than taste
 decisions:
@@ -99,6 +100,10 @@ change, not the other way around.
 feasibility blocker (not a preference), the AskUserQuestion framing explicitly
 warns: "Both models believe this is a security/feasibility risk, not just a
 preference." The user still decides, but the framing is appropriately urgent.
+
+---
+
+{{DECISION_CONFIDENCE}}
 
 ---
 
@@ -144,6 +149,10 @@ AskUserQuestion: you do, using the 6 principles, instead of the user.
 "No issues found" is a valid output for a section — but only after doing the analysis.
 State what you examined and why nothing was flagged (1-2 sentences minimum).
 "Skipped" is never valid for a non-skip-listed section.
+
+---
+
+{{AUTOPLAN_UNATTENDED}}
 
 ---
 
@@ -276,7 +285,8 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 - Mode selection: SELECTIVE EXPANSION
 - Premises: accept reasonable ones (P6), challenge only clearly wrong ones
 - **GATE: Present premises to user for confirmation** — this is the ONE AskUserQuestion
-  that is NOT auto-decided. Premises require human judgment.
+  that is NOT auto-decided. Premises require human judgment. In an unattended run, park this
+  gate per Unattended Mode (proceed on the stated premises, tag `PENDING_PREMISE_REVIEW`).
 - Alternatives: pick highest completeness (P1). If tied, pick simplest (P5).
   If top 2 are close → mark TASTE DECISION.
 - Scope expansion: in blast radius + <1d CC → approve (P2). Outside → defer to TODOS.md (P3).
@@ -702,8 +712,8 @@ After each auto-decision, append a row to the plan file using Edit:
 <!-- AUTONOMOUS DECISION LOG -->
 ## Decision Audit Trail
 
-| # | Phase | Decision | Classification | Principle | Rationale | Rejected |
-|---|-------|----------|-----------|-----------|----------|
+| # | Phase | Decision | Classification | Confidence | Principle | Rationale | Rejected |
+|---|-------|----------|----------------|-----------|-----------|----------|----------|
 ```
 
 Write one row per decision incrementally (via Edit). This keeps the audit on disk,
@@ -901,8 +911,9 @@ Suggest next step: `/ship` when ready to create the PR.
 
 ## Important Rules
 
-- **Never abort.** The user chose /autoplan. Respect that choice. Surface all taste decisions, never redirect to interactive review.
-- **Two gates.** The non-auto-decided AskUserQuestions are: (1) premise confirmation in Phase 1, and (2) User Challenges — when both models agree the user's stated direction should change. Everything else is auto-decided using the 6 principles.
+- **Never abort.** The user chose /autoplan. Respect that choice. Surface all taste decisions, never redirect to interactive review. (One sanctioned stop: a security/feasibility-flagged User Challenge in an unattended run HALTS with `BLOCKED` — see Unattended Mode.)
+- **Two gates.** The non-auto-decided AskUserQuestions are: (1) premise confirmation in Phase 1, and (2) User Challenges — when both models agree the user's stated direction should change. Everything else is auto-decided using the 6 principles. In unattended/spawned runs these two gates are parked to a pending-decisions queue and resumed with `/autoplan --resume`, never silently auto-accepted (see Unattended Mode).
+- **Confidence-gated escalation.** Every auto-decision carries a 1-10 confidence score. A Taste decision below the threshold (default 6, `autoplan_escalate_below`) is escalated, not silently auto-decided (see Decision Confidence).
 - **Log every decision.** No silent auto-decisions. Every choice gets a row in the audit trail.
 - **Full depth means full depth.** Do not compress or skip sections from the loaded skill files (except the skip list in Phase 0). "Full depth" means: read the code the section asks you to read, produce the outputs the section requires, identify every issue, and decide each one. A one-sentence summary of a section is not "full depth" — it is a skip. If you catch yourself writing fewer than 3 sentences for any review section, you are likely compressing.
 - **Artifacts are deliverables.** Test plan artifact, failure modes registry, error/rescue table, ASCII diagrams — these must exist on disk or in the plan file when the review completes. If they don't exist, the review is incomplete.

--- a/scripts/resolvers/autoplan-unattended.ts
+++ b/scripts/resolvers/autoplan-unattended.ts
@@ -1,0 +1,73 @@
+/**
+ * Autoplan Unattended Mode resolver (G1 + G2)
+ *
+ * /autoplan is built to run unattended — spawned by an orchestrator (OpenClaw),
+ * batched across parallel sprints, or in a host that disables AskUserQuestion
+ * (Conductor runs `--disallowedTools AskUserQuestion`). The generic preamble
+ * tells spawned sessions to "auto-choose the recommended option," but autoplan
+ * has TWO gates it refuses to auto-decide: premise confirmation and User
+ * Challenges. Before this resolver, those gates silently collapsed to their
+ * default in any unattended run — the exact high-stakes judgment the skill is
+ * built to never automate (regression documented in CHANGELOG: the autoplan
+ * E2E bailed at the premise gate under `--disallowedTools AskUserQuestion`).
+ *
+ * This block defines the unattended contract: PARK the two gates to a durable
+ * pending-decisions queue, keep the user's original direction as the default,
+ * HALT on security/feasibility-flagged challenges, optionally notify a webhook,
+ * and resume with `/autoplan --resume`. Interactive runs are unchanged.
+ *
+ * Scoped to autoplan on purpose: the SPAWNED_SESSION rule lives in the shared
+ * preamble, so refining it here (not there) keeps the blast radius to one skill.
+ */
+import type { TemplateContext } from './types';
+
+export function generateAutoplanUnattended(_ctx: TemplateContext): string {
+  return `## Unattended Mode — the two gates when no human is watching
+
+\`/autoplan\` is built to run unattended: spawned by an orchestrator (OpenClaw sets
+\`OPENCLAW_SESSION\`, surfaced as \`SPAWNED_SESSION: true\` in the preamble echo), batched
+across parallel sprints, or in a host that disables interactive prompts (Conductor runs
+\`--disallowedTools AskUserQuestion\`). Treat the run as unattended when ANY of these hold:
+\`SPAWNED_SESSION: true\` in the preamble echo, no AskUserQuestion variant is callable, or
+\`gstack-config get autoplan_unattended\` returns \`true\`.
+
+The generic preamble tells spawned sessions to "auto-choose the recommended option." That
+rule is correct for **Mechanical** and **Taste** decisions. **It does NOT apply to the two
+hard gates** — premise confirmation (Phase 1) and User Challenges. Silently accepting the
+default on those is exactly the high-stakes judgment the rest of this skill refuses to
+automate. When unattended, PARK them instead of auto-accepting:
+
+**1. Park, don't silently accept.** Append one row per gate to a durable queue artifact
+(create the project dir first):
+
+\`\`\`bash
+eval "$(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)" && mkdir -p ~/.gstack/projects/$SLUG
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-')
+PENDING="$HOME/.gstack/projects/$SLUG/$BRANCH-autoplan-pending-$(date +%Y%m%d-%H%M%S).jsonl"
+\`\`\`
+
+Write each row with \`jq -nc\` (never hand-rolled echo), one JSON object per line:
+\`{"kind":"premise|user_challenge","phase":"ceo|design|eng|dx","default":"<documented default>","context":"<full gate context: what the user said, what both models recommend, why, blind spots, cost-if-wrong>","security_flag":false,"resolved":false}\`
+
+**2. Parking policy by kind:**
+- **Premise gate** → proceed on the user's stated premises (the documented default) and tag
+  the run \`PENDING_PREMISE_REVIEW\`. Do not invent or "improve" premises unattended.
+- **User Challenge** → keep the user's original direction (already the default) and tag
+  \`PENDING_CHALLENGE\`. Two models agreeing does not let them silently overrule an absent human.
+- **Security/feasibility-flagged challenge** (both models call it a risk, not a preference)
+  → **HALT.** Write the row with \`"security_flag":true\`, report
+  \`BLOCKED — security/feasibility challenge requires human review\`, and stop. Never proceed
+  unattended past a flagged security risk. This is the one sanctioned stop (see Important Rules).
+
+**3. Notify (optional).** If \`gstack-config get notify_webhook\` returns a URL, POST a
+one-line summary to it (parked-decision count + the resume command). No webhook configured →
+no-op, zero cost.
+
+**4. Resume.** When a human returns, \`/autoplan --resume\` reads the newest
+\`*-autoplan-pending-*.jsonl\`, replays each unresolved row as a real AskUserQuestion using its
+stored context, applies the answers, marks rows \`"resolved":true\`, and continues to the Final
+Approval Gate.
+
+When AskUserQuestion IS available (a normal interactive run), Unattended Mode changes nothing —
+the two gates behave exactly as specified elsewhere in this skill.`;
+}

--- a/scripts/resolvers/confidence.ts
+++ b/scripts/resolvers/confidence.ts
@@ -79,3 +79,30 @@ confirms it IS a real issue, that is a calibration event. Your initial confidenc
 too low. Log the corrected pattern as a learning so future reviews catch it with
 higher confidence.`;
 }
+
+/**
+ * Decision confidence resolver (G7) — for skills that AUTO-DECIDE rather than
+ * report findings (e.g. /autoplan). Reuses the 1-10 rubric above, but applies
+ * it to each auto-decision and adds an escalation threshold: a Taste decision
+ * scored below the threshold is surfaced to a human instead of silently
+ * auto-resolved. Without this, a near-coin-flip taste call is auto-decided
+ * identically to a clear one — dangerous precisely when no human is watching.
+ */
+export function generateDecisionConfidence(_ctx: TemplateContext): string {
+  return `## Decision Confidence — escalate the coin-flips
+
+Every auto-decision carries a confidence score (1-10), using the same rubric as finding
+confidence: 9-10 verified by reading specific code; 7-8 high-confidence pattern; 5-6 moderate,
+could go either way; 3-4 low; 1-2 speculation.
+
+**Escalation rule:** a **Taste** decision scored **below the threshold** (default 6; override
+with \`gstack-config get autoplan_escalate_below\`) is escalated instead of silently
+auto-decided — to the Final Approval Gate when a human is present, or to the Unattended Mode
+pending-queue when not. A near-coin-flip is not a call the 6 principles should make alone.
+Mechanical decisions and Taste decisions at or above the threshold auto-decide as before. This
+rule never downgrades a User Challenge (those are always surfaced) and never overrides the
+two hard gates.
+
+Record the score in the Decision Audit Trail \`Confidence\` column. When a decision is escalated
+for low confidence, set its Rationale to \`escalated: confidence N/10 < threshold\`.`;
+}

--- a/scripts/resolvers/index.ts
+++ b/scripts/resolvers/index.ts
@@ -25,7 +25,8 @@ import { generateTestBootstrap, generateTestCoverageAuditPlan, generateTestCover
 import { generateReviewDashboard, generatePlanFileReviewReport, generateExitPlanModeGate, generateAntiShortcutClause, generateSpecReviewLoop, generateBenefitsFrom, generateCodexSecondOpinion, generateAdversarialStep, generateCodexPlanReview, generatePlanCompletionAuditShip, generatePlanCompletionAuditReview, generatePlanVerificationExec, generateScopeDrift, generateCrossReviewDedup } from './review';
 import { generateSlugEval, generateSlugSetup, generateBaseBranchDetect, generateDeployBootstrap, generateQAMethodology, generateCoAuthorTrailer, generateChangelogWorkflow } from './utility';
 import { generateLearningsSearch, generateLearningsLog } from './learnings';
-import { generateConfidenceCalibration } from './confidence';
+import { generateConfidenceCalibration, generateDecisionConfidence } from './confidence';
+import { generateAutoplanUnattended } from './autoplan-unattended';
 import { generateInvokeSkill } from './composition';
 import { generateReviewArmy } from './review-army';
 import { generateDxFramework } from './dx';
@@ -80,6 +81,8 @@ export const RESOLVERS: Record<string, ResolverValue> = {
   LEARNINGS_SEARCH: generateLearningsSearch,
   LEARNINGS_LOG: generateLearningsLog,
   CONFIDENCE_CALIBRATION: generateConfidenceCalibration,
+  DECISION_CONFIDENCE: generateDecisionConfidence,
+  AUTOPLAN_UNATTENDED: generateAutoplanUnattended,
   INVOKE_SKILL: generateInvokeSkill,
   CHANGELOG_WORKFLOW: generateChangelogWorkflow,
   REVIEW_ARMY: generateReviewArmy,

--- a/test/resolver-autoplan-unattended.test.ts
+++ b/test/resolver-autoplan-unattended.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Autoplan Unattended Mode (G1+G2) + Decision Confidence (G7) — gate-tier
+ * assertions on the generated prose and resolver wiring.
+ *
+ * These are the load-bearing strings the feature depends on. They're prose the
+ * agent obeys at runtime, so this can't test agent compliance — it asserts the
+ * blocks are present, registered, and composed into the generated autoplan
+ * SKILL.md. (Agent-compliance is the periodic E2E auto-mode test.)
+ *
+ * What this enforces:
+ * - Unattended Mode parks the two hard gates instead of silently auto-accepting
+ * - Security/feasibility-flagged challenges HALT, not proceed
+ * - A resume path exists (/autoplan --resume + pending-queue artifact)
+ * - Decision Confidence adds an escalation threshold for low-confidence taste calls
+ * - Both resolvers are registered in RESOLVERS and wired into autoplan/SKILL.md
+ * - No unescaped `${` interpolation leaked into the bash (template-literal hazard)
+ */
+import { describe, test, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { TemplateContext } from '../scripts/resolvers/types';
+import { HOST_PATHS } from '../scripts/resolvers/types';
+import { generateAutoplanUnattended } from '../scripts/resolvers/autoplan-unattended';
+import { generateDecisionConfidence } from '../scripts/resolvers/confidence';
+import { RESOLVERS } from '../scripts/resolvers/index';
+
+function makeCtx(host: 'claude' | 'codex' = 'claude'): TemplateContext {
+  return {
+    skillName: 'autoplan',
+    tmplPath: 'autoplan/SKILL.md.tmpl',
+    host,
+    paths: HOST_PATHS[host],
+    preambleTier: 3,
+  };
+}
+
+describe('Autoplan Unattended Mode resolver (G1+G2)', () => {
+  const out = generateAutoplanUnattended(makeCtx());
+
+  test('parks the two hard gates instead of silently auto-accepting', () => {
+    expect(out).toContain('## Unattended Mode');
+    expect(out).toContain('PARK them instead of auto-accepting');
+    expect(out).toContain('PENDING_PREMISE_REVIEW');
+    expect(out).toContain('PENDING_CHALLENGE');
+  });
+
+  test('writes a durable pending-decisions queue artifact', () => {
+    expect(out).toContain('autoplan-pending');
+    expect(out).toMatch(/\.jsonl/);
+    expect(out).toContain('"resolved":false');
+  });
+
+  test('HALTS on a security/feasibility-flagged challenge', () => {
+    expect(out).toContain('"security_flag":true');
+    expect(out).toContain('BLOCKED — security/feasibility challenge requires human review');
+  });
+
+  test('offers an async notify hook and a resume path', () => {
+    expect(out).toContain('notify_webhook');
+    expect(out).toContain('/autoplan --resume');
+  });
+
+  test('is a no-op when AskUserQuestion is available (interactive unchanged)', () => {
+    expect(out).toMatch(/interactive run.*changes nothing|changes nothing.*interactive/);
+  });
+
+  test('no unescaped ${ interpolation leaked into the bash', () => {
+    // The embedded bash uses $BRANCH/$SLUG/$HOME (no braces) precisely so the
+    // TS template literal does not interpolate. A literal "${" in the output
+    // would mean an interpolation hazard slipped through.
+    expect(out).not.toContain('${');
+  });
+});
+
+describe('Decision Confidence resolver (G7)', () => {
+  const out = generateDecisionConfidence(makeCtx());
+
+  test('adds a 1-10 score and an escalation threshold for taste calls', () => {
+    expect(out).toContain('## Decision Confidence');
+    expect(out).toContain('autoplan_escalate_below');
+    expect(out).toMatch(/below the threshold/i);
+    expect(out).toContain('escalated: confidence N/10 < threshold');
+  });
+
+  test('never downgrades a User Challenge or the two hard gates', () => {
+    expect(out).toMatch(/never downgrades a User Challenge/);
+    expect(out).toMatch(/never overrides the\s+two hard gates/);
+  });
+});
+
+describe('resolver registration + template wiring', () => {
+  test('both resolvers are registered in RESOLVERS', () => {
+    expect(RESOLVERS.AUTOPLAN_UNATTENDED).toBeDefined();
+    expect(RESOLVERS.DECISION_CONFIDENCE).toBeDefined();
+  });
+
+  test('generated autoplan/SKILL.md composes both blocks (token wired + regenerated)', () => {
+    const skillMd = fs.readFileSync(
+      path.join(import.meta.dir, '..', 'autoplan', 'SKILL.md'),
+      'utf-8',
+    );
+    expect(skillMd).toContain('## Unattended Mode');
+    expect(skillMd).toContain('## Decision Confidence');
+    expect(skillMd).toContain('/autoplan --resume');
+    // Audit-trail table gained the Confidence column
+    expect(skillMd).toContain('| # | Phase | Decision | Classification | Confidence | Principle | Rationale | Rejected |');
+  });
+});


### PR DESCRIPTION
## What & why

`/autoplan` is built to run unattended — spawned by OpenClaw, batched across parallel sprints, or in a host that disables interactive prompts (Conductor runs `--disallowedTools AskUserQuestion`). But its two *never-auto-decided* gates — **premise confirmation** (Phase 1) and **User Challenges** — silently collapsed to their default whenever `AskUserQuestion` was unavailable, because `SPAWNED_SESSION` mode says "auto-choose the recommended option." That auto-accepts exactly the high-stakes judgment the skill otherwise refuses to automate. (The CHANGELOG already documents the symptom: the autoplan E2E bails at the premise gate under `--disallowedTools AskUserQuestion`, and the gates were "broken in any Conductor session.")

This PR closes that gap with two small, composable changes.

### 1. Unattended Mode (G1 + G2)

A new **autoplan-local** override — deliberately scoped to this skill, *not* the shared `{{PREAMBLE}}`, to keep the blast radius to one skill. When unattended (`SPAWNED_SESSION: true`, no AUQ variant callable, or `autoplan_unattended` config), the two hard gates are **parked, not silently accepted**:

- **Park** each premise / User-Challenge to a durable `*-autoplan-pending-*.jsonl` queue (one row per gate, full context).
- **Keep the user's original direction** as the default (`PENDING_PREMISE_REVIEW` / `PENDING_CHALLENGE`). Two models agreeing doesn't let them silently overrule an absent human.
- **HALT** on a security/feasibility-flagged challenge (`BLOCKED — …`). One sanctioned stop, never a silent proceed.
- **Notify** an optional `notify_webhook` (no-op if unset).
- **Resume** with `/autoplan --resume`, which replays each parked row as a real `AskUserQuestion`.

Interactive runs are unchanged — when AUQ is available, the gates behave exactly as before.

### 2. Decision Confidence (G7)

Every auto-decision now carries a 1–10 score (reusing the existing `confidence.ts` rubric). A **Taste** decision scored **below a configurable threshold** (`autoplan_escalate_below`, default 6) is escalated to the gate — or to the pending queue when unattended — instead of silently auto-decided. A near-coin-flip shouldn't be a call the 6 principles make alone. Mechanical decisions and clear taste calls auto-decide as before; User Challenges and the two hard gates are never downgraded. Adds a `Confidence` column to the Decision Audit Trail.

## Implementation

- `scripts/resolvers/autoplan-unattended.ts` — new `{{AUTOPLAN_UNATTENDED}}` resolver
- `scripts/resolvers/confidence.ts` — new `generateDecisionConfidence` (`{{DECISION_CONFIDENCE}}`)
- `scripts/resolvers/index.ts` — register both tokens
- `autoplan/SKILL.md.tmpl` — wire both blocks + gate pointers + audit column + Important Rules
- `autoplan/SKILL.md` — regenerated (`bun run gen:skill-docs`)
- `test/resolver-autoplan-unattended.test.ts` — 10 gate-tier assertions

New config keys (free-form, default-on-absent): `autoplan_unattended`, `notify_webhook`, `autoplan_escalate_below`.

## Testing

- New test: **10/10 pass**
- `gen:skill-docs --host all --dry-run`: **0 stale**
- Guards green: idempotency, gen-skill-docs, spec-template-sync, template-context-parity, resolver-entry, touchfiles, skill-validation, budget-regression, collision-sentinel, llms-txt-shape, docs-config-keys, version, parity, coverage-floor (~1170 assertions, 0 failures)

## Notes

- **Backward-compatible:** interactive behavior is unchanged; the new behavior only fires when AUQ is unavailable or config opts in.
- Left `VERSION` / `CHANGELOG` to your release flow to avoid conflicts — happy to add a bump if you prefer.
- Origin: a focused audit of `/autoplan` against its unattended/parallel ICP. Two further gaps from that audit — risk-aware principles keyed on `REPO_MODE`, and a post-implementation `/autoreview` sibling — are intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
