### PR TITLE
fix(auq-hook): stop emitting permissionDecision:'defer' — silently breaks AUQ

### DIFF
--- a/docs/spikes/claude-code-hook-mutation.md
+++ b/docs/spikes/claude-code-hook-mutation.md
@@ -51,7 +51,17 @@ Optional in subagent context: `agent_id`, `agent_type`.
 - `"deny"` — block (feedback to Claude, NOT a synthetic answer per Codex
   correction in D-prefixed decisions)
 - `"ask"` — escalate to user
-- `"defer"` — let permission flow continue
+
+**Important (issue #2035):** `"defer"` is documented in some references as
+"let permission flow continue," but **do not emit it**. Recent Claude Code
+builds (Opus 4.8 era, June 2026+) reject a `permissionDecision: "defer"`
+output and abort the AUQ tool call with
+`[Tool result missing due to internal error]`. The actual "no decision /
+proceed via the normal permission flow" contract is **exit 0 with no
+stdout** (or, if you have `additionalContext` to inject, exit 0 + a
+`hookSpecificOutput` payload with **only** `additionalContext` — no
+`permissionDecision` field at all). This is the contract
+`hosts/claude/hooks/question-preference-hook.ts` now follows.
 
 **`updatedInput` semantics:** shallow merge of fields present in the returned
 object onto the original `tool_input`. Only valid with
@@ -88,7 +98,9 @@ required for our hook to fire there.
   accepting.
 
 **`permissionDecision` precedence (when multiple hooks decide):**
-`deny > ask > allow > defer` — most restrictive wins.
+`deny > ask > allow` — most restrictive wins. A hook that exits 0 with no
+stdout (the legacy "defer" semantic) does not contribute a decision and is
+treated as a no-op for precedence purposes.
 
 ## Implementation hookSpecificOutput examples
 
@@ -111,10 +123,13 @@ required for our hook to fire there.
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "defer"
+    "additionalContext": "[plan-tune memory] ..."
   }
 }
 ```
+or, if there is no `additionalContext` to inject, simply **exit 0 with no
+stdout**. Do NOT emit `permissionDecision: "defer"` — see issue #2035,
+Claude Code rejects that value.
 
 **PostToolUse capture (always):**
 ```json

--- a/hosts/claude/hooks/question-preference-hook.ts
+++ b/hosts/claude/hooks/question-preference-hook.ts
@@ -93,12 +93,23 @@ function readStdin(): Promise<string> {
 }
 
 function defer(additionalContext?: string): void {
-  const out: Record<string, unknown> = {
-    hookEventName: 'PreToolUse',
-    permissionDecision: 'defer',
-  };
-  if (additionalContext) out.additionalContext = additionalContext;
-  process.stdout.write(JSON.stringify({ hookSpecificOutput: out }));
+  // "Proceed via the normal permission flow" is exit 0 with no stdout.
+  // Emitting permissionDecision:'defer' makes recent Claude Code builds reject
+  // the tool call with an internal error, silently breaking every AUQ call.
+  // Only emit JSON when there is actually additionalContext to inject, and
+  // without a permissionDecision so Claude Code treats the output as
+  // context-only and lets the normal permission flow proceed.
+  // See https://github.com/garrytan/gstack/issues/2035.
+  if (additionalContext) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext,
+        },
+      }),
+    );
+  }
   process.exit(0);
 }
 

--- a/test/memory-cache-injection.test.ts
+++ b/test/memory-cache-injection.test.ts
@@ -91,7 +91,9 @@ describe('memory injection', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    // Issue #2035: defer path emits additionalContext but NO permissionDecision
+    // (which would make Claude Code abort the tool call).
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toContain('verbose explanations');
   });
 
@@ -115,7 +117,9 @@ describe('memory injection', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    // Issue #2035: with no context to inject, defer is silent (no stdout at all).
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toBeUndefined();
   });
 
@@ -219,7 +223,9 @@ describe('per-session memory cache', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    // Issue #2035: defer path with no context is silent.
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toBeUndefined();
   });
 });

