### PR TITLE
feat: add Kimi Code host connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bin/gstack-global-discover*
 .cursor/
 .openclaw/
 .hermes/
+.kimi-code/
 .gbrain/
 .gbrain-source
 .context/

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,10 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import kimi from './kimi';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, kimi];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, kimi };

--- a/hosts/kimi.ts
+++ b/hosts/kimi.ts
@@ -1,0 +1,52 @@
+import type { HostConfig } from '../scripts/host-config';
+
+const kimi: HostConfig = {
+  name: 'kimi',
+  displayName: 'Kimi Code',
+  cliCommand: 'kimi',
+  cliAliases: [],
+
+  globalRoot: '.kimi-code/skills/gstack',
+  localSkillRoot: '.kimi-code/skills/gstack',
+  hostSubdir: '.kimi-code',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: null,
+  },
+
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.kimi-code/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.kimi-code/skills/gstack' },
+    { from: '.claude/skills', to: '.kimi-code/skills' },
+    { from: '~/.config/opencode/skills/gstack', to: '~/.kimi-code/skills/gstack' },
+    { from: '.config/opencode/skills/gstack', to: '.kimi-code/skills/gstack' },
+    { from: '~/.agents/skills/gstack', to: '~/.kimi-code/skills/gstack' },
+    { from: '.agents/skills/gstack', to: '.kimi-code/skills/gstack' },
+  ],
+
+  suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
+
+  runtimeRoot: {
+    globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'design/dist', 'gstack-upgrade', 'ETHOS.md', 'review/specialists', 'qa/templates', 'qa/references', 'plan-devex-review/dx-hall-of-fame.md'],
+    globalFiles: {
+      'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  learningsMode: 'basic',
+};
+
+export default kimi;

--- a/scripts/resolvers/browse.ts
+++ b/scripts/resolvers/browse.ts
@@ -1,4 +1,5 @@
 import type { TemplateContext } from './types';
+import { shellPath } from './types';
 import { COMMAND_DESCRIPTIONS } from '../../browse/src/commands';
 import { SNAPSHOT_FLAGS } from '../../browse/src/snapshot';
 
@@ -106,7 +107,7 @@ export function generateBrowseSetup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse" ] && B="$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse"
-[ -z "$B" ] && B="$HOME${ctx.paths.browseDir.replace(/^~/, '')}/browse"
+[ -z "$B" ] && B="${shellPath(ctx.paths.browseDir)}/browse"
 if [ -x "$B" ]; then
   echo "READY: $B"
 else

--- a/scripts/resolvers/design.ts
+++ b/scripts/resolvers/design.ts
@@ -1,4 +1,5 @@
 import type { TemplateContext } from './types';
