### PR TITLE
fix(setup): don't auto-install plan-tune AUQ hooks in Conductor (fixes #2207)

### DIFF
--- a/setup
+++ b/setup
@@ -1380,16 +1380,22 @@ if [ "$NO_TEAM_MODE" -ne 1 ] \
     *)                       PT_DECISION="prompt" ;;
   esac
 
-  # Conductor host reliability: the PreToolUse preference hook also carries the
-  # Conductor-prose enforcement (deny the flaky mcp__conductor__AskUserQuestion,
-  # redirect to a prose decision brief). A Conductor workspace setup otherwise
-  # falls through to "prompt" → the non-interactive skip below, leaving Conductor
-  # users without that backstop. Treat Conductor as an implicit opt-in — but
-  # only on the silent fall-through, never overriding an explicit --no-plan-tune-hooks.
-  if [ "$PT_DECISION" = "prompt" ] && { [ -n "${CONDUCTOR_WORKSPACE_PATH:-}" ] || [ -n "${CONDUCTOR_PORT:-}" ]; }; then
-    PT_DECISION="yes"
-    _PT_CONDUCTOR_AUTO=1
-  fi
+  # Conductor host: do NOT auto-install the plan-tune AUQ hooks here.
+  #
+  # The PreToolUse preference hook participates in the Agent-SDK `canUseTool`
+  # elicitation flow that Conductor uses to render AskUserQuestion. Its mere
+  # presence corrupts that round-trip — even when it returns `defer` — so the
+  # tool comes back as `[Tool result missing due to internal error]` and no
+  # options render. In other words, native AUQ works fine in Conductor UNTIL
+  # this hook is registered; the "flaky mcp__conductor__AskUserQuestion" this
+  # backstop was meant to work around is caused by the backstop itself.
+  # (Codex sessions never read ~/.claude/settings.json, so they're unaffected —
+  # which is why AUQ works in Codex but breaks in Claude on the same workspace.)
+  #
+  # Fall through to the normal decision below: a Conductor workspace with no
+  # explicit --plan-tune-hooks / GSTACK_PLAN_TUNE_HOOKS / plan_tune_hooks config
+  # takes the non-interactive skip and keeps native AUQ working. Users who
+  # genuinely want the prose backstop can still opt in explicitly.
 
   _install_plan_tune_hooks() {
     "$SETTINGS_HOOK" add-event \


### PR DESCRIPTION
Fixes the Conductor + Claude AskUserQuestion breakage described in #2207.

## Problem

In Conductor + Claude Code (Agent SDK, `CLAUDE_CODE_ENTRYPOINT=sdk-ts`), the plan-tune **PreToolUse** hook `question-preference-hook` participates in Conductor's `canUseTool` elicitation flow for `AskUserQuestion`. Its presence corrupts the round-trip — **even when it returns `defer`** — so AUQ comes back as `[Tool result missing due to internal error]` and no options render.

Native AUQ works fine in Conductor *until* this hook is registered. So the "flaky `mcp__conductor__AskUserQuestion`" that the v1.58.1.0 Conductor-prose backstop was built to work around appears to be caused by the backstop itself. Codex sessions never read `~/.claude/settings.json`, so they're unaffected — which is exactly why AUQ breaks in Claude but works in Codex on the same workspace.

`setup` currently treats any Conductor workspace as an **implicit opt-in** for these hooks, so a routine `/gstack-upgrade` silently plants the breakage.

## Change

`setup`: drop the Conductor implicit opt-in for the plan-tune AUQ hooks. A Conductor workspace with no explicit `--plan-tune-hooks` / `GSTACK_PLAN_TUNE_HOOKS` / `plan_tune_hooks` config now falls through to the normal non-interactive skip, keeping native AUQ working. Explicit opt-in still installs the hooks for anyone who wants the prose backstop.

Minimal, comment-heavy, no behavior change outside Conductor.

## Verification

- `bash -n setup` passes.
- Reproduced on real Conductor hardware: with the hooks registered, AUQ returns `[Tool result missing due to internal error]`; after unregistering them (equivalently: this change → no auto-install), AUQ renders and answers correctly (confirmed 3×).
- Cross-checked against Codex on the same workspace (works throughout), isolating the hook as the cause.

## Notes / open questions

- I kept the diff to the auto-install trigger only. If you'd prefer, the deeper question is whether the PostToolUse capture/fallback hooks are also unsafe on the Conductor bridge — they fire *after* the result so they're likely fine, but I didn't want to over-reach without a test you'd trust.
- Left `VERSION` / `CHANGELOG.md` untouched since versioning is your release call — happy to add a CHANGELOG entry if you want it in the PR.

Environment: gstack v1.58.5.0, Claude Code 2.1.201 (sdk-ts), Conductor/macOS. Regression introduced in v1.58.1.0 (c7ae632).
