### PR TITLE
fix(gpt): bound implementation execution posture

### DIFF
--- a/model-overlays/gpt.md
+++ b/model-overlays/gpt.md
@@ -1,10 +1,22 @@
-**Completion bias.** Do not end your turn with a partial solution when the full
-solution is reachable. If you encounter an error, debug it. If a test fails, fix it.
-If something is ambiguous, make your best judgment and proceed — don't stop and ask
-unless you're genuinely blocked.
+**Bounded execution (authoritative for execution posture).** Treat the user's
+requested outcome and its explicit completion criteria as the ceiling. Break
+implementation into the smallest independently verifiable work unit that should fit
+within about five minutes. Complete and directly verify one unit at a time.
 
-**Prefer doing over listing.** When you'd be tempted to write "you could also try X,
-Y, or Z," try the best option yourself. Pick, execute, report results.
+When the current unit and its direct verification are complete, stop and report the
+result. Do not start optional cleanup, broader audits, adjacent refactors, extra docs,
+extra tests, or another review pass unless they are explicitly required by the request
+or completion criteria.
+
+If the current unit cannot finish within about five minutes, stop at the next safe
+boundary and report what completed, the exact remainder, and any blocker. Do not
+silently extend the unit, open another workstream, or repeat review/verification loops.
+After two unsuccessful attempts at the same direct failure, stop and report it instead
+of trying a third substantially identical approach.
+
+**Prefer doing within the current unit.** When you'd be tempted to write "you could
+also try X, Y, or Z," try the best in-scope option yourself. Pick, execute, verify,
+and stop. This does not authorize a second unit or optional expansion.
 
 **No preamble.** Skip "Great question!", "Let me help with that", and restating the
 user's request. Start with the work.
@@ -27,6 +39,7 @@ paragraph, without a RECOMMENDATION line, or by just listing options and asking 
 one?" — stop, back up, and emit the full format. The user will ask you to do it anyway,
 so do it the first time.
 
-**Reminder: subordination applies.** When a skill workflow says STOP, stop. When the
-skill asks via AskUserQuestion, that is the wait-for-user gate, not an ambiguity.
-Completion bias does not override safety gates.
+**Reminder: safety and workflow gates still win.** When a skill workflow says STOP,
+stop. When the skill asks via AskUserQuestion, that is the wait-for-user gate, not an
+ambiguity. Bounded execution does not weaken safety gates, explicit user scope, or the
+skill's completion criteria.

--- a/scripts/resolvers/model-overlay.ts
+++ b/scripts/resolvers/model-overlay.ts
@@ -12,8 +12,9 @@
  *   4. No ctx.model set: returns empty string.
  *
  * The returned block is subordinate to skill workflow, safety gates, and
- * AskUserQuestion instructions. The subordination language is part of the
- * wrapper heading so it appears with every overlay regardless of file content.
+ * AskUserQuestion instructions. GPT-family overlays additionally make their
+ * bounded-execution directive authoritative for execution posture only. This
+ * does not redefine the skill's scope or completion criteria.
  */
 
 import * as fs from 'fs';
@@ -48,6 +49,18 @@ export function generateModelOverlay(ctx: TemplateContext): string {
 
   const content = readOverlay(ctx.model);
   if (!content) return '';
+
+  if (ctx.model === 'gpt' || ctx.model.startsWith('gpt-')) {
+    return `## Model-Specific Behavioral Patch (${ctx.model})
+
+The **Bounded execution** directive below is authoritative for GPT execution
+posture: it controls work-unit size, retry limits, and when optional expansion
+stops. It remains subordinate to explicit user scope, safety gates, skill STOP
+points, AskUserQuestion gates, plan-mode safety, /ship review gates, and the
+skill's completion criteria. The remaining nudges are preferences.
+
+${content}`;
+  }
 
   return `## Model-Specific Behavioral Patch (${ctx.model})
 

--- a/test/model-overlay-gpt.test.ts
+++ b/test/model-overlay-gpt.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { generateModelOverlay } from '../scripts/resolvers/model-overlay';
+import type { TemplateContext } from '../scripts/resolvers/types';
+import { HOST_PATHS } from '../scripts/resolvers/types';
+
+const ROOT = path.resolve(__dirname, '..');
+
+function makeCtx(model: string): TemplateContext {
+  return {
+    skillName: 'test-skill',
+    tmplPath: 'test.tmpl',
+    host: 'codex',
+    paths: HOST_PATHS.codex,
+    preambleTier: 2,
+    model,
+  };
+}
+
+describe('GPT overlay — bounded execution', () => {
+  test('replaces open-ended completion bias with bounded work units', () => {
+    const raw = fs.readFileSync(
+      path.join(ROOT, 'model-overlays/gpt.md'),
+      'utf-8',
+    );
+
+    expect(raw).toContain('**Bounded execution (authoritative for execution posture).**');
+    expect(raw).toContain('within about five minutes');
+    expect(raw).toContain('After two unsuccessful attempts');
+    expect(raw).not.toContain('**Completion bias.**');
+  });
+
+  test('makes bounded execution authoritative for GPT posture only', () => {
+    const out = generateModelOverlay(makeCtx('gpt'));
+
+    expect(out).toContain('authoritative for GPT execution');
+    expect(out).toContain('controls work-unit size, retry limits');
+    expect(out).toContain("skill's completion criteria");
+  });
+
+  test('gpt-5.4 inherits the bounded directive exactly once', () => {
+    const out = generateModelOverlay(makeCtx('gpt-5.4'));
+    const directiveCount = out.match(
+      /\*\*Bounded execution \(authoritative for execution posture\)\.\*\*/g,
+    )?.length ?? 0;
+
+    expect(directiveCount).toBe(1);
+    expect(out).toContain('Anti-verbosity protocol');
+  });
+
+  test('keeps the Claude wrapper byte-for-byte on the non-GPT path', () => {
+    const raw = fs.readFileSync(
+      path.join(ROOT, 'model-overlays/claude.md'),
+      'utf-8',
+    ).trim();
+    const expected = `## Model-Specific Behavioral Patch (claude)
+
+The following nudges are tuned for the claude model family. They are
+**subordinate** to skill workflow, STOP points, AskUserQuestion gates, plan-mode
+safety, and /ship review gates. If a nudge below conflicts with skill instructions,
+the skill wins. Treat these as preferences, not rules.
+
+${raw}`;
+
+    expect(generateModelOverlay(makeCtx('claude'))).toBe(expected);
+  });
+
+  test('does not give the GPT precedence wrapper to o-series', () => {
+    const out = generateModelOverlay(makeCtx('o-series'));
+
+    expect(out).toContain('Treat these as preferences, not rules.');
+    expect(out).not.toContain('authoritative for GPT execution');
+  });
+});


### PR DESCRIPTION
Replaces the GPT overlay's open-ended completion bias with bounded, independently verifiable work units sized for about five minutes. Adds a two-attempt stop-loss, prevents optional scope expansion, and makes the directive authoritative only for GPT execution posture.

Claude and other model wrappers remain unchanged.

Verification:
- 23 focused tests pass
- Claude generation dry-run reports all committed artifacts fresh
- 49 generated Codex skills contain the bounded directive