### PR TITLE
docs(claude): add compact gstack skills quick-reference to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,18 @@
 # gstack development
 
+## gstack skills
+
+Use the `/browse` skill for all web browsing. NEVER use `mcp__claude-in-chrome__*`
+tools (see the detailed "Browser interaction" section below for why).
+
+Available skills: /office-hours, /plan-ceo-review, /plan-eng-review,
+/plan-design-review, /design-consultation, /design-shotgun, /design-html,
+/review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome,
+/qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy,
+/setup-gbrain, /retro, /investigate, /document-release, /document-generate,
+/codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze,
+/guard, /unfreeze, /gstack-upgrade, /learn.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## What

Adds a short "gstack skills" section near the top of `CLAUDE.md`: a flat list of the available slash-command skills and a one-line restatement of the `/browse`-over-`mcp__claude-in-chrome__*` rule as a quick reference.

## Why

Gives a single scannable skill index + browsing rule at the top of the file, without disturbing the detailed guidance already present.

## Reviewer notes

- This is additive (+13 lines, one file).
- It intentionally complements, and partially overlaps with, the existing `Browser interaction` and `Skill routing` sections lower in the file. If maintainers consider the overlap unwanted, this can be dropped without affecting anything else.
- Opened from a fork (no write access to base), so CI jobs needing base-repo secrets (evals/E2E) will fail with empty-env auth; that is expected for fork PRs per the repo's CLAUDE.md and is unrelated to the change.