### PR TITLE
fix: force LF on *.txt so generated llms.txt stays clean on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 *.yaml       text eol=lf
 *.json       text eol=lf
 *.toml       text eol=lf
+*.txt        text eol=lf
 
 # Bash scripts must always use LF — CRLF in bash scripts produces bizarre
 # "Bad interpreter" / "command not found" errors on Linux runners.


### PR DESCRIPTION
## Symptom

On Windows, `git status` in a gstack install permanently reports `M gstack/llms.txt`. Because `/gstack-upgrade` runs `git stash` before `git reset --hard origin/main`, every upgrade silently stashes this phantom change, accruing empty stashes and printing `warning: in the working copy of 'gstack/llms.txt', LF will be replaced by CRLF the next time Git touches it`.

## Cause

`.gitattributes` already pins `text eol=lf` for every other generated/parsed text type — `*.md`, `*.tmpl`, `*.yml`, `*.json`, `*.toml`, `*.ts`, `*.sh`, `setup`, `bin/*` — and its own header comment says why:

> Without this, Windows checkouts with core.autocrlf=true convert these to CRLF and break tests...

But there is no `*.txt` rule. `gstack/llms.txt` is regenerated as LF by `./setup`'s `gen-llms-txt` on every run, while the Git for Windows installer sets `core.autocrlf=true` at the **system** level (`C:/Program Files/Git/etc/gitconfig`). So the file falls through to the CRLF expectation and is flagged dirty forever.

## Evidence

Both the committed blob and the worktree copy are **pure LF** (zero CR bytes), and `git diff` is empty — the file is *phantom*-modified, not content-modified:

```
$ git show HEAD:gstack/llms.txt | grep -c $'\r'   # 0
$ grep -c $'\r' gstack/llms.txt                   # 0
$ git diff gstack/llms.txt                        # (empty)
$ git status --porcelain                          #  M gstack/llms.txt
```

Only `llms.txt` trips it because `./setup` rewrites the file each run, resetting its mtime and forcing git to re-evaluate it. Other `.txt` files keep a matching stat cache and are never re-examined.

## Scope

`*.txt` matches exactly two tracked files:

- `gstack/llms.txt` — the target.
- `make-pdf/test/fixtures/combined-gate.expected.txt` — already pure LF and clean, so unaffected. LF is also correct here: it is compared against generated output, and a CRLF fixture vs LF output would fail.

No CI impact: on Linux runners `autocrlf` is off and files are already LF, so `text eol=lf` is a no-op there.

## Verification

With the rule in place, `git check-attr text eol -- gstack/llms.txt` reports `text: set` / `eol: lf`, and rewriting the file with identical LF content (what `./setup` does) leaves the worktree clean instead of dirty.

## Deliberately omitted

No VERSION bump and no CHANGELOG entry — those belong to the maintainer's `/ship` release flow rather than a contributor's one-line fix.