### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,37 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly on Monday at 06:00 UTC - catches new advisories between pushes
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite


### PR DESCRIPTION
Hi @garrytan  - I'm Sonu Kapoor, the creator of CVE Lite CLI (https://github.com/OWASP/cve-lite-cli), an OWASP Lab Project for dependency vulnerability scanning in JS/TS projects.

gstack has no dependency scanning configured today. This workflow adds it using the official action:

- Scans all lockfiles on every push, PR, and weekly schedule
- Fails the job on high/critical findings (`fail-on: high`)
- Uploads findings to the GitHub Security tab via SARIF

All action references are SHA-pinned per the repo's policy.

Happy to adjust the `fail-on` threshold or anything else if you have a preference.