### PR TITLE
feat(benchmark): add Antigravity (`agy`) provider adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.52.1.1] - 2026-06-24
+
+## **Antigravity (`agy`) joins the benchmark/second-opinion providers. Google retired the standalone Gemini CLI for individuals; the new `agy` CLI is now a first-class provider adapter.**
+
+Google replaced the standalone Gemini CLI (`gemini`) with the **Antigravity CLI** (`agy`) for individual accounts — the old binary now fails with `IneligibleTierError`. A new `AntigravityAdapter` (`test/helpers/providers/antigravity.ts`) wraps `agy`'s non-interactive mode so multi-provider benchmarks and outside-voice second opinions keep working.
+
+### What changed
+
+- **New `antigravity` provider family** added to the `Family` union, the `ADAPTERS` map, and tool-compatibility table. The legacy `gemini` adapter is left in place for anyone still on the old CLI.
+- **Headless contract** (verified against `agy` 1.0.11): `agy --print "<prompt>" --dangerously-skip-permissions [--model "<name>"] --print-timeout <dur>`. Unlike `gemini`, `agy --print` emits **plain text** — there is no `--output-format stream-json`, so the adapter reports `tokens: 0` / `toolCalls: 0` (no CLI telemetry) and treats stdout as the response. Auth is configured at install / first TUI launch (no login flag, no API-key env var), so `available()` only checks the binary is on PATH.
+- **Tool surface**: `agy --print` runs a full agentic session (Read/Write/Edit/Bash/Glob/Grep/WebSearch/WebFetch), a richer surface than the old Gemini CLI.
+- **Tests**: unit coverage for the new family in `benchmark-runner.test.ts`, plus live availability + smoke + 4-provider `runBenchmark` cases in `skill-e2e-benchmark-providers.test.ts` (the smoke asserts on output, not token counts, since `agy` reports none). Verified live: `EVALS=1 bun test test/skill-e2e-benchmark-providers.test.ts -t antigravity` → 2 pass.
+
 ## [1.52.1.0] - 2026-05-27
 
 ## **Brain-aware planning lands. Five planning skills read structured context from any personal gbrain before asking — same questions, smarter answers, no token tax.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gstack",
-  "version": "1.52.1.0",
+  "version": "1.52.1.1",
   "description": "Garry's Stack — Claude Code skills + fast headless browser. One repo, one install, entire AI engineering workflow.",
   "license": "MIT",
   "type": "module",

--- a/test/benchmark-runner.test.ts
+++ b/test/benchmark-runner.test.ts
@@ -51,12 +51,15 @@ test('missingTools reports unsupported tools per provider', () => {
   expect(missingTools('claude', ['Edit', 'Glob', 'Grep', 'Bash', 'Read'])).toEqual([]);
   // Gemini has very limited agentic surface
   expect(missingTools('gemini', ['Bash', 'Edit'])).toEqual(['Bash', 'Edit']);
+  // Antigravity (`agy --print`) is a full agentic session: supports Bash/Edit
+  expect(missingTools('antigravity', ['Bash', 'Edit', 'Read', 'Grep'])).toEqual([]);
 });
 