+import { shellPath } from './types';
 import { AI_SLOP_BLACKLIST, OPENAI_HARD_REJECTIONS, OPENAI_LITMUS_CHECKS } from './constants';
 
 export function generateDesignReviewLite(ctx: TemplateContext): string {
@@ -792,7 +793,7 @@ export function generateDesignSetup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 D=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design" ] && D="$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design"
-[ -z "$D" ] && D="$HOME${ctx.paths.designDir.replace(/^~/, '')}/design"
+[ -z "$D" ] && D="${shellPath(ctx.paths.designDir)}/design"
 if [ -x "$D" ]; then
   echo "DESIGN_READY: $D"
 else
@@ -800,7 +801,7 @@ else
 fi
 B=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse" ] && B="$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse"
-[ -z "$B" ] && B="$HOME${ctx.paths.browseDir.replace(/^~/, '')}/browse"
+[ -z "$B" ] && B="${shellPath(ctx.paths.browseDir)}/browse"
 if [ -x "$B" ]; then
   echo "BROWSE_READY: $B"
 else
@@ -837,7 +838,7 @@ export function generateDesignMockup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 D=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design" ] && D="$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design"
-[ -z "$D" ] && D="$HOME${ctx.paths.designDir.replace(/^~/, '')}/design"
+[ -z "$D" ] && D="${shellPath(ctx.paths.designDir)}/design"
 [ -x "$D" ] && echo "DESIGN_READY" || echo "DESIGN_NOT_AVAILABLE"
 \`\`\`
 

--- a/scripts/resolvers/make-pdf.ts
+++ b/scripts/resolvers/make-pdf.ts
@@ -1,4 +1,5 @@
 import type { TemplateContext } from './types';
+import { shellPath } from './types';
 
 /**
  * {{MAKE_PDF_SETUP}} — emits the shell preamble that resolves $P to the
@@ -19,7 +20,7 @@ _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 P=""
 [ -n "$MAKE_PDF_BIN" ] && [ -x "$MAKE_PDF_BIN" ] && P="$MAKE_PDF_BIN"
 [ -z "$P" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf" ] && P="$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf"
-[ -z "$P" ] && P="$HOME${ctx.paths.makePdfDir.replace(/^~/, '')}/pdf"
+[ -z "$P" ] && P="${shellPath(ctx.paths.makePdfDir)}/pdf"
 if [ -x "$P" ]; then
   echo "MAKE_PDF_READY: $P"
   alias _p_="$P"   # shellcheck alias helper (not exported)

--- a/scripts/resolvers/types.ts
+++ b/scripts/resolvers/types.ts
@@ -50,6 +50,17 @@ function buildHostPaths(): Record<string, HostPaths> {
 
 export const HOST_PATHS: Record<string, HostPaths> = buildHostPaths();
 
+/**
+ * shellPath — resolve a HostPaths dir for inline shell snippets.
+ * Tilde-prefixed dirs (Claude host) get a $HOME prefix at runtime.
+ * $GSTACK_* env-var dirs (non-Claude hosts) are already absolute via the
+ * preamble (GSTACK_ROOT="$HOME/..."), so they must NOT be prefixed —
+ * otherwise you get the "$HOME$GSTACK_BROWSE/browse" double-prefix bug.
+ */
+export function shellPath(dir: string): string {
+  return dir.startsWith('~') ? `$HOME${dir.replace(/^~/, '')}` : dir;
+}
+
 import type { Model } from '../models';
 export type { Model } from '../models';
 

--- a/setup
+++ b/setup
@@ -24,6 +24,8 @@ FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
 OPENCODE_SKILLS="$HOME/.config/opencode/skills"
 OPENCODE_GSTACK="$OPENCODE_SKILLS/gstack"
+KIMI_SKILLS="$HOME/.kimi-code/skills"
+KIMI_GSTACK="$KIMI_SKILLS/gstack"
 
 IS_WINDOWS=0
 case "$(uname -s)" in
@@ -101,7 +103,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|opencode|auto) ;;
+  claude|codex|kiro|factory|opencode|kimi|auto) ;;
   openclaw)
     echo ""
     echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
@@ -136,7 +138,7 @@ case "$HOST" in
     echo "GBrain setup and brain skills ship from the GBrain repo."
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, kimi, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -200,14 +202,16 @@ INSTALL_CODEX=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
 INSTALL_OPENCODE=0
+INSTALL_KIMI=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
   command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
+  command -v kimi >/dev/null 2>&1 && INSTALL_KIMI=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ] && [ "$INSTALL_KIMI" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
@@ -220,6 +224,8 @@ elif [ "$HOST" = "factory" ]; then
   INSTALL_FACTORY=1
 elif [ "$HOST" = "opencode" ]; then
   INSTALL_OPENCODE=1
+elif [ "$HOST" = "kimi" ]; then
+  INSTALL_KIMI=1
 fi
 
 migrate_direct_codex_install() {
@@ -472,6 +478,16 @@ if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
     cd "$SOURCE_GSTACK_DIR"
     bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
     bun_cmd run gen:skill-docs --host opencode
+  )
+fi
+
+# 1e. Generate .agents/ Kimi Code skill docs
+if [ "$INSTALL_KIMI" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .agents/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
+    bun_cmd run gen:skill-docs --host kimi
   )
 fi
 
@@ -972,6 +988,91 @@ link_opencode_skill_dirs() {
   fi
 }
 
+create_kimi_runtime_root() {
+  local gstack_dir="$1"
+  local kimi_gstack="$2"
+  local kimi_dir="$gstack_dir/.kimi-code/skills"
+
+  if [ -L "$kimi_gstack" ]; then
+    rm -f "$kimi_gstack"
+  elif [ -d "$kimi_gstack" ] && [ "$kimi_gstack" != "$gstack_dir" ]; then
+    rm -rf "$kimi_gstack"
+  fi
+
+  mkdir -p "$kimi_gstack" "$kimi_gstack/browse" "$kimi_gstack/design" "$kimi_gstack/gstack-upgrade" "$kimi_gstack/review" "$kimi_gstack/qa" "$kimi_gstack/plan-devex-review"
+
+  if [ -f "$kimi_dir/gstack/SKILL.md" ]; then
+    _link_or_copy "$kimi_dir/gstack/SKILL.md" "$kimi_gstack/SKILL.md"
+  fi
+  if [ -d "$gstack_dir/bin" ]; then
+    _link_or_copy "$gstack_dir/bin" "$kimi_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/browse/dist" ]; then
+    _link_or_copy "$gstack_dir/browse/dist" "$kimi_gstack/browse/dist"
+  fi
+  if [ -d "$gstack_dir/browse/bin" ]; then
+    _link_or_copy "$gstack_dir/browse/bin" "$kimi_gstack/browse/bin"
+  fi
+  if [ -d "$gstack_dir/design/dist" ]; then
+    _link_or_copy "$gstack_dir/design/dist" "$kimi_gstack/design/dist"
+  fi
+  if [ -f "$kimi_dir/gstack-upgrade/SKILL.md" ]; then
+    _link_or_copy "$kimi_dir/gstack-upgrade/SKILL.md" "$kimi_gstack/gstack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      _link_or_copy "$gstack_dir/review/$f" "$kimi_gstack/review/$f"
+    fi
+  done
+  if [ -d "$gstack_dir/review/specialists" ]; then
+    _link_or_copy "$gstack_dir/review/specialists" "$kimi_gstack/review/specialists"
+  fi
+  if [ -d "$gstack_dir/qa/templates" ]; then
+    _link_or_copy "$gstack_dir/qa/templates" "$kimi_gstack/qa/templates"
+  fi
+  if [ -d "$gstack_dir/qa/references" ]; then
+    _link_or_copy "$gstack_dir/qa/references" "$kimi_gstack/qa/references"
+  fi
+  if [ -f "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" ]; then
+    _link_or_copy "$gstack_dir/plan-devex-review/dx-hall-of-fame.md" "$kimi_gstack/plan-devex-review/dx-hall-of-fame.md"
+  fi
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    _link_or_copy "$gstack_dir/ETHOS.md" "$kimi_gstack/ETHOS.md"
+  fi
+}
+
+link_kimi_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local kimi_dir="$gstack_dir/.kimi-code/skills"
+  local linked=()
+
+  if [ ! -d "$kimi_dir" ]; then
+    echo "  Generating .agents/ skill docs..."
+    ( cd "$gstack_dir" && bun run gen:skill-docs --host kimi )
+  fi
+
+  if [ ! -d "$kimi_dir" ]; then
+    echo "  warning: .agents/skills/ generation failed — run 'bun run gen:skill-docs --host kimi' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$kimi_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        _link_or_copy "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
 # 4. Install for Claude (default)
 SKILLS_BASENAME="$(basename "$INSTALL_SKILLS_DIR")"
 SKILLS_PARENT_BASENAME="$(basename "$(dirname "$INSTALL_SKILLS_DIR")")"
@@ -1191,6 +1292,16 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   echo "gstack ready (opencode)."
   echo "  browse: $BROWSE_BIN"
   echo "  opencode skills: $OPENCODE_SKILLS"
+fi
+
+# 6d. Install for Kimi Code
+if [ "$INSTALL_KIMI" -eq 1 ]; then
+  mkdir -p "$KIMI_SKILLS"
+  create_kimi_runtime_root "$SOURCE_GSTACK_DIR" "$KIMI_GSTACK"
+  link_kimi_skill_dirs "$SOURCE_GSTACK_DIR" "$KIMI_SKILLS"
+  echo "gstack ready (kimi)."
+  echo "  browse: $BROWSE_BIN"
+  echo "  kimi skills: $KIMI_SKILLS"
 fi
 
 # 7. Create .agents/ sidecar symlinks for the real Codex skill target.

--- a/setup
+++ b/setup
@@ -1007,6 +1007,16 @@ create_kimi_runtime_root() {
   if [ -d "$gstack_dir/bin" ]; then
     _link_or_copy "$gstack_dir/bin" "$kimi_gstack/bin"
   fi
+  # Runtime deps of the bin/* wrappers: they invoke bun with "$SCRIPT_DIR/../lib/..."
+  # and "$SCRIPT_DIR/../scripts/..." paths, and bun resolves them textually —
+  # without these links every wrapper fails with "Cannot find module" (e.g.
+  # gstack-learnings-log → lib/jsonl-store.ts).
+  if [ -d "$gstack_dir/lib" ]; then
+    _link_or_copy "$gstack_dir/lib" "$kimi_gstack/lib"
+  fi
+  if [ -d "$gstack_dir/scripts" ]; then
+    _link_or_copy "$gstack_dir/scripts" "$kimi_gstack/scripts"
+  fi
   if [ -d "$gstack_dir/browse/dist" ]; then
     _link_or_copy "$gstack_dir/browse/dist" "$kimi_gstack/browse/dist"
   fi

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -32,8 +32,8 @@ const RESOLVER_NAMES = new Set(Object.keys(RESOLVERS));
 // ─── hosts/index.ts ─────────────────────────────────────────
 
 describe('hosts/index.ts', () => {
-  test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+  test('ALL_HOST_CONFIGS has 11 hosts', () => {
+    expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {


### PR DESCRIPTION
## What

Add support for Kimi Code as a gstack host.

## Changes

- New `hosts/kimi.ts` with `HostConfig` for Kimi Code
- Register `kimi` in `hosts/index.ts`
- Update `setup` to detect `kimi` CLI and install skills to `~/.kimi-code/skills/gstack`
- Add `.kimi-code/` to `.gitignore`
- Update `host-config` tests for 11 hosts

## Notes

Kimi Code reads Agent Skills from `~/.kimi-code/skills/` and `~/.agents/skills/`. This connector installs gstack skills to `~/.kimi-code/skills/gstack-*/` so they are discoverable by Kimi Code as `/skill:gstack-*`.

Co-authored-by: abkrim <abdelkarim.mateos@castris.com>
Co-authored-by: Kimi 3 <kimi-3@example.com>