### PR TITLE
feat(model-overlays): add gpt-5.6 overlay + resolver mapping

### DIFF
--- a/model-overlays/gpt-5.6.md
+++ b/model-overlays/gpt-5.6.md
@@ -1,0 +1,15 @@
+{{INHERIT:gpt}}
+
+**Anti-verbosity protocol (additional).** Your default output mode is too verbose for
+tools that value terse output. Constrain:
+
+- Status updates: one line, not a paragraph.
+- Code explanations: only when the user asked for one, or when the code is genuinely
+  surprising.
+- Do not narrate what you are about to do. Just do it.
+- Do not repeat the user's request back to them.
+- When showing code changes, show the changed lines with minimal surrounding context.
+- Markdown headings are not decoration. Use them only when structural.
+
+**Cap answers at the shortest form that contains the answer.** If the answer is a
+one-line command, reply with a one-line command.

--- a/scripts/models.ts
+++ b/scripts/models.ts
@@ -16,6 +16,7 @@ export const ALL_MODEL_NAMES = [
   'opus-4-7',
   'gpt',
   'gpt-5.4',
+  'gpt-5.6',
   'gemini',
   'o-series',
 ] as const;
@@ -28,6 +29,7 @@ export type Model = (typeof ALL_MODEL_NAMES)[number];
  * Precedence rules:
  * 1. Exact match against ALL_MODEL_NAMES → return as-is.
  * 2. Family heuristics for common variants:
+ *    - `gpt-5.6-sol`, `gpt-5.6-*` → `gpt-5.6`
  *    - `gpt-5.4-mini`, `gpt-5.4-turbo`, `gpt-5.4-*` → `gpt-5.4`
  *    - `gpt-*` (anything else GPT) → `gpt`
  *    - `o3`, `o4`, `o4-mini`, `o1`, `o1-mini`, `o1-pro` → `o-series`
@@ -49,6 +51,7 @@ export function resolveModel(input: string): Model | null {
   }
 
   // Family heuristics
+  if (/^gpt-5\.6(-|$)/.test(s)) return 'gpt-5.6';
   if (/^gpt-5\.4(-|$)/.test(s)) return 'gpt-5.4';
   if (/^gpt(-|$)/.test(s)) return 'gpt';
   if (/^o[0-9]+(-|$)/.test(s)) return 'o-series';


### PR DESCRIPTION
## What

OpenAI's current flagship is **GPT-5.6** (tiers: Sol / Terra / Luna), generally
available across ChatGPT, Codex, and the API since ~2026-07-09. Today `gpt-5.6*`
resolves through `models.ts` to the generic `gpt` overlay, missing the GPT-5.x
family's anti-verbosity tuning. This adds a dedicated `gpt-5.6` overlay so it
inherits the `gpt` base **plus** the terse-output layer — the same treatment
`gpt-5.4` already gets.

## Changes

- `model-overlays/gpt-5.6.md` (new) — `{{INHERIT:gpt}}` + the anti-verbosity /
  shortest-form-answer nudges (mirrors `gpt-5.4.md`).
- `scripts/models.ts` — add `gpt-5.6` to `ALL_MODEL_NAMES` and a `resolveModel`
  mapping (`/^gpt-5\.6(-|$)/ → gpt-5.6`, matching the Sol/Terra/Luna tier
  suffixes), placed before the generic `gpt` fallback; doc-comment updated.

## Notes

- Content mirrors `gpt-5.4`'s family nudges — a family-inheritance overlay, not
  empirically re-tuned for 5.6. Retune as 5.6-specific patterns emerge.
- Follows the `gpt-5.4` precedent: no dedicated overlay test (the `gpt-*`
  overlays don't carry one; the `opus-*` overlays do). Resolver + generated-doc
  behavior is validated below.

## Validation

- `resolveModel('gpt-5.6')`, `'gpt-5.6-sol'`, `'gpt-5.6-terra'` → `gpt-5.6`;
  `gpt-5.4`, `gpt-4o`, and bare `gpt` unchanged.
- Resolved `gpt-5.6` overlay inherits the `gpt` base (`Completion bias`) and
  carries the `Anti-verbosity protocol`, with no unresolved `{{INHERIT:...}}`.
- `bun run gen:skill-docs` → no generated-doc churn (only the two files above);
  the docs-freshness CI gate stays green.
- `bun run typecheck` → no new errors in the changed files.
