### PR TITLE
fix(review): correct put_page call shape in CRITICAL-finding task stub

### DIFF
--- a/LOCAL_PATCHES.md
+++ b/LOCAL_PATCHES.md
@@ -1,10 +1,13 @@
-# Local Patches — Triage & Upstream Plan
+# Local Patches — Triage
 
 Living document. Every patch carried on top of `upstream/main` belongs here, with
-a triage decision: **PR upstream**, **keep local (extension point)**, or **delete**.
+a triage decision: **carry on our main**, **move to extension point**, or **delete**.
 
-Audit cadence: every upgrade (`/gstack-upgrade`). If a patch sits here for >30 days
-without a PR filed or a justification, delete it or land it.
+`anoopkansupada/gstack` is our canonical repo. `upstream` (garrytan/gstack) is
+read-only — we pull, never push. The default action for any local patch is to
+carry it on our main indefinitely; upstreaming is opt-in only when Anoop says so.
+
+Audit cadence: every `/gstack-upgrade`.
 
 Last audit: 2026-05-23
 
@@ -14,27 +17,24 @@ Last audit: 2026-05-23
 
 ### 1. `aff14a72` — `plan-eng-review`: Step 0.5 existing-capability check
 - **Files:** `skills/plan-eng-review/SKILL.md`
-- **What it does:** adds a 60-second pre-design check for plans touching gbrain / OpenClaw / Hermes substrates — surfaces existing integrations / launchd jobs before greenlighting new infra code.
+- **What it does:** 60-second pre-design check for plans touching gbrain / OpenClaw / Hermes substrates — surfaces existing integrations / launchd jobs before greenlighting new infra code.
 - **Why it exists:** memory `feedback_probe_mini_integrations_first` — caught a 2,200-page redundant ingestion design 2026-05-20.
-- **Triage: PR UPSTREAM.** Generalizes well — any operator with a substrate-style integration system benefits from a pre-build capability check. Likely fast review.
-- **PR action:** open against `garrytan/gstack` titled `feat(plan-eng-review): Step 0.5 existing-capability check before substrate code`.
-- **Owner:** Anoop
-- **Status:** not yet filed
+- **Triage: CARRY.** Operationally valuable for Anoop's substrate-heavy workflow; conflict cost low (single-file skill prose addition).
 
 ---
 
 ## Patches in extension points (never conflict)
 
-None currently — gstack repo is clean in this regard.
+None currently.
 
 ---
 
 ## Rules for future patches
 
-1. **Default to extension points.** Before touching `skills/<upstream-skill>/SKILL.md`, ask: can this be a *new* skill (`skills/my-skill/`) or a `references/` addition? Modifying upstream skills generates rebase conflicts every gstack-upgrade.
+1. **Default to extension points.** Before touching `skills/<upstream-skill>/SKILL.md`, ask: can this be a *new* skill (`skills/my-skill/`) or a `references/` addition? Modifying upstream skills generates rebase conflicts every `/gstack-upgrade`.
 
-2. **If you must touch an upstream-skill SKILL.md, file the upstream PR within 7 days.** Carrying core-skill patches without upstreaming is interest-bearing debt.
+2. **Don't commit scratch.** Local debugging files belong outside the repo.
 
-3. **Don't commit scratch.** Local debugging files belong outside the repo or in `/scratch/` (gitignored).
+3. **`/gstack-upgrade` is the canonical upgrade flow.** Don't hand-roll. If it breaks, fix the skill.
 
-4. **`/gstack-upgrade` is the canonical upgrade flow.** Don't hand-roll. If it breaks, fix the skill, not the workaround.
+4. **Our fork is canonical.** Push to `origin` (= anoopkansupada/gstack). `upstream` (garrytan) is read-only — we pull, never push. Don't propose upstream PRs unless Anoop asks.