--- a/test/question-preference-hook.test.ts
+++ b/test/question-preference-hook.test.ts
@@ -114,7 +114,14 @@ function autoDecidedEvents(): Array<Record<string, unknown>> {
 // ----------------------------------------------------------------------
 
 describe('defers (no enforcement)', () => {
-  test('no preference set → defer', () => {
+  // Issue #2035: defer() must NOT emit permissionDecision:'defer' — recent
+  // Claude Code builds reject that value and abort the AUQ tool call with
+  // "Tool result missing due to internal error". The "proceed via the normal
+  // permission flow" contract is exit 0 with no stdout when there's nothing
+  // to inject, or exit 0 + hookSpecificOutput with only additionalContext when
+  // there IS context (never permissionDecision on the defer path).
+
+  test('no preference set → exit 0, no stdout (defer path is silent)', () => {
     const r = runHook({
       session_id: 's1',
       tool_name: 'AskUserQuestion',
@@ -126,10 +133,11 @@ describe('defers (no enforcement)', () => {
       },
     });
     expect(r.status).toBe(0);
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
-  test('marker missing → defer (D18)', () => {
+  test('marker missing → exit 0, no stdout (D18)', () => {
     writeProjectPref('test-q', 'never-ask');
     const r = runHook({
       session_id: 's2',
@@ -141,10 +149,12 @@ describe('defers (no enforcement)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
-  test('always-ask preference → defer', () => {
+  test('always-ask preference → exit 0, no stdout', () => {
     writeProjectPref('test-q', 'always-ask');
     const r = runHook({
       session_id: 's3',
@@ -156,10 +166,12 @@ describe('defers (no enforcement)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
-  test('empty stdin → defer (crash safety)', () => {
+  test('empty stdin → exit 0, no stdout (crash safety)', () => {
     const env: Record<string, string> = {};
     for (const [k, v] of Object.entries(process.env)) {
       if (v !== undefined) env[k] = v;
@@ -167,14 +179,15 @@ describe('defers (no enforcement)', () => {
     env.GSTACK_STATE_ROOT = stateRoot;
     const res = spawnSync(HOOK, [], { env, input: '', encoding: 'utf-8' });
     expect(res.status).toBe(0);
-    const parsed = JSON.parse(res.stdout || '{}');
-    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(res.stdout).toBe('');
   });
 
-  test('non-AUQ tool_name → defer (defensive)', () => {
+  test('non-AUQ tool_name → exit 0, no stdout (defensive)', () => {
     writeProjectPref('test-q', 'never-ask');
     const r = runHook({ session_id: 's4', tool_name: 'Bash', tool_use_id: 'tu-4', tool_input: {} });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 
@@ -204,7 +217,7 @@ describe('enforces never-ask preferences', () => {
     expect(r.parsed?.hookSpecificOutput?.permissionDecisionReason).toContain('Fix now');
   });
 
-  test('one-way door → defer even with never-ask (safety override)', () => {
+  test('one-way door → exit 0, no stdout even with never-ask (safety override)', () => {
     writeProjectPref('ship-test-failure-triage', 'never-ask');
     const r = runHook({
       session_id: 's6',
@@ -219,10 +232,12 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
-  test('ambiguous recommendation (two labels) → defer (D2 refuse-on-ambiguous)', () => {
+  test('ambiguous recommendation (two labels) → exit 0, no stdout (D2 refuse-on-ambiguous)', () => {
     writeProjectPref('ship-pre-landing-review-fix', 'never-ask');
     const r = runHook({
       session_id: 's7',
@@ -237,10 +252,12 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
-  test('no recommendation marker AND no prose match → defer', () => {
+  test('no recommendation marker AND no prose match → exit 0, no stdout', () => {
     writeProjectPref('ship-pre-landing-review-fix', 'never-ask');
     const r = runHook({
       session_id: 's8',
@@ -255,7 +272,9 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 
@@ -301,7 +320,7 @@ describe('precedence: project wins over global (D8)', () => {
     expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('deny');
   });
 
-  test('project always-ask + global never-ask → defer (project wins)', () => {
+  test('project always-ask + global never-ask → exit 0, no stdout (project wins)', () => {
     writeProjectPref('ship-pre-landing-review-fix', 'always-ask');
     writeGlobalPref('ship-pre-landing-review-fix', 'never-ask');
     const r = runHook({
@@ -317,7 +336,9 @@ describe('precedence: project wins over global (D8)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 
@@ -437,13 +458,15 @@ describe('Conductor prose redirect', () => {
     expect(r.parsed?.hookSpecificOutput?.permissionDecisionReason).not.toContain('[conductor]');
   });
 
-  test('non-AUQ tool in Conductor → still defer (no redirect on unrelated tools)', () => {
+  test('non-AUQ tool in Conductor → still exit 0, no stdout (no redirect on unrelated tools)', () => {
     const r = runHook(
       { session_id: 'c6', tool_name: 'Bash', tool_use_id: 'tu-c6', tool_input: {} },
       undefined,
       CONDUCTOR,
     );
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 
@@ -491,5 +514,64 @@ describe('auto-decided event tagging', () => {
     });
     const markerPath = path.join(stateRoot, 'sessions', 's14', '.auto-decided-tu-14');
     expect(fs.existsSync(markerPath)).toBe(true);
+  });
+});
+
+// ----------------------------------------------------------------------
+// Regression: issue #2035 — defer() must never emit permissionDecision:'defer'
+// ----------------------------------------------------------------------
+
+describe('issue #2035: defer path never emits permissionDecision', () => {
+  test('silent defer (no context): stdout is empty AND no permissionDecision field', () => {
+    const r = runHook({
+      session_id: 'r1',
+      tool_name: 'AskUserQuestion',
+      tool_use_id: 'tu-r1',
+      tool_input: {
+        questions: [
+          { question: 'Generic question with no marker', options: ['A', 'B'] },
+        ],
+      },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
+    // The bug: emitting {"hookSpecificOutput":{"permissionDecision":"defer"}}
+    // caused Claude Code to abort the AUQ call with "Tool result missing
+    // due to internal error". Make sure we never go back to that output.
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
+  });
+
+  test('context-injecting defer: emits additionalContext but NEVER permissionDecision', () => {
+    // Seed a memory nugget matching ship-todos-reorganize's signal_key so
+    // the hook surfaces memoryContext via defer(additionalContext).
+    fs.writeFileSync(
+      path.join(stateRoot, 'free-text-memory.json'),
+      JSON.stringify({
+        nuggets: [
+          {
+            nugget: 'User prefers terse output',
+            applies_to_signal_keys: ['detail-preference'],
+            applied_at: '2026-05-01T00:00:00Z',
+          },
+        ],
+      }),
+    );
+    const r = runHook({
+      session_id: 'r2',
+      tool_name: 'AskUserQuestion',
+      tool_use_id: 'tu-r2',
+      tool_input: {
+        questions: [
+          {
+            question: '<gstack-qid:ship-todos-reorganize> Reorganize?',
+            options: ['A) Accept (recommended)', 'B) Skip'],
+          },
+        ],
+      },
+    });
+    expect(r.status).toBe(0);
+    // Context-only payload: additionalContext present, permissionDecision absent.
+    expect(r.parsed?.hookSpecificOutput?.additionalContext).toContain('terse output');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });

--- a/test/skill-e2e-plan-tune-cathedral.test.ts
+++ b/test/skill-e2e-plan-tune-cathedral.test.ts
@@ -296,7 +296,8 @@ describeIfSelected('PlanTune cathedral E2E: annotation', ['plan-tune-annotation'
     });
     expect(res.status).toBe(0);
     const parsed = JSON.parse(res.stdout || '{}');
-    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('defer');
+    // Issue #2035: defer path emits additionalContext but NO permissionDecision.
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(parsed.hookSpecificOutput?.additionalContext).toContain('verbose explanations');
   });
 });


### PR DESCRIPTION
## Summary

The PreToolUse `question-preference-hook` was emitting
`hookSpecificOutput.permissionDecision:'defer'` on the no-op (defer)
path. Recent Claude Code builds (Opus 4.8 era, June 2026+) reject that
value and abort the AskUserQuestion tool call with
`[Tool result missing due to internal error]` — so every AUQ call
without a matching `never-ask` preference (essentially all of them)
was failing silently.

The documented "no decision / proceed via the normal permission flow"
contract is **exit 0 with no stdout** (or, when `additionalContext`
needs to be injected, a payload with **only** `additionalContext` —
no `permissionDecision` field at all). This fix updates `defer()` to
match that contract.

## What changed

- `hosts/claude/hooks/question-preference-hook.ts` — `defer()` now:
  - exits 0 silently when there is no `additionalContext` to inject
  - emits a payload with only `additionalContext` (no
    `permissionDecision`) when context needs to be surfaced
- `test/question-preference-hook.test.ts` — defer-path tests now
  assert `stdout === ''` and `permissionDecision === undefined`; plus
  two new regression tests that pin the #2035 contract
- `test/memory-cache-injection.test.ts`,
  `test/skill-e2e-plan-tune-cathedral.test.ts` — same assertion
  updates for the memory-injection variants
- `docs/spikes/claude-code-hook-mutation.md` — corrected: removed
  `defer` from the `permissionDecision` values list, updated the
  pass-through example, updated the precedence rule

## Verification

```
bun test test/question-preference-hook.test.ts test/memory-cache-injection.test.ts
# 29 pass / 0 fail
```

The deny path (used for never-ask auto-decide and Conductor prose
redirect) is **unchanged** — `permissionDecision:'deny'` is a standard
value and works fine.

Fixes #2035.