### PR TITLE
fix(setup): copy lib/ into opencode runtime root

### DIFF
--- a/setup
+++ b/setup
@@ -866,13 +866,16 @@ create_opencode_runtime_root() {
     rm -rf "$opencode_gstack"
   fi
 
-  mkdir -p "$opencode_gstack" "$opencode_gstack/browse" "$opencode_gstack/design" "$opencode_gstack/gstack-upgrade" "$opencode_gstack/review" "$opencode_gstack/qa" "$opencode_gstack/plan-devex-review"
+  mkdir -p "$opencode_gstack" "$opencode_gstack/browse" "$opencode_gstack/design" "$opencode_gstack/gstack-upgrade" "$opencode_gstack/lib" "$opencode_gstack/review" "$opencode_gstack/qa" "$opencode_gstack/plan-devex-review"
 
   if [ -f "$opencode_dir/gstack/SKILL.md" ]; then
     _link_or_copy "$opencode_dir/gstack/SKILL.md" "$opencode_gstack/SKILL.md"
   fi
   if [ -d "$gstack_dir/bin" ]; then
     _link_or_copy "$gstack_dir/bin" "$opencode_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/lib" ]; then
+    _link_or_copy "$gstack_dir/lib" "$opencode_gstack/lib"
   fi
   if [ -d "$gstack_dir/browse/dist" ]; then
     _link_or_copy "$gstack_dir/browse/dist" "$opencode_gstack/browse/dist"


### PR DESCRIPTION
The `create_opencode_runtime_root` function (used by `./setup --host opencode`) links/copies `bin/`, `browse/`, `design/`, `ETHOS.md`, and several other files into the opencode install root, but does not include `lib/`. As a result, any `.ts` script in `bin/` that imports from `../lib/...` (e.g. `gstack-gbrain-detect`, `gstack-decision-*`, `gstack-redact`, `gstack-telemetry-log`, `gstack-memory-ingest`, etc.) fails on opencode hosts with errors like:

```
error: Cannot find module '../lib/gbrain-local-status' from '.../bin/gstack-gbrain-detect.ts'
```

This patch mirrors the existing `bin/` block to also link/copy `lib/`, and adds `lib/` to the `mkdir` list so the directory is created on a clean install.

## Reproduction

Before the patch, on a fresh `./setup --host opencode` install:

```bash
$ bun run ~/.config/opencode/skills/gstack/bin/gstack-gbrain-detect.ts
error: Cannot find module "../lib/gbrain-local-status" from ".../bin/gstack-gbrain-detect.ts"
```

After the patch, the same command runs and returns the detection JSON.

## Diff

```diff
--- a/setup
+++ b/setup
@@ -866,7 +866,7 @@ create_opencode_runtime_root() {
     rm -rf "$opencode_gstack"
   fi
 
-  mkdir -p "$opencode_gstack" "$opencode_gstack/browse" "$opencode_gstack/design" "$opencode_gstack/gstack-upgrade" "$opencode_gstack/review" "$opencode_gstack/qa" "$opencode_gstack/plan-devex-review"
+  mkdir -p "$opencode_gstack" "$opencode_gstack/browse" "$opencode_gstack/design" "$opencode_gstack/gstack-upgrade" "$opencode_gstack/lib" "$opencode_gstack/review" "$opencode_gstack/qa" "$opencode_gstack/plan-devex-review"
 
   if [ -f "$opencode_dir/gstack/SKILL.md" ]; then
     _link_or_copy "$opencode_dir/gstack/SKILL.md" "$opencode_gstack/SKILL.md"
@@ -874,6 +874,9 @@ create_opencode_runtime_root() {
   if [ -d "$gstack_dir/bin" ]; then
     _link_or_copy "$gstack_dir/bin" "$opencode_gstack/bin"
   fi
+  if [ -d "$gstack_dir/lib" ]; then
+    _link_or_copy "$gstack_dir/lib" "$opencode_gstack/lib"
+  fi
   if [ -d "$gstack_dir/browse/dist" ]; then
     _link_or_copy "$gstack_dir/browse/dist" "$opencode_gstack/browse/dist"
   fi
```

## Test

Smoke test (Windows + Git Bash): extract the function with `sed`, `eval` it, call it against a synthetic install root. `lib/` is created with `gbrain-local-status.ts` and the other 15 `lib/*.ts` files. `bin/` and `ETHOS.md` paths still work. Test script at `C:\Users\Kurt\AppData\Local\Temp\opencode\oc-test\test.sh` (not part of the PR).

Tested on gstack v1.58.5.0 (the local `.last-setup-version` reported by `gstack-gbrain-detect` matches upstream `main`).
