### PR TITLE
gstack-upgrade: stop the browse daemon after upgrading

### DIFF
--- a/gstack-upgrade/SKILL.md
+++ b/gstack-upgrade/SKILL.md
@@ -229,6 +229,29 @@ rm -f ~/.gstack/last-update-check
 rm -f ~/.gstack/update-snoozed
 ```
 
+### Step 5.5: Settle the browse daemon
+
+A running `browse` daemon is still on the OLD version. Until it's recycled, every
+`browse` call detects the version mismatch and kills + relaunches the daemon — and
+each relaunch resets the viewport to the default and wipes the browser context, so
+logged-in sessions drop and tabs land on `about:blank`. That churn is the usual
+cause of "browse suddenly can't hold a viewport / keeps logging me out / lands on
+about:blank" right after an upgrade.
+
+Stop it cleanly so the next `browse` call relaunches exactly once, on the new
+version:
+
+```bash
+BROWSE_BIN="$INSTALL_DIR/browse/dist/browse"
+if [ -x "$BROWSE_BIN" ] && "$BROWSE_BIN" status 2>/dev/null | grep -qi '^PID:'; then
+  "$BROWSE_BIN" stop 2>/dev/null || true
+  echo "Stopped the browse daemon so it relaunches on the new version."
+fi
+```
+
+Only ever use `browse stop` for this. Never `pkill`/pattern-kill chromium or browse
+processes — that can take down the user's real browser windows.
+
 ### Step 6: Show What's New
 
 Read `$INSTALL_DIR/CHANGELOG.md`. Find all version entries between the old version and the new version. Summarize as 5-7 bullets grouped by theme. Don't overwhelm — focus on user-facing changes. Skip internal refactors unless they're significant.

--- a/gstack-upgrade/SKILL.md.tmpl
+++ b/gstack-upgrade/SKILL.md.tmpl
@@ -226,6 +226,29 @@ rm -f ~/.gstack/last-update-check
 rm -f ~/.gstack/update-snoozed
 ```
 
+### Step 5.5: Settle the browse daemon
+
+A running `browse` daemon is still on the OLD version. Until it's recycled, every
+`browse` call detects the version mismatch and kills + relaunches the daemon — and
+each relaunch resets the viewport to the default and wipes the browser context, so
+logged-in sessions drop and tabs land on `about:blank`. That churn is the usual
+cause of "browse suddenly can't hold a viewport / keeps logging me out / lands on
+about:blank" right after an upgrade.
+
+Stop it cleanly so the next `browse` call relaunches exactly once, on the new
+version:
+
+```bash
+BROWSE_BIN="$INSTALL_DIR/browse/dist/browse"
+if [ -x "$BROWSE_BIN" ] && "$BROWSE_BIN" status 2>/dev/null | grep -qi '^PID:'; then
+  "$BROWSE_BIN" stop 2>/dev/null || true
+  echo "Stopped the browse daemon so it relaunches on the new version."
+fi
+```
+
+Only ever use `browse stop` for this. Never `pkill`/pattern-kill chromium or browse
+processes — that can take down the user's real browser windows.
+
 ### Step 6: Show What's New
 
 Read `$INSTALL_DIR/CHANGELOG.md`. Find all version entries between the old version and the new version. Summarize as 5-7 bullets grouped by theme. Don't overwhelm — focus on user-facing changes. Skip internal refactors unless they're significant.


### PR DESCRIPTION
## Problem

After a gstack upgrade, a still-running `browse` daemon is on the *pre-upgrade* version. Until it's recycled, every subsequent `browse` call detects the version mismatch and kills + relaunches the daemon. Each relaunch:

- resets the viewport to the default, and
- wipes the browser context — logged-in sessions drop and tabs land on `about:blank`.

In practice this reads as *"browse suddenly can't hold a viewport / keeps logging me out / lands on about:blank"* for a stretch right after an upgrade, until the daemon happens to settle on the new version. It's easy to misdiagnose as a browse bug or a flaky site. Observed the daemon PID change 3× across one session during the churn window (viewport reset + auth-cookie loss each time); it stabilized once it settled on the new version.

## Fix

Add **Step 5.5: Settle the browse daemon** to the inline upgrade flow (right after the version marker is written). If a daemon is running, `browse stop` it so the next `browse` call relaunches exactly once, cleanly, on the new version:

```bash
BROWSE_BIN="$INSTALL_DIR/browse/dist/browse"
if [ -x "$BROWSE_BIN" ] && "$BROWSE_BIN" status 2>/dev/null | grep -qi '^PID:'; then
  "$BROWSE_BIN" stop 2>/dev/null || true
fi
```

Uses only `browse stop` — never `pkill`/pattern-kill, which can take down the user's real browser windows.

## Notes

- Edited `SKILL.md.tmpl` (source) and `SKILL.md` together with the identical block; regenerate `SKILL.md` from the template if that's preferred in CI.
- Scoped to the inline upgrade flow; guarded so it's a no-op when no daemon is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)