### PR TITLE
fix(browse): preserve live daemon during busy loads

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -89,7 +89,7 @@ if (IS_WINDOWS && !NODE_SERVER_SCRIPT) {
   );
 }
 
-interface ServerState {
+export interface ServerState {
   pid: number;
   port: number;
   token: string;
@@ -103,6 +103,16 @@ interface ServerState {
   xvfbPid?: number;
   xvfbStartTime?: number;
   xvfbDisplay?: string;
+}
+
+/** A daemon whose process still exists may be busy even when HTTP health checks
+ * time out. Preserve it (and its browser session) instead of guessing that it
+ * is dead. The caller can retry once the current page load settles. */
+export function shouldPreserveUnresponsiveServer(
+  state: ServerState | null,
+  processAlive: (pid: number) => boolean = isProcessAlive,
+): boolean {
+  return !!state?.pid && processAlive(state.pid);
 }
 
 // ─── State File ────────────────────────────────────────────────
@@ -451,12 +461,14 @@ async function ensureServer(flags?: GlobalFlags): Promise<ServerState> {
     process.exit(1);
   }
 
-  // Guard: never silently replace a headed server with a headless one.
-  // Headed mode means a user-visible Chrome window is (or was) controlled.
-  // Silently replacing it would be confusing — tell the user to reconnect.
-  if (state && state.mode === 'headed' && isProcessAlive(state.pid)) {
-    console.error(`[browse] Headed server running (PID ${state.pid}) but not responding.`);
-    console.error(`[browse] Run '/open-gstack-browser' to restart.`);
+  // A live daemon can stop answering HTTP while Chromium finishes a heavy
+  // navigation. Restarting here destroys tabs, cookies, and login state. Only
+  // auto-restart after the daemon process itself is demonstrably gone.
+  if (shouldPreserveUnresponsiveServer(state)) {
+    console.error(`[browse] Server running (PID ${state!.pid}) but not responding — busy, not restarting.`);
+    console.error(state!.mode === 'headed'
+      ? `[browse] Retry shortly, or run '/open-gstack-browser' to restart intentionally.`
+      : '[browse] Retry shortly, or run `browse disconnect` to restart intentionally.');
     process.exit(1);
   }
 
@@ -590,10 +602,13 @@ async function sendCommand(state: ServerState, command: string, args: string[], 
       // can briefly stop answering HTTP while still alive. Before declaring a
       // crash, if the process is alive give /health a bounded chance to recover
       // and just retry the command — never kill+restart a live-but-busy server.
-      if (oldState?.pid && isProcessAlive(oldState.pid) && await probeHealthWithBackoff(oldState.port)) {
-        if (retries >= 1) throw new Error('[browse] Server unresponsive after retry — aborting');
-        console.error('[browse] Server was briefly unresponsive (busy); retrying command...');
-        return sendCommand(oldState, command, args, retries + 1);
+      if (shouldPreserveUnresponsiveServer(oldState)) {
+        if (await probeHealthWithBackoff(oldState!.port)) {
+          if (retries >= 1) throw new Error('[browse] Server unresponsive after retry — aborting');
+          console.error('[browse] Server was briefly unresponsive (busy); retrying command...');
+          return sendCommand(oldState!, command, args, retries + 1);
+        }
+        throw new Error('[browse] Server is still running but unresponsive — busy, not restarting. Retry shortly.');
       }
       // Truly dead (or health never recovered) → restart.
       if (retries >= 1) throw new Error('[browse] Server crashed twice in a row — aborting');

--- a/browse/test/live-daemon-preservation.test.ts
+++ b/browse/test/live-daemon-preservation.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { shouldPreserveUnresponsiveServer, type ServerState } from '../src/cli';
+
+const state = { pid: 42 } as ServerState;
+
+describe('live daemon preservation (#2219)', () => {
+  test('preserves an unresponsive daemon while its process is alive', () => {
+    expect(shouldPreserveUnresponsiveServer(state, pid => pid === 42)).toBe(true);
+  });
+
+  test('allows restart after the daemon process is gone', () => {
+    expect(shouldPreserveUnresponsiveServer(state, () => false)).toBe(false);
+  });
+
+  test('allows startup when no prior daemon state exists', () => {
+    expect(shouldPreserveUnresponsiveServer(null, () => true)).toBe(false);
+  });
+});


### PR DESCRIPTION
During a heavy page load, browse could mistake a busy browser daemon for a dead one and restart it. That discarded open tabs, cookies, and logged-in sessions.

Browse now preserves an unresponsive daemon while its process is still alive and asks the user to retry. Automatic restart happens only after the daemon process is actually gone.

## Technical details

- Treat an OS-live daemon as busy when its HTTP health endpoint temporarily times out.
- Apply the safeguard during initial daemon discovery and command connection failures.
- Preserve existing recovery behavior for processes that are actually dead.
- Add regression coverage for live, dead, and missing daemon states.

## Evidence

The same live CLI probe ran in five isolated baseline/candidate repo pairs:

- gstack-auto: baseline failed; candidate passed
- zotero-arxiv-daily: baseline failed; candidate passed
- lacp: baseline failed; candidate passed
- stagehand: baseline failed; candidate passed
- plane: baseline failed; candidate passed

Every baseline killed the daemon and replaced its session state. Every candidate preserved the original PID and session token.

## Secondary checks

- 12 targeted tests passed
- `bun run build` passed
- Version and release files were not changed

Fixes #2219