### PR TITLE
fix(gstack-config): accept @local endpoint ids for brain_trust_policy

### DIFF
--- a/bin/gstack-config
+++ b/bin/gstack-config
@@ -134,12 +134,12 @@ lookup_default() {
     redact_repo_visibility) echo "" ;; # empty → fall through to gh/glab detection
     redact_prepush_hook) echo "false" ;;
     # Brain-aware planning (v1.48 / T5+T10+T16). Defaults documented inline:
-    #   brain_trust_policy@<hash>  — unset on fresh install; setup-gbrain
+    #   brain_trust_policy@<endpoint-id>  — unset on fresh install; setup-gbrain
     #                                writes 'personal' for local engines,
     #                                asks the user for remote-ambiguous.
     #   salience_allowlist          — empty falls through to
     #                                SALIENCE_DEFAULT_ALLOWLIST (D9).
-    #   user_slug_at_<hash>         — empty triggers resolve-user-slug
+    #   user_slug_at_<endpoint-id>  — empty triggers resolve-user-slug
     #                                fallback chain (D4 A3) on first call.
     brain_trust_policy*) echo "unset" ;;
     salience_allowlist) echo "" ;;
@@ -260,14 +260,16 @@ resolve_user_slug() {
 case "${1:-}" in
   get)
     KEY="${2:?Usage: gstack-config get <key>}"
-    # Validate key (alphanumeric + underscore + optional @<hash> suffix for
-    # endpoint-namespaced keys introduced by the brain-aware planning layer)
-    if ! printf '%s' "$KEY" | grep -qE '^[a-zA-Z0-9_]+(@[a-f0-9]+)?$'; then
-      echo "Error: key must contain only alphanumeric characters, underscores, and an optional @<hex-hash> suffix" >&2
+    # Validate key (alphanumeric + underscore + optional @<endpoint-id> suffix for
+    # endpoint-namespaced keys introduced by the brain-aware planning layer).
+    # Endpoint ids are sha8/sha16 hex for remote MCP URLs, or the literal
+    # "local" for stdio/PGLite engines (see endpoint_hash).
+    if ! printf '%s' "$KEY" | grep -qE '^[a-zA-Z0-9_]+(@[a-zA-Z0-9]+)?$'; then
+      echo "Error: key must contain only alphanumeric characters, underscores, and an optional @<endpoint-id> suffix" >&2
       exit 1
     fi
-    # Use literal match for keys containing @ (sha hashes), regex otherwise
-    VALUE=$(grep -F "${KEY}:" "$CONFIG_FILE" 2>/dev/null | grep -E "^${KEY%@*}(@[a-f0-9]+)?:" | grep -F "${KEY}:" | tail -1 | awk '{print $2}' | tr -d '[:space:]' || true)
+    # Use literal match for keys containing @ (endpoint ids), regex otherwise
+    VALUE=$(grep -F "${KEY}:" "$CONFIG_FILE" 2>/dev/null | grep -E "^${KEY%@*}(@[a-zA-Z0-9]+)?:" | grep -F "${KEY}:" | tail -1 | awk '{print $2}' | tr -d '[:space:]' || true)
     if [ -z "$VALUE" ]; then
       VALUE=$(lookup_default "$KEY")
     fi
@@ -276,9 +278,10 @@ case "${1:-}" in
   set)
     KEY="${2:?Usage: gstack-config set <key> <value>}"
     VALUE="${3:?Usage: gstack-config set <key> <value>}"
-    # Validate key (alphanumeric + underscore + optional @<hash> suffix)
-    if ! printf '%s' "$KEY" | grep -qE '^[a-zA-Z0-9_]+(@[a-f0-9]+)?$'; then
-      echo "Error: key must contain only alphanumeric characters, underscores, and an optional @<hex-hash> suffix" >&2
+    # Validate key (alphanumeric + underscore + optional @<endpoint-id> suffix).
+    # Accepts hex hashes and the literal "local" from endpoint_hash.
+    if ! printf '%s' "$KEY" | grep -qE '^[a-zA-Z0-9_]+(@[a-zA-Z0-9]+)?$'; then
+      echo "Error: key must contain only alphanumeric characters, underscores, and an optional @<endpoint-id> suffix" >&2
       exit 1
     fi
     # Validate brain_trust_policy value domain (D4 / D11)

--- a/browse/test/gstack-config.test.ts
+++ b/browse/test/gstack-config.test.ts
@@ -108,6 +108,13 @@ describe('gstack-config', () => {
     expect(existsSync(join(nestedDir, 'config.yaml'))).toBe(true);
   });
 
