### PR TITLE
ci: add dependency-review-action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,6 +1,17 @@
 name: Dependency Review
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'bun.lock'
+      - '**/package.json'
+      - '**/bun.lock'
+      - '.github/workflows/**'
+
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -8,6 +19,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubicloud-standard-8
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -16,4 +28,5 @@ jobs:
       - uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
+          fail-on-scopes: runtime, development
           comment-summary-in-pr: on-failure

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubicloud-standard-8
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
## Summary
- Adds `actions/dependency-review-action@v4` on every PR, scanning dependency manifest changes (package.json / bun.lock) against the GitHub Advisory Database.
- Fails the check when a newly introduced dependency has a known **high or critical** vulnerability; posts a summary comment on the PR only when it fails.
- Repo is public so the dependency graph is already enabled — no settings change needed.

## Notes
- Runner matches existing workflows (`ubicloud-standard-8`); the job is a single API-backed diff check, so it's fast and free of repo build steps.
- Doesn't touch VERSION/CHANGELOG (CI-only change, no user-facing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)