### PR TITLE
fix(windows): node-path console flashes + watchdog split-brain — polyfill windowsHide, signal-0 isProcessAlive, trippable respawn guard

### DIFF
--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -75,6 +75,9 @@ globalThis.Bun = {
       timeout: options.timeout,
       env: options.env,
       cwd: options.cwd,
+      // The browse server runs console-less on Windows; without this every
+      // subprocess (tasklist, git, icacls) pops a visible console window.
+      windowsHide: true,
     });
 
     return {
@@ -91,6 +94,10 @@ globalThis.Bun = {
       stdio,
       env: options.env,
       cwd: options.cwd,
+      detached: options.detached,
+      // Same as spawnSync: detached daemons (terminal-agent respawns) must
+      // not flash a console window on Windows.
+      windowsHide: true,
     });
 
     return {

--- a/browse/src/error-handling.ts
+++ b/browse/src/error-handling.ts
@@ -7,8 +7,6 @@
 
 import * as fs from 'fs';
 
-const IS_WINDOWS = process.platform === 'win32';
-
 // ─── Filesystem ────────────────────────────────────────────────
 
 /** Remove a file, ignoring ENOENT (already gone). Rethrows other errors. */
@@ -36,23 +34,26 @@ export function safeKill(pid: number, signal: NodeJS.Signals | number): void {
   }
 }
 
-/** Check if a PID is alive. Pure boolean probe — returns false for ALL errors. */
+/**
+ * Check if a PID is alive. Pure boolean probe — never throws.
+ *
+ * signal-0 on every platform: Node and Bun both implement
+ * `process.kill(pid, 0)` on Windows via an OpenProcess existence check —
+ * no child process, no console window. The previous Windows branch spawned
+ * `tasklist`, which (a) flashed a visible console window from console-less
+ * daemons on every call (#1952), and (b) silently returned false for LIVE
+ * processes when tasklist exceeded its 3s timeout — node's spawnSync
+ * reports timeout via `result.error` without throwing, so the empty-stdout
+ * path read as "dead". A false "dead" makes the terminal-agent watchdog
+ * respawn around a live agent and orphan it (split-brain, #2151).
+ *
+ * EPERM ⇒ alive: the process exists but can't be signalled by this user.
+ */
 export function isProcessAlive(pid: number): boolean {
-  if (IS_WINDOWS) {
-    try {
-      const result = Bun.spawnSync(
-        ['tasklist', '/FI', `PID eq ${pid}`, '/NH', '/FO', 'CSV'],
-        { stdout: 'pipe', stderr: 'pipe', timeout: 3000 }
-      );
-      return result.stdout.toString().includes(`"${pid}"`);
-    } catch {
-      return false;
-    }
-  }
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (err: any) {
+    return err?.code === 'EPERM';
   }
 }

