### PR TITLE
Add free Search MCP setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ Invoke them by name (e.g., `/office-hours`).
 | `/benchmark` | Performance regression detection (page load, Core Web Vitals). |
 | `/benchmark-models` | Cross-model benchmark for skills (Claude, GPT, Gemini side-by-side). |
 | `/cso` | OWASP Top 10 + STRIDE security audit. |
+| `/setup-search-mcp` | Optional free Search MCP setup for Search Before Building. |
 | `/setup-gbrain` | Set up gbrain for cross-machine session memory sync. |
 | `/sync-gbrain` | Keep gbrain current with this repo's code; refresh agent search guidance in CLAUDE.md. |
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Fork it. Improve it. Make it yours. And if you want to hate on free open source 
 
 Open Claude Code and paste this. Claude does the rest.
 
-> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /document-generate, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.
+> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-search-mcp, /setup-gbrain, /retro, /investigate, /document-release, /document-generate, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.
 
 ### Step 2: Team mode — auto-update for shared repos (recommended)
 
@@ -229,6 +229,7 @@ Each skill feeds into the next. `/office-hours` writes a design doc that `/plan-
 | `/unfreeze` | **Unlock** — remove the `/freeze` boundary. |
 | `/open-gstack-browser` | **GStack Browser** — launch GStack Browser with sidebar, anti-bot stealth, auto model routing (Sonnet for actions, Opus for analysis), one-click cookie import, and Claude Code integration. Clean up pages, take smart screenshots, edit CSS, and pass info back to your terminal. |
 | `/setup-deploy` | **Deploy Configurator** — one-time setup for `/land-and-deploy`. Detects your platform, production URL, and deploy commands. |
+| `/setup-search-mcp` | **Search MCP Setup** — free web search for agents. Adds Parallel Search MCP on supported hosts; no account or API key by default. |
 | `/setup-gbrain` | **GBrain Onboarding** — from zero to running gbrain in under 5 minutes. PGLite local, Supabase existing URL, or auto-provision a new Supabase project via Management API. MCP registration for Claude Code + per-repo trust triad (read-write/read-only/deny). [Full guide](USING_GBRAIN_WITH_GSTACK.md). |
 | `/sync-gbrain` | **Keep Brain Current** — re-index this repo's code into gbrain via `gbrain sources add` + `gbrain sync --strategy code`, refresh the `## GBrain Search Guidance` block in CLAUDE.md, and auto-remove guidance when the capability check fails. `--incremental` (default), `--full`, `--dry-run`. Idempotent; safe to re-run. |
 | `/gstack-upgrade` | **Self-Updater** — upgrade gstack to latest. Detects global vs vendored install, syncs both, shows what changed. |
@@ -480,7 +481,7 @@ Use /browse from gstack for all web browsing. Never use mcp__claude-in-chrome__*
 Available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review,
 /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy,
 /canary, /benchmark, /browse, /open-gstack-browser, /qa, /qa-only, /design-review,
