### PR TITLE
fix(build): escape literal braces in bun:sqlite stub regex (Perl strict)

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -32,7 +32,7 @@ bun build "$SRC_DIR/server.ts" \
 # Replace import.meta.dir with a resolvable reference
 perl -pi -e 's/import\.meta\.dir/__browseNodeSrcDir/g' "$DIST_DIR/server-node.mjs"
 # Stub out bun:sqlite (macOS-only cookie import, not needed on Windows)
-perl -pi -e 's|import { Database } from "bun:sqlite";|const Database = null; // bun:sqlite stubbed on Node|g' "$DIST_DIR/server-node.mjs"
+perl -pi -e 's|import \{ Database \} from "bun:sqlite";|const Database = null; // bun:sqlite stubbed on Node|g' "$DIST_DIR/server-node.mjs"
 
 # Step 3: Create the final file with polyfill header injected after the first line
 {


### PR DESCRIPTION
## Problem

`./setup` fails on Windows with exit code 255 during the final build step:

```
Unescaped left brace in regex is illegal here in regex;
marked by <-- HERE in m/import { <-- HERE  Database } from "bun:sqlite";/
error: script "build" exited with code 255
```

`browse/scripts/build-node-server.sh` post-processes the Node server bundle with a Perl substitution that stubs out the `bun:sqlite` import. The pattern contains an unescaped literal `{`:

```sh
perl -pi -e 's|import { Database } from "bun:sqlite";|const Database = null; ...|g' ...
```

Perl treats an unescaped `{` that is not part of a valid quantifier as an error, so the build hard-fails before the stub is applied.

## Environment

- Reproduced on **Windows Git Bash (msys Perl 5.26.2)**.
- Also affects modern **Perl 5.32+** on Linux, where the long-standing deprecation became a hard error.

## Fix

Escape the braces (`\{ \}`) so they match literally. One-line change, behavior-preserving.

## Verification

After the fix, on the same Windows environment:

- Build completes with exit code 0.
- The substitution correctly produces `const Database = null; // bun:sqlite stubbed on Node` (no real `from "bun:sqlite"` import remains).
- The Windows compatibility polyfill header is injected.
- `node --check browse/dist/server-node.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
