### PR TITLE
Allowlist Input.dispatchMouseEvent for trusted mouse gestures

### DIFF
--- a/browse/src/cdp-allowlist.ts
+++ b/browse/src/cdp-allowlist.ts
@@ -199,6 +199,14 @@ export const CDP_ALLOWLIST: ReadonlyArray<CdpAllowEntry> = Object.freeze([
     output: 'untrusted',
     justification: 'Inspect properties of an existing remote object. Read-only; output may contain page data.',
   },
+  // ─── Input (synthetic trusted user gestures) ───────────────
+  {
+    domain: 'Input',
+    method: 'dispatchMouseEvent',
+    scope: 'tab',
+    output: 'trusted',
+    justification: 'Trusted mouse gesture for widgets that ignore JS clicks (e.g. Personio Gefahrtarifstelle "Monat auswählen" dropdown). Focused tab only; returns an ack, no page content.',
+  },
 ]);
 
 const CDP_ALLOWLIST_INDEX: Map<string, CdpAllowEntry> = new Map(


### PR DESCRIPTION
## What

Adds `Input.dispatchMouseEvent` to `CDP_ALLOWLIST` (`browse/src/cdp-allowlist.ts`), scope `tab`, output `trusted`.

## Why

Some web widgets only open on a **genuine OS-level mouse event** and ignore every synthetic/JS-dispatched click. Concrete real-world case: Personio's Gefahrtarifstelle "Monat auswählen" month dropdown — a normal `$B click`, JS `.click()`, a full PointerEvent sequence, the React `onClick` handler, and keyboard activation all fail to open it, while the *sibling* dropdown right next to it opens on a plain click. The only thing that opens it is a real pointer event via `$B cdp Input.dispatchMouseEvent` (mousePressed + mouseReleased at the element's CSS-pixel center).

Without this, such widgets are undrivable from automation and require a manual human click.

## Safety

- **scope: `tab`** — input is delivered to the focused tab only (goes through the existing T7 mutex tier).
- **output: `trusted`** — the method returns only an ack, no page content, so there's no exfil/injection vector (unlike `Network.getResponseBody` et al.).
- Does not enable navigation, evaluation, or data extraction.

## Test

`browse/test/cdp-allowlist.test.ts`: **6 pass / 0 fail** (every entry validated for the 4 required fields).