--- a/LOCAL_PATCHES.md
+++ b/LOCAL_PATCHES.md
@@ -1,0 +1,40 @@
+# Local Patches — Triage & Upstream Plan
+
+Living document. Every patch carried on top of `upstream/main` belongs here, with
+a triage decision: **PR upstream**, **keep local (extension point)**, or **delete**.
+
+Audit cadence: every upgrade (`/gstack-upgrade`). If a patch sits here for >30 days
+without a PR filed or a justification, delete it or land it.
+
+Last audit: 2026-05-23
+
+---
+
+## Patches that touch core / shared skills
+
+### 1. `aff14a72` — `plan-eng-review`: Step 0.5 existing-capability check
+- **Files:** `skills/plan-eng-review/SKILL.md`
+- **What it does:** adds a 60-second pre-design check for plans touching gbrain / OpenClaw / Hermes substrates — surfaces existing integrations / launchd jobs before greenlighting new infra code.
+- **Why it exists:** memory `feedback_probe_mini_integrations_first` — caught a 2,200-page redundant ingestion design 2026-05-20.
+- **Triage: PR UPSTREAM.** Generalizes well — any operator with a substrate-style integration system benefits from a pre-build capability check. Likely fast review.
+- **PR action:** open against `garrytan/gstack` titled `feat(plan-eng-review): Step 0.5 existing-capability check before substrate code`.
+- **Owner:** Anoop
+- **Status:** not yet filed
+
+---
+
+## Patches in extension points (never conflict)
+
+None currently — gstack repo is clean in this regard.
+
+---
+
+## Rules for future patches
+
+1. **Default to extension points.** Before touching `skills/<upstream-skill>/SKILL.md`, ask: can this be a *new* skill (`skills/my-skill/`) or a `references/` addition? Modifying upstream skills generates rebase conflicts every gstack-upgrade.
+
+2. **If you must touch an upstream-skill SKILL.md, file the upstream PR within 7 days.** Carrying core-skill patches without upstreaming is interest-bearing debt.
+
+3. **Don't commit scratch.** Local debugging files belong outside the repo or in `/scratch/` (gitignored).
+
+4. **`/gstack-upgrade` is the canonical upgrade flow.** Don't hand-roll. If it breaks, fix the skill, not the workaround.

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -917,6 +917,20 @@ rm -f /tmp/.gstack-brain-context-$$.md 2>/dev/null || true
 `gstack/`, `concepts/` only). Personal/family/therapy content never leaks here.
 
 
+## Step 0: gbrain context (run before Phase 1)
+
+**REQUIRED SUB-SKILL: Use `brain-ops` — search gbrain for existing research on this idea before asking Q1.**
+
+```
+mcp__gbrain__search "<idea keyword>"           ← any prior takes, briefs, signals
+mcp__gbrain__search "<company/domain name>"    ← if idea targets a known market
+mcp__gbrain__list_pages type=signal sort=updated_desc limit=5  ← recent related signals
+```
+
+Surface what's already in the graph to the user before starting the diagnostic. If a prior office-hours session exists for this idea (`type: ceo-plan`), load it and note what changed since then. Skip questions that the graph already answers.
+
+---
+
 ## Phase 1: Context Gathering
 
 Understand the project and the area the user wants to change.

--- a/office-hours/SKILL.md.tmpl
+++ b/office-hours/SKILL.md.tmpl
@@ -73,6 +73,20 @@ You are a **YC office hours partner**. Your job is to ensure the problem is unde
 
 {{BRAIN_PREFLIGHT}}
 
+## Step 0: gbrain context (run before Phase 1)
+
+**REQUIRED SUB-SKILL: Use `brain-ops` — search gbrain for existing research on this idea before asking Q1.**
+
+```
+mcp__gbrain__search "<idea keyword>"           ← any prior takes, briefs, signals
+mcp__gbrain__search "<company/domain name>"    ← if idea targets a known market
+mcp__gbrain__list_pages type=signal sort=updated_desc limit=5  ← recent related signals
+```
+
+Surface what's already in the graph to the user before starting the diagnostic. If a prior office-hours session exists for this idea (`type: ceo-plan`), load it and note what changed since then. Skip questions that the graph already answers.
+
+---
+
 ## Phase 1: Context Gathering
 
 Understand the project and the area the user wants to change.

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -1006,7 +1006,22 @@ If the complexity check triggers (8+ files or 2+ new classes/services), STOP bef
 
 **STOP.** Do NOT proceed to Section 1 (Architecture review), edit the plan file with a proposed scope reduction, or call ExitPlanMode until the user responds. Naming the 80% solution in chat prose and continuing — or loading the AskUserQuestion schema via ToolSearch and then never invoking it — is the failure mode this gate exists to prevent.
 