-/setup-browser-cookies, /setup-deploy, /setup-gbrain, /sync-gbrain, /retro, /investigate,
+/setup-browser-cookies, /setup-deploy, /setup-search-mcp, /setup-gbrain, /sync-gbrain, /retro, /investigate,
 /document-release, /document-generate, /codex, /cso, /autoplan, /pair-agent, /careful, /freeze,
 /guard, /unfreeze, /gstack-upgrade, /learn.
 ```

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -62,6 +62,7 @@ quality gates that produce better results than answering inline.
 - User asks to ship, deploy, push, create a PR, "let's land this", "send it" → invoke `/ship`
 - User asks to merge + deploy + verify as one flow → invoke `/land-and-deploy`
 - User asks to configure deployment for the project → invoke `/setup-deploy`
+- User asks to set up search, install web search MCP, connect Parallel Search MCP, or make Search Before Building work → invoke `/setup-search-mcp`
 - User asks to monitor prod after shipping, post-deploy checks → invoke `/canary`
 - User asks to update docs after shipping → invoke `/document-release`
 - User asks to write docs from scratch, generate documentation, "document this feature/module" → invoke `/document-generate`

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -44,6 +44,7 @@ Detailed guides for every gstack skill — philosophy, workflow, and examples.
 | **Multi-AI** | | |
 | [`/codex`](#codex) | **Second Opinion** | Independent review from OpenAI Codex CLI. Three modes: code review (pass/fail gate), adversarial challenge, and open consultation with session continuity. Cross-model analysis when both `/review` and `/codex` have run. |
 | [`/pair-agent`](#pair-agent) | **Remote Agent Bridge** | Pair a remote AI agent (OpenClaw, Codex, Cursor, Hermes) with your browser. Scoped tunnel, locked allowlist, session token. |
+| [`/setup-search-mcp`](#setup-search-mcp) | **Search MCP Setup** | Free web search for agents. No account or API key by default. |
 | [`/setup-gbrain`](#setup-gbrain) | **Memory Sync** | Set up gbrain for cross-machine session memory sync. One command from zero to live. |
 | [`/sync-gbrain`](#sync-gbrain) | **Keep Brain Current** | Refresh gbrain against this repo's code; teach the agent when to use `gbrain search`/`code-def` over Grep. Idempotent; safe to re-run. |
 | | | |
@@ -920,6 +921,25 @@ You:   /setup-browser-cookies github.com
 
 Claude: Imported 12 cookies for github.com from Comet.
 ```
+
+---
+
+## `/setup-search-mcp`
+
+This sets up free web search for agents through Parallel Search MCP. It gives
+gstack's Search Before Building workflow a no-key path to public web search and
+clean markdown from public URLs.
+
+```
+You:   /setup-search-mcp
+
+Claude: Configured Parallel Search MCP for Claude Code.
+        Default setup is free and no-auth.
+        Restart Claude Code if the new MCP tools are not visible yet.
+```
+
+Use Search MCP for public web search. Use `/browse` for authenticated flows,
+screenshots, clicks, visual QA, and stateful browser work.
 
 ---
 

--- a/gstack/llms.txt
+++ b/gstack/llms.txt
@@ -60,6 +60,7 @@ Conventions:
 - [/setup-browser-cookies](setup-browser-cookies/SKILL.md): Import cookies from your real Chromium browser into the headless browse session.
 - [/setup-deploy](setup-deploy/SKILL.md): Configure deployment settings for /land-and-deploy.
 - [/setup-gbrain](setup-gbrain/SKILL.md): Set up gbrain for this coding agent: install the CLI, initialize a local PGLite or Supabase brain, register MCP, capture per-remote trust policy.
+- [/setup-search-mcp](setup-search-mcp/SKILL.md): Set up free web search for agents in gstack's Search Before Building workflow.
 - [/ship](ship/SKILL.md): Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR.
 - [/skillify](skillify/SKILL.md): Codify the most recent successful /scrape flow into a permanent browser-skill on disk.
 - [/spec](spec/SKILL.md): Turn vague intent into a precise, executable spec in five phases.

--- a/scripts/proactive-suggestions.json
+++ b/scripts/proactive-suggestions.json
@@ -248,6 +248,11 @@
       "routing": "One command from zero to \"gbrain is running, and this agent\ncan call it.\" Use when: \"setup gbrain\", \"connect gbrain\", \"start\ngbrain\", \"install gbrain\", \"configure gbrain for this machine\".",
       "voice_line": null
     },
