### PR TITLE
fix: count tracked files for test-file metric in /retro and /ship

### DIFF
--- a/openclaw/skills/gstack-openclaw-retro/SKILL.md
+++ b/openclaw/skills/gstack-openclaw-retro/SKILL.md
@@ -60,7 +60,7 @@ git log origin/main --since="<window>" --format="AUTHOR:%aN" --name-only
 git shortlog origin/main --since="<window>" -sn --no-merges
 
 # Test file count
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' 2>/dev/null | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
 
 # Test files changed in window
 git log origin/main --since="<window>" --format="" --name-only | grep -E '\.(test|spec)\.' | sort -u | wc -l

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -1026,7 +1026,7 @@ cat ~/.gstack/greptile-history.md 2>/dev/null || true
 cat TODOS.md 2>/dev/null || true
 
 # 10. Test file count
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' 2>/dev/null | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
 
 # 11. Regression test commits in window
 git log origin/<default> --since="<window>" --oneline --grep="test(qa):" --grep="test(design):" --grep="test: coverage"

--- a/retro/SKILL.md.tmpl
+++ b/retro/SKILL.md.tmpl
@@ -197,7 +197,7 @@ cat ~/.gstack/greptile-history.md 2>/dev/null || true
 cat TODOS.md 2>/dev/null || true
 
 # 10. Test file count
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' 2>/dev/null | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
 
 # 11. Regression test commits in window
 git log origin/<default> --since="<window>" --oneline --grep="test(qa):" --grep="test(design):" --grep="test: coverage"

--- a/scripts/resolvers/testing.ts
+++ b/scripts/resolvers/testing.ts
@@ -222,7 +222,7 @@ ls -d test/ tests/ spec/ __tests__/ cypress/ e2e/ 2>/dev/null
 
 \`\`\`bash
 # Count test files before any generation
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\\.test\\.|\\.spec\\.|_test\\.|_spec\\.)' | wc -l
 \`\`\`
 
 Store this number for the PR body.`);
@@ -430,7 +430,7 @@ If no test framework AND user declined bootstrap → diagram only, no generation
 
 \`\`\`bash
 # Count test files after generation
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\\.test\\.|\\.spec\\.|_test\\.|_spec\\.)' | wc -l
 \`\`\`
 
 For PR body: \`Tests: {before} → {after} (+{delta} new)\`

--- a/ship/sections/test-coverage.md
+++ b/ship/sections/test-coverage.md
@@ -36,7 +36,7 @@ ls -d test/ tests/ spec/ __tests__/ cypress/ e2e/ 2>/dev/null
 
 ```bash
 # Count test files before any generation
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
 ```
 
 Store this number for the PR body.
@@ -174,7 +174,7 @@ If no test framework AND user declined bootstrap → diagram only, no generation
 
 ```bash
 # Count test files after generation
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
 ```
 
 For PR body: `Tests: {before} → {after} (+{delta} new)`

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -1387,7 +1387,7 @@ ls -d test/ tests/ spec/ __tests__/ cypress/ e2e/ 2>/dev/null
 
 ```bash
 # Count test files before any generation
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
 ```
 
 Store this number for the PR body.
@@ -1525,7 +1525,7 @@ If no test framework AND user declined bootstrap → diagram only, no generation
 
 ```bash
 # Count test files after generation
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
 ```
 
 For PR body: `Tests: {before} → {after} (+{delta} new)`

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -1389,7 +1389,7 @@ ls -d test/ tests/ spec/ __tests__/ cypress/ e2e/ 2>/dev/null
 
 ```bash
 # Count test files before any generation
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
 ```
 
 Store this number for the PR body.
@@ -1527,7 +1527,7 @@ If no test framework AND user declined bootstrap → diagram only, no generation
 
 ```bash
 # Count test files after generation
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
 ```
 
 For PR body: `Tests: {before} → {after} (+{delta} new)`


### PR DESCRIPTION
Fixes #2307.

## Problem

The test-file count used by `/retro` and `/ship` scans the working tree with `find`, so untracked build output is counted as test files. On a Rails repo with bundled gems it over-reports by **37x**.

Measured on a Rails 8 app with 17 real test files:

```
$ find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' 2>/dev/null | grep -v node_modules | wc -l
623