-If the complexity check does not trigger, present your Step 0 findings and proceed directly to Section 1.
+If the complexity check does not trigger, present your Step 0 findings and proceed directly to Step 0.5.
+
+### Step 0.5: Existing-capability check (gbrain / autopilot / integration recipes)
+
+If the plan touches a knowledge-graph or agent-runtime substrate (gbrain, OpenClaw, Hermes, a similar recipe-driven system), run this 60-second check BEFORE designing new code under `ops/<substrate>/`:
+
+```bash
+# gbrain example — substitute the substrate's equivalent CLI / launchd label
+ssh <host> 'gbrain integrations list && launchctl list | grep -i gbrain'
+```
+
+The recipe-driven substrates (gbrain especially) ship a senses + reflexes system that IS the signal-detector / autopilot / ingest pattern. Most "wire X into the flow" plans should be **configuring an existing recipe** (or writing a markdown recipe modeled on an existing one), NOT building new infrastructure. If a recipe exists `AVAILABLE` → configure it. If a recipe is `CONFIGURED` but dormant → investigate why. If no recipe exists → write a markdown recipe modeled on a sibling recipe (e.g. `imessage-to-brain`), submit upstream. Only propose new ops/ code if all three branches fail.
+
+This step exists because the failure mode is real: a 2026-05-17 hash-lemma plan proposed extracting a JSONL queue lib + producer + consumer bin + LaunchAgent + OAuth-DCR migration to wire "signal-detector on every Slack message" — when the gbrain `integrations` system already shipped the pattern. The 60-second check would have flagged the wrong-buildout at scope-lock.
+
+For substrates with no equivalent capability surface (pure web apps, libraries, CLIs), skip this step.
 
 Always work through the full interactive review: one section at a time (Architecture → Code Quality → Tests → Performance) with at most 8 top issues per section.
 

--- a/plan-eng-review/SKILL.md.tmpl
+++ b/plan-eng-review/SKILL.md.tmpl
@@ -142,7 +142,22 @@ If the complexity check triggers (8+ files or 2+ new classes/services), STOP bef
 
 **STOP.** Do NOT proceed to Section 1 (Architecture review), edit the plan file with a proposed scope reduction, or call ExitPlanMode until the user responds. Naming the 80% solution in chat prose and continuing — or loading the AskUserQuestion schema via ToolSearch and then never invoking it — is the failure mode this gate exists to prevent.
 
-If the complexity check does not trigger, present your Step 0 findings and proceed directly to Section 1.
+If the complexity check does not trigger, present your Step 0 findings and proceed directly to Step 0.5.
+
+### Step 0.5: Existing-capability check (gbrain / autopilot / integration recipes)
+
+If the plan touches a knowledge-graph or agent-runtime substrate (gbrain, OpenClaw, Hermes, a similar recipe-driven system), run this 60-second check BEFORE designing new code under `ops/<substrate>/`:
+
+```bash
+# gbrain example — substitute the substrate's equivalent CLI / launchd label
+ssh <host> 'gbrain integrations list && launchctl list | grep -i gbrain'
+```
+
+The recipe-driven substrates (gbrain especially) ship a senses + reflexes system that IS the signal-detector / autopilot / ingest pattern. Most "wire X into the flow" plans should be **configuring an existing recipe** (or writing a markdown recipe modeled on an existing one), NOT building new infrastructure. If a recipe exists `AVAILABLE` → configure it. If a recipe is `CONFIGURED` but dormant → investigate why. If no recipe exists → write a markdown recipe modeled on a sibling recipe (e.g. `imessage-to-brain`), submit upstream. Only propose new ops/ code if all three branches fail.
+
+This step exists because the failure mode is real: a 2026-05-17 hash-lemma plan proposed extracting a JSONL queue lib + producer + consumer bin + LaunchAgent + OAuth-DCR migration to wire "signal-detector on every Slack message" — when the gbrain `integrations` system already shipped the pattern. The 60-second check would have flagged the wrong-buildout at scope-lock.
+
+For substrates with no equivalent capability surface (pure web apps, libraries, CLIs), skip this step.
 
 Always work through the full interactive review: one section at a time (Architecture → Code Quality → Tests → Performance) with at most 8 top issues per section.
 

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -855,6 +855,20 @@ When the user types `/retro`, run this skill.
 
 
 
+## Step 0: gbrain goals context (run before git analysis)
+
+Pull the active goals pages from gbrain to measure shipped work against stated commitments — not just git log:
+
+```
+mcp__gbrain__get_page goals/weekly/2026-w{N}     ← current week's goals
+mcp__gbrain__get_page goals/monthly/YYYY-MM       ← month's commitments
+mcp__gbrain__list_pages type=task status=in_progress sort=updated_desc limit=10
+```
+
+Note which weekly goals had corresponding commits and which didn't. This becomes the "commitment vs shipped" section of the retro output.
+
+---
+
 ## Instructions
 
 Parse the argument to determine the time window. Default to 7 days if no argument given. All times should be reported in the user's **local timezone** (use the system default — do NOT set `TZ`).
@@ -1802,6 +1816,17 @@ When the user runs `/retro compare` (or `/retro compare 14d`):
 ## Important Rules
 
 - ALL narrative output goes directly to the user in the conversation. The ONLY file written is the `.context/retros/` JSON snapshot.
