### PR TITLE
docs: add Health Stack section to pin /health to the fast path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,21 @@ bun run test:evals   # run before shipping — paid, diff-based (~$4/run max)
 integration tests. `bun run test:evals` runs LLM-judge quality evals and E2E
 tests via `claude -p`. Both must pass before creating a PR.
 
+## Health Stack
+
+The `/health` skill auto-detects nothing useful here: there's no `tsconfig.json`
+(Bun runs TypeScript directly), no biome/eslint, no knip, and shellcheck usually
+isn't installed. The real quality gates are the test suite and slop-scan. The full
+`bun test` script also spawns browser integration tests that hang in non-interactive
+agent shells, so `/health` targets the fast deterministic tier instead. slop-scan is
+this repo's linter (see the Slop-scan section below).
+
+- test: bun test test/skill-validation.test.ts test/gen-skill-docs.test.ts test/hermetic-wiring.test.ts
+- lint: npx slop-scan scan .
+
+Run the full `bun test` yourself in a real terminal before a PR — the `/health` entry
+above is the subset that completes without a browser, not a replacement for it.
+
 ## Project structure
 
 ```


### PR DESCRIPTION
## What

Adds a `## Health Stack` section to `CLAUDE.md` so `/health` targets the real quality gates on this repo instead of auto-detecting tools that don't exist here.

## Why

`/health` auto-detects `tsconfig.json`, biome/eslint, knip, and shellcheck — none of which gstack uses (Bun runs TypeScript directly; slop-scan is the linter). It also runs the full `bun test` script, which spawns browser integration tests that hang in non-interactive agent shells. The result is a dashboard that either scores nothing or times out.

The new section pins the fast deterministic test tier plus `slop-scan`, and notes that the full `bun test` still has to run in a real terminal before a PR.

```
- test: bun test test/skill-validation.test.ts test/gen-skill-docs.test.ts test/hermetic-wiring.test.ts
- lint: npx slop-scan scan .
```

## Scope

Docs only. One file. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BV2RsGpwAdbDid7yAHBtXK

Made with [Orca](https://github.com/stablyai/orca) 🐋
