### PR TITLE
fix(browse): pass windowsHide in bun-polyfill spawn wrappers (Windows console flash every 60s)

### DIFF
--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -75,6 +75,9 @@ globalThis.Bun = {
       timeout: options.timeout,
       env: options.env,
       cwd: options.cwd,
+      // Suppress the console window Windows allocates per child process;
+      // without this every spawn flashes a visible conhost window.
+      windowsHide: true,
     });
 
     return {
@@ -91,6 +94,9 @@ globalThis.Bun = {
       stdio,
       env: options.env,
       cwd: options.cwd,
+      // Suppress the console window Windows allocates per child process;
+      // without this every spawn flashes a visible conhost window.
+      windowsHide: true,
     });
 
     return {


### PR DESCRIPTION
## What

Adds `windowsHide: true` to the `spawn`/`spawnSync` wrappers in `browse/src/bun-polyfill.cjs`.

## Why

On Windows the browse daemon runs under **Node via `bun-polyfill.cjs`** (Bun can't drive Playwright's Chromium there — the polyfill's own header cites oven-sh/bun#4253/#9911). The polyfill forwards only `{stdio, env, cwd}` to `child_process` and **drops `windowsHide`**, so every child process the daemon spawns gets a visible conhost window.

The most user-visible symptom: the terminal-agent watchdog in `server-node.mjs` respawns `bun run terminal-agent.ts` every 60s (`AGENT_WATCHDOG_TICK_MS` default), so users see a `bun.exe` console window **flash roughly once a minute per daemon, indefinitely**. I measured two daemons alive concurrently on my machine → a flash every ~30 seconds, all day.

Because the polyfill is the single choke-point every `Bun.spawn`/`Bun.spawnSync` call goes through on Windows, fixing it here covers all spawn sites at once (`tasklist` liveness probes, PowerShell helpers, the terminal-agent, etc.). `windowsHide` is ignored by Node on non-Windows platforms, so this is a no-op everywhere else.

Note: patching the call sites instead would *not* work — the options never reach `child_process` unless the polyfill forwards them.

## Testing

- `node --check` passes.
- Applied the same two-line change to a live install (Windows 11 Pro, build 26200): watchdog respawns continue (separate issue, filed with measurements) but no console window is shown.

There's a companion issue with full measurements of the watchdog respawn/leak behavior this change makes *invisible* but does not fix — the leak itself deserves its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