+
+## Step Final: capture findings to gbrain
+
+After the retro output is complete, invoke `signal-detector` in parallel — the "what we learned" and "3 habits for next week" sections qualify as original thinking and must be captured:
+
+```
+Invoke signal-detector with the key insights from the retro.
+Write target: signals/YYYY-MM-DD/retro-w{N}
+```
+
+Do NOT write the full retro to gbrain — only the distilled insights (patterns, surprises, decisions made).
 - Use `origin/<default>` for all git queries (not local main which may be stale)
 - Display all timestamps in the user's local timezone (do not override `TZ`)
 - If the window has zero commits, say so and suggest a different window

--- a/retro/SKILL.md.tmpl
+++ b/retro/SKILL.md.tmpl
@@ -62,6 +62,20 @@ When the user types `/retro`, run this skill.
 
 {{GBRAIN_CONTEXT_LOAD}}
 
+## Step 0: gbrain goals context (run before git analysis)
+
+Pull the active goals pages from gbrain to measure shipped work against stated commitments — not just git log:
+
+```
+mcp__gbrain__get_page goals/weekly/2026-w{N}     ← current week's goals
+mcp__gbrain__get_page goals/monthly/YYYY-MM       ← month's commitments
+mcp__gbrain__list_pages type=task status=in_progress sort=updated_desc limit=10
+```
+
+Note which weekly goals had corresponding commits and which didn't. This becomes the "commitment vs shipped" section of the retro output.
+
+---
+
 ## Instructions
 
 Parse the argument to determine the time window. Default to 7 days if no argument given. All times should be reported in the user's **local timezone** (use the system default — do NOT set `TZ`).
@@ -950,6 +964,17 @@ When the user runs `/retro compare` (or `/retro compare 14d`):
 ## Important Rules
 
 - ALL narrative output goes directly to the user in the conversation. The ONLY file written is the `.context/retros/` JSON snapshot.
+
+## Step Final: capture findings to gbrain
+
+After the retro output is complete, invoke `signal-detector` in parallel — the "what we learned" and "3 habits for next week" sections qualify as original thinking and must be captured:
+
+```
+Invoke signal-detector with the key insights from the retro.
+Write target: signals/YYYY-MM-DD/retro-w{N}
+```
+
+Do NOT write the full retro to gbrain — only the distilled insights (patterns, surprises, decisions made).
 - Use `origin/<default>` for all git queries (not local main which may be stale)
 - Display all timestamps in the user's local timezone (do not override `TZ`)
 - If the window has zero commits, say so and suggest a different window

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -845,6 +845,19 @@ You are running the `/review` workflow. Analyze the current branch's diff agains
 
 ---
 
+## Step 0: gbrain task context
+
+**REQUIRED SUB-SKILL: Use `brain-ops` — look up any task or brief pages linked to this PR's feature before reading the diff.**
+
+```
+mcp__gbrain__list_pages type=task status=in_progress sort=updated_desc limit=5
+mcp__gbrain__search "<branch name or feature keyword>"
+```
+
+If a task page exists: pull its acceptance criteria and use them as an additional review lens alongside the checklist. Note any mismatches between what the task says should ship and what the diff actually ships.
+
+---
+
 ## Step 1: Check branch
 
 1. Run `git branch --show-current` to get the current branch.
@@ -1842,6 +1855,43 @@ staleness detection: if those files are later deleted, the learning can be flagg
 already knows. A good test: would this insight save time in a future session? If yes, log it.
 
 If the review exits early before a real review completes (for example, no diff against the base branch), do **not** write this entry.
