### PR TITLE
fix(setup): auto-detect Ubuntu 26.04 and set PLAYWRIGHT_HOST_PLATFORM_OVERRIDE

### DIFF
--- a/setup
+++ b/setup
@@ -476,11 +476,29 @@ if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
 fi
 
 # 2. Ensure Playwright's Chromium is available
+# Detect Ubuntu 26.04: Playwright does not yet ship a native chromium build for
+# ubuntu26.04-x64. Override the platform to ubuntu24.04-x64 so the installer
+# picks the correct binary. This is safe because the ubuntu24.04 build runs
+# fine on ubuntu26.04 (same glibc lineage). See #2101.
+_PLAYWRIGHT_PLATFORM_OVERRIDE=""
+if [ -f /etc/os-release ]; then
+  _os_id=$(grep '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
+  _os_ver=$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
+  if [ "$_os_id" = "ubuntu" ] && [ "$_os_ver" = "26.04" ]; then
+    _PLAYWRIGHT_PLATFORM_OVERRIDE="ubuntu24.04-x64"
+    echo "Ubuntu 26.04 detected — using PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=$_PLAYWRIGHT_PLATFORM_OVERRIDE"
+  fi
+fi
+
 if ! ensure_playwright_browser; then
   echo "Installing Playwright Chromium..."
   (
     cd "$SOURCE_GSTACK_DIR"
-    bunx playwright install chromium
+    if [ -n "$_PLAYWRIGHT_PLATFORM_OVERRIDE" ]; then
+      PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="$_PLAYWRIGHT_PLATFORM_OVERRIDE" bunx playwright install chromium
+    else
+      bunx playwright install chromium
+    fi
   )
 
   if [ "$IS_WINDOWS" -eq 1 ]; then


### PR DESCRIPTION
## Summary

Fixes #2101

Playwright does not yet ship a native chromium build for ubuntu26.04-x64. Running ./setup on Ubuntu 26.04 fails immediately with:

\\\
Failed to install browsers
Error: ERROR: Playwright does not support chromium on ubuntu26.04-x64
\\\

## Fix

The setup script now reads /etc/os-release before calling unx playwright install chromium. When it detects Ubuntu 26.04, it sets PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 for the install subshell only. The ubuntu24.04 binary runs correctly on ubuntu26.04 (same glibc lineage).

The override is scoped to the subshell — it does not persist to the caller's environment or affect any other setup step.

The workaround documented in #2101 (PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 ./setup) still works for users on other unsupported future Ubuntu versions.

## Testing

- The change is confined to the setup bash script (no TypeScript changes, no SKILL.md changes).
- On non-Ubuntu-26.04 systems the code path is unchanged; _PLAYWRIGHT_PLATFORM_OVERRIDE stays empty and the existing unx playwright install chromium runs as before.