### PR TITLE
fix: scope benchmark routing to web performance

### DIFF
--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -2,11 +2,11 @@
 name: benchmark
 preamble-tier: 1
 version: 1.0.0
-description: Performance regression detection using the browse daemon. (gstack)
+description: Web page performance regression detection using the browse daemon. (gstack)
 triggers:
-  - performance benchmark
+  - web performance benchmark
   - check page speed
-  - detect performance regression
+  - detect page performance regression
 allowed-tools:
   - Bash
   - Read
@@ -23,8 +23,9 @@ allowed-tools:
 Establishes
 baselines for page load times, Core Web Vitals, and resource sizes.
 Compares before/after on every PR. Tracks performance trends over time.
-Use when: "performance", "benchmark", "page speed", "lighthouse", "web vitals",
-"bundle size", "load time".
+Use when: "web performance benchmark", "page speed", "lighthouse",
+"web vitals", "bundle size", "load time". Do not use for AI model, product,
+business, eval, or research benchmark work.
 
 Voice triggers (speech-to-text aliases): "speed test", "check performance".
 
@@ -576,6 +577,13 @@ If `NEEDS_SETUP`:
 You are a **Performance Engineer** who has optimized apps serving millions of requests. You know that performance doesn't degrade in one big regression — it dies by a thousand paper cuts. Each PR adds 50ms here, 20KB there, and one day the app takes 8 seconds to load and nobody knows when it got slow.
 
 Your job is to measure, baseline, compare, and alert. You use the browse daemon's `perf` command and JavaScript evaluation to gather real performance data from running pages.
+
+## Not For
+
+Do not run this skill for the bare word "benchmark" unless the request is clearly
+about web page performance. Skip it for model benchmarks, agent evals, business
+benchmark research, product metric design, or atrib behavior measurement. For
+cross-model gstack skill comparisons, use `/benchmark-models`.
 
 ## User-invocable
 When the user types `/benchmark`, run this skill.

--- a/benchmark/SKILL.md.tmpl
+++ b/benchmark/SKILL.md.tmpl
@@ -3,18 +3,19 @@ name: benchmark
 preamble-tier: 1
 version: 1.0.0
 description: |
-  Performance regression detection using the browse daemon. Establishes
+  Web page performance regression detection using the browse daemon. Establishes
   baselines for page load times, Core Web Vitals, and resource sizes.
   Compares before/after on every PR. Tracks performance trends over time.
-  Use when: "performance", "benchmark", "page speed", "lighthouse", "web vitals",
-  "bundle size", "load time". (gstack)
+  Use when: "web performance benchmark", "page speed", "lighthouse",
+  "web vitals", "bundle size", "load time". Do not use for AI model, product,
+  business, eval, or research benchmark work. (gstack)
 voice-triggers:
   - "speed test"
   - "check performance"
 triggers:
-  - performance benchmark
+  - web performance benchmark
   - check page speed
-  - detect performance regression
+  - detect page performance regression
 allowed-tools:
   - Bash
   - Read
@@ -32,6 +33,13 @@ allowed-tools:
 You are a **Performance Engineer** who has optimized apps serving millions of requests. You know that performance doesn't degrade in one big regression — it dies by a thousand paper cuts. Each PR adds 50ms here, 20KB there, and one day the app takes 8 seconds to load and nobody knows when it got slow.
 
 Your job is to measure, baseline, compare, and alert. You use the browse daemon's `perf` command and JavaScript evaluation to gather real performance data from running pages.
+
+## Not For
+
+Do not run this skill for the bare word "benchmark" unless the request is clearly
+about web page performance. Skip it for model benchmarks, agent evals, business
+benchmark research, product metric design, or atrib behavior measurement. For
+cross-model gstack skill comparisons, use `/benchmark-models`.
 
 ## User-invocable
 When the user types `/benchmark`, run this skill.

--- a/gstack/llms.txt
+++ b/gstack/llms.txt
@@ -11,7 +11,7 @@ Conventions:
 ## Skills
 
 - [/autoplan](autoplan/SKILL.md): Auto-review pipeline — reads the full CEO, design, eng, and DX review skills from disk and runs them sequentially with auto-decisions using 6 decision principles.
-- [/benchmark](benchmark/SKILL.md): Performance regression detection using the browse daemon.
+- [/benchmark](benchmark/SKILL.md): Web page performance regression detection using the browse daemon.
 - [/benchmark-models](benchmark-models/SKILL.md): Cross-model benchmark for gstack skills.
 - [/browse](browse/SKILL.md): Fast headless browser for QA testing and site dogfooding.
 - [/canary](canary/SKILL.md): Post-deploy canary monitoring.

--- a/scripts/proactive-suggestions.json
+++ b/scripts/proactive-suggestions.json
@@ -9,8 +9,8 @@
       "voice_line": "Voice triggers (speech-to-text aliases): \"auto plan\", \"automatic review\"."
     },
     "benchmark": {
-      "lead": "Performance regression detection using the browse daemon.",
-      "routing": "Establishes\nbaselines for page load times, Core Web Vitals, and resource sizes.\nCompares before/after on every PR. Tracks performance trends over time.\nUse when: \"performance\", \"benchmark\", \"page speed\", \"lighthouse\", \"web vitals\",\n\"bundle size\", \"load time\".",
+      "lead": "Web page performance regression detection using the browse daemon.",
+      "routing": "Establishes\nbaselines for page load times, Core Web Vitals, and resource sizes.\nCompares before/after on every PR. Tracks performance trends over time.\nUse when: \"web performance benchmark\", \"page speed\", \"lighthouse\",\n\"web vitals\", \"bundle size\", \"load time\". Do not use for AI model, product,\nbusiness, eval, or research benchmark work.",
       "voice_line": "Voice triggers (speech-to-text aliases): \"speed test\", \"check performance\"."
     },
     "benchmark-models": {

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -467,6 +467,21 @@ describe('gen-skill-docs', () => {
     }
   });
 
+  test('benchmark skill is scoped to web page performance', () => {
+    const generated = fs.readFileSync(path.join(ROOT, 'benchmark', 'SKILL.md'), 'utf-8');
+    const template = fs.readFileSync(path.join(ROOT, 'benchmark', 'SKILL.md.tmpl'), 'utf-8');
+
+    for (const content of [generated, template]) {
+      const frontmatter = content.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+      expect(frontmatter).toContain('name: benchmark');
+      expect(frontmatter).toContain('web performance benchmark');
+      expect(frontmatter).not.toMatch(/Use when: [^\n]*["']benchmark["']/);
+      expect(content).toContain('Do not run this skill for the bare word "benchmark"');
+      expect(content).toContain('For\ncross-model gstack skill comparisons, use `/benchmark-models`.');
+      expect(content).toContain('/benchmark <url>');
+    }
+  });
+
   test('qa and qa-only templates use QA_METHODOLOGY placeholder', () => {
     const qaTmpl = fs.readFileSync(path.join(ROOT, 'qa', 'SKILL.md.tmpl'), 'utf-8');
     expect(qaTmpl).toContain('{{QA_METHODOLOGY}}');


### PR DESCRIPTION
## Summary

- Narrow `/benchmark` routing to web page performance requests.
- Keep the current `/benchmark` command name while excluding model, product, business, eval, and research benchmarks.
- Add a regression test for the routing boundary and regenerate the skill index.

## Verification

- `bun run gen:skill-docs`
- `bun run gen:skill-docs --host codex`
- `bun test test/gen-skill-docs.test.ts test/llms-txt-shape.test.ts` (411 passed)
