### PR TITLE
fix(browse): wait for web fonts before screenshots

### DIFF
--- a/browse/src/meta-commands.ts
+++ b/browse/src/meta-commands.ts
@@ -20,6 +20,7 @@ import * as path from 'path';
 import { writeSecureFile, mkdirSecure } from './file-permissions';
 import { TEMP_DIR } from './platform';
 import { resolveConfig } from './config';
+import { waitForFonts } from './screenshot-utils';
 import type { Frame } from 'playwright';
 
 /** Tokenize a pipe segment respecting double-quoted strings. */
@@ -496,6 +497,9 @@ export async function handleMetaCommand(
         throw new Error('Cannot use --viewport with --clip — choose one');
       }
 
+      // Let web fonts settle so text renders in the intended typeface, not a fallback.
+      await waitForFonts(page);
+
       // --base64 mode: capture to buffer instead of disk
       if (base64Mode) {
         let buffer: Buffer;
@@ -581,6 +585,7 @@ export async function handleMetaCommand(
         await page.setViewportSize({ width: vp.width, height: vp.height });
         const screenshotPath = `${prefix}-${vp.name}.png`;
         validateOutputPath(screenshotPath);
+        await waitForFonts(page);
         await page.screenshot({ path: screenshotPath, fullPage: true });
         await guardScreenshotPath(screenshotPath);
         results.push(`${vp.name} (${vp.width}x${vp.height}): ${screenshotPath}`);

--- a/browse/src/screenshot-utils.ts
+++ b/browse/src/screenshot-utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared screenshot pre-flight helpers.
+ */
+
+import type { Page } from 'playwright';
+
+/**
+ * Wait for web fonts to finish loading before capturing a screenshot.
+ *
+ * Without this, `page.screenshot()` can fire mid-FOIT (flash of invisible /
+ * fallback text): `@font-face` and Google-Font glyphs haven't downloaded yet,
+ * so text renders in a system fallback or blank — the "bad images" seen from
+ * qa / design-review / responsive captures. `document.fonts.ready` resolves
+ * once all pending font loads settle. Best-effort and capped so a page that
+ * never settles (streaming/lazy fonts) can't hang the capture.
+ */
+export async function waitForFonts(page: Page, timeoutMs = 3000): Promise<void> {
+  try {
+    await page.evaluate(
+      (ms) =>
+        Promise.race([
+          (document as any).fonts?.ready ?? Promise.resolve(),
+          new Promise((resolve) => setTimeout(resolve, ms)),
+        ]).then(() => undefined),
+      timeoutMs,
+    );
+  } catch {
+    // Navigation/context teardown races are non-fatal — proceed with capture.
+  }
+}

--- a/browse/src/snapshot.ts
+++ b/browse/src/snapshot.ts
@@ -22,6 +22,7 @@ import type { TabSession, RefEntry } from './tab-session';
 import * as Diff from 'diff';
 import { TEMP_DIR, isPathWithin } from './platform';
 import { escapeEnvelopeSentinels } from './content-security';
+import { waitForFonts } from './screenshot-utils';
 import { stripLoneSurrogates } from './sanitize';
 import { guardScreenshotPath } from './screenshot-size-guard';
 
@@ -418,6 +419,7 @@ export async function handleSnapshot(
         }
       }, boxes);
 
+      await waitForFonts(page);
       await page.screenshot({ path: screenshotPath, fullPage: true });
       await guardScreenshotPath(screenshotPath);
 
@@ -539,6 +541,7 @@ export async function handleSnapshot(
         }
       }, boxes);
 
+      await waitForFonts(page);
       await page.screenshot({ path: heatmapPath, fullPage: true });
       await guardScreenshotPath(heatmapPath);
 

--- a/browse/src/write-commands.ts
+++ b/browse/src/write-commands.ts
@@ -18,6 +18,7 @@ import type { SetContentWaitUntil } from './tab-session';
 import { TEMP_DIR, isPathWithin } from './platform';
 import { SAFE_DIRECTORIES } from './path-security';
 import { modifyStyle, undoModification, resetModifications, getModificationHistory } from './cdp-inspector';
