### PR TITLE
fix(settings-hook): respect CLAUDE_CONFIG_DIR when resolving settings.json

### DIFF
--- a/bin/gstack-settings-hook
+++ b/bin/gstack-settings-hook
@@ -26,7 +26,7 @@
 set -euo pipefail
 
 ACTION="${1:-}"
-SETTINGS_FILE="${GSTACK_SETTINGS_FILE:-$HOME/.claude/settings.json}"
+SETTINGS_FILE="${GSTACK_SETTINGS_FILE:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json}"
 
 if [ -z "$ACTION" ]; then
   cat <<EOF >&2


### PR DESCRIPTION
## Problem

Claude Code supports alternate profile directories via the `CLAUDE_CONFIG_DIR` environment variable, but `bin/gstack-settings-hook` hardcodes `$HOME/.claude/settings.json` as its default target.

On machines where sessions run with `CLAUDE_CONFIG_DIR` set (e.g. isolated agent profiles like `~/.claude-agentos`), hooks registered by `./setup --plan-tune-hooks` land in the wrong profile's `settings.json` and never execute in the active session.

## Fix

One line — fall back to `CLAUDE_CONFIG_DIR` before `$HOME/.claude`:

```bash
SETTINGS_FILE="${GSTACK_SETTINGS_FILE:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json}"
```

- Behavior unchanged when `CLAUDE_CONFIG_DIR` is unset (default `~/.claude`).
- Explicit `GSTACK_SETTINGS_FILE` override still takes precedence.

## Tested

On a machine with two profiles (`~/.claude` and `~/.claude-agentos`):

- `CLAUDE_CONFIG_DIR=~/.claude-agentos gstack-settings-hook list-sources` → reads/writes the agentos profile (3 registered hooks listed).
- `env -u CLAUDE_CONFIG_DIR gstack-settings-hook list-sources` → falls back to `~/.claude/settings.json` ("no gstack-tagged hooks").
- `add-event`/`remove-source` round-trip verified against the profile selected by the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)