### PR TITLE
fix: copy supabase/config.sh in non-Claude host setup paths

### DIFF
--- a/setup
+++ b/setup
@@ -815,6 +815,11 @@ create_codex_runtime_root() {
   if [ -f "$gstack_dir/ETHOS.md" ]; then
     _link_or_copy "$gstack_dir/ETHOS.md" "$codex_gstack/ETHOS.md"
   fi
+  # supabase/config.sh — required by gstack-telemetry-sync to resolve GSTACK_SUPABASE_URL
+  if [ -f "$gstack_dir/supabase/config.sh" ]; then
+    mkdir -p "$codex_gstack/supabase"
+    _link_or_copy "$gstack_dir/supabase/config.sh" "$codex_gstack/supabase/config.sh"
+  fi
 }
 
 create_factory_runtime_root() {
@@ -852,6 +857,11 @@ create_factory_runtime_root() {
   done
   if [ -f "$gstack_dir/ETHOS.md" ]; then
     _link_or_copy "$gstack_dir/ETHOS.md" "$factory_gstack/ETHOS.md"
+  fi
+  # supabase/config.sh — required by gstack-telemetry-sync to resolve GSTACK_SUPABASE_URL
+  if [ -f "$gstack_dir/supabase/config.sh" ]; then
+    mkdir -p "$factory_gstack/supabase"
+    _link_or_copy "$gstack_dir/supabase/config.sh" "$factory_gstack/supabase/config.sh"
   fi
 }
 
@@ -905,6 +915,11 @@ create_opencode_runtime_root() {
   fi
   if [ -f "$gstack_dir/ETHOS.md" ]; then
     _link_or_copy "$gstack_dir/ETHOS.md" "$opencode_gstack/ETHOS.md"
+  fi
+  # supabase/config.sh — required by gstack-telemetry-sync to resolve GSTACK_SUPABASE_URL
+  if [ -f "$gstack_dir/supabase/config.sh" ]; then
+    mkdir -p "$opencode_gstack/supabase"
+    _link_or_copy "$gstack_dir/supabase/config.sh" "$opencode_gstack/supabase/config.sh"
   fi
 }
 
@@ -1120,6 +1135,11 @@ if [ "$INSTALL_KIRO" -eq 1 ]; then
   # ETHOS.md — referenced by "Search Before Building" in all skill preambles
   if [ -f "$SOURCE_GSTACK_DIR/ETHOS.md" ]; then
     _link_or_copy "$SOURCE_GSTACK_DIR/ETHOS.md" "$KIRO_GSTACK/ETHOS.md"
+  fi
+  # supabase/config.sh — required by gstack-telemetry-sync to resolve GSTACK_SUPABASE_URL
+  if [ -f "$SOURCE_GSTACK_DIR/supabase/config.sh" ]; then
+    mkdir -p "$KIRO_GSTACK/supabase"
+    _link_or_copy "$SOURCE_GSTACK_DIR/supabase/config.sh" "$KIRO_GSTACK/supabase/config.sh"
   fi
   # gstack-upgrade skill
   if [ -f "$AGENTS_DIR/gstack-upgrade/SKILL.md" ]; then


### PR DESCRIPTION
## Summary

The `setup` script's non-Claude host paths (Kiro, Codex, Factory, OpenCode) use selective file linking rather than symlinking the entire repo root. This missed `supabase/config.sh`, causing `gstack-telemetry-sync` to silently exit (`SUPABASE_URL` empty) for all users on these hosts who opted into telemetry.

## What changed

Added `supabase/config.sh` to the asset list in:
- `create_codex_runtime_root()`
- `create_factory_runtime_root()`
- `create_opencode_runtime_root()`
- Kiro install block (step 6)

Each uses the existing `_link_or_copy` helper and guards with `[ -f ... ]` so nothing breaks if the file is absent.

## Root cause

`gstack-telemetry-sync` sources `$GSTACK_DIR/supabase/config.sh` to get `GSTACK_SUPABASE_URL`. For Claude, `$GSTACK_DIR` is a symlink to the repo root so it resolves. For other hosts, `$GSTACK_DIR` points to the selective-copy target (e.g. `~/.kiro/skills/gstack/`) which never had `supabase/` copied in.

## Verification

Tested locally on Linux (Ubuntu) with `--host kiro`:

**Before fix:**
```
$ ls ~/.kiro/skills/gstack/supabase/config.sh
ls: cannot access ... No such file or directory
```

**After fix (symlink created):**
```
$ ls -la ~/.kiro/skills/gstack/supabase/config.sh
lrwxrwxrwx 1 appadmin appadmin 40 Jul 10 08:33
  ~/.kiro/skills/gstack/supabase/config.sh -> /home/appadmin/gstack/supabase/config.sh
```

**Telemetry-sync URL resolution (bash -x trace):**
```
+ [ -f /home/appadmin/.kiro/skills/gstack/supabase/config.sh ]
+ . /home/appadmin/.kiro/skills/gstack/supabase/config.sh
++ GSTACK_SUPABASE_URL=https://frugpmstpnojnhfyimgv.supabase.co
++ GSTACK_SUPABASE_ANON_KEY=sb_publishable_...
+ SUPABASE_URL=https://frugpmstpnojnhfyimgv.supabase.co
+ [ -z https://frugpmstpnojnhfyimgv.supabase.co ]
```

The script now passes the `[ -z "$SUPABASE_URL" ] && exit 0` guard and proceeds to sync. Previously it would exit silently at that line.

**End-to-end telemetry-log test:**
```
$ gstack-telemetry-log --skill test-verification --duration 5 --outcome success ...
# Successfully wrote to ~/.gstack/analytics/skill-usage.jsonl
# installation_id generated, all fields populated
# telemetry-sync triggered in background (rate-limited, so exited after URL resolution)
```

Fixes #2215