### PR TITLE
[codex] Align Codex install paths with current skill spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Or target a specific agent with `./setup --host <name>`:
 
 | Agent | Flag | Skills install to |
 |-------|------|-------------------|
-| OpenAI Codex CLI | `--host codex` | `~/.codex/skills/gstack-*/` |
+| OpenAI Codex CLI | `--host codex` | `~/.agents/skills/gstack-*/` |
 | OpenCode | `--host opencode` | `~/.config/opencode/skills/gstack-*/` |
 | Cursor | `--host cursor` | `~/.cursor/skills/gstack-*/` |
 | Factory Droid | `--host factory` | `~/.factory/skills/gstack-*/` |
@@ -356,7 +356,7 @@ rm -rf ~/.claude/skills/gstack
 rm -rf ~/.gstack
 
 # 5. Remove integrations (skip any you never installed)
-rm -rf ~/.codex/skills/gstack* 2>/dev/null
+rm -rf ~/.agents/skills/gstack* ~/.codex/skills/gstack* 2>/dev/null
 rm -rf ~/.factory/skills/gstack* 2>/dev/null
 rm -rf ~/.kiro/skills/gstack* 2>/dev/null
 rm -rf ~/.openclaw/skills/gstack* 2>/dev/null
@@ -466,7 +466,7 @@ Data is stored in [Supabase](https://supabase.com) (open source Firebase alterna
 
 **Want namespaced commands?** `cd ~/.claude/skills/gstack && ./setup --prefix` — switches from `/qa` to `/gstack-qa`. Useful if you run other skill packs alongside gstack.
 
-**Codex says "Skipped loading skill(s) due to invalid SKILL.md"?** Your Codex skill descriptions are stale. Fix: `cd ~/.codex/skills/gstack && git pull && ./setup --host codex` — or for repo-local installs: `cd "$(readlink -f .agents/skills/gstack)" && git pull && ./setup --host codex`
+**Codex says "Skipped loading skill(s) due to invalid SKILL.md"?** Your Codex skill descriptions are stale. Fix: `cd ~/.agents/skills/gstack && git pull && ./setup --host codex` — or for repo-local installs: `cd "$(readlink -f .agents/skills/gstack)" && git pull && ./setup --host codex`
 
 **Windows users:** gstack works on Windows 11 via Git Bash or WSL. Node.js is required in addition to Bun — Bun has a known bug with Playwright's pipe transport on Windows ([bun#4253](https://github.com/oven-sh/bun/issues/4253)). The browse server automatically falls back to Node.js. Make sure both `bun` and `node` are on your PATH.
 

--- a/docs/REMOTE_BROWSER_ACCESS.md
+++ b/docs/REMOTE_BROWSER_ACCESS.md
@@ -186,7 +186,7 @@ If both agents are on the same machine, skip the copy-paste:
 
 ```bash
 $B pair-agent --local openclaw    # writes to ~/.openclaw/skills/gstack/browse-remote.json
-$B pair-agent --local codex       # writes to ~/.codex/skills/gstack/browse-remote.json
+$B pair-agent --local codex       # writes to ~/.agents/skills/gstack/browse-remote.json
 $B pair-agent --local cursor      # writes to ~/.cursor/skills/gstack/browse-remote.json
 ```
 

--- a/hosts/codex.ts
+++ b/hosts/codex.ts
@@ -6,7 +6,7 @@ const codex: HostConfig = {
   cliCommand: 'codex',
   cliAliases: ['agents'],
 
-  globalRoot: '.codex/skills/gstack',
+  globalRoot: '.agents/skills/gstack',
   localSkillRoot: '.agents/skills/gstack',
   hostSubdir: '.agents',
   usesEnvVars: true,

--- a/setup
+++ b/setup
@@ -18,7 +18,7 @@ INSTALL_GSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_GSTACK_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 INSTALL_SKILLS_DIR="$(dirname "$INSTALL_GSTACK_DIR")"
 BROWSE_BIN="$SOURCE_GSTACK_DIR/browse/dist/browse"
-CODEX_SKILLS="$HOME/.codex/skills"
+CODEX_SKILLS="$HOME/.agents/skills"
 CODEX_GSTACK="$CODEX_SKILLS/gstack"
 FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
@@ -771,8 +771,8 @@ create_agents_sidecar() {
   done
 }
 
-# ─── Helper: create a minimal ~/.codex/skills/gstack runtime root ───────────
-# Codex scans ~/.codex/skills recursively. Exposing the whole repo here causes
+# ─── Helper: create a minimal ~/.agents/skills/gstack runtime root ───────────
+# Codex scans ~/.agents/skills recursively. Exposing the whole repo here causes
 # duplicate skills because source SKILL.md files and generated Codex skills are
 # both discoverable. Keep this directory limited to runtime assets + root skill.
 create_codex_runtime_root() {
@@ -1146,9 +1146,10 @@ if [ "$INSTALL_KIRO" -eq 1 ]; then
       skill_name="$(basename "$skill_dir")"
       target_dir="$KIRO_SKILLS/$skill_name"
       mkdir -p "$target_dir"
-      # Generated Codex skills use $HOME/.codex (not ~/), plus $GSTACK_ROOT variables.
+      # Generated Codex skills use $HOME/.agents (not ~/), plus $GSTACK_ROOT variables.
       # Rewrite the default GSTACK_ROOT value and any remaining literal paths.
-      sed -e 's|\$HOME/.codex/skills/gstack|$HOME/.kiro/skills/gstack|g' \
+      sed -e 's|\$HOME/.agents/skills/gstack|$HOME/.kiro/skills/gstack|g' \
+          -e 's|\$HOME/.codex/skills/gstack|$HOME/.kiro/skills/gstack|g' \
           -e "s|~/.codex/skills/gstack|~/.kiro/skills/gstack|g" \
           -e "s|~/.claude/skills/gstack|~/.kiro/skills/gstack|g" \
           "$skill_dir/SKILL.md" > "$target_dir/SKILL.md"
@@ -1160,7 +1161,8 @@ if [ "$INSTALL_KIRO" -eq 1 ]; then
         mkdir -p "$target_dir/sections"
         for section_file in "$skill_dir/sections"/*; do
           [ -f "$section_file" ] || continue
-          sed -e 's|\$HOME/.codex/skills/gstack|$HOME/.kiro/skills/gstack|g' \
+          sed -e 's|\$HOME/.agents/skills/gstack|$HOME/.kiro/skills/gstack|g' \
+              -e 's|\$HOME/.codex/skills/gstack|$HOME/.kiro/skills/gstack|g' \
               -e "s|~/.codex/skills/gstack|~/.kiro/skills/gstack|g" \
               -e "s|~/.claude/skills/gstack|~/.kiro/skills/gstack|g" \
               "$section_file" > "$target_dir/sections/$(basename "$section_file")"

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -14,7 +14,7 @@ description: |
 
 ```bash
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-GSTACK_ROOT="$HOME/.codex/skills/gstack"
+GSTACK_ROOT="$HOME/.agents/skills/gstack"
 [ -n "$_ROOT" ] && [ -d "$_ROOT/.agents/skills/gstack" ] && GSTACK_ROOT="$_ROOT/.agents/skills/gstack"
 GSTACK_BIN="$GSTACK_ROOT/bin"
 GSTACK_BROWSE="$GSTACK_ROOT/browse/dist"

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2450,7 +2450,7 @@ describe('setup script validation', () => {
     expect(fnBody).not.toContain('_link_or_copy "$gstack_dir" "$codex_gstack"');
   });
 
-  test('direct Codex installs are migrated out of ~/.codex/skills/gstack', () => {
+  test('direct Codex installs are migrated out of ~/.agents/skills/gstack', () => {
     expect(setupContent).toContain('migrate_direct_codex_install');
     expect(setupContent).toContain('$HOME/.gstack/repos/gstack');
     expect(setupContent).toContain('avoid duplicate skill discovery');

--- a/test/helpers/codex-session-runner.ts
+++ b/test/helpers/codex-session-runner.ts
@@ -9,7 +9,7 @@
  * - Uses `codex exec` instead of `claude -p`
  * - Output is JSONL with different event types (item.completed, turn.completed, thread.started)
  * - Uses `--json` flag instead of `--output-format stream-json`
- * - Needs temp HOME with skill installed at ~/.codex/skills/{skillName}/SKILL.md
+ * - Needs temp HOME with skill installed at ~/.agents/skills/{skillName}/SKILL.md
  */
 
 import * as fs from 'fs';
@@ -100,7 +100,7 @@ export function parseCodexJSONL(lines: string[]): ParsedCodexJSONL {
 
 /**
  * Install a SKILL.md into a temp HOME directory for Codex to discover.
- * Creates ~/.codex/skills/{skillName}/SKILL.md in the temp HOME and copies
+ * Creates ~/.agents/skills/{skillName}/SKILL.md in the temp HOME and copies
  * agents/openai.yaml when present so Codex sees the same metadata as a real install.
  *
  * Returns the temp HOME path. Caller is responsible for cleanup.
@@ -111,7 +111,7 @@ export function installSkillToTempHome(
   tempHome?: string,
 ): string {
   const home = tempHome || fs.mkdtempSync(path.join(os.tmpdir(), 'codex-e2e-'));
-  const destDir = path.join(home, '.codex', 'skills', skillName);
+  const destDir = path.join(home, '.agents', 'skills', skillName);
   fs.mkdirSync(destDir, { recursive: true });
 
   const srcSkill = path.join(skillDir, 'SKILL.md');

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -314,7 +314,7 @@ describe('host-config-export.ts CLI', () => {
   test('get returns string field', () => {
     const { stdout, exitCode } = run('get', 'codex', 'globalRoot');
     expect(exitCode).toBe(0);
-    expect(stdout).toBe('.codex/skills/gstack');
+    expect(stdout).toBe('.agents/skills/gstack');
   });
 
   test('get returns boolean as 1/0', () => {


### PR DESCRIPTION
## Summary

- update Codex global skill installation from `~/.codex/skills` to `~/.agents/skills`
- keep repo-local Codex skills under `.agents/skills`
- update setup, docs, E2E helper paths, and golden tests to match current Codex skill discovery
- keep legacy `~/.codex/skills` cleanup/rewrite handling where useful for old installs/downstream host rewrites

## Why

Current Codex docs list user skills under `$HOME/.agents/skills` and repo skills under `.agents/skills`. The existing Codex host config and setup path still used `~/.codex/skills` as the global install root, so fresh global installs could land outside the documented discovery path.

## Validation

- `bun run gen:skill-docs --host codex`
- `bun run gen:skill-docs --host factory`
- `bun test test/host-config.test.ts test/gen-skill-docs.test.ts`
- temp-HOME setup smoke: `env HOME=/private/tmp/gstack-codex-home-test ./setup --host codex --quiet`