+
+## Step Final: capture findings to gbrain
+
+After review completes, run both writes in parallel:
+
+**A — Signal capture (architectural insights)**
+If findings include non-trivial architectural observations, invoke `signal-detector`:
+```
+Write target: signals/YYYY-MM-DD/review-{branch-slug}
+```
+Skip for purely mechanical findings (formatting, null checks).
+
+**B — Task stub for CRITICAL unresolved findings**
+For any finding that remains `status: unresolved` AND severity `CRITICAL` after the Fix-First pass:
+```
+mcp__gbrain__put_page
+  slug: tasks/review-{branch-slug}-{fingerprint-short}
+  type: task
+  frontmatter:
+    status: open
+    priority: high
+    source: review
+    source_branch: <branch>
+    parent_meeting: null
+    parent_goal: null        ← Milo week ritual will wire this
+    due: <today + 3 days>
+    author: "anoop@hashdirectors.com // ghosty"
+  content: |
+    ## Finding
+    {finding title + one-line description}
+    ## Why it matters
+    {from the review's critical-pass rationale}
+    ## Suggested fix
+    {from Fix-First classification}
+```
+
+This makes critical findings visible to Milo's open ritual (Bucket B orphan tasks) and the week ritual's cascade-linking pass. Without this write, the finding dies in signals/.
 
 ## Important Rules
 

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -1872,8 +1872,9 @@ For any finding that remains `status: unresolved` AND severity `CRITICAL` after 
 ```
 mcp__gbrain__put_page
   slug: tasks/review-{branch-slug}-{fingerprint-short}
-  type: task
-  frontmatter:
+  content: |
+    ---
+    type: task
     status: open
     priority: high
     source: review
@@ -1882,7 +1883,7 @@ mcp__gbrain__put_page
     parent_goal: null        ← Milo week ritual will wire this
     due: <today + 3 days>
     author: "anoop@hashdirectors.com // ghosty"
-  content: |
+    ---
     ## Finding
     {finding title + one-line description}
     ## Why it matters

--- a/review/SKILL.md.tmpl
+++ b/review/SKILL.md.tmpl
@@ -34,6 +34,19 @@ You are running the `/review` workflow. Analyze the current branch's diff agains
 
 ---
 
+## Step 0: gbrain task context
+
+**REQUIRED SUB-SKILL: Use `brain-ops` — look up any task or brief pages linked to this PR's feature before reading the diff.**
+
+```
+mcp__gbrain__list_pages type=task status=in_progress sort=updated_desc limit=5
+mcp__gbrain__search "<branch name or feature keyword>"
+```
+
+If a task page exists: pull its acceptance criteria and use them as an additional review lens alongside the checklist. Note any mismatches between what the task says should ship and what the diff actually ships.
+
+---
+
 ## Step 1: Check branch
 
 1. Run `git branch --show-current` to get the current branch.
@@ -293,6 +306,43 @@ Substitute:
 {{LEARNINGS_LOG}}
 
 If the review exits early before a real review completes (for example, no diff against the base branch), do **not** write this entry.
+
+## Step Final: capture findings to gbrain
+
+After review completes, run both writes in parallel:
+
+**A — Signal capture (architectural insights)**
+If findings include non-trivial architectural observations, invoke `signal-detector`:
+```
+Write target: signals/YYYY-MM-DD/review-{branch-slug}
+```
+Skip for purely mechanical findings (formatting, null checks).
+
+**B — Task stub for CRITICAL unresolved findings**
+For any finding that remains `status: unresolved` AND severity `CRITICAL` after the Fix-First pass:
+```
+mcp__gbrain__put_page
+  slug: tasks/review-{branch-slug}-{fingerprint-short}
+  type: task
+  frontmatter:
+    status: open
+    priority: high
+    source: review
+    source_branch: <branch>
+    parent_meeting: null
+    parent_goal: null        ← Milo week ritual will wire this
+    due: <today + 3 days>
+    author: "anoop@hashdirectors.com // ghosty"
+  content: |
+    ## Finding
+    {finding title + one-line description}
+    ## Why it matters
+    {from the review's critical-pass rationale}
+    ## Suggested fix
+    {from Fix-First classification}
+```
+
+This makes critical findings visible to Milo's open ritual (Bucket B orphan tasks) and the week ritual's cascade-linking pass. Without this write, the finding dies in signals/.
 
 ## Important Rules
 

--- a/review/SKILL.md.tmpl
+++ b/review/SKILL.md.tmpl
@@ -323,8 +323,9 @@ For any finding that remains `status: unresolved` AND severity `CRITICAL` after 
 ```
 mcp__gbrain__put_page
   slug: tasks/review-{branch-slug}-{fingerprint-short}
-  type: task
-  frontmatter:
+  content: |
+    ---
+    type: task
     status: open
     priority: high
     source: review
@@ -333,7 +334,7 @@ mcp__gbrain__put_page
     parent_goal: null        ← Milo week ritual will wire this
     due: <today + 3 days>
     author: "anoop@hashdirectors.com // ghosty"
-  content: |
+    ---
     ## Finding
     {finding title + one-line description}
     ## Why it matters


### PR DESCRIPTION
The Step B task-stub block passed `type:` and `frontmatter:` as sibling kwargs, which the live `mcp__gbrain__put_page` tool rejects — the silent-write class. Frontmatter now lives inside the `content: |` string between `---` fences. Fixed in the .tmpl (source of truth) and regenerated via `bun run gen:skill-docs`. Verified: `scan-write-schemas.py` exits 0 across the library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)