--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -1504,9 +1504,9 @@ export function buildFetchHandler(cfg: ServerConfig): ServerHandle {
   // (which would create split-brain — two agents writing the port file,
   // tokens diverging between them, mystery PTY upgrade failures).
   //
-  // Crash-loop guard: 3 respawn attempts inside 60s → stop trying and emit
-  // a one-line error. Manual `forceRestart` from the sidebar clears the
-  // history (the user is the explicit signal to retry).
+  // Crash-loop guard: 3 respawn attempts inside 3 ticks → stop trying and
+  // emit a one-line error. Manual `forceRestart` from the sidebar clears
+  // the history (the user is the explicit signal to retry).
   //
   // Only active when ownsTerminalAgent === true. Embedders that pre-launch
   // their own PTY server (gbrowser phoenix overlay) must not be auto-respawned
@@ -1517,8 +1517,11 @@ export function buildFetchHandler(cfg: ServerConfig): ServerHandle {
     process.env.GSTACK_AGENT_WATCHDOG_TICK_MS || '60000',
     10,
   );
-  const RESPAWN_GUARD_WINDOW_MS = 60_000;
   const RESPAWN_GUARD_MAX = 3;
+  // The guard must span at least RESPAWN_GUARD_MAX ticks or it can never
+  // trip: respawn attempts land at most once per tick, so a 60s window
+  // over a 60s tick sees a single attempt forever (see #2151).
+  const RESPAWN_GUARD_WINDOW_MS = Math.max(60_000, AGENT_WATCHDOG_TICK_MS * RESPAWN_GUARD_MAX);
   let agentRespawnGuardTripped = false;
 
   if (ownsTerminalAgent) {

--- a/browse/test/bun-polyfill.test.ts
+++ b/browse/test/bun-polyfill.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, afterAll } from 'bun:test';
+import * as fs from 'fs';
 import * as path from 'path';
 
 // Load the polyfill into a fresh object (don't clobber globalThis.Bun)
@@ -46,6 +47,23 @@ describe('bun-polyfill', () => {
     expect(lines[0]).toBe('HAS_PID');
     expect(lines[1]).toBe('HAS_KILL');
     expect(lines[2]).toBe('HAS_UNREF');
+  });
+
+  test('spawn and spawnSync pass windowsHide (no console flash from console-less daemons)', () => {
+    // Static tripwire (#2151): on Windows the browse server always runs
+    // under Node via this polyfill, and node's child_process defaults to
+    // windowsHide: false — so every subprocess the console-less daemon
+    // spawns (terminal-agent respawns, git, icacls) pops a visible console
+    // window. Both spawn paths must pass windowsHide: true, and spawn must
+    // forward `detached` for daemon children. Behavioral assertion isn't
+    // possible cross-platform (window creation is invisible to the child),
+    // hence source-level pinning.
+    const src = fs.readFileSync(polyfillPath, 'utf-8');
+    const spawnSyncBlock = src.slice(src.indexOf('spawnSync(cmd'), src.indexOf('spawn(cmd'));
+    const spawnBlock = src.slice(src.indexOf('spawn(cmd'));
+    expect(spawnSyncBlock).toContain('windowsHide: true');
+    expect(spawnBlock).toContain('windowsHide: true');
+    expect(spawnBlock).toContain('detached: options.detached');
   });
 
   test('Bun.serve creates an HTTP server that responds', async () => {

--- a/browse/test/error-handling.test.ts
+++ b/browse/test/error-handling.test.ts
@@ -44,4 +44,28 @@ describe('isProcessAlive', () => {
   test('returns false for non-existent process', () => {
     expect(isProcessAlive(99999999)).toBe(false);
   });
+
+  test('returns true for a live but unsignallable process (EPERM ⇒ alive)', () => {
+    // PID 4 = System on Windows, PID 1 = init/launchd on POSIX. Both are
+    // always alive; signalling them as an unprivileged user throws EPERM,
+    // which must read as "alive" (as root/admin the probe just succeeds).
+    const protectedPid = process.platform === 'win32' ? 4 : 1;
+    expect(isProcessAlive(protectedPid)).toBe(true);
+  });
+
+  test('never spawns a subprocess (no tasklist on Windows)', () => {
+    // Static tripwire: the pre-#2151 Windows branch shelled out to
+    // `tasklist`, which flashed a console window from console-less daemons
+    // on every watchdog tick (#1952) and silently reported live agents as
+    // dead when tasklist exceeded its timeout — triggering split-brain
+    // respawns (#2151). signal-0 is a pure syscall on every platform.
+    const src = fs.readFileSync(
+      path.resolve(import.meta.dir, '..', 'src', 'error-handling.ts'),
+      'utf-8',
+    );
+    // Reject only actual invocations — the doc comment on isProcessAlive
+    // may mention tasklist when explaining what the signal-0 probe replaced.
+    expect(src).not.toMatch(/spawnSync\s*\(\s*\[?\s*['"]tasklist/);
+    expect(src).not.toMatch(/spawn\s*\(\s*\[?\s*['"]tasklist/);
+  });
 });

--- a/browse/test/terminal-agent-watchdog.test.ts
+++ b/browse/test/terminal-agent-watchdog.test.ts
@@ -50,7 +50,12 @@ describe('terminal-agent watchdog (v1.44+)', () => {
   test('4. crash-loop guard with rolling window', () => {
     const src = fs.readFileSync(SERVER_TS, 'utf-8');
     const block = sliceBetween(src, '─── Terminal-Agent Watchdog', 'Factory-scoped validateAuth');
-    expect(block).toContain('RESPAWN_GUARD_WINDOW_MS = 60_000');
+    // The window must span at least RESPAWN_GUARD_MAX ticks. Respawn
+    // attempts land at most once per tick, so a fixed 60s window over a
+    // 60s tick would see a single attempt forever and never trip (#2151).
+    expect(block).toContain(
+      'RESPAWN_GUARD_WINDOW_MS = Math.max(60_000, AGENT_WATCHDOG_TICK_MS * RESPAWN_GUARD_MAX)',
+    );
     expect(block).toContain('RESPAWN_GUARD_MAX = 3');
     expect(block).toContain('respawnHistory');
     expect(block).toContain('agentRespawnGuardTripped');


### PR DESCRIPTION
Fixes #2151. Fixes #1952.

## What

Three small fixes for the Windows node path (`server-node.mjs` + `bun-polyfill.cjs`), one commit each:

1. **`bun-polyfill.cjs`: pass `windowsHide: true` in `spawn`/`spawnSync`, forward `detached`.** The polyfill forwarded only `stdio`/`env`/`cwd`, and node's `child_process` defaults `windowsHide` to false — so every subprocess the console-less daemon spawned (terminal-agent respawns, `tasklist` probes, `git`, `icacls`) flashed a visible console window. This is also why call-site fixes like the one proposed in #2019 would have been silently swallowed on Windows: on the node path `Bun.spawn` is this polyfill, and it dropped the option.

2. **`isProcessAlive`: signal-0 on all platforms, replacing the Windows `tasklist` branch** — the fix proposed in #1952 (credit to that report). Beyond the per-tick console flash, the `tasklist` branch had a correctness bug: node's `spawnSync` reports a timeout via `result.error` *without throwing*, so a slow `tasklist` (>3s on a loaded box) returned empty stdout and read as **"dead" for a live agent**. The watchdog then cleared the live agent's record and spawned a duplicate around it, while `killAgentByRecord` consulted the same false probe and skipped the kill — the split-brain documented in #2151 (two live agents one tick apart, prior never reaped). Signal-0 removes the subprocess, the flash, and the false-dead path in one line, and fixes the old Unix branch collapsing EPERM (exists-but-unsignallable) to "dead".

3. **Respawn guard window spans `guard-max` ticks.** The crash-loop guard (3 respawns in 60s → stop, require manual restart) could never trip: respawn attempts land at most once per tick and the window equaled the tick interval, so the rolling history never held more than one entry. A crash-looping agent respawned once a minute indefinitely. Now `RESPAWN_GUARD_WINDOW_MS = Math.max(60_000, AGENT_WATCHDOG_TICK_MS * RESPAWN_GUARD_MAX)`.

`killAgentByRecord`'s liveness gate is deliberately **untouched**: with a reliable probe (fix 2) the gate's PID-reuse defense is harmless again, so the design pinned by `terminal-agent-pid-identity.test.ts` tests 5–6 stands.

## Verification

- **Signal-0 on Windows** (Windows 11, node 22 / bun 1.3.14): alive PID → `true`, dead PID → `false`, PID 4 (System, unsignallable) → EPERM → `true`. Verified under both runtimes.
- **Live incident** (from #2151): with the unpatched install, the daemon respawned a duplicate agent one tick after the first, both stayed alive, and every spawn flashed a console window. With these patches applied to the local install (`src` + `dist` bundle), spawn/probe subprocesses no longer open windows and the polyfill smoke-tests pass under node.
- **Tests**: new static tripwires pin `windowsHide: true` in both polyfill spawn paths and reject any `tasklist` invocation in `error-handling.ts`; new EPERM⇒alive case; watchdog static test updated for the new window expression. On this Windows machine the branch *improves* the suite vs upstream main (e.g. `server-embedder-terminal-port.test.ts` goes 1 pass/3 fail → 3 pass/1 fail; every remaining failure reproduces identically on clean upstream main — pre-existing `new URL(import.meta.url).pathname` path mangling on Windows in the static tests, unrelated to this diff).

## Not covered (left to their own issues)

- Cross-session orphan reaping from #2019 (this PR fixes the *within-session* duplication trigger; stale agents from crashed sessions still need the boot-time sweep proposed there). #2019's call-site `windowsHide` for the Bun-runtime path also composes cleanly on top of this.
- The Bun-runtime `Bun.spawnSync` flash surfaces in #1784/#1989.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
