### PR TITLE
fix(test): make chromium profile fallback path portable

### DIFF
--- a/browse/test/config.test.ts
+++ b/browse/test/config.test.ts
@@ -367,7 +367,7 @@ describe('resolveChromiumProfile', () => {
     delete process.env.CHROMIUM_PROFILE;
     process.env.GSTACK_HOME = '/tmp/fallback-gstack';
     try {
-      expect(resolveChromiumProfile()).toBe('/tmp/fallback-gstack/chromium-profile');
+      expect(resolveChromiumProfile()).toBe(path.join('/tmp/fallback-gstack', 'chromium-profile'));
     } finally {
       if (origEnv !== undefined) process.env.CHROMIUM_PROFILE = origEnv;
       if (origHome === undefined) delete process.env.GSTACK_HOME;


### PR DESCRIPTION
## Summary

- make the Chromium profile fallback test compare with `path.join(...)`
- keep the assertion portable across POSIX and Windows path separators

## Verification

- `bun test browse/test/config.test.ts`: 41 pass, 0 fail
- `git diff --check`