+  test('brain trust policy accepts local endpoint suffix', () => {
+    const { exitCode, stderr } = run(['set', 'brain_trust_policy@local', 'personal']);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe('');
+    expect(run(['get', 'brain_trust_policy@local']).stdout).toBe('personal');
+  });
+
   // ─── list ─────────────────────────────────────────────────
   test('list shows all keys', () => {
     writeFileSync(join(stateDir, 'config.yaml'), 'auto_upgrade: true\nupdate_check: false\n');
@@ -137,6 +144,12 @@ describe('gstack-config', () => {
     const { exitCode, stderr } = run(['set', '.*', 'value']);
     expect(exitCode).toBe(1);
     expect(stderr).toContain('alphanumeric');
+  });
+
+  test('set rejects endpoint suffix with punctuation', () => {
+    const { exitCode, stderr } = run(['set', 'brain_trust_policy@local-dev', 'personal']);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('endpoint-id');
   });
 
   test('set preserves value with sed special chars', () => {

--- a/test/user-slug-fallback.test.ts
+++ b/test/user-slug-fallback.test.ts
@@ -8,7 +8,7 @@
  *   3. sha8($(git config user.email))
  *   4. anonymous-<sha8(hostname)>
  *
- * Result is persisted under user_slug_at_<endpoint-hash> for stability.
+ * Result is persisted under user_slug_at_<endpoint-id> for stability.
  * Test isolation via GSTACK_HOME and HOME env overrides.
  *
  * Gate-tier, free, ~50ms.
@@ -87,12 +87,12 @@ describe('resolve-user-slug fallback chain', () => {
     expect(slug).toMatch(/^(email-|anonymous-)[a-f0-9]+$|^[a-zA-Z0-9-]+$/);
   });
 
-  test('persists resolution to user_slug_at_<hash> on first call', () => {
+  test('persists resolution to user_slug_at_<endpoint-id> on first call', () => {
     runConfig(['resolve-user-slug'], { GSTACK_HOME: TMP_HOME, USER: 'persisttest' });
     const configFile = join(TMP_HOME, 'config.yaml');
     expect(existsSync(configFile)).toBe(true);
     const content = readFileSync(configFile, 'utf-8');
-    expect(content).toMatch(/^user_slug_at_[a-f0-9]+:\s+persisttest/m);
+    expect(content).toMatch(/^user_slug_at_(local|[a-f0-9]{8}|[a-f0-9]{16}):\s+persisttest/m);
   });
 
   test('subsequent calls return same slug (stable across sessions)', () => {
@@ -104,7 +104,7 @@ describe('resolve-user-slug fallback chain', () => {
   });
 });
 
-describe('brain_trust_policy@<hash> namespace', () => {
+describe('brain_trust_policy@<endpoint-id> namespace', () => {
   test('default value is "unset"', () => {
     const result = runConfig(['get', 'brain_trust_policy@deadbeef'], { GSTACK_HOME: TMP_HOME });
     expect(result.status).toBe(0);
@@ -157,5 +157,11 @@ describe('key validation', () => {
   test('accepts @<hex-hash> suffix on key', () => {
     const result = runConfig(['get', 'brain_trust_policy@abc123ff'], { GSTACK_HOME: TMP_HOME });
     expect(result.status).toBe(0);
+  });
+
+  test('accepts @local suffix on key', () => {
+    const result = runConfig(['get', 'brain_trust_policy@local'], { GSTACK_HOME: TMP_HOME });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('unset');
   });
 });


### PR DESCRIPTION
## Summary
- `endpoint-hash` returns the literal `local` for stdio/PGLite engines, but key validation only allowed `@[a-f0-9]+`, so `/setup-gbrain` Step 9.5 and `/sync-gbrain` could not persist `brain_trust_policy@local`.
- Widen the `@` suffix to alphanumeric endpoint ids (hex hashes + `local`) in get/set validators and lookup.
- Add regression coverage for `@local` accept and punctuation reject; fix `user_slug_at_local` persist assertion.

Fixes #2210
Fixes #1988

## Test plan
- [x] `bun test browse/test/gstack-config.test.ts`
- [x] `bun test test/user-slug-fallback.test.ts`
- [x] Manual: origin/main binary rejects `set brain_trust_policy@local`; fixed binary persists `personal`
- [x] Consumer/control clones (gbrain, zotero-arxiv-daily, actionbook, plane, twenty): Step 9.5 before/after
- [x] plane (without-gstack) Path 3: init → MCP → `gbrain put`/search → policy persist with YC OpenAI key


Made with [Cursor](https://cursor.com)