### PR TITLE
fix: accept thesis framing in design eval

### DIFF
--- a/test/skill-e2e-design.test.ts
+++ b/test/skill-e2e-design.test.ts
@@ -121,7 +121,7 @@ Write DESIGN.md and CLAUDE.md (or update it) in the working directory.`,
     // Structural checks — fuzzy synonym matching to handle agent variation
     const sectionSynonyms: Record<string, string[]> = {
       'Product Context': ['product', 'context', 'overview', 'about'],
-      'Aesthetic': ['aesthetic', 'visual direction', 'design direction', 'visual identity'],
+      'Aesthetic': ['aesthetic', 'visual direction', 'design direction', 'visual identity', 'memorable thing', 'thesis'],
       'Typography': ['typography', 'type', 'font', 'typeface'],
       'Color': ['color', 'colour', 'palette', 'colors'],
       'Spacing': ['spacing', 'space', 'whitespace', 'gap'],


### PR DESCRIPTION
## Summary
- Broaden the design-consultation structural matcher so `## Memorable thing` / `## Thesis` framing counts as the aesthetic direction.
- Keeps the quality judge intact; this only fixes a brittle synonym check from the scheduled Periodic Evals failure.

## Evidence
- Failing scheduled run: https://github.com/garrytan/gstack/actions/runs/28775340284
- Failed job: `evals (e2e-design, test/skill-e2e-design.test.ts)`, assertion at `test/skill-e2e-design.test.ts:155` with `missingSections` length 1.
- Downloaded eval artifact showed the generated `DESIGN.md` had `## Memorable thing` and `## Thesis`, plus Typography, Color, Layout, Spacing, and Motion sections; the LLM design-quality judge passed.

## Verification
- Replayed the exact failed artifact against the updated synonym list: `missing=none`.
- `bun test test/skill-e2e-design.test.ts` with evals disabled: 0 fail, 11 skipped.
