### PR TITLE
fix: skill:check no longer fails on host-skipped skill templates

### DIFF
--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -65,7 +65,17 @@ for (const file of SKILL_FILES) {
 console.log('\n  Templates:');
 const TEMPLATES = discoverTemplates(ROOT);
 
+// Skills the claude host never generates (e.g. the /claude outside-voice
+// wrapper, which only exists for non-Claude hosts) — a missing output for
+// these is intentional, not staleness.
+const CLAUDE_SKIP_SKILLS = new Set(getHostConfig('claude').generation.skipSkills ?? []);
+
 for (const { tmpl, output } of TEMPLATES) {
+  const skillDir = tmpl.includes('/') ? tmpl.split('/')[0] : '';
+  if (skillDir && CLAUDE_SKIP_SKILLS.has(skillDir)) {
+    console.log(`  -  ${output.padEnd(30)} — not generated for claude host (skipSkills)`);
+    continue;
+  }
   const tmplPath = path.join(ROOT, tmpl);
   const outPath = path.join(ROOT, output);
   if (!fs.existsSync(tmplPath)) {
@@ -90,7 +100,7 @@ for (const file of SKILL_FILES) {
 
 // ─── External Host Skills (config-driven) ───────────────────
 
-import { getExternalHosts } from '../hosts/index';
+import { getExternalHosts, getHostConfig } from '../hosts/index';
 
 for (const hostConfig of getExternalHosts()) {
   const hostDir = path.join(ROOT, hostConfig.hostSubdir, 'skills');


### PR DESCRIPTION
## What was broken

`bun run skill:check` exits 1 on a pristine checkout of main. The template-coverage loop in `scripts/skill-check.ts` flags `claude/SKILL.md` as "generated file missing! Run: bun run gen:skill-docs" — but running that command doesn't (and shouldn't) create the file: `hosts/claude.ts` declares `generation.skipSkills: ['claude']`, since the `/claude` outside-voice wrapper (added in #2078) is only generated for non-Claude hosts.

## The fix

The template loop now consults `getHostConfig('claude').generation.skipSkills` (same registry already imported for `getExternalHosts`) and prints an informational line for host-skipped skills instead of an error:

```
  -  claude/SKILL.md                — not generated for claude host (skipSkills)
```

## Verification

In a fresh worktree of main with all host files generated (`gen-skill-docs --host <h>` for each external host):

- **Without the fix:** `skill:check` exits 1 with exactly one ❌ (`claude/SKILL.md — generated file missing`)
- **With the fix:** exits 0, zero ❌, informational skip line present
- `bun test` (free tier) passes

## Note on CI

This is a fork PR, so per the repo's CLAUDE.md, eval/E2E jobs will fail with empty-env auth errors — that's the fork-secrets issue, not this change. check-freshness, workflow-lint, and windows-tests should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