+    "setup-search-mcp": {
+      "lead": "Set up free web search for agents in gstack's Search Before Building workflow.",
+      "routing": "Adds Parallel Search MCP with no account or API key by default.\nUse when: \"setup search\", \"install search mcp\", \"connect Parallel Search MCP\",\n\"free web search\", \"agent web search\", \"make Search Before Building work\".",
+      "voice_line": null
+    },
     "ship": {
       "lead": "Ship workflow: detect + merge base branch, run tests, review diff, bump VERSION, update CHANGELOG, commit, push, create PR.",
       "routing": "Use when asked to \"ship\", \"deploy\",\n\"push to main\", \"create a PR\", \"merge and push\", or \"get it deployed\".\nProactively invoke this skill (do NOT push/PR directly) when the user says code\nis ready, asks about deploying, wants to push code up, or asks to create a PR.",

--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -13,9 +13,11 @@ import { discoverTemplates, discoverSkillFiles } from './discover-skills';
 import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
+import { ALL_HOST_CONFIGS, getExternalHosts, getHostConfig } from '../hosts/index';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const ROOT_REALPATH = fs.realpathSync(ROOT);
+const CLAUDE_SKIPPED_SKILLS = new Set(getHostConfig('claude').generation.skipSkills ?? []);
 
 function isRepoRootSymlink(candidateDir: string): boolean {
   try {
@@ -73,6 +75,11 @@ for (const { tmpl, output } of TEMPLATES) {
     continue;
   }
   if (!fs.existsSync(outPath)) {
+    const skillDir = path.dirname(tmpl);
+    if (CLAUDE_SKIPPED_SKILLS.has(skillDir)) {
+      console.log(`  -  ${output.padEnd(30)} — Claude-host generation skipped by host config`);
+      continue;
+    }
     hasErrors = true;
     console.log(`  \u274c ${output.padEnd(30)} — generated file missing! Run: bun run gen:skill-docs`);
     continue;
@@ -89,8 +96,6 @@ for (const file of SKILL_FILES) {
 }
 
 // ─── External Host Skills (config-driven) ───────────────────
-
-import { getExternalHosts } from '../hosts/index';
 
 for (const hostConfig of getExternalHosts()) {
   const hostDir = path.join(ROOT, hostConfig.hostSubdir, 'skills');
@@ -129,8 +134,6 @@ for (const hostConfig of getExternalHosts()) {
 }
 
 // ─── Freshness (config-driven) ──────────────────────────────
-
-import { ALL_HOST_CONFIGS } from '../hosts/index';
 
 for (const hostConfig of ALL_HOST_CONFIGS) {
   const hostFlag = hostConfig.name === 'claude' ? '' : ` --host ${hostConfig.name}`;

--- a/setup-search-mcp/SKILL.md
+++ b/setup-search-mcp/SKILL.md
@@ -1,17 +1,19 @@
 ---
-name: gstack
+name: setup-search-mcp
 preamble-tier: 1
-version: 1.2.0
-description: Router for the gstack skill suite. (gstack)
+version: 1.0.0
+description: Set up free web search for agents in gstack's Search Before Building workflow. (gstack)
+triggers:
+  - setup search
+  - install search mcp
+  - connect parallel search mcp
+  - free web search
+  - free search mcp
+  - agent web search
+  - search before building setup
 allowed-tools:
   - Bash
-  - Read
   - AskUserQuestion
-triggers:
-  - gstack
-  - which gstack skill
-  - route this with gstack
-
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->
@@ -19,10 +21,9 @@ triggers:
 
 ## When to invoke this skill
 
-Sends any gstack request to the right skill
-(planning, review, QA, shipping, debugging, docs, security, design). For browser/QA
-and dogfooding it points you at /browse. Use when you invoke gstack without a specific
-skill, or ask "which gstack skill fits this?".
+Adds Parallel Search MCP with no account or API key by default.
+Use when: "setup search", "install search mcp", "connect Parallel Search MCP",
+"free web search", "agent web search", "make Search Before Building work".
 
 ## Preamble (run first)
 
@@ -80,7 +81,7 @@ _QUESTION_TUNING=$(~/.claude/skills/gstack/bin/gstack-config get question_tuning
 echo "QUESTION_TUNING: $_QUESTION_TUNING"
 mkdir -p ~/.gstack/analytics
 if [ "$_TEL" != "off" ]; then
-echo '{"skill":"gstack","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(_repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null | tr -cd 'a-zA-Z0-9._-'); echo "${_repo:-unknown}")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+echo '{"skill":"setup-search-mcp","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(_repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null | tr -cd 'a-zA-Z0-9._-'); echo "${_repo:-unknown}")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 fi
 for _PF in $(find ~/.gstack/analytics -maxdepth 1 -name '.pending-*' 2>/dev/null); do
   if [ -f "$_PF" ]; then
@@ -102,7 +103,7 @@ if [ -f "$_LEARN_FILE" ]; then
 else
   echo "LEARNINGS: 0"
 fi
-~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"gstack","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"setup-search-mcp","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
 _HAS_ROUTING="no"
 if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
   _HAS_ROUTING="yes"
@@ -531,73 +532,81 @@ Replace `SKILL_NAME`, `OUTCOME`, and `USED_BROWSE` before running.
 
 Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXIT PLAN MODE GATE blocking checklist at the end of the skill, which verifies the plan file ends with `## GSTACK REVIEW REPORT` before ExitPlanMode is called. Skills that don't run plan reviews (operational skills like `/ship`, `/qa`, `/review`) typically don't operate in plan mode and have no review report to verify; this footer is a no-op for them. Writing the plan file is the one edit allowed in plan mode.
 
-## Route first
+# /setup-search-mcp — Free Web Search for Agents
 
-This is the gstack router. Its one job is to send the request to the right skill.
+Set up Parallel Search MCP so agents working through Search Before Building get
+free web search. The default setup is free and no-auth: no account, no API key,
+no OAuth.
 
-1. If the request is about a browser, QA, dogfooding, screenshots, or inspecting a page
-   (open a site, test a deploy, take a screenshot, check a flow visually) → invoke `/browse`.
-2. Otherwise, route by the rules below. If nothing matches, answer directly.
+This is not browser automation. Keep `/browse` and `/open-gstack-browser` for
+authenticated pages, screenshots, clicks, visual QA, and stateful browser work.
+Use Search MCP for public web search and clean markdown from public URLs.
 
-Best-effort, record which way you routed (never block on it). Set `ROUTE_OUTCOME` to
-`browse` (sent to /browse), `routed` (sent to another skill), or `direct` (answered
-directly, no skill matched):
+## User-invocable
+
+When the user types `/setup-search-mcp`, run this skill.
+
+## Rules
+
+- Prefer the current agent host. If this session is Claude Code, configure
+  Claude Code. If this session is Codex, configure Codex.
+- Do not install into a different client just because its CLI exists.
+- Do not edit private config files for unknown hosts. Print the manual MCP
+  values instead.
+- Do not configure API-key auth or OAuth unless the user explicitly asks for
+  higher rate limits. If they do, use AskUserQuestion to ask whether they want
+  API-key auth or OAuth before printing or running auth-specific commands.
+
+## MCP Values
+
+- Server URL: `https://search.parallel.ai/mcp`
+- Transport: Streamable HTTP
+- Authentication: none by default
+- Expected tools after restart: `web_search`, `web_fetch`
+- OAuth URL, only if the user opts in: `https://search.parallel.ai/mcp-oauth`
+
+## Claude Code Setup
+
+Use this path only when the current agent host is Claude Code:
+
 ```bash
-~/.claude/skills/gstack/bin/gstack-telemetry-log --event-type route --skill gstack --outcome ROUTE_OUTCOME --session-id "$_SESSION_ID" 2>/dev/null || true
+claude mcp remove -s user "Parallel-Search-MCP" 2>/dev/null || true
+claude mcp remove "Parallel-Search-MCP" 2>/dev/null || true
+claude mcp add --scope user --transport http "Parallel-Search-MCP" https://search.parallel.ai/mcp
+claude mcp list
 ```
 
-If `PROACTIVE` is `false`: do NOT proactively invoke or suggest other gstack skills during
-this session. Only run skills the user explicitly invokes. This preference persists across
-sessions via `gstack-config`.
+Then tell the user to restart Claude Code if the new MCP tools are not visible
+in the current session. After restart, Claude-style tool names usually appear as
+`mcp__Parallel-Search-MCP__web_search` and
+`mcp__Parallel-Search-MCP__web_fetch`.
 
-If `PROACTIVE` is `true` (default): **invoke the Skill tool** when the user's request
-matches a skill's purpose. Do NOT answer directly when a skill exists for the task.
-Use the Skill tool to invoke it. The skill has specialized workflows, checklists, and
-quality gates that produce better results than answering inline.
+## Codex Setup
 
-**Routing rules — when you see these patterns, INVOKE the skill via the Skill tool:**
-- User describes a new idea, asks "is this worth building", brainstorms, pitches a concept → invoke `/office-hours`
-- User asks to spec something out, file an issue, write up a ticket, "turn this into a GitHub issue", "backlog item" → invoke `/spec`
-- User asks about strategy, scope, ambition, "think bigger", "what should we build" → invoke `/plan-ceo-review`
-- User asks to review architecture, lock in the plan, "does this design make sense" → invoke `/plan-eng-review`
-- User asks about design system, brand, visual identity, "how should this look" → invoke `/design-consultation`
-- User asks to review design of a plan → invoke `/plan-design-review`
-- User asks about developer experience of a plan, API/CLI/SDK design → invoke `/plan-devex-review`
-- User wants all reviews done automatically, "review everything" → invoke `/autoplan`
-- User reports a bug, error, broken behavior, "why is this broken", "this doesn't work", "wtf", "something's wrong" → invoke `/investigate`
-- User asks to test the site, find bugs, QA, "does this work", "check the deploy" → invoke `/qa`
-- User asks to just report bugs without fixing → invoke `/qa-only`
-- User asks to review code, check the diff, pre-landing review, "look at my changes" → invoke `/review`
-- User asks about visual polish, design audit of a live site, "this looks off" → invoke `/design-review`
-- User asks to audit the live developer experience, time-to-hello-world → invoke `/devex-review`
-- User asks to ship, deploy, push, create a PR, "let's land this", "send it" → invoke `/ship`
-- User asks to merge + deploy + verify as one flow → invoke `/land-and-deploy`
-- User asks to configure deployment for the project → invoke `/setup-deploy`
-- User asks to set up search, install web search MCP, connect Parallel Search MCP, or make Search Before Building work → invoke `/setup-search-mcp`
-- User asks to monitor prod after shipping, post-deploy checks → invoke `/canary`
-- User asks to update docs after shipping → invoke `/document-release`
-- User asks to write docs from scratch, generate documentation, "document this feature/module" → invoke `/document-generate`
-- User asks for a weekly retro, what did we ship, "how'd we do" → invoke `/retro`
-- User asks for a second opinion, codex review → invoke `/codex`
-- User asks for safety mode, careful mode → invoke `/careful` or `/guard`
-- User asks to restrict edits to a directory → invoke `/freeze` or `/unfreeze`
-- User asks to upgrade gstack → invoke `/gstack-upgrade`
-- User asks to save progress, checkpoint, "save my work" → invoke `/context-save`
-- User asks to resume, restore, "where was I" → invoke `/context-restore`
-- User asks about security, OWASP, vulnerabilities, "is this secure" → invoke `/cso`
-- User asks to make a PDF, document, publication → invoke `/make-pdf`
-- User asks to launch a real browser for QA, "open the browser" → invoke `/open-gstack-browser`
-- User asks to import cookies for authenticated testing → invoke `/setup-browser-cookies`
-- User asks about page speed, performance regression, benchmarks → invoke `/benchmark`
-- User asks what gstack has learned, "show learnings" → invoke `/learn`
-- User asks to tune question sensitivity, "stop asking me that" → invoke `/plan-tune`
-- User asks for code quality dashboard, "health check" → invoke `/health`
+Use this path only when the current agent host is Codex:
 
-**When in doubt, invoke the skill.** A false positive (invoking a skill that wasn't
-needed) is cheaper than a false negative (answering ad-hoc when a structured workflow
-exists). The skill provides multi-step workflows, checklists, and quality gates that
-always produce better results than an ad-hoc answer. If no skill matches, answer
-directly as usual.
+```bash
+codex mcp remove parallel-search 2>/dev/null || true
+codex mcp add parallel-search --url https://search.parallel.ai/mcp
+codex mcp list --json
+```
 
-If the user opts out of suggestions, run `gstack-config set proactive false`.
-If they opt back in, run `gstack-config set proactive true`.
+Then tell the user to restart Codex if the new MCP tools are not visible in the
+current session.
+
+## Manual Setup
+
+For any other MCP-capable host, do not guess at the config file. Give the user
+the MCP values above and ask them to add the server through that host's normal
+MCP settings. Tell them the host may need a restart before `web_search` and
+`web_fetch` appear.
+
+## Report
+
+After setup, report:
+
+- Which host path you used.
+- That the default setup is free and no-auth.
+- Whether the host command listed the server.
+- Whether the current agent session must be restarted before the new tools are
+  available.

--- a/setup-search-mcp/SKILL.md.tmpl
+++ b/setup-search-mcp/SKILL.md.tmpl
@@ -1,0 +1,102 @@
+---
+name: setup-search-mcp
+preamble-tier: 1
+version: 1.0.0
+description: |
+  Set up free web search for agents in gstack's Search Before Building workflow.
+  Adds Parallel Search MCP with no account or API key by default.
+  Use when: "setup search", "install search mcp", "connect Parallel Search MCP",
+  "free web search", "agent web search", "make Search Before Building work". (gstack)
+triggers:
+  - setup search
+  - install search mcp
+  - connect parallel search mcp
+  - free web search
+  - free search mcp
+  - agent web search
+  - search before building setup
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+{{PREAMBLE}}
+
+# /setup-search-mcp — Free Web Search for Agents
+
+Set up Parallel Search MCP so agents working through Search Before Building get
+free web search. The default setup is free and no-auth: no account, no API key,
+no OAuth.
+
+This is not browser automation. Keep `/browse` and `/open-gstack-browser` for
+authenticated pages, screenshots, clicks, visual QA, and stateful browser work.
+Use Search MCP for public web search and clean markdown from public URLs.
+
+## User-invocable
+
+When the user types `/setup-search-mcp`, run this skill.
+
+## Rules
+
+- Prefer the current agent host. If this session is Claude Code, configure
+  Claude Code. If this session is Codex, configure Codex.
+- Do not install into a different client just because its CLI exists.
+- Do not edit private config files for unknown hosts. Print the manual MCP
+  values instead.
+- Do not configure API-key auth or OAuth unless the user explicitly asks for
+  higher rate limits. If they do, use AskUserQuestion to ask whether they want
+  API-key auth or OAuth before printing or running auth-specific commands.
+
+## MCP Values
+
+- Server URL: `https://search.parallel.ai/mcp`
+- Transport: Streamable HTTP
+- Authentication: none by default
+- Expected tools after restart: `web_search`, `web_fetch`
+- OAuth URL, only if the user opts in: `https://search.parallel.ai/mcp-oauth`
+
+## Claude Code Setup
+
+Use this path only when the current agent host is Claude Code:
+
+```bash
+claude mcp remove -s user "Parallel-Search-MCP" 2>/dev/null || true
+claude mcp remove "Parallel-Search-MCP" 2>/dev/null || true
+claude mcp add --scope user --transport http "Parallel-Search-MCP" https://search.parallel.ai/mcp
+claude mcp list
+```
+
+Then tell the user to restart Claude Code if the new MCP tools are not visible
+in the current session. After restart, Claude-style tool names usually appear as
+`mcp__Parallel-Search-MCP__web_search` and
+`mcp__Parallel-Search-MCP__web_fetch`.
+
+## Codex Setup
+
+Use this path only when the current agent host is Codex:
+
+```bash
+codex mcp remove parallel-search 2>/dev/null || true
+codex mcp add parallel-search --url https://search.parallel.ai/mcp
+codex mcp list --json
+```
+
+Then tell the user to restart Codex if the new MCP tools are not visible in the
+current session.
+
+## Manual Setup
+
+For any other MCP-capable host, do not guess at the config file. Give the user
+the MCP values above and ask them to add the server through that host's normal
+MCP settings. Tell them the host may need a restart before `web_search` and
+`web_fetch` appear.
+
+## Report
+
+After setup, report:
+
+- Which host path you used.
+- That the default setup is free and no-auth.
+- Whether the host command listed the server.
+- Whether the current agent session must be restarted before the new tools are
+  available.

--- a/test/setup-search-mcp-structure.test.ts
+++ b/test/setup-search-mcp-structure.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const TMPL = fs.readFileSync(path.join(ROOT, 'setup-search-mcp', 'SKILL.md.tmpl'), 'utf-8');
+
+describe('setup-search-mcp structural contract', () => {
+  test('defaults to free no-auth setup', () => {
+    expect(TMPL).toContain('free web search for agents');
+    expect(TMPL).toContain('no account, no API key');
+    expect(TMPL).toContain('no OAuth');
+    expect(TMPL).toContain('Authentication: none by default');
+    expect(TMPL).not.toContain('Authorization: Bearer');
+  });
+
+  test('uses exact supported host commands', () => {
+    expect(TMPL).toContain('claude mcp add --scope user --transport http "Parallel-Search-MCP" https://search.parallel.ai/mcp');
+    expect(TMPL).toContain('codex mcp add parallel-search --url https://search.parallel.ai/mcp');
+    expect(TMPL).toContain('claude mcp list');
+    expect(TMPL).toContain('codex mcp list --json');
+  });
+
+  test('does not guess unknown host config files', () => {
+    expect(TMPL).toContain('Do not install into a different client just because its CLI exists');
+    expect(TMPL).toContain('do not guess at the config file');
+    expect(TMPL).toContain('Expected tools after restart: `web_search`, `web_fetch`');
+  });
+
+  test('keeps auth and browser automation boundaries explicit', () => {
+    expect(TMPL).toContain('AskUserQuestion');
+    expect(TMPL).toContain('API-key auth or OAuth');
+    expect(TMPL).toContain('This is not browser automation');
+    expect(TMPL).toContain('/browse');
+    expect(TMPL).toContain('/open-gstack-browser');
+  });
+
+  test('does not depend on the removed verifier helper', () => {
+    expect(TMPL).not.toContain('gstack-search-mcp-verify');
+  });
+});

--- a/test/skill-coverage-matrix.ts
+++ b/test/skill-coverage-matrix.ts
@@ -159,6 +159,11 @@ export const SKILL_COVERAGE: Record<string, SkillCoverage> = {
   'context-restore': { gate: ['test/skill-e2e-context-skills.test.ts', 'test/skill-coverage-floor.test.ts'], periodic: [] },
   'setup-deploy': { gate: ['test/skill-coverage-floor.test.ts'], periodic: [] },
   'setup-browser-cookies': { gate: ['test/skill-coverage-floor.test.ts'], periodic: [] },
+  'setup-search-mcp': {
+    gate: ['test/setup-search-mcp-structure.test.ts', 'test/skill-coverage-floor.test.ts'],
+    periodic: [],
+    rationale: 'Search MCP setup has deterministic structural coverage for no-auth defaults, supported host commands, and manual-host guidance.',
+  },
   'setup-gbrain': {
     gate: [
       'test/skill-e2e-setup-gbrain-bad-token.test.ts',


### PR DESCRIPTION
## Summary
- add `/setup-search-mcp` to configure Parallel Search MCP for supported agent hosts
- default to the free, no-auth setup: no account, API key, or OAuth required
- document the new setup skill in the router, README, skills guide, `llms.txt`, and proactive suggestions
- add focused structural coverage for host commands, no-auth defaults, manual setup guidance, and browser/search boundaries

## Why
Gstack's Search Before Building workflow works best when agents have a reliable way to search the public web. This gives users an explicit opt-in setup path for free web search through Parallel Search MCP while keeping `/browse` for authenticated pages, screenshots, clicks, and visual QA.

## Validation
- `npx --yes bun test test/setup-search-mcp-structure.test.ts test/skill-coverage-matrix.test.ts test/skill-coverage-floor.test.ts`
- `npx --yes bun test test/gen-skill-docs.test.ts test/gen-skill-docs-idempotency.test.ts test/llms-txt-shape.test.ts test/skill-validation.test.ts test/catalog-trim.test.ts`
- `npx --yes bun run skill:check`
- `git diff --check origin/main..HEAD`