-test('TOOL_COMPATIBILITY is populated for all three families', () => {
+test('TOOL_COMPATIBILITY is populated for all provider families', () => {
   expect(TOOL_COMPATIBILITY.claude).toBeDefined();
   expect(TOOL_COMPATIBILITY.gpt).toBeDefined();
   expect(TOOL_COMPATIBILITY.gemini).toBeDefined();
+  expect(TOOL_COMPATIBILITY.antigravity).toBeDefined();
 });
 
 test('formatTable handles a report with mixed success/error/unavailable entries', () => {

--- a/test/helpers/benchmark-runner.ts
+++ b/test/helpers/benchmark-runner.ts
@@ -11,22 +11,26 @@ import type { ProviderAdapter, RunOpts, RunResult } from './providers/types';
 import { ClaudeAdapter } from './providers/claude';
 import { GptAdapter } from './providers/gpt';
 import { GeminiAdapter } from './providers/gemini';
+import { AntigravityAdapter } from './providers/antigravity';
+
+/** Provider names the benchmark harness knows how to instantiate. */
+export type ProviderName = 'claude' | 'gpt' | 'gemini' | 'antigravity';
 
 export interface BenchmarkInput {
   prompt: string;
   workdir: string;
   timeoutMs?: number;
-  /** Adapter names to run (e.g., ['claude', 'gpt', 'gemini']). */
-  providers: Array<'claude' | 'gpt' | 'gemini'>;
+  /** Adapter names to run (e.g., ['claude', 'gpt', 'antigravity']). */
+  providers: ProviderName[];
   /** Optional per-provider model overrides. */
-  models?: Partial<Record<'claude' | 'gpt' | 'gemini', string>>;
+  models?: Partial<Record<ProviderName, string>>;
   /** If true, skip providers whose available() returns !ok. If false, include them with error. */
   skipUnavailable?: boolean;
 }
 
 export interface BenchmarkEntry {
   provider: string;
-  family: 'claude' | 'gpt' | 'gemini';
+  family: ProviderName;
   available: boolean;
   unavailable_reason?: string;
   result?: RunResult;
@@ -44,10 +48,11 @@ export interface BenchmarkReport {
   entries: BenchmarkEntry[];
 }
 
-const ADAPTERS: Record<'claude' | 'gpt' | 'gemini', () => ProviderAdapter> = {
+const ADAPTERS: Record<ProviderName, () => ProviderAdapter> = {
   claude: () => new ClaudeAdapter(),
   gpt: () => new GptAdapter(),
   gemini: () => new GeminiAdapter(),
+  antigravity: () => new AntigravityAdapter(),
 };
 
 export async function runBenchmark(input: BenchmarkInput): Promise<BenchmarkReport> {

--- a/test/helpers/providers/antigravity.ts
+++ b/test/helpers/providers/antigravity.ts
@@ -1,0 +1,106 @@
+import type { ProviderAdapter, RunOpts, RunResult, AvailabilityCheck } from './types';
+import { estimateCostUsd } from '../pricing';
+import { execFileSync, spawnSync } from 'child_process';
+
+/**
+ * Antigravity adapter — wraps Google's `agy` CLI.
+ *
+ * Google retired the standalone Gemini CLI for individuals and replaced it with
+ * the Antigravity CLI (`agy`). Unlike `gemini`, `agy --print` emits PLAIN TEXT,
+ * not stream-json — there is no `--output-format` flag (verified on agy 1.0.11,
+ * `agy --help`). So this adapter cannot recover per-run token counts or tool-call
+ * counts from the CLI; those are reported as 0. Output text is the whole stdout.
+ *
+ * Headless contract (verified against agy 1.0.11):
+ *   agy -p "<prompt>" --dangerously-skip-permissions [--model "<name>"]
+ *   -p/--print/--prompt   run a single prompt non-interactively, print response
+ *   --dangerously-skip-permissions   auto-approve tool use (yolo equivalent)
+ *   --model "<display name>"   e.g. "Gemini 3.1 Pro (High)" (see `agy models`)
+ *   --print-timeout <dur>   print-mode wait timeout (Go duration, default 5m)
+ *
+ * Auth is configured at install / first TUI launch — there is no login flag and
+ * no API key env var, so availability only checks that the binary is on PATH.
+ *
+ * Note: `agy -p` runs as a full agentic session (it may read workspace files when
+ * a workspace is present). For controlled benchmark prompts, run it in an isolated
+ * workdir.
+ */
+export class AntigravityAdapter implements ProviderAdapter {
+  readonly name = 'antigravity';
+  readonly family = 'antigravity' as const;
+
+  async available(): Promise<AvailabilityCheck> {
+    const res = spawnSync('sh', ['-c', 'command -v agy'], { timeout: 2000 });
+    if (res.status !== 0) {
+      return {
+        ok: false,
+        reason:
+          'agy (Antigravity) CLI not found on PATH. Install per ' +
+          'https://antigravity.google/docs/cli-getting-started ' +
+          '(curl -fsSL https://antigravity.google/cli/install.sh | bash).',
+      };
+    }
+    // agy stores its auth from install/TUI setup; there is no env-var or login
+    // flag to probe non-interactively, so presence of the binary is the check.
+    return { ok: true };
+  }
+
+  async run(opts: RunOpts): Promise<RunResult> {
+    const start = Date.now();
+    // --print runs one prompt non-interactively and prints plain text to stdout.
+    // --dangerously-skip-permissions is the non-interactive yolo equivalent.
+    const args = ['--print', opts.prompt, '--dangerously-skip-permissions'];
+    if (opts.model) args.push('--model', opts.model);
+    // Keep the CLI's own print-mode timeout in step with our wall-clock budget so
+    // it doesn't hang past it. agy expects a Go duration string (e.g. "300s").
+    args.push('--print-timeout', `${Math.max(1, Math.round(opts.timeoutMs / 1000))}s`);
+    if (opts.extraArgs) args.push(...opts.extraArgs);
+
+    try {
+      const out = execFileSync('agy', args, {
+        cwd: opts.workdir,
+        timeout: opts.timeoutMs,
+        encoding: 'utf-8',
+        maxBuffer: 32 * 1024 * 1024,
+      });
+      return {
+        // agy --print emits plain text; the whole stdout is the response.
+        output: out.trim(),
+        // The CLI exposes no token/tool telemetry in print mode.
+        tokens: { input: 0, output: 0 },
+        durationMs: Date.now() - start,
+        toolCalls: 0,
+        modelUsed: opts.model || 'antigravity-default',
+      };
+    } catch (err: unknown) {
+      const durationMs = Date.now() - start;
+      const e = err as { code?: string; stderr?: Buffer; signal?: string; message?: string };
+      const stderr = e.stderr?.toString() ?? '';
+      if (e.signal === 'SIGTERM' || e.code === 'ETIMEDOUT') {
+        return this.emptyResult(durationMs, { code: 'timeout', reason: `exceeded ${opts.timeoutMs}ms` }, opts.model);
+      }
+      if (/unauthorized|auth|login|not signed in|sign in/i.test(stderr)) {
+        return this.emptyResult(durationMs, { code: 'auth', reason: stderr.slice(0, 400) }, opts.model);
+      }
+      if (/rate[- ]?limit|429|quota/i.test(stderr)) {
+        return this.emptyResult(durationMs, { code: 'rate_limit', reason: stderr.slice(0, 400) }, opts.model);
+      }
+      return this.emptyResult(durationMs, { code: 'unknown', reason: (e.message ?? stderr ?? 'unknown').slice(0, 400) }, opts.model);
+    }
+  }
+
+  estimateCost(tokens: { input: number; output: number; cached?: number }, model?: string): number {
+    return estimateCostUsd(tokens, model ?? 'gemini-2.5-pro');
+  }
+
+  private emptyResult(durationMs: number, error: RunResult['error'], model?: string): RunResult {
+    return {
+      output: '',
+      tokens: { input: 0, output: 0 },
+      durationMs,
+      toolCalls: 0,
+      modelUsed: model ?? 'antigravity-default',
+      error,
+    };
+  }
+}

--- a/test/helpers/providers/types.ts
+++ b/test/helpers/providers/types.ts
@@ -55,7 +55,7 @@ export interface AvailabilityCheck {
   reason?: string;
 }
 
-export type Family = 'claude' | 'gpt' | 'gemini';
+export type Family = 'claude' | 'gpt' | 'gemini' | 'antigravity';
 
 export interface ProviderAdapter {
   /** Stable name used in output tables and config (e.g., 'claude', 'gpt', 'gemini'). */

--- a/test/helpers/tool-map.ts
+++ b/test/helpers/tool-map.ts
@@ -26,7 +26,7 @@ export type ToolName =
   | 'WebSearch'
   | 'WebFetch';
 
-export const TOOL_COMPATIBILITY: Record<'claude' | 'gpt' | 'gemini', Record<ToolName, boolean>> = {
+export const TOOL_COMPATIBILITY: Record<'claude' | 'gpt' | 'gemini' | 'antigravity', Record<ToolName, boolean>> = {
   claude: {
     Read: true,
     Write: true,
@@ -67,6 +67,22 @@ export const TOOL_COMPATIBILITY: Record<'claude' | 'gpt' | 'gemini', Record<Tool
     WebSearch: true,
     WebFetch: false,
   },
+  antigravity: {
+    // Antigravity CLI (`agy`, as of 1.0.11) runs `--print` as a full agentic
+    // session: it reads workspace files and can write/edit/run when permissions
+    // are granted (`--dangerously-skip-permissions`). Richer tool surface than
+    // the old Gemini CLI. AskUserQuestion is N/A in non-interactive print mode.
+    Read: true,
+    Write: true,
+    Edit: true,
+    Bash: true,
+    Agent: false,
+    Glob: true,
+    Grep: true,
+    AskUserQuestion: false,
+    WebSearch: true,
+    WebFetch: true,
+  },
 };
 
 /**
@@ -74,7 +90,7 @@ export const TOOL_COMPATIBILITY: Record<'claude' | 'gpt' | 'gemini', Record<Tool
  * Empty array means full compatibility.
  */
 export function missingTools(
-  provider: 'claude' | 'gpt' | 'gemini',
+  provider: 'claude' | 'gpt' | 'gemini' | 'antigravity',
   requiredTools: ToolName[]
 ): ToolName[] {
   const map = TOOL_COMPATIBILITY[provider];

--- a/test/skill-e2e-benchmark-providers.test.ts
+++ b/test/skill-e2e-benchmark-providers.test.ts
@@ -22,6 +22,7 @@ import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { ClaudeAdapter } from './helpers/providers/claude';
 import { GptAdapter } from './helpers/providers/gpt';
 import { GeminiAdapter } from './helpers/providers/gemini';
+import { AntigravityAdapter } from './helpers/providers/antigravity';
 import { runBenchmark } from './helpers/benchmark-runner';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -39,6 +40,7 @@ const PROMPT = 'Reply with exactly this text and nothing else: ok';
 const claude = new ClaudeAdapter();
 const gpt = new GptAdapter();
 const gemini = new GeminiAdapter();
+const antigravity = new AntigravityAdapter();
 
 // Use a temp working directory so provider CLIs can't accidentally touch the repo.
 // Created in beforeAll / cleaned in afterAll so concurrent CI runs don't leak.
@@ -144,6 +146,36 @@ describeIfEvals('multi-provider benchmark adapters (live)', () => {
     expect(typeof result.modelUsed).toBe('string');
   }, 150_000);
 
+  test('antigravity: available() returns structured ok/reason', async () => {
+    const check = await antigravity.available();
+    expect(check).toHaveProperty('ok');
+    if (!check.ok) {
+      expect(typeof check.reason).toBe('string');
+    }
+  });
+
+  test('antigravity: trivial prompt produces parseable output', async () => {
+    const check = await antigravity.available();
+    if (!check.ok) {
+      process.stderr.write(`\nantigravity live smoke: SKIPPED — ${check.reason}\n`);
+      return;
+    }
+    const result = await antigravity.run({ prompt: PROMPT, workdir, timeoutMs: 120_000 });
+    if (result.error) {
+      throw new Error(`antigravity errored: ${result.error.code} — ${result.error.reason}`);
+    }
+    // `agy --print` emits plain text and exposes NO token/tool telemetry, so we
+    // assert on output (not token counts, unlike claude/gpt). The smoke is "did
+    // the adapter wire up and the run terminate successfully with content?"
+    expect(typeof result.output).toBe('string');
+    expect(result.output.toLowerCase()).toContain('ok');
+    expect(result.tokens.input).toBe(0);   // CLI reports no telemetry
+    expect(result.tokens.output).toBe(0);
+    expect(result.durationMs).toBeGreaterThan(0);
+    expect(typeof result.modelUsed).toBe('string');
+    expect(result.modelUsed.length).toBeGreaterThan(0);
+  }, 150_000);
+
   test('timeout error surfaces as error.code=timeout (no exception)', async () => {
     // Use whatever adapter is available first — all three should share timeout semantics.
     const adapter = (await claude.available()).ok ? claude
@@ -164,18 +196,18 @@ describeIfEvals('multi-provider benchmark adapters (live)', () => {
   }, 30_000);
 
   test('runBenchmark: Promise.allSettled means one unavailable provider does not block others', async () => {
-    // Use the full runner with all three providers — whichever are unauthed should
+    // Use the full runner with all four providers — whichever are unauthed should
     // return entries with available=false and not crash the batch.
     const report = await runBenchmark({
       prompt: PROMPT,
       workdir,
-      providers: ['claude', 'gpt', 'gemini'],
+      providers: ['claude', 'gpt', 'gemini', 'antigravity'],
       timeoutMs: 120_000,
       skipUnavailable: false,
     });
-    expect(report.entries).toHaveLength(3);
+    expect(report.entries).toHaveLength(4);
     for (const e of report.entries) {
-      expect(['claude', 'gpt', 'gemini']).toContain(e.family);
+      expect(['claude', 'gpt', 'gemini', 'antigravity']).toContain(e.family);
       if (e.available) {
         expect(e.result).toBeDefined();
       } else {


### PR DESCRIPTION
## Add Antigravity (`agy`) provider adapter

Google retired the standalone **Gemini CLI** for individual accounts — the `gemini` binary now fails at startup with `IneligibleTierError` ("This client is no longer supported for Gemini Code Assist for individuals… migrate to the Antigravity suite"). It's replaced by the **Antigravity CLI** (`agy`). This breaks the `gemini` provider leg of multi-provider benchmarks and the outside-voice second-opinion flow.

This PR adds a first-class **`antigravity`** provider that wraps `agy`, leaving the legacy `gemini` adapter intact for anyone still on the old CLI.

### Headless contract (verified against `agy` 1.0.11)
```
agy --print "<prompt>" --dangerously-skip-permissions [--model "<name>"] --print-timeout <dur>
```
- `-p` / `--print` / `--prompt` → run one prompt non-interactively, print response.
- `--dangerously-skip-permissions` → auto-approve tool use (the `--yolo` equivalent).
- `--model "<display name>"` → e.g. `"Gemini 3.1 Pro (High)"` (values from `agy models`).
- `--print-timeout <Go-duration>` → print-mode wait (kept in step with our wall-clock budget).

**Key difference from `gemini`:** `agy --print` emits **plain text** — there is **no `--output-format stream-json`**. So the adapter:
- treats stdout as the response,
- reports `tokens: {input:0, output:0}` and `toolCalls: 0` (the CLI exposes no telemetry in print mode),
- checks only that the binary is on PATH in `available()` (auth is configured at install / first TUI launch — no login flag, no API-key env var).

Tool surface is richer than the old Gemini CLI: `agy --print` runs a full agentic session (Read/Write/Edit/Bash/Glob/Grep/WebSearch/WebFetch).

### Changes
- `test/helpers/providers/antigravity.ts` — new `AntigravityAdapter`.
- `test/helpers/providers/types.ts` — `'antigravity'` added to `Family`.
- `test/helpers/benchmark-runner.ts` — new `ProviderName` type, `ADAPTERS` entry.
- `test/helpers/tool-map.ts` — `antigravity` tool-compatibility row + widened signatures.
- `test/benchmark-runner.test.ts` — unit coverage for the new family.
- `test/skill-e2e-benchmark-providers.test.ts` — live availability + smoke (asserts on output, not tokens, since `agy` reports none) + 4-provider `runBenchmark` case.
- `CHANGELOG.md` + `package.json` bump `1.52.1.0` → `1.52.1.1`.

### Verification
- `bun test test/benchmark-runner.test.ts` → 9 pass.
- `bun test test/benchmark-runner.test.ts test/benchmark-cli.test.ts test/helpers/gemini-session-runner.test.ts` → 34 pass.
- **Live against real `agy`:** `EVALS=1 bun test test/skill-e2e-benchmark-providers.test.ts -t antigravity` → 2 pass (availability + trivial-prompt smoke, ~12s).

### Notes / open questions for the maintainer
- I left the `gemini` adapter and its e2e in place rather than removing them — happy to deprecate/remove if you'd prefer, but kept this additive to avoid breaking anyone mid-migration.
- `scripts/models.ts` (model-overlay families) is intentionally **not** touched: Antigravity proxies the existing Gemini/Claude/GPT families (`agy models`), so the existing overlays apply and adding an `antigravity` overlay file felt out of scope.
- `agy --print` has no token telemetry, so cost estimation for this provider is best-effort (0 tokens → $0). If telemetry matters for benchmarks, we may need to parse a future `--output-format` flag if/when Google adds one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