$ git ls-files | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
17
```

```
433  vendor/bundle/ruby/3.4.0/gems/...     bundled gem test suites
189  .claude/worktrees/agent-*/            agent worktree copies
  4  nested node_modules                   vendor/.../axe-core-api-4.11.1/node_modules
 17  test/                                 the real answer
```

`/retro` prints this as "Total test files: N", so the retro is just wrong. `/ship` uses it for a before/after delta, so the delta survives but both endpoints are inflated.

Two things are broken: `grep -v node_modules` filters output lines rather than pruning the walk (find still descends into every ignored tree), and no exclusion list can be complete — `vendor/` is Ruby, `.claude/worktrees/` is gstack's own feature, and every ecosystem adds more (`target/`, `.venv/`, `Pods/`).

## Fix

```diff
-find . -name '*.test.*' -o -name '*.spec.*' -o -name '*_test.*' -o -name '*_spec.*' 2>/dev/null | grep -v node_modules | wc -l
+git ls-files 2>/dev/null | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
```

Untracked build output is excluded by definition, `.gitignore` is respected for free, and the full-tree walk goes away. Both skills already require a git repo and run `git log origin/<default>` in the same step, so no new dependency.

`.claude/worktrees/` is untracked in the parent repo, so this also fixes the worktree inflation without special-casing gstack's own directory.

## Changes

Sources of truth:
- `retro/SKILL.md.tmpl`
- `ship/sections/test-coverage.md` (x2)
- `scripts/resolvers/testing.ts` (x2, inside a template literal so the escape is `\\.`)
- `openclaw/skills/gstack-openclaw-retro/SKILL.md`

Regenerated / updated:
- `retro/SKILL.md` via `bun run gen:skill-docs`
- `test/fixtures/golden/{codex,factory}-ship-SKILL.md` to match the regenerated `.agents/` and `.factory/` ship skills

## Verification

Generated output is correct shell (single backslashes survive the TS template literal):

```
$ grep -n 'git ls-files' retro/SKILL.md
1029:git ls-files 2>/dev/null | grep -E '(\.test\.|\.spec\.|_test\.|_spec\.)' | wc -l
```

Behavior on the affected repo: **623 -> 17**.

Test suite (`bun test test/` with the e2e/eval ignores from `package.json`):

- `test/host-config.test.ts` — 77/77 pass, including all three golden-file regression tests
- Two failures remain, both reproduced **3/3 on clean `main` (a3259400) with zero changes**, so they are pre-existing and unrelated:
  - `gstack-model-benchmark --dry-run > NOT READY path fires when auth env vars are stripped`
  - `session-runner observability > 11: all new I/O is wrapped in try/catch (non-fatal)`

## Left alone deliberately

`test/fixtures/golden-ship-claude.md` still contains the old command at lines 1090 and 1250. Nothing reads it — no `.ts` in the repo references that path, and it is not the fixture used by the `golden-file regression` suite (that one is `test/fixtures/golden/claude-ship-SKILL.md`, which does not contain the pattern at all). It looks like an orphaned fixture from an earlier layout, so hand-editing it seemed more likely to entrench drift than fix it. Happy to update or delete it if you'd prefer.

## Tradeoff worth a look

Test files written but not yet `git add`-ed stop counting. Correct for `/retro`, which reports on merged history. For `/ship`'s before/after delta it is a slight semantic change — if you want untracked-but-not-ignored files included, `git ls-files --cached --others --exclude-standard` does that while still honoring `.gitignore`. Happy to switch `/ship` to that variant.
