### PR TITLE
fix(browse): grant Windows ACLs by SID to avoid owner lockout when username matches machine name

### DIFF
--- a/browse/src/file-permissions.ts
+++ b/browse/src/file-permissions.ts
@@ -42,6 +42,42 @@ import * as os from 'os';
 
 let warnedOnce = false;
 
+let cachedGrantee: string | undefined;
+
+/**
+ * Resolve the identity to use in icacls `/grant` arguments.
+ *
+ * Granting by bare username (`os.userInfo().username`) is ambiguous:
+ * LookupAccountName can resolve the name to the wrong principal when it
+ * collides with another account object — e.g. when the machine name equals
+ * the username (user "alice" on machine "ALICE"), the bare name can resolve
+ * to the machine's *domain* SID (S-1-5-21-… with no RID), producing an ACL
+ * that denies even the owner.
+ * A SID grant (`*S-1-5-21-…-1001`) is unambiguous, so we resolve the
+ * current user's SID via `whoami /user` and fall back to the fully
+ * qualified `DOMAIN\username` (still unambiguous) only if that fails.
+ */
+function getWindowsGrantee(): string {
+  if (cachedGrantee !== undefined) return cachedGrantee;
+  try {
+    // Absolute path: a bare `whoami` can resolve to GNU coreutils' whoami
+    // (Git for Windows / MSYS2 put usr/bin on PATH), which rejects /user.
+    const whoami = `${process.env.SystemRoot || 'C:\\Windows'}\\System32\\whoami.exe`;
+    const out = execFileSync(whoami, ['/user', '/fo', 'csv', '/nh'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const sid = out.match(/"(S-1-[0-9-]+)"/)?.[1];
+    if (sid) {
+      cachedGrantee = `*${sid}`;
+      return cachedGrantee;
+    }
+  } catch { /* fall through to name-based grant */ }
+  const user = process.env.USERNAME || os.userInfo().username;
+  cachedGrantee = process.env.USERDOMAIN ? `${process.env.USERDOMAIN}\\${user}` : user;
+  return cachedGrantee;
+}
+
 function warnIcaclsFailure(fsPath: string, err: unknown): void {
   if (warnedOnce) return;
   warnedOnce = true;
@@ -67,7 +103,7 @@ function warnIcaclsFailure(fsPath: string, err: unknown): void {
 export function restrictFilePermissions(filePath: string): void {
   if (process.platform === 'win32') {
     try {
-      const user = os.userInfo().username;
+      const user = getWindowsGrantee();
       execFileSync(
         'icacls',
         [filePath, '/inheritance:r', '/grant:r', `${user}:(F)`],
@@ -97,7 +133,7 @@ export function restrictFilePermissions(filePath: string): void {
 export function restrictDirectoryPermissions(dirPath: string): void {
   if (process.platform === 'win32') {
     try {
-      const user = os.userInfo().username;
+      const user = getWindowsGrantee();
       execFileSync(
         'icacls',
         [dirPath, '/inheritance:r', '/grant:r', `${user}:(OI)(CI)(F)`],
@@ -154,4 +190,11 @@ export function mkdirSecure(dirPath: string): void {
  */
 export function __resetWarnedForTests(): void {
   warnedOnce = false;
+}
+
+/**
+ * Expose the resolved icacls grantee. Test-only.
+ */
+export function __getWindowsGranteeForTests(): string {
+  return getWindowsGrantee();
 }

--- a/browse/test/file-permissions.test.ts
+++ b/browse/test/file-permissions.test.ts
@@ -23,6 +23,7 @@ import {
   appendSecureFile,
   mkdirSecure,
   __resetWarnedForTests,
+  __getWindowsGranteeForTests,
 } from '../src/file-permissions';
 
 let tmpDir: string;
@@ -34,6 +35,20 @@ beforeEach(() => {
 
 afterEach(() => {
   try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('getWindowsGrantee', () => {
+  test('on Windows, resolves an unambiguous grantee (SID or DOMAIN\\user)', () => {
+    if (process.platform !== 'win32') return;
+    // A bare-username grant is ambiguous when the username collides with
+    // another account object (e.g. machine name == username), which locks
+    // even the owner out. The grantee must be a SID (`*S-1-...`) or, as a
+    // fallback, a domain-qualified name — never a bare username.
+    const grantee = __getWindowsGranteeForTests();
+    const isSid = /^\*S-1-[0-9-]+$/.test(grantee);
+    const isQualified = grantee.includes('\\');
+    expect(isSid || isQualified).toBe(true);
+  });
 });
 
 describe('restrictFilePermissions', () => {


### PR DESCRIPTION
## Problem

`restrictFilePermissions` / `restrictDirectoryPermissions` in `browse/src/file-permissions.ts` harden Windows ACLs with:

```
icacls <path> /inheritance:r /grant:r <os.userInfo().username>:(F)
```

Granting by **bare username** is ambiguous. On machines where the username collides with another account object — most commonly when the **machine name equals the username** (e.g. user `Eshan` on machine `ESHAN`) — `LookupAccountName` resolves the bare name to the machine's *domain* SID (`S-1-5-21-…` with **no RID**) instead of the user account. The resulting ACL has inheritance stripped and a single grant to a principal that isn't the user, so it **denies even the owner**.

Symptoms: `~/.gstack` becomes inaccessible and browse fails with `EPERM` on `mkdir` — a self-lockout caused by the hardening itself. This is easy to hit in the wild: OOBE suggests the user's first name as the machine name, so `Alice` on `ALICE` is a common single-user-laptop configuration.

## Fix

Add a `getWindowsGrantee()` helper (cached per process) that:

1. Resolves the current user's **SID** via `%SystemRoot%\System32\whoami.exe /user /fo csv /nh` and grants `*<SID>:(F)` — SID grants are unambiguous by construction.
   - The **absolute path** matters: a bare `whoami` can resolve to GNU coreutils' `whoami` (Git for Windows / MSYS2 put `usr/bin` on `PATH`), which rejects `/user`.
2. Falls back to `USERDOMAIN\USERNAME` (domain-qualified, still unambiguous) if SID resolution fails, before ever falling back to the bare username.

Both `restrictFilePermissions` and `restrictDirectoryPermissions` now use the helper.

## Tests

- Added a Windows-only test asserting the resolved grantee is a SID (`*S-1-…`) or a domain-qualified name — never a bare username — via a `__getWindowsGranteeForTests` export (same pattern as the existing `__resetWarnedForTests`).
- Full `browse/test/file-permissions.test.ts` suite passes on a Windows 11 machine that exhibits the original bug (username == machine name): 14 pass, 0 fail. The existing "file remains readable by the caller" test is the behavioral regression guard on such machines.

## Note for release

`dist/browse.exe` and `dist/server-node.mjs` embed this module, so a **dist rebuild is required** for the fix to reach releases — the source change alone doesn't affect already-built binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)