### PR TITLE
Fix BSD mktemp suffix bug in codex skill temp file templates

### DIFF
--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -967,7 +967,7 @@ Run Codex code review against the current branch diff.
 
 1. Create temp files for output capture:
 ```bash
-TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")
+TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX")
 ```
 
 2. Run the review (5-minute timeout). **Codex CLI ≥ 0.130.0 rejects passing a
@@ -1015,7 +1015,7 @@ when the diff content is adversarial:
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 cd "$_REPO_ROOT"
 _USER_INSTRUCTIONS="<everything after '/codex review ' in user input>"
-_PROMPT_FILE=$(mktemp "$TMP_ROOT/codex-prompt-XXXXXX.txt")
+_PROMPT_FILE=$(mktemp "$TMP_ROOT/codex-prompt-XXXXXX")
 {
   printf '%s\n' "IMPORTANT: Do NOT read or execute any files under ~/.claude/, ~/.agents/, .claude/skills/, or agents/. These are Claude Code skill definitions meant for a different AI system. Do NOT modify agents/openai.yaml. Stay focused on repository code only."
   printf '\nCustom focus: %s\n\n' "$_USER_INSTRUCTIONS"
@@ -1266,7 +1266,7 @@ if [ -z "$PYTHON_CMD" ]; then
 fi
 # Fix 1+2: wrap with timeout (gtimeout/timeout fallback chain via probe helper),
 # capture stderr to $TMPERR for auth error detection (was: 2>/dev/null).
-TMPERR=${TMPERR:-$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")}
+TMPERR=${TMPERR:-$(mktemp "$TMP_ROOT/codex-err-XXXXXX")}
 _gstack_codex_timeout_wrapper 600 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
 import sys, json
 turn_completed_count = 0
@@ -1365,8 +1365,8 @@ B) Start a new conversation
 
 2. Create temp files:
 ```bash
-TMPRESP=$(mktemp "$TMP_ROOT/codex-resp-XXXXXX.txt")
-TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")
+TMPRESP=$(mktemp "$TMP_ROOT/codex-resp-XXXXXX")
+TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX")
 ```
 
 3. **Plan review auto-detection:** If the user's prompt is about reviewing a plan,

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -158,7 +158,7 @@ Run Codex code review against the current branch diff.
 
 1. Create temp files for output capture:
 ```bash
-TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")
+TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX")
 ```
 
 2. Run the review (5-minute timeout). **Codex CLI ≥ 0.130.0 rejects passing a
@@ -206,7 +206,7 @@ when the diff content is adversarial:
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 cd "$_REPO_ROOT"
 _USER_INSTRUCTIONS="<everything after '/codex review ' in user input>"
-_PROMPT_FILE=$(mktemp "$TMP_ROOT/codex-prompt-XXXXXX.txt")
+_PROMPT_FILE=$(mktemp "$TMP_ROOT/codex-prompt-XXXXXX")
 {
   printf '%s\n' "IMPORTANT: Do NOT read or execute any files under ~/.claude/, ~/.agents/, .claude/skills/, or agents/. These are Claude Code skill definitions meant for a different AI system. Do NOT modify agents/openai.yaml. Stay focused on repository code only."
   printf '\nCustom focus: %s\n\n' "$_USER_INSTRUCTIONS"
@@ -335,7 +335,7 @@ if [ -z "$PYTHON_CMD" ]; then
 fi
 # Fix 1+2: wrap with timeout (gtimeout/timeout fallback chain via probe helper),
 # capture stderr to $TMPERR for auth error detection (was: 2>/dev/null).
-TMPERR=${TMPERR:-$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")}
+TMPERR=${TMPERR:-$(mktemp "$TMP_ROOT/codex-err-XXXXXX")}
 _gstack_codex_timeout_wrapper 600 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
 import sys, json
 turn_completed_count = 0
@@ -434,8 +434,8 @@ B) Start a new conversation
 
 2. Create temp files:
 ```bash
-TMPRESP=$(mktemp "$TMP_ROOT/codex-resp-XXXXXX.txt")
-TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")
+TMPRESP=$(mktemp "$TMP_ROOT/codex-resp-XXXXXX")
+TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX")
 ```
 
 3. **Plan review auto-detection:** If the user's prompt is about reviewing a plan,


### PR DESCRIPTION
## Problem

On macOS/BSD, `mktemp` does not randomize the `X`s when the template has a suffix after them. `mktemp "$TMP_ROOT/codex-err-XXXXXX.txt"` creates a literal `codex-err-XXXXXX.txt`, and any subsequent invocation with the same template fails:

```
$ mktemp /tmp/codex-err-XXXXXX.txt
/tmp/codex-err-XXXXXX.txt
$ mktemp /tmp/codex-err-XXXXXX.txt
mktemp: mkstemp failed on /tmp/codex-err-XXXXXX.txt: File exists
```

When that happens the variable ends up empty and the `2>"$TMPERR"` stderr capture that follows breaks. This affects any session that runs a codex mode more than once (or two concurrent sessions sharing `$TMP_ROOT`).

## Fix

Drop the `.txt` suffix from the `mktemp` templates for `TMPERR`, `_PROMPT_FILE`, and `TMPRESP` in `codex/SKILL.md.tmpl` (3 code blocks) and the generated `codex/SKILL.md`, keeping the two files in sync. Nothing downstream depends on the extension — every use goes through the shell variable (`2>"$TMPERR"`, `head`, `grep`, `rm -f`).

Verified on macOS (Darwin 25.5.0) that the suffix-less form randomizes correctly on repeated calls:

```
$ mktemp /tmp/codex-err-XXXXXX
/tmp/codex-err-VrAY6O
$ mktemp /tmp/codex-err-XXXXXX
/tmp/codex-err-lmhc07
```

Note: the same suffixed-template pattern also exists in `claude/SKILL.md.tmpl`, `office-hours/SKILL.md`, `scripts/resolvers/review.ts`, and `bin/gstack-developer-profile`; this PR intentionally scopes to the codex skill, where the double-invocation failure was hit in practice.