### PR TITLE
fix: honor skipped Claude skills in validation

### DIFF
--- a/scripts/skill-check.ts
+++ b/scripts/skill-check.ts
@@ -13,6 +13,7 @@ import { discoverTemplates, discoverSkillFiles } from './discover-skills';
 import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
+import { claude, getExternalHosts } from '../hosts/index';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const ROOT_REALPATH = fs.realpathSync(ROOT);
@@ -64,12 +65,24 @@ for (const file of SKILL_FILES) {
 
 console.log('\n  Templates:');
 const TEMPLATES = discoverTemplates(ROOT);
+const CLAUDE_SKIPPED_SKILLS = new Set(claude.generation.skipSkills ?? []);
 
 for (const { tmpl, output } of TEMPLATES) {
   const tmplPath = path.join(ROOT, tmpl);
   const outPath = path.join(ROOT, output);
+  const skillDir = path.dirname(tmpl);
+  const skillName = skillDir === '.' ? null : skillDir.split(path.sep)[0];
   if (!fs.existsSync(tmplPath)) {
     console.log(`  \u26a0\ufe0f  ${output.padEnd(30)} — no template`);
+    continue;
+  }
+  if (skillName && CLAUDE_SKIPPED_SKILLS.has(skillName)) {
+    if (fs.existsSync(outPath)) {
+      hasErrors = true;
+      console.log(`  \u274c ${output.padEnd(30)} — generated file exists but Claude Code skips this skill`);
+    } else {
+      console.log(`  \u23ed\ufe0f  ${output.padEnd(30)} — intentionally skipped for Claude Code`);
+    }
     continue;
   }
   if (!fs.existsSync(outPath)) {
@@ -89,8 +102,6 @@ for (const file of SKILL_FILES) {
 }
 
 // ─── External Host Skills (config-driven) ───────────────────
-
-import { getExternalHosts } from '../hosts/index';
 
 for (const hostConfig of getExternalHosts()) {
   const hostDir = path.join(ROOT, hostConfig.hostSubdir, 'skills');

--- a/test/skill-check.test.ts
+++ b/test/skill-check.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+
+describe('skill-check template coverage', () => {
+  test('accepts skills intentionally skipped by the Claude host', () => {
+    const result = spawnSync('bun', ['run', 'scripts/skill-check.ts'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+
+    const claudeTemplateLine = result.stdout
+      .split('\n')
+      .find((line) => line.includes('claude/SKILL.md'));
+
+    expect(claudeTemplateLine).toContain('intentionally skipped for Claude Code');
+    expect(claudeTemplateLine).not.toContain('generated file missing');
+  });
+});


### PR DESCRIPTION
## What changed

- make `skill:check` honor the Claude host's configured `skipSkills` list during template coverage
- report intentionally skipped Claude-only outputs explicitly
- fail if a skipped output unexpectedly exists
- add a regression test for the `claude/SKILL.md` case

## Why

The Claude generator intentionally skips the outside-voice `claude` skill, but the validator still required `claude/SKILL.md` to exist. That made `skill:check` report a missing generated file even when generation behaved correctly.

## Impact

`skill:check` no longer produces a false failure for intentionally omitted Claude skills, while retaining protection against stale or unexpected generated outputs.

## Validation

- `bun test test/skill-check.test.ts` (pass)
- `npm test` (exit 0)
- `git diff --check` (pass)
- gstack redaction scan over added lines: 0 findings
