### PR TITLE
fix(make-pdf): stop URLs from swallowing smartypants placeholders

### DIFF
--- a/make-pdf/src/smartypants.ts
+++ b/make-pdf/src/smartypants.ts
@@ -20,7 +20,12 @@
 
 const CODE_ZONE_RE = /<(pre|code|script|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
 const TAG_RE = /<[^>]+>/g;
-const URL_RE = /\bhttps?:\/\/\S+/g;
+// \u0000 is the placeholder sentinel (see PLACEHOLDER below). It must be
+// excluded here: URLs are carved AFTER tags, so a URL sitting flush against
+// a tag (`<a href="...">https://ex.com</a>`) would otherwise let \S+ swallow
+// the placeholder standing in for `</a>` — that placeholder then never
+// restores (restore is a single pass) and the tag is lost.
+const URL_RE = /\bhttps?:\/\/[^\s\u0000]+/g;
 
 /**
  * Apply smartypants to an HTML string. Zones that should not be touched:

--- a/make-pdf/test/render.test.ts
+++ b/make-pdf/test/render.test.ts
@@ -56,6 +56,34 @@ describe("smartypants", () => {
     expect(out).toContain("\u201cdetails\u201d");
   });
 
+  // A URL flush against a following tag (no whitespace between) used to let
+  // URL_RE's \S+ swallow the placeholder standing in for that tag. The
+  // placeholder never restored, so the tag vanished and its styling bled
+  // into the rest of the document. The test above misses this because its
+  // URL is followed by a space.
+  test("does not leak placeholders for a bare autolinked URL", () => {
+    const input = `<p>see <a href="https://ex.com">https://ex.com</a> ok</p>`;
+    const out = smartypants(input);
+    expect(out).not.toContain("SMARTPANTS_PRESERVED");
+    expect(out).toContain("</a>");
+    expect(out).toBe(input);
+  });
+
+  test("does not leak placeholders for a bold URL", () => {
+    const input = `<p>see <strong><a href="https://ex.com">https://ex.com</a></strong> ok</p>`;
+    const out = smartypants(input);
+    expect(out).not.toContain("SMARTPANTS_PRESERVED");
+    expect(out).toContain("</a></strong>");
+    expect(out).toBe(input);
+  });
+
+  test("does not leak placeholders when a URL is followed by punctuation", () => {
+    const input = `<p>see <a href="https://ex.com">https://ex.com</a>, ok</p>`;
+    const out = smartypants(input);
+    expect(out).not.toContain("SMARTPANTS_PRESERVED");
+    expect(out).toContain("</a>");
+  });
+
   test("does NOT touch HTML attribute values", () => {
     const out = smartypants(`<a href="it's-a-test.html">link</a>`);
     expect(out).toContain(`href="it's-a-test.html"`);


### PR DESCRIPTION
Fixes #2084.

## Root cause

`make-pdf/src/smartypants.ts` carves preserved zones in this order:

```
s = carve(s, CODE_ZONE_RE);
s = carve(s, TAG_RE);
s = carve(s, URL_RE);   // <- runs last
```

`TAG_RE` replaces each tag with a placeholder (`\u0000SMARTPANTS_PRESERVED_N\u0000`),
which contains **no whitespace**. `URL_RE` is `/\bhttps?:\/\/\S+/g`, so when a
URL sits flush against a tag, `\S+` runs straight through the placeholder and
swallows it.

For a bare autolinked URL, marked emits:

```html
<p>see <a href="https://ex.com">https://ex.com</a> ok</p>
```

which carves to `PH_0see PH_1https://ex.comPH_2 okPH_3`. `URL_RE` then matches
`https://ex.comPH_2` and preserves *that* as a single entry. Restoration is a
single `.replace()` pass, so the nested `PH_2` inside the restored text is
never re-scanned:

- the literal text `SMARTPANTS_PRESERVED_2` renders into the PDF, and
- the `</a>` it stood for is **gone** — an unclosed anchor that bleeds
  link-blue through every following paragraph until some later `</a>` happens
  to close it.

`**bold URL**` swallows `</a></strong>` and leaks bold as well.
`[text](https://…)` is fine: the URL only lives inside an attribute, which
`TAG_RE` already carved as part of the whole tag.

## Fix

Exclude the sentinel from `URL_RE` so carved placeholders survive:

```diff
-const URL_RE = /\bhttps?:\/\/\S+/g;
+const URL_RE = /\bhttps?:\/\/[^\s\u0000]+/g;
```

## Tests

Three regression tests added to `make-pdf/test/render.test.ts` (bare URL, bold
URL, URL followed by punctuation). Verified they are load-bearing:

- reverting `smartypants.ts` alone → **3 fail**
- with the fix → **69 pass / 0 fail** (`render.test.ts`), **188 pass / 0 fail**
  (full `make-pdf/test/`, 9 e2e skipped — no built binary in a fresh clone)

The existing `does NOT touch URLs` test missed this because its URL is followed
by a space rather than a tag.

## Repro before the fix

`pdftotext` on a PDF generated from a bare URL, using the shipped 1.58.5.0
binary:

```
報價單網址是 https://quote.thinkrocket.com.twSMARTPANTS_PRESERVED_10 請點進去看。
```

with everything after that paragraph rendered blue.
