### PR TITLE
feat(context-save): persist plan file before saving checkpoint when in plan mode

### DIFF
--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -870,6 +870,26 @@ echo "FILE=$FILE"
 The on-disk directory name is `checkpoints/` (not `contexts/`) — this is a legacy
 path kept so existing saved files remain loadable. Users never see it.
 
+### Step 4a: Persist plan file (if in plan mode)
+
+If plan mode is active, the plan lives in a temp file (`CLAUDE_PLAN_FILE`) that
+is lost if the session ends without ExitPlanMode approval. Persist it to
+`.claude/plans/` so `/context-restore` can find it even when the user saves
+and exits before approving the plan.
+
+```bash
+if [ "${GSTACK_PLAN_MODE:-}" = "active" ] && [ -n "${CLAUDE_PLAN_FILE:-}" ] && [ -f "$CLAUDE_PLAN_FILE" ]; then
+  mkdir -p .claude/plans
+  PLAN_TS=$(date +%Y%m%d-%H%M%S)
+  cp "$CLAUDE_PLAN_FILE" ".claude/plans/plan-$PLAN_TS.md"
+  cp "$CLAUDE_PLAN_FILE" ".claude/plans/active-plan.md"
+  echo "PLAN_PERSISTED=.claude/plans/plan-$PLAN_TS.md"
+fi
+```
+
+If `PLAN_PERSISTED` is echoed, include it in the saved context's Notes section
+so the checkpoint records where the plan was saved.
+
 Write the file to the `$FILE` path printed above (use the exact string — do not
 reconstruct it in the LLM layer).
 

--- a/context-save/SKILL.md.tmpl
+++ b/context-save/SKILL.md.tmpl
@@ -144,6 +144,26 @@ echo "FILE=$FILE"
 The on-disk directory name is `checkpoints/` (not `contexts/`) — this is a legacy
 path kept so existing saved files remain loadable. Users never see it.
 
+### Step 4a: Persist plan file (if in plan mode)
+
+If plan mode is active, the plan lives in a temp file (`CLAUDE_PLAN_FILE`) that
+is lost if the session ends without ExitPlanMode approval. Persist it to
+`.claude/plans/` so `/context-restore` can find it even when the user saves
+and exits before approving the plan.
+
+```bash
+if [ "${GSTACK_PLAN_MODE:-}" = "active" ] && [ -n "${CLAUDE_PLAN_FILE:-}" ] && [ -f "$CLAUDE_PLAN_FILE" ]; then
+  mkdir -p .claude/plans
+  PLAN_TS=$(date +%Y%m%d-%H%M%S)
+  cp "$CLAUDE_PLAN_FILE" ".claude/plans/plan-$PLAN_TS.md"
+  cp "$CLAUDE_PLAN_FILE" ".claude/plans/active-plan.md"
+  echo "PLAN_PERSISTED=.claude/plans/plan-$PLAN_TS.md"
+fi
+```
+
+If `PLAN_PERSISTED` is echoed, include it in the saved context's Notes section
+so the checkpoint records where the plan was saved.
+
 Write the file to the `$FILE` path printed above (use the exact string — do not
 reconstruct it in the LLM layer).
 


### PR DESCRIPTION
When GSTACK_PLAN_MODE=active and CLAUDE_PLAN_FILE exists, /context-save now
persists the plan to .claude/plans/ before writing the checkpoint. This
prevents plan loss when the user saves and exits without approving the plan
(via ExitPlanMode) — common on unstable hardware or when the user needs to
rest.

The plan is saved with a timestamp and also copied to active-plan.md as a
stable symlink target for /context-restore.

Fixes: checkpoint referencing a plan path that does not exist on disk.