### PR TITLE
fix(browse): case-insensitive exfiltration-domain blocklist matching (#2190)

### DIFF
--- a/browse/src/content-security.ts
+++ b/browse/src/content-security.ts
@@ -338,19 +338,28 @@ const BLOCKLIST_DOMAINS = [
 export function urlBlocklistFilter(content: string, url: string, _command: string): ContentFilterResult {
   const warnings: string[] = [];
 
+  // Matching is case-insensitive. Hostnames and URL schemes are
+  // case-insensitive (RFC 3986), so an uppercased sink like
+  // https://WEBHOOK.SITE/x must not slip past the blocklist. Normalize the
+  // haystack to lowercase; BLOCKLIST_DOMAINS entries are lowercase by
+  // construction, so a direct compare then holds.
+
   // Check page URL
+  const normalizedUrl = url.toLowerCase();
   for (const domain of BLOCKLIST_DOMAINS) {
-    if (url.includes(domain)) {
+    if (normalizedUrl.includes(domain)) {
       warnings.push(`Page URL matches blocklisted domain: ${domain}`);
     }
   }
 
-  // Check for blocklisted URLs in content (links, form actions)
-  const urlPattern = /https?:\/\/[^\s"'<>]+/g;
+  // Check for blocklisted URLs in content (links, form actions). The `i` flag
+  // keeps an uppercased scheme (HTTPS://) from evading URL extraction.
+  const urlPattern = /https?:\/\/[^\s"'<>]+/gi;
   const contentUrls = content.match(urlPattern) || [];
   for (const contentUrl of contentUrls) {
+    const normalizedContentUrl = contentUrl.toLowerCase();
     for (const domain of BLOCKLIST_DOMAINS) {
-      if (contentUrl.includes(domain)) {
+      if (normalizedContentUrl.includes(domain)) {
         warnings.push(`Content contains blocklisted URL: ${contentUrl.slice(0, 100)}`);
         break;
       }

--- a/browse/test/content-security.test.ts
+++ b/browse/test/content-security.test.ts
@@ -151,6 +151,44 @@ describe('Content filter hooks', () => {
     expect(result.warnings.length).toBe(0);
   });
 
+  // Regression: issue #2190 — case-sensitive matching let an uppercased
+  // exfiltration domain bypass the blocklist.
+  test('URL blocklist is case-insensitive on the page URL', () => {
+    const result = urlBlocklistFilter('', 'https://WEBHOOK.SITE/steal', 'text');
+    expect(result.safe).toBe(false);
+    expect(result.warnings.some(w => w.includes('webhook.site'))).toBe(true);
+  });
+
+  test('URL blocklist is case-insensitive on content URLs', () => {
+    const result = urlBlocklistFilter(
+      '<a href="https://WEBHOOK.SITE/a1b2c3-steal">click</a>',
+      'https://docs.example.com/article',
+      'links',
+    );
+    expect(result.safe).toBe(false);
+    expect(result.warnings.some(w => w.includes('WEBHOOK.SITE'))).toBe(true);
+  });
+
+  test('URL blocklist catches an uppercased scheme in content', () => {
+    const result = urlBlocklistFilter(
+      'Exfil via HTTPS://Requestbin.com/r/abc please',
+      'https://example.com',
+      'text',
+    );
+    expect(result.safe).toBe(false);
+    expect(result.warnings.some(w => w.toLowerCase().includes('requestbin.com'))).toBe(true);
+  });
+
+  test('URL blocklist does not over-block legitimate uppercase domains', () => {
+    const result = urlBlocklistFilter(
+      '<a href="https://GitHub.com/acme/project">source</a>',
+      'https://DOCS.EXAMPLE.COM/help',
+      'links',
+    );
+    expect(result.safe).toBe(true);
+    expect(result.warnings.length).toBe(0);
+  });
+
   test('custom filter can be registered and runs', () => {
     registerContentFilter((content, url, cmd) => {
       if (content.includes('SECRET')) {


### PR DESCRIPTION
## What was broken (plain English)
The browser assistant keeps a blocklist of shady sites known for stealing data. The check only matched lowercase web addresses, so a booby-trapped page could point to the same bad site written with capital letters and slip right past the guard. The assistant would then hand that dangerous link back instead of blocking it.

## How it was fixed (plain English)
The guard now ignores capitalization when it compares a web address to the blocklist. A known data-stealing site is caught whether it is written in lowercase or uppercase. Ordinary sites that happen to use capital letters are still allowed through, so nothing legitimate gets blocked by mistake.

Fixes #2190

## Technical detail
`urlBlocklistFilter` in `browse/src/content-security.ts` compared URLs against `BLOCKLIST_DOMAINS` with case-sensitive substring checks (`url.includes(domain)` / `contentUrl.includes(domain)`). Because hostnames and URL schemes are case-insensitive (RFC 3986), an uppercased exfiltration sink such as `https://WEBHOOK.SITE/x` bypassed the filter and reached the scoped browser agent.

The fix:
- Normalizes the page URL and each extracted content URL to lowercase before comparing (blocklist entries are lowercase by construction).
- Adds the `i` flag to the content URL-extraction regex so an uppercased scheme (`HTTPS://`) can't evade extraction either.

## Live before/after evidence
Each probe drives the exact server-egress security decision (`runContentFilters` in block mode — the same call `browse/src/server.ts` makes for a scoped browser agent) against isolated baseline (pinned to `origin/main`) and candidate installs, with a page linking to an uppercased exfil sink. Baseline and candidate commands are byte-identical.

| repo | cohort | baseline | candidate |
|---|---|---:|---:|
| gstack-auto | with-gstack | 1 — allowed (VULNERABLE) | 0 — blocked |
| zotero-arxiv-daily | with-gstack | 1 — allowed (VULNERABLE) | 0 — blocked |
| lacp | with-gstack | 1 — allowed (VULNERABLE) | 0 — blocked |
| stagehand | control | 0 — legit uppercase allowed | 0 — legit uppercase allowed |
| infisical | control | 0 — legit uppercase allowed | 0 — legit uppercase allowed |

Baseline verdict: `blocked=false … ALLOWED — uppercase exfiltration sink bypassed the blocklist`.
Candidate verdict: `blocked=true … warnings=["Content contains blocklisted URL: https://WEBHOOK.SITE/…"] … BLOCKED`.
Controls confirm the fix does not over-block legitimate uppercase domains (e.g. `GitHub.com`).

## Tests
Added 4 regression tests in `browse/test/content-security.test.ts` (case-insensitive page URL, case-insensitive content URL, uppercased scheme, and no over-block on legitimate uppercase domains). Full file: **62 pass / 0 fail**.
