### PR TITLE
fix(setup): resolve hardcoded ~/.claude/skills/gstack paths for installs not named "gstack" (#1882)

### DIFF
--- a/setup
+++ b/setup
@@ -606,6 +606,45 @@ link_claude_root_skill_alias() {
   _print_windows_copy_note_once
 }
 
+# ─── Helper: compatibility alias for installs not named "gstack" ──────────────
+# Every generated SKILL.md preamble hard-references the absolute self-path
+# ~/.claude/skills/gstack/bin/... (config, telemetry, update-check, and every
+# other bin/asset call). When gstack is installed at ~/.claude/skills/<name>
+# with <name> != gstack, the per-skill symlinks resolve but those in-file
+# references point at a non-existent ~/.claude/skills/gstack/ and fail SILENTLY
+# at skill-invocation time (the preamble swallows the 127 via `|| echo default`).
+# See issue #1882.
+#
+# Fix: plant a sibling alias <skills_dir>/gstack -> <install_dir> so the
+# hardcoded paths resolve with zero file edits. Claude Code already skips the
+# repo-shaped gstack directory when building the slash-command list (see
+# link_claude_root_skill_alias above), so this alias is a path-resolution
+# target only, not a duplicate skill. When the install is already named gstack
+# the references resolve natively and this is a no-op.
+link_gstack_compat_alias() {
+  local install_dir="$1"   # actual gstack checkout (INSTALL_GSTACK_DIR)
+  local skills_dir="$2"    # skills parent (INSTALL_SKILLS_DIR)
+
+  # Already named gstack — nothing to reconcile.
+  [ "$(basename "$install_dir")" = "gstack" ] && return 0
+
+  local alias="$skills_dir/gstack"
+
+  # Never clobber a real (non-symlink) gstack install already living here — its
+  # own bin/ already satisfies the hardcoded references, and it may be a
+  # separate global install we must not destroy.
+  if [ -e "$alias" ] && [ ! -L "$alias" ]; then
+    return 0
+  fi
+
+  # Idempotently (re)point a name-only/self alias. On Windows _link_or_copy
+  # falls back to a directory copy (no symlinks without Developer Mode), which
+  # is heavier but keeps the hardcoded paths resolvable there too.
+  _link_or_copy "$install_dir" "$alias"
+  echo "  linked compatibility alias: gstack -> $(basename "$install_dir") (install dir not named 'gstack', issue #1882)"
+  _print_windows_copy_note_once
+}
+
 # ─── Helper: remove old unprefixed Claude skill entries ───────────────────────
 # Migration: when switching from flat names to gstack- prefixed names,
 # clean up stale symlinks or directories that point into the gstack directory.
@@ -993,6 +1032,9 @@ if [ "$INSTALL_CLAUDE" -eq 1 ]; then
     "$SOURCE_GSTACK_DIR/bin/gstack-patch-names" "$SOURCE_GSTACK_DIR" "$SKILL_PREFIX"
     link_claude_skill_dirs "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
     link_claude_root_skill_alias "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
+    # Reconcile hardcoded ~/.claude/skills/gstack/ self-paths when the install
+    # dir isn't literally named "gstack" (issue #1882). No-op when it is.
+    link_gstack_compat_alias "$INSTALL_GSTACK_DIR" "$INSTALL_SKILLS_DIR"
     # Self-healing: re-run gstack-relink to ensure name: fields and directory
     # names are consistent with the config. This catches cases where an interrupted
     # setup, stale git state, or gen:skill-docs left name: fields out of sync.

--- a/test/setup-gstack-compat-alias.test.ts
+++ b/test/setup-gstack-compat-alias.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Regression coverage for issue #1882: every generated SKILL.md preamble
+// hard-references ~/.claude/skills/gstack/bin/... When gstack is installed at
+// ~/.claude/skills/<name> with <name> != gstack, those references break
+// silently at skill-invocation time. `setup` reconciles this with a
+// compatibility alias (<skills_dir>/gstack -> <install_dir>) planted by
+// link_gstack_compat_alias.
+
+const SETUP_SRC = fs.readFileSync(path.join(import.meta.dir, '..', 'setup'), 'utf-8');
+
+// Pull the bodies of the helpers we need to exercise in isolation. Anchors are
+// the function-definition lines; each body ends at the first line that is a
+// lone `}` at column 0.
+function extractFn(name: string): string {
+  const start = SETUP_SRC.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`Could not locate ${name}() in setup`);
+  const end = SETUP_SRC.indexOf('\n}\n', start);
+  if (end < 0) throw new Error(`Could not locate end of ${name}() in setup`);
+  return SETUP_SRC.slice(start, end + 3);
+}
+
+describe('setup: link_gstack_compat_alias — static invariants (#1882)', () => {
+  test('helper is defined', () => {
+    expect(SETUP_SRC).toContain('link_gstack_compat_alias() {');
+  });
+
+  test('helper is called in the Claude install path with install + skills dirs', () => {
+    expect(SETUP_SRC).toContain(
+      'link_gstack_compat_alias "$INSTALL_GSTACK_DIR" "$INSTALL_SKILLS_DIR"',
+    );
+  });
+
+  test('helper no-ops when the install dir is already named gstack', () => {
+    const body = extractFn('link_gstack_compat_alias');
+    expect(body).toContain('= "gstack" ] && return 0');
+  });
+
+  test('helper never clobbers a real (non-symlink) gstack install', () => {
+    const body = extractFn('link_gstack_compat_alias');
+    // Must bail before writing when a real dir already occupies the alias slot.
+    expect(body).toMatch(/\[ ! -L "\$alias" \][\s\S]*return 0/);
+  });
+
+  test('helper routes through _link_or_copy (no raw ln, Windows-safe)', () => {
+    const body = extractFn('link_gstack_compat_alias');
+    expect(body).toContain('_link_or_copy "$install_dir" "$alias"');
+  });
+});
+
+// Behavioral matrix: source the three helpers into a Unix shell and drive each
+// case. Symlink semantics only make sense off Windows.
+describe.skipIf(process.platform === 'win32')(
+  'setup: link_gstack_compat_alias — behavior',
+  () => {
+    function run(
+      installBasename: string,
+      preexisting?: 'real-dir' | 'symlink',
+    ): {
+      ok: boolean;
+      aliasExists: boolean;
+      aliasIsSymlink: boolean;
+      aliasTarget: string | null;
+      aliasRealContent: string | null;
+      stdout: string;
+    } {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-1882-'));
+      try {
+        const skillsDir = path.join(tmp, 'skills');
+        const installDir = path.join(skillsDir, installBasename);
+        // A minimal install dir with a recognisable bin/ marker.
+        fs.mkdirSync(path.join(installDir, 'bin'), { recursive: true });
+        fs.writeFileSync(path.join(installDir, 'bin', 'gstack-config'), 'echo real-install\n');
+
+        const alias = path.join(skillsDir, 'gstack');
+        if (preexisting === 'real-dir') {
+          fs.mkdirSync(path.join(alias, 'bin'), { recursive: true });
+          fs.writeFileSync(path.join(alias, 'bin', 'gstack-config'), 'echo pre-existing\n');
+        } else if (preexisting === 'symlink') {
+          // stale self-link pointing somewhere else; helper should refresh it
+          const stale = path.join(tmp, 'stale');
+          fs.mkdirSync(stale, { recursive: true });
+          fs.symlinkSync(stale, alias);
+        }
+
+        const helpers = [
+          extractFn('_link_or_copy'),
+          extractFn('_print_windows_copy_note_once'),
+          extractFn('link_gstack_compat_alias'),
+        ].join('\n');
+        const script = `IS_WINDOWS=0\n_WINDOWS_COPY_NOTE_PRINTED=0\n${helpers}\nlink_gstack_compat_alias "${installDir}" "${skillsDir}"\n`;
+        const result = spawnSync('bash', ['-c', script], { encoding: 'utf-8', timeout: 5000 });
+
+        const lst = fs.lstatSync(alias, { throwIfNoEntry: false });
+        let target: string | null = null;
+        let realContent: string | null = null;
+        if (lst?.isSymbolicLink()) target = fs.readlinkSync(alias);
+        const cfg = path.join(alias, 'bin', 'gstack-config');
+        if (fs.existsSync(cfg)) realContent = fs.readFileSync(cfg, 'utf-8').trim();
+        return {
+          ok: result.status === 0,
+          aliasExists: lst !== undefined,
+          aliasIsSymlink: lst?.isSymbolicLink() ?? false,
+          aliasTarget: target,
+          aliasRealContent: realContent,
+          stdout: result.stdout,
+        };
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    }
+
+    test('non-gstack install dir → alias symlink planted at skills/gstack', () => {
+      const r = run('i-gstack');
+      expect(r.ok).toBe(true);
+      expect(r.aliasIsSymlink).toBe(true);
+      expect(r.aliasTarget).toMatch(/i-gstack$/);
+      // The alias resolves the hardcoded ~/.claude/skills/gstack/bin path.
+      expect(r.aliasRealContent).toBe('echo real-install');
+      expect(r.stdout).toContain('compatibility alias: gstack -> i-gstack');
+    });
+
+    test('install dir already named gstack → no alias planted (no-op)', () => {
+      const r = run('gstack');
+      expect(r.ok).toBe(true);
+      // The alias slot IS the install dir here, so it exists — but the helper
+      // must NOT plant a symlink or announce a compatibility alias.
+      expect(r.aliasIsSymlink).toBe(false);
+      expect(r.aliasRealContent).toBe('echo real-install');
+      expect(r.stdout).not.toContain('compatibility alias');
+    });
+
+    test('pre-existing REAL gstack dir → not clobbered', () => {
+      const r = run('i-gstack', 'real-dir');
+      expect(r.ok).toBe(true);
+      expect(r.aliasIsSymlink).toBe(false);
+      expect(r.aliasRealContent).toBe('echo pre-existing');
+    });
+
+    test('stale gstack symlink → refreshed to this install (idempotent)', () => {
+      const r = run('i-gstack', 'symlink');
+      expect(r.ok).toBe(true);
+      expect(r.aliasIsSymlink).toBe(true);
+      expect(r.aliasTarget).toMatch(/i-gstack$/);
+    });
+  },
+);


### PR DESCRIPTION
Fixes #1882.

## The issue, in plain terms

When you install gstack, `setup` puts each skill (`/qa`, `/ship`, ...) into `~/.claude/skills/` and points it back at your gstack checkout. That part works no matter what you name the folder you cloned into.

The problem: the text **inside** every skill hardcodes one exact path — `~/.claude/skills/gstack/bin/...`. Every skill, on every run, quietly calls things like `~/.claude/skills/gstack/bin/gstack-config` in its opening steps (reading your config, logging telemetry, checking for updates).

So if you cloned gstack into a folder that **isn't literally named `gstack`** (say `~/.claude/skills/gstack-dev` or `~/.claude/skills/i-gstack`), those calls point at a folder that doesn't exist. And because each call ends in `2>/dev/null || echo default`, the failure is **swallowed** — nothing errors out. Every config setting silently falls back to its default, telemetry silently does nothing, the update check silently skips.

The nasty part: **install looks completely fine.** Nothing warns you. The skills only misbehave later, when you actually run one, and it looks like the skill itself is broken rather than the folder name.

**Who hits this:** anyone whose install folder isn't named exactly `gstack`. `setup` accepts that layout (it installs the skills as siblings of whatever folder you cloned into) — it just never reconciled the hardcoded path inside the skill files. This is the folder-name sibling of #349 (which is about the `~/.claude` prefix), and both point toward the dynamic-path-resolution direction from #289.

## Proof (before → after)

Reproduced in a throwaway `$HOME` with the checkout copied to `~/.claude/skills/i-gstack` (a name that isn't `gstack`) and `./setup --host claude`, then running the exact commands a skill's opening steps run:

| What a skill runs on startup | Before this fix | After this fix |
|---|---|---|
| `~/.claude/skills/gstack/bin/gstack-config get proactive` | exit **127** (No such file) | exit **0** → `true` |
| `~/.claude/skills/gstack/bin/gstack-telemetry-log` | exit **127** | exit **0** |
| `~/.claude/skills/gstack/bin/gstack-update-check` | exit **127** | exit **0** |
| `~/.claude/skills/gstack` | didn't exist | `-> i-gstack` |

## The fix (issue's option #1 — a compatibility symlink)

After `setup` links the Claude skills, if your install folder isn't named `gstack` it now plants one extra symlink: `~/.claude/skills/gstack -> <your install folder>`. That makes every hardcoded `~/.claude/skills/gstack/...` path resolve, with zero edits to any skill file.

Safe by design (`link_gstack_compat_alias` in `setup`):
- **No-op** when your install is already named `gstack` (paths resolve natively).
- **Never clobbers** a real `gstack` directory that's already there — that could be a separate install, and its own `bin/` already works.
- **Idempotent** — refreshes a stale alias instead of duplicating.
- Routes through the existing `_link_or_copy` helper, so Windows-without-Developer-Mode falls back to a directory copy and the raw-`ln` invariant test stays green.

Claude Code already skips the repo-shaped `gstack` directory when it builds the slash-command list (see `link_claude_root_skill_alias`), so this alias is purely a path-resolution target, not a duplicate skill — which resolves the caveat the issue flagged.

Why not the other options: #2 (make the preamble resolve its own path at runtime) touches every generated skill and can't reliably self-locate in bash; #3 (rewrite the in-file paths for the Claude host) dirties the working tree, since that host symlinks to source instead of copying.

## Tests

New: `test/setup-gstack-compat-alias.test.ts` — static wiring checks plus a behavioral matrix: non-`gstack` install plants the alias, `gstack` install is a no-op, a real pre-existing dir is not clobbered, a stale symlink is refreshed.

- `bun test test/setup-gstack-compat-alias.test.ts` — pass
- `bun test test/setup-*.test.ts` — 74 pass (includes the Windows raw-`ln` invariant)

## Note for maintainers

Raw bug fix only — no `VERSION`/`CHANGELOG` bump. Leave versioning to a `/ship` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)