+import { waitForFonts } from './screenshot-utils';
 import { withCdpSession } from './cdp-bridge';
 
 /**
@@ -1124,6 +1125,7 @@ export async function handleWriteCommand(
       }
 
       // Take screenshot
+      await waitForFonts(page);
       await page.screenshot({ path: outputPath, fullPage: !scrollTo });
       // Guard against Anthropic vision API >2000px brick (#1214). Only
       // applies to fullPage captures; scrollTo viewport-bound shots are

--- a/browse/test/screenshot-utils.test.ts
+++ b/browse/test/screenshot-utils.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for the screenshot font pre-flight helper.
+ *
+ * `waitForFonts` lets `document.fonts.ready` settle before a capture so text
+ * renders in the intended typeface instead of a fallback (the "bad fonts" seen
+ * from qa / design-review / responsive screenshots). The contract is
+ * best-effort: it must pass the page a numeric cap and must never throw, since
+ * a font wait failing should not abort the screenshot.
+ *
+ * The real Chromium capture paths are exercised by the browse E2E suite — we
+ * don't spin up a browser here. The static invariant below pins that every
+ * full-page callsite waits for fonts.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { waitForFonts } from '../src/screenshot-utils';
+
+// Minimal Page stub — only `evaluate` is touched by the helper.
+function fakePage(evaluate: (fn: unknown, arg: unknown) => Promise<unknown>) {
+  return { evaluate } as any;
+}
+
+describe('waitForFonts', () => {
+  test('awaits page.evaluate with a numeric timeout argument', async () => {
+    let seenArg: unknown;
+    await waitForFonts(
+      fakePage(async (_fn, arg) => {
+        seenArg = arg;
+        return undefined;
+      }),
+      1234,
+    );
+    expect(seenArg).toBe(1234);
+  });
+
+  test('defaults to a finite timeout when none is given', async () => {
+    let seenArg: unknown;
+    await waitForFonts(
+      fakePage(async (_fn, arg) => {
+        seenArg = arg;
+        return undefined;
+      }),
+    );
+    expect(typeof seenArg).toBe('number');
+    expect(Number.isFinite(seenArg as number)).toBe(true);
+  });
+
+  test('never throws when evaluate rejects (navigation/teardown race)', async () => {
+    await expect(
+      waitForFonts(
+        fakePage(() => Promise.reject(new Error('Execution context was destroyed'))),
+        10,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('static invariant: every full-page callsite waits for fonts', () => {
+  test('snapshot.ts, meta-commands.ts, and write-commands.ts wire waitForFonts', () => {
+    const browseSrc = join(import.meta.dir, '..', 'src');
+    const paths = ['snapshot.ts', 'meta-commands.ts', 'write-commands.ts'];
+    for (const rel of paths) {
+      const content = readFileSync(join(browseSrc, rel), 'utf-8');
+      expect(content).toContain('waitForFonts');
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Every screenshot capture path fires `page.screenshot()` immediately with no wait for web fonts. On any page using `@font-face` / Google Fonts, the shot lands mid-FOIT (flash of invisible/fallback text) — the fonts haven't downloaded yet, so text renders in a system fallback or blank. This shows up as "bad images" from `/qa`, `/design-review`, and `responsive` captures, especially on the first capture after navigation.

The `screenshot-size-guard` work already touched these same callsites; this is the timing gap right before them.

## Fix

New shared helper `browse/src/screenshot-utils.ts`:

```ts
export async function waitForFonts(page, timeoutMs = 3000) {
  // await document.fonts.ready, raced against a cap so lazy/streaming
  // fonts can't hang the capture; best-effort, never throws
}
```

Called before every full-page screenshot:

| File | Path |
|---|---|
| `meta-commands.ts` | `screenshot` (disk / `--base64` / `--clip` / `--selector`) |
| `meta-commands.ts` | `responsive` (per viewport — a resize can re-trigger font loads) |
| `write-commands.ts` | `prettyscreenshot` |
| `snapshot.ts` | annotated (`-a`) + heatmap |

It's best-effort and capped at 3s via `Promise.race`, so a page whose fonts never settle can't hang a capture, and a font-wait failure (navigation/context teardown race) never aborts the screenshot.

## Testing

- `browse/test/screenshot-utils.test.ts` — verifies the helper passes a numeric cap, defaults to a finite timeout, and never throws when `evaluate` rejects; plus a static invariant pinning that all three full-page callsites wire `waitForFonts` (mirrors the `screenshot-size-guard` test pattern).
- `bun test browse/test/screenshot-utils.test.ts` → 4 pass.
- `bash browse/scripts/build-node-server.sh` bundles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)