### PR TITLE
fix(setup): prefer symlinks on Windows when SeCreateSymbolicLinkPrivilege is available

### DIFF
--- a/setup
+++ b/setup
@@ -44,7 +44,6 @@ _link_or_copy() {
   local src="$1"
   local dst="$2"
   if [ "$IS_WINDOWS" -eq 1 ]; then
-    rm -rf "$dst"
     # Unix `ln -snf` accepts a name-only or relative-path source even when the
     # target doesn't resolve from CWD (e.g. the connect-chrome alias points at
     # the sibling-relative "gstack/open-gstack-browser"). On Windows the
@@ -53,6 +52,19 @@ _link_or_copy() {
     if [ ! -e "$src" ]; then
       return 0
     fi
+    rm -rf "$dst"
+    # Prefer symlinks when the user has SeCreateSymbolicLinkPrivilege
+    # (Developer Mode ON, or running as admin). Real symlinks auto-refresh
+    # on `git pull`, unlike file copies. Fall back to copy on EACCES so
+    # unprivileged users without Developer Mode still get a working install.
+    if ln -sn "$src" "$dst" 2>/dev/null && [ -L "$dst" ]; then
+      return 0
+    fi
+    # Symlink attempt didn't produce a real symlink — clean up any partial
+    # artifact (e.g. ln exited 0 but created a regular file under dst) and
+    # fall through to copy. Without this, cp -R would fail with "cannot
+    # overwrite non-directory ... with directory" when src is a directory.
+    rm -rf "$dst"
     if [ -d "$src" ]; then
       cp -R "$src" "$dst"
     else

--- a/test/setup-windows-fallback.test.ts
+++ b/test/setup-windows-fallback.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, afterAll } from 'bun:test';
 import { spawnSync } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -124,5 +124,112 @@ describe.skipIf(process.platform === 'win32')('setup: _link_or_copy helper — b
     expect(r.ok).toBe(true);
     expect(r.targetExists).toBe(true);
     expect(r.targetIsSymlink).toBe(false);
+  });
+});
+
+describe('setup: _link_or_copy Windows symlink-fallback paths', () => {
+  const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-win-symlink-'));
+
+  afterAll(() => fs.rmSync(TMP, { recursive: true, force: true }));
+
+  /** Create a `ln` shim at a temp path with the given behavior. */
+  function createShim(behavior: 'always-succeed' | 'always-fail' | 'fake-file'): string {
+    const shimDir = fs.mkdtempSync(path.join(TMP, 'shim-'));
+    const shim = path.join(shimDir, 'ln');
+    let script: string;
+    switch (behavior) {
+      case 'always-succeed':
+        script = `#!/usr/bin/env bash
+src="\${@: -2:1}"
+dst="\${@: -1}"
+# Bypass PATH to avoid re-invoking this very shim.
+/usr/bin/ln -snf "\$src" "\$dst" 2>/dev/null || true
+exit 0
+`;
+        break;
+      case 'always-fail':
+        script = `#!/usr/bin/env bash
+echo "permission denied" >&2
+exit 1
+`;
+        break;
+      case 'fake-file':
+        script = `#!/usr/bin/env bash
+touch "\${@: -1}"
+exit 0
+`;
+        break;
+    }
+    fs.writeFileSync(shim, script, { mode: 0o755 });
+    return shimDir;
+  }
+
+  /** Run the _link_or_copy helper in a subprocess with a custom PATH. */
+  function runWithShim(
+    srcKind: 'file' | 'dir',
+    shimDir: string,
+  ): { ok: boolean; dstIsSymlink: boolean; dstIsDir: boolean; content: string; stderr: string } {
+    const tmp = fs.mkdtempSync(path.join(TMP, 'run-'));
+    try {
+      const src = path.join(tmp, 'source');
+      const dst = path.join(tmp, 'dest');
+      if (srcKind === 'file') {
+        fs.writeFileSync(src, 'hello\n');
+      } else {
+        fs.mkdirSync(src);
+        fs.writeFileSync(path.join(src, 'inner.txt'), 'hello\n');
+      }
+      const helper = extractHelper();
+      const script = `IS_WINDOWS=1\n${helper}\n_link_or_copy "${src}" "${dst}"\n`;
+      const result = spawnSync('bash', ['-c', script], {
+        cwd: tmp,
+        encoding: 'utf-8',
+        timeout: 5000,
+        env: { ...process.env, PATH: `${shimDir}${path.delimiter}${process.env.PATH}` },
+      });
+      const lst = fs.lstatSync(dst, { throwIfNoEntry: false });
+      const exists = lst !== undefined;
+      let content = '';
+      if (exists) {
+        try { content = srcKind === 'dir'
+          ? fs.readdirSync(dst).sort().join(',')
+          : fs.readFileSync(dst, 'utf-8');
+        } catch { content = '<error reading>'; }
+      }
+      return {
+        ok: result.status === 0,
+        dstIsSymlink: exists && lst.isSymbolicLink(),
+        dstIsDir: exists && lst.isDirectory(),
+        content,
+        stderr: result.stderr,
+      };
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
+  test('_link_or_copy prefers symlinks when supported (Windows)', () => {
+    const shimDir = createShim('always-succeed');
+    const r = runWithShim('file', shimDir);
+    expect(r.ok).toBe(true);
+    expect(r.dstIsSymlink).toBe(true);
+    expect(r.content).toBe('hello\n');
+  });
+
+  test('_link_or_copy falls back to copy when symlink denied (Windows)', () => {
+    const shimDir = createShim('always-fail');
+    const r = runWithShim('file', shimDir);
+    expect(r.ok).toBe(true);
+    expect(r.dstIsSymlink).toBe(false);
+    expect(r.content).toBe('hello\n');
+  });
+
+  test('_link_or_copy handles "success-but-not-link" postcondition (race condition guard)', () => {
+    const shimDir = createShim('fake-file');
+    const r = runWithShim('dir', shimDir);
+    expect(r.ok).toBe(true);
+    expect(r.dstIsSymlink).toBe(false);
+    expect(r.dstIsDir).toBe(true);
+    expect(r.content).toContain('inner.txt');
   });
 });


### PR DESCRIPTION
## What

Lets `_link_or_copy()` try `ln -sn` before falling back to `cp` on Windows, when Developer Mode or elevation is present.

## Why

Today's helper unconditionally takes the `cp` branch on Windows to avoid "frozen copies" — `ln -snf` without `SeCreateSymbolicLinkPrivilege` silently produces a copy that doesn't refresh after `git pull`. But this is over-defense: users with Developer Mode get the worst of both worlds (frozen copies) despite having the capability for true symlinks. macOS/Linux users get live symlinks; Windows users with Developer Mode should too.

## How

Three changes to `_link_or_copy()`, all inside the existing IS_WINDOWS=1 branch:

1. Try `ln -sn src dst` first (stderr redirected to /dev/null).
2. Verify the result is a real symlink (`[ -L "$dst" ]` postcondition — catches races where `ln` exits 0 but writes a regular file under `dst`).
3. On failure, run a second `rm -rf "$dst"` and fall through to `cp -R` / `cp -f` (preserves today's behavior for non-Developer-Mode users).

The second `rm -rf` is load-bearing: without it, `cp -R` would fail with "cannot overwrite non-directory ... with directory" when a half-successful `ln` left a regular file at `dst` and `src` is a directory.

All raw `ln` calls stay inside the helper body, preserving the D7 static invariant (`test/setup-windows-fallback.test.ts:25-44`). The `if [ ! -e "$src" ]; return 0` early-return is preserved from the original helper, not introduced here.

### Verification

- [x] `bun test test/setup-windows-fallback.test.ts` — D7 invariant + 3 new symlink-fallback cases pass
- [x] `bun test` — full Tier 1 suite passes
- [ ] `bun run test:e2e` (Tier 2) — requires EVALS secret, maintainer-side gate
- [ ] Manual: Developer Mode ON → `ls -la ~/.claude/skills/qa/SKILL.md` shows symlink (`lrwxrwxrwx`)
- [ ] Manual: Developer Mode OFF → `ls -la` shows regular file (`-rw-r--r--`)

### Notes for reviewer

- No `chore: regenerate llms.txt` commit: the local modification produces no content diff in `gstack/llms.txt` (the file is generated from SKILL.md frontmatter, not from `setup`).
- No Windows path edge cases covered (spaces, non-ASCII, UNC). Follow-up if reported.
- CI's `windows-setup-e2e.yml` will rebuild binaries on this branch's push (paths trigger includes `setup`).