### PR TITLE
Fix spaced-out terminal text on Windows (CJK-font cell sizing)

### DIFF
--- a/extension/sidepanel-terminal.js
+++ b/extension/sidepanel-terminal.js
@@ -391,7 +391,13 @@
   function ensureXterm() {
     if (term) return;
     term = new Terminal({
-      fontFamily: '"JetBrains Mono", "SF Mono", Menlo, "Noto Sans Mono CJK KR", "Malgun Gothic", monospace',
+      // Windows Latin monospace (Consolas, always present; Cascadia ships with Terminal/VS)
+      // MUST precede the CJK fallbacks: xterm sizes the character cell from the first
+      // resolved font's advance width, and Malgun Gothic (the Windows Korean UI font, the
+      // first that resolves here when the Mac/Linux fonts are absent) advances Latin glyphs
+      // in a full-width CJK cell — doubling every cell into spaced-out text. The CJK fonts
+      // stay last for actual CJK glyph coverage.
+      fontFamily: '"JetBrains Mono", "SF Mono", "Cascadia Mono", "Cascadia Code", Consolas, Menlo, "DejaVu Sans Mono", "Noto Sans Mono CJK KR", "Malgun Gothic", monospace',
       fontSize: 13,
       theme: { background: '#0a0a0a', foreground: '#e5e5e5' },
       cursorBlink: true,

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -38,7 +38,9 @@
 
   /* Typography */
   --font-system: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', 'Noto Sans Mono CJK KR', 'Malgun Gothic', monospace;
+  /* Consolas (always on Windows) before the CJK fallbacks — else Latin text resolves to
+     Malgun Gothic and renders full-width/spaced-out. Same fix as the xterm fontFamily. */
+  --font-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Mono', 'Cascadia Code', Consolas, 'DejaVu Sans Mono', 'Noto Sans Mono CJK KR', 'Malgun Gothic', monospace;
 
   /* Radius */
   --radius-sm: 4px;


### PR DESCRIPTION
## Problem

On Windows, the sidebar terminal (and the mono-font sidepanel UI) renders every character spaced out — `C l a u d e   C o d e` instead of `Claude Code`. Screenshot of the symptom on a clean Windows 11 install: each glyph sits in a double-wide cell.

## Cause

The xterm `fontFamily` and the `--font-mono` CSS var list only Mac/Linux monospace fonts (`JetBrains Mono`, `SF Mono`, `Menlo`, `Fira Code`, `Cascadia Code`) before the CJK fallbacks (`Noto Sans Mono CJK KR`, `Malgun Gothic`). None of the leading fonts ship with Windows, so the first font that actually resolves is **Malgun Gothic** — the Windows Korean UI font, present on every install. xterm.js sizes its character cell from the resolved font's advance width, and Malgun Gothic advances Latin glyphs in a **full-width CJK cell**, doubling every cell.

## Fix

Insert `Consolas` (present on every Windows install) plus the Cascadia faces **before** the CJK fonts in both places. The CJK fonts stay last for genuine CJK glyph coverage. No bundled font, no user install.

- `extension/sidepanel-terminal.js` — xterm `fontFamily`
- `extension/sidepanel.css` — `--font-mono`

Two lines of font-stack, verified on the affected Windows machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)