### PR TITLE
fix(setup-gbrain): invoke shipped TypeScript scripts

### DIFF
--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -1441,7 +1441,7 @@ curated `~/.gstack/` artifacts into gbrain so the retrieval surface
 
 Run the probe to size the operation:
 ```bash
-~/.claude/skills/gstack/bin/gstack-memory-ingest --probe
+bun run ~/.claude/skills/gstack/bin/gstack-memory-ingest.ts --probe
 ```
 
 Read the output. If `Total files in window: 0`, skip — there's nothing
@@ -1486,7 +1486,7 @@ Options:
 After answer:
 ```bash
 ~/.claude/skills/gstack/bin/gstack-config set transcript_ingest_mode <choice>
-~/.claude/skills/gstack/bin/gstack-gbrain-sync --full --no-brain-sync
+bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --full --no-brain-sync
 ```
 (`--no-brain-sync` because Step 7 already wired that path; this just
 runs the code import + memory ingest stages. Brain-sync will run on the

--- a/setup-gbrain/SKILL.md.tmpl
+++ b/setup-gbrain/SKILL.md.tmpl
@@ -687,7 +687,7 @@ curated `~/.gstack/` artifacts into gbrain so the retrieval surface
 
 Run the probe to size the operation:
 ```bash
-~/.claude/skills/gstack/bin/gstack-memory-ingest --probe
+bun run ~/.claude/skills/gstack/bin/gstack-memory-ingest.ts --probe
 ```
 
 Read the output. If `Total files in window: 0`, skip — there's nothing
@@ -732,7 +732,7 @@ Options:
 After answer:
 ```bash
 ~/.claude/skills/gstack/bin/gstack-config set transcript_ingest_mode <choice>
-~/.claude/skills/gstack/bin/gstack-gbrain-sync --full --no-brain-sync
+bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --full --no-brain-sync
 ```
 (`--no-brain-sync` because Step 7 already wired that path; this just
 runs the code import + memory ingest stages. Brain-sync will run on the

--- a/test/setup-gbrain-script-invocations.test.ts
+++ b/test/setup-gbrain-script-invocations.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const template = readFileSync(
+  join(import.meta.dir, "..", "setup-gbrain", "SKILL.md.tmpl"),
+  "utf-8",
+);
+
+describe("setup-gbrain script invocations", () => {
+  test("runs the TypeScript transcript probe through Bun", () => {
+    expect(template).toContain(
+      "bun run ~/.claude/skills/gstack/bin/gstack-memory-ingest.ts --probe",
+    );
+  });
+
+  test("runs the TypeScript full sync through Bun", () => {
+    expect(template).toContain(
+      "bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --full --no-brain-sync",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- invoke the shipped `gstack-memory-ingest.ts` and `gstack-gbrain-sync.ts` files explicitly through Bun
- regenerate the Claude `setup-gbrain` skill from its canonical template
- add a static regression test for both transcript-ingest call sites

## Verification

- `bun test`
- `bun test test/setup-gbrain-script-invocations.test.ts`
- `bun run gen:skill-docs --dry-run`
- `git diff --check`

Paid E2E evals were not run locally because `ANTHROPIC_API_KEY` is not configured; this PR is opened as a draft for CI and maintainer review.

Fixes #2250
