### PR TITLE
harden(worktree): symlink-plant defense in pruneStale

### DIFF
--- a/lib/worktree.ts
+++ b/lib/worktree.ts
@@ -245,6 +245,18 @@ export class WorktreeManager {
     } catch { /* non-fatal */ }
   }
 
+  /** Verify a path resolves inside worktreeBase (defends against symlink-plant attacks). */
+  private safeInsideWorktrees(p: string): boolean {
+    try {
+      const real = fs.realpathSync.native(p);
+      const baseReal = fs.realpathSync.native(this.worktreeBase);
+      const rel = path.relative(baseReal, real);
+      return !!rel && !rel.startsWith('..') && !path.isAbsolute(rel);
+    } catch {
+      return false;
+    }
+  }
+
   /** Remove worktrees from previous runs that weren't cleaned up. */
   pruneStale(): void {
     try {
@@ -264,6 +276,11 @@ export class WorktreeManager {
           const stat = fs.statSync(entryPath);
           const ageMs = Date.now() - stat.mtimeMs;
           if (ageMs < 3600_000) continue;
+          // Defend against symlink-plant: ensure it resolves inside worktreeBase
+          if (!this.safeInsideWorktrees(entryPath)) {
+            process.stderr.write(`  WORKTREE: skip suspicious path: ${entryPath}\n`);
+            continue;
+          }
           fs.rmSync(entryPath, { recursive: true, force: true });
         } catch { /* non-fatal */ }
       }


### PR DESCRIPTION
## Motivation

`WorktreeManager.pruneStale()` recursively deletes sub-directories under
`.gstack-worktrees/` older than 1 hour. Today the only validation is an
mtime check — no path containment check.

In a shared CI / multi-tenant environment, an attacker could pre-plant a
symlink inside `.gstack-worktrees/` that redirects `fs.rmSync` to a
directory outside `worktreeBase`.

## Fix

Add `safeInsideWorktrees()` method that:
1. Uses `fs.realpathSync.native` to resolve symlinks
2. Computes `path.relative(baseReal, real)`
3. Returns `false` if the result starts with `..` or is absolute

Call `safeInsideWorktrees()` before every `fs.rmSync` in `pruneStale()`.
Suspicious paths are logged and skipped instead of deleted.

## Changes

- `lib/worktree.ts`: Added `safeInsideWorktrees()` + call site in `pruneStale()`

*Submitted by 璇玑-58 via security audit*