### PR TITLE
fix(browse): stop the Bun polyfill flashing console windows on Windows

### DIFF
--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -75,6 +75,10 @@ globalThis.Bun = {
       timeout: options.timeout,
       env: options.env,
       cwd: options.cwd,
+      // Node defaults windowsHide to false, so every child opens a console
+      // window on Windows. Bun.spawnSync has no such behaviour, so the
+      // polyfill has to opt in to stay faithful to the API it's emulating.
+      windowsHide: options.windowsHide !== false,
     });
 
     return {
@@ -91,6 +95,10 @@ globalThis.Bun = {
       stdio,
       env: options.env,
       cwd: options.cwd,
+      // See spawnSync above. This one is the visible offender: the detached
+      // terminal-agent the browse watchdog respawns every 60s left an empty
+      // console window on screen each time.
+      windowsHide: options.windowsHide !== false,
     });
 
     return {

--- a/browse/test/bun-polyfill.test.ts
+++ b/browse/test/bun-polyfill.test.ts
@@ -48,6 +48,44 @@ describe('bun-polyfill', () => {
     expect(lines[2]).toBe('HAS_UNREF');
   });
 
+  // Regression: Node defaults windowsHide to false, so before this the browse
+  // server flashed an empty console window on Windows for every child it
+  // spawned -- most visibly the terminal-agent the watchdog respawns on a 60s
+  // tick. Asserts the option reaches child_process rather than trying to
+  // observe a window, so it is meaningful on every platform.
+  test('Bun.spawn/spawnSync pass windowsHide to child_process', () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      const cp = require('child_process');
+      const realSpawn = cp.spawn, realSpawnSync = cp.spawnSync;
+      const seen = {};
+      cp.spawn = (c, a, o) => { seen.spawn = o.windowsHide; return realSpawn(c, a, o); };
+      cp.spawnSync = (c, a, o) => { seen.spawnSync = o.windowsHide; return realSpawnSync(c, a, o); };
+      require('${polyfillPath}');
+      Bun.spawnSync([process.execPath, '-e', ''], { stdout: 'pipe' });
+      Bun.spawn([process.execPath, '-e', ''], { stdio: ['ignore', 'ignore', 'ignore'] });
+      console.log('spawnSync:' + seen.spawnSync);
+      console.log('spawn:' + seen.spawn);
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    const lines = result.stdout.toString().trim().split('\n');
+    expect(lines[0]).toBe('spawnSync:true');
+    expect(lines[1]).toBe('spawn:true');
+  });
+
+  // An explicit windowsHide: false must still win, so a caller that genuinely
+  // wants a visible console (e.g. debugging a child) keeps that escape hatch.
+  test('Bun.spawn honours an explicit windowsHide: false', () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      const cp = require('child_process');
+      const realSpawn = cp.spawn;
+      const seen = {};
+      cp.spawn = (c, a, o) => { seen.spawn = o.windowsHide; return realSpawn(c, a, o); };
+      require('${polyfillPath}');
+      Bun.spawn([process.execPath, '-e', ''], { stdio: ['ignore', 'ignore', 'ignore'], windowsHide: false });
+      console.log('spawn:' + seen.spawn);
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    expect(result.stdout.toString().trim()).toBe('spawn:false');
+  });
+
   test('Bun.serve creates an HTTP server that responds', async () => {
     const result = Bun.spawnSync(['node', '-e', `
       require('${polyfillPath}');


### PR DESCRIPTION
## The symptom

On Windows, using any browse-backed skill pops up empty black `bun.exe` console windows — one roughly every 60 seconds, with nothing in them.

## The cause

`browse/src/bun-polyfill.cjs` supplies a `Bun` global so the bundled `browse/dist/server-node.mjs` can run under Node. Its `spawn`/`spawnSync` forward to `child_process` without `windowsHide`, and [Node defaults that to `false`](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options) — so every child gets a console window on Windows. Real `Bun.spawn` doesn't do this, so the polyfill was quietly drifting from the API it emulates.

Two details explain the exact symptom:

- **Why every ~60s:** the agent watchdog in `browse/src/server.ts` (`GSTACK_AGENT_WATCHDOG_TICK_MS`, default 60000) respawns the `terminal-agent` when it isn't alive. A crash-looping agent therefore yields a fresh window per tick.
- **Why empty:** the agent is spawned with `stdio: ['ignore', 'ignore', 'ignore']`, so the window it opens has no output in it.

It isn't only the terminal-agent — the `tasklist`, `powershell`, and `chrome --version` helpers all flow through the same polyfill and pop windows too.

## The fix

`windowsHide: options.windowsHide !== false` on both polyfill spawn paths. Fixed at the polyfill rather than at each call site because it's the single choke point every `Bun.spawn` under Node passes through. An explicit `windowsHide: false` still wins, so anyone who genuinely wants a visible console keeps the escape hatch.

## Verification

Intercepted `child_process` and compared the current polyfill against the patched one:

| | `spawnSync` | `spawn` | explicit `windowsHide: false` |
|---|---|---|---|
| before | `undefined` | `undefined` | `undefined` |
| after | `true` | `true` | `false` |

`undefined` is what Node reads as false — hence the window.

Added two regression tests to `browse/test/bun-polyfill.test.ts`, following the file's existing "require the polyfill in a Node subprocess" style. They assert the option reaches `child_process` rather than trying to observe a window, so they're meaningful on Linux CI too. Confirmed they fail against the unpatched polyfill and pass against the patched one.

## Notes for the reviewer

- Scope is deliberately limited to the Node polyfill, which is what `server-node.mjs` uses. The `Bun.spawn` call in `browse/src/terminal-agent-control.ts` (the real-Bun path, used by the compiled `browse.exe`) is untouched — I couldn't verify real-Bun window behaviour on this machine and didn't want to guess. Happy to extend if you know it needs the same treatment.
- `browse/test/bun-polyfill.test.ts` currently can't run on Windows at all, independent of this PR: it interpolates an absolute path into a `node -e` string, so on Windows `require('C:\Users\...')` hits invalid `\U`/`\A` escapes, and two tests also assume a POSIX `echo`. Left alone as out of scope — mentioning it since this is a Windows fix whose tests only actually execute on Linux.
- No `VERSION`/`CHANGELOG.md` bump, so `version-gate` doesn't trigger. Let me know if you'd like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
