### PR TITLE
fix(hooks): question-preference-hook must not emit permissionDecision 'defer' (merges #2165 + #1924)

### DIFF
--- a/docs/spikes/claude-code-hook-mutation.md
+++ b/docs/spikes/claude-code-hook-mutation.md
@@ -51,7 +51,8 @@ Optional in subagent context: `agent_id`, `agent_type`.
 - `"deny"` — block (feedback to Claude, NOT a synthetic answer per Codex
   correction in D-prefixed decisions)
 - `"ask"` — escalate to user
-- `"defer"` — let permission flow continue
+- No output — let permission flow continue
+- `"defer"` — pause a non-interactive SDK/tool caller so it can resume later
 
 **`updatedInput` semantics:** shallow merge of fields present in the returned
 object onto the original `tool_input`. Only valid with
@@ -88,7 +89,7 @@ required for our hook to fire there.
   accepting.
 
 **`permissionDecision` precedence (when multiple hooks decide):**
-`deny > ask > allow > defer` — most restrictive wins.
+Claude Code treats `defer` as an explicit pause/resume decision, not as the normal pass-through path. Hooks that do not need to decide should exit 0 with no output.
 
 ## Implementation hookSpecificOutput examples
 
@@ -107,11 +108,12 @@ required for our hook to fire there.
 ```
 
 **Pass-through (no preference, or one-way safety override):**
+Exit 0 with no stdout. If the hook has context to add, omit `permissionDecision`:
 ```json
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "defer"
+    "additionalContext": "optional context for Claude"
   }
 }
 ```

--- a/docs/spikes/claude-code-hook-mutation.md
+++ b/docs/spikes/claude-code-hook-mutation.md
@@ -13,8 +13,9 @@ answer via `updatedInput`? If yes, what's the exact protocol?
 
 ## Answer
 
-**Yes.** `updatedInput` is the supported mechanism. Source:
-https://code.claude.com/docs/en/hooks (confirmed 2026-04 reference).
+**Yes.** `updatedInput` is the supported mechanism (platform capability;
+this plan-tune hook does not take that path — see Implementation examples).
+Source: https://code.claude.com/docs/en/hooks (confirmed 2026-04 reference).
 
 ## Hook stdin schema (PreToolUse + PostToolUse)
 
@@ -60,8 +61,9 @@ the pass-through path that lets the permission flow continue unchanged.
 
 **`updatedInput` semantics:** shallow merge of fields present in the returned
 object onto the original `tool_input`. Only valid with
-`permissionDecision: "allow"`. This is what lets us substitute an
-auto-decided answer for `never-ask` preferences.
+`permissionDecision: "allow"`. This is what would let a hook substitute an
+auto-decided answer for `never-ask` preferences; the live plan-tune hook
+instead uses `deny` + reason (see Implementation examples).
 
 ## Matcher schema
 

--- a/docs/spikes/claude-code-hook-mutation.md
+++ b/docs/spikes/claude-code-hook-mutation.md
@@ -1,6 +1,8 @@
 # Spike: Claude Code hook mutation for plan-tune cathedral
 
 **Status:** complete (2026-05-27)
+**Revised:** 2026-07-22 — pass-through is empty stdout (not `defer`); restored
+decision-precedence facts alongside defer semantics.
 **Surfaces:** D10 (does PreToolUse allow mutating AUQ input?), D19/Codex (matcher must cover MCP variants)
 **Downstream consumers:** T3, T5, T6, T8
 
@@ -51,8 +53,10 @@ Optional in subagent context: `agent_id`, `agent_type`.
 - `"deny"` — block (feedback to Claude, NOT a synthetic answer per Codex
   correction in D-prefixed decisions)
 - `"ask"` — escalate to user
-- No output — let permission flow continue
 - `"defer"` — pause a non-interactive SDK/tool caller so it can resume later
+
+No output (exit 0, empty stdout) is not a `permissionDecision` value. It is
+the pass-through path that lets the permission flow continue unchanged.
 
 **`updatedInput` semantics:** shallow merge of fields present in the returned
 object onto the original `tool_input`. Only valid with
@@ -89,7 +93,10 @@ required for our hook to fire there.
   accepting.
 
 **`permissionDecision` precedence (when multiple hooks decide):**
-Claude Code treats `defer` as an explicit pause/resume decision, not as the normal pass-through path. Hooks that do not need to decide should exit 0 with no output.
+`deny > ask > allow` — most restrictive wins.
+Claude Code treats `defer` as an explicit pause/resume decision, not as the
+normal pass-through path. Hooks that do not need to decide should exit 0 with
+no output (empty stdout), not emit `permissionDecision: "defer"`.
 
 ## Implementation hookSpecificOutput examples
 

--- a/docs/spikes/claude-code-hook-mutation.md
+++ b/docs/spikes/claude-code-hook-mutation.md
@@ -101,15 +101,17 @@ no output (empty stdout), not emit `permissionDecision: "defer"`.
 ## Implementation hookSpecificOutput examples
 
 **Auto-decide (PreToolUse, `never-ask` preference + non-one-way):**
+
+The live hook uses `deny` + reason (not `allow` + `updatedInput`). See the
+hook header: AskUserQuestion's pre-resolve `updatedInput` shape is not
+structurally pinned, so deny naming the recommended option is the reliable
+path; the model reads the reason and proceeds without re-firing AUQ.
 ```json
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "permissionDecisionReason": "plan-tune: never-ask preference on ship-test-failure-triage",
-    "updatedInput": {
-      "questions": [{ /* same as input, but with auto-selected answer */ }]
-    }
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "[plan-tune auto-decide] ship-pre-landing-review-fix → A) Fix now (recommended) (your never-ask preference). Proceed with that option without re-prompting. Change with /plan-tune."
   }
 }
 ```
@@ -215,12 +217,11 @@ shells into bun.
    examples: ship/SKILL.md.tmpl emits options like `"A) Fix now"
    (recommended)`.
 
-2. **Auto-decided event tagging.** When hook returns `updatedInput`, the
-   PostToolUse hook will see the resolved input and log a normal event.
-   Need an extra field on the PostToolUse payload (e.g.,
-   `was_auto_decided: true`) that the hook can set via session state
-   tracking — write a marker file in `~/.gstack/sessions/<id>/.auto-decided-<tool_use_id>`
-   from PreToolUse, read it from PostToolUse, delete on read.
+2. **Auto-decided event tagging.** Auto-decide is `deny` + reason, so
+   PostToolUse never fires on that tool call. The PreToolUse hook itself
+   writes a session marker and logs `source=auto-decided` events before
+   deny (see `markAutoDecided` / `logAutoDecided` in the hook). No
+   PostToolUse payload field is required for the current path.
 
 3. **Timeout behavior.** Default hook timeout is 60s but the docs are
    thin on what happens at timeout. Set explicit `timeout: 5` so the

--- a/hosts/claude/hooks/question-preference-hook.ts
+++ b/hosts/claude/hooks/question-preference-hook.ts
@@ -12,11 +12,11 @@
  *   2. Look up door_type from scripts/question-registry.ts (default two-way).
  *   3. Read preferences with precedence: project-local > global (D8).
  *   4. Apply:
- *        never-ask + one-way → defer (safety override; one-way always asks).
+ *        never-ask + one-way → no decision (safety override; one-way always asks).
  *        never-ask + two-way + marker → deny with auto-decided recommendation
  *          in reason. Mark tool_use_id so PostToolUse logs as 'auto-decided'.
  *        ask-only-for-one-way + two-way + marker → same as never-ask.
- *        always-ask, or no preference → defer.
+ *        always-ask, or no preference → no decision.
  *
  * Why deny+reason instead of allow+updatedInput:
  *   AskUserQuestion's `updatedInput` shape for "pre-resolve this question"
@@ -31,7 +31,7 @@
  *   - First: (recommended) label suffix on an option.
  *   - Fall back: "Recommendation: X" prose match against option labels.
  *   - Refuse to auto-decide if ambiguous (multiple labels OR no parseable
- *     recommendation): defer instead of silent-wrong.
+ *     recommendation): no decision instead of silent-wrong.
  *
  * Always exits 0. Hook errors land in ~/.gstack/hook-errors.log.
  * See docs/spikes/claude-code-hook-mutation.md for the protocol contract.
@@ -92,13 +92,24 @@ function readStdin(): Promise<string> {
   });
 }
 
-function defer(additionalContext?: string): void {
-  const out: Record<string, unknown> = {
-    hookEventName: 'PreToolUse',
-    permissionDecision: 'defer',
-  };
-  if (additionalContext) out.additionalContext = additionalContext;
-  process.stdout.write(JSON.stringify({ hookSpecificOutput: out }));
+function passThrough(additionalContext?: string): void {
+  // "No opinion" must be a SILENT exit 0 (optionally with additionalContext
+  // only), never an explicit `permissionDecision: 'defer'`. `defer` is a real
+  // value in Claude Code, but it means "pause this tool call and hand control
+  // back" and is honored in print/non-interactive mode. Emitting it here made
+  // every AskUserQuestion get deferred in non-interactive sessions (e.g. the
+  // desktop app) — the question UI never rendered. Interactive mode merely
+  // warns and ignores it.
+  if (additionalContext) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext,
+        },
+      }),
+    );
+  }
   process.exit(0);
 }
 
@@ -347,7 +358,7 @@ function logAutoDecided(
 async function main(): Promise<void> {
   const raw = await readStdin();
   if (!raw.trim()) {
-    defer();
+    passThrough();
     return;
   }
   let stdin: HookStdin;
@@ -355,7 +366,7 @@ async function main(): Promise<void> {
     stdin = JSON.parse(raw);
   } catch (e) {
     logHookError(`stdin parse failed: ${(e as Error).message}`);
-    defer();
+    passThrough();
     return;
   }
 
@@ -364,26 +375,26 @@ async function main(): Promise<void> {
     toolName !== 'AskUserQuestion' &&
     !toolName.match(/^mcp__.+__AskUserQuestion$/)
   ) {
-    defer();
+    passThrough();
     return;
   }
 
   const questions = stdin.tool_input?.questions || [];
   if (questions.length === 0) {
-    defer();
+    passThrough();
     return;
   }
 
   // For multi-question AUQ, enforcement is all-or-nothing per call:
   // we deny only if ALL questions have marker + never-ask + safe door type.
-  // Mixed cases pass through (defer) so the user still gets to answer.
+  // Mixed cases pass through so the user still gets to answer.
   const registry = loadRegistry();
   const slug = slugFromCwd(stdin.cwd);
   const memoryNuggets = loadMemoryNuggets(stdin.session_id);
 
   // Compute Layer 8 memory context inline: any nuggets matching the
   // signal_keys of the questions in this AUQ get surfaced as additionalContext.
-  // This applies whether we defer OR deny — gives the agent + user the
+  // This applies whether we pass through OR deny — gives the agent + user the
   // relevant prior context either way.
   const contextNuggets: string[] = [];
   for (const q of questions) {
@@ -402,11 +413,11 @@ async function main(): Promise<void> {
     : undefined;
 
   // Determine whether EVERY question is eligible for never-ask auto-decide.
-  // We deliberately do NOT early-return defer on the first ineligible question:
-  // a Conductor session still needs the [conductor] prose deny as a fallback,
-  // so we compute eligibility, then branch. memoryContext is preserved on every
-  // non-enforcing exit. (All-or-nothing per-call semantics are unchanged: any
-  // ineligible question makes the whole call not auto-decidable.)
+  // We deliberately do NOT early-return passThrough on the first ineligible
+  // question: a Conductor session still needs the [conductor] prose deny as a
+  // fallback, so we compute eligibility, then branch. memoryContext is preserved
+  // on every non-enforcing exit. (All-or-nothing per-call semantics are unchanged:
+  // any ineligible question makes the whole call not auto-decidable.)
   const autoDecisions: Array<{ id: string; recommended: string }> = [];
   let fullyAutoDecidable = true;
   for (const q of questions) {
@@ -471,10 +482,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  defer(memoryContext);
+  passThrough(memoryContext);
 }
 
 main().catch((e) => {
   logHookError(`main crash: ${(e as Error).message}`);
-  defer();
+  passThrough();
 });

--- a/test/memory-cache-injection.test.ts
+++ b/test/memory-cache-injection.test.ts
@@ -43,9 +43,9 @@ function runHook(stdin: object): { stdout: string; stderr: string; status: numbe
   env.GSTACK_STATE_ROOT = stateRoot;
   env.GSTACK_QUESTION_LOG_NO_DERIVE = '1';
   delete env.GSTACK_HOME;
-  // These cases assert the defer-path memoryContext injection. Strip ambient
+  // These cases assert pass-through memoryContext injection. Strip ambient
   // Conductor markers so running inside Conductor (CONDUCTOR_WORKSPACE_PATH/PORT
-  // set) doesn't flip the hook into the [conductor] prose deny instead of defer.
+  // set) doesn't flip the hook into the [conductor] prose deny instead of pass-through.
   delete env.CONDUCTOR_WORKSPACE_PATH;
   delete env.CONDUCTOR_PORT;
   const res = spawnSync(HOOK, [], {
@@ -69,7 +69,7 @@ function runHook(stdin: object): { stdout: string; stderr: string; status: numbe
 // ----------------------------------------------------------------------
 
 describe('memory injection', () => {
-  test('injects matching nugget into additionalContext on defer', () => {
+  test('injects matching nugget into additionalContext while passing through', () => {
     writeMemory([
       {
         nugget: 'User prefers verbose explanations with tradeoffs',
@@ -91,7 +91,7 @@ describe('memory injection', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toContain('verbose explanations');
   });
 
@@ -115,7 +115,8 @@ describe('memory injection', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toBeUndefined();
   });
 
@@ -219,7 +220,8 @@ describe('per-session memory cache', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.stdout).toBe('');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toBeUndefined();
   });
 });

--- a/test/memory-cache-injection.test.ts
+++ b/test/memory-cache-injection.test.ts
@@ -91,6 +91,7 @@ describe('memory injection', () => {
         ],
       },
     });
+    expect(r.parsed?.hookSpecificOutput?.hookEventName).toBe('PreToolUse');
     expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toContain('verbose explanations');
   });

--- a/test/question-preference-hook.test.ts
+++ b/test/question-preference-hook.test.ts
@@ -173,10 +173,8 @@ describe('passes through (no enforcement)', () => {
     env.GSTACK_STATE_ROOT = stateRoot;
     const res = spawnSync(HOOK, [], { env, input: '', encoding: 'utf-8' });
     expect(res.status).toBe(0);
-    // Same shape as runHook so expectNoDecision applies (strict empty stdout).
-    let parsed: any = null;
-    try { parsed = JSON.parse(res.stdout || '{}'); } catch {}
-    expectNoDecision({ stdout: res.stdout ?? '', parsed });
+    // Crash-safety pass-through: empty stdout only (no permissionDecision).
+    expect(res.stdout ?? '').toBe('');
   });
 
   test('non-AUQ tool_name → no decision (defensive)', () => {

--- a/test/question-preference-hook.test.ts
+++ b/test/question-preference-hook.test.ts
@@ -3,15 +3,15 @@
  *
  * Covers:
  *   - never-ask + marker + two-way + clean recommendation → deny+reason
- *   - never-ask + no marker → defer (D18 marker gate)
- *   - never-ask + one-way → defer (safety override)
- *   - never-ask + ambiguous recommendation → defer (D2 refuse-on-ambiguous)
- *   - always-ask → defer
- *   - no preference → defer
+ *   - never-ask + no marker → no decision (D18 marker gate)
+ *   - never-ask + one-way → no decision (safety override)
+ *   - never-ask + ambiguous recommendation → no decision (D2 refuse-on-ambiguous)
+ *   - always-ask → no decision
+ *   - no preference → no decision
  *   - project preference wins over global (D8 precedence)
  *   - global preference applies when no project preference set
  *   - mcp__*__AskUserQuestion matcher accepted
- *   - empty stdin → defer (crash safety)
+ *   - empty stdin → no decision (crash safety)
  *   - auto-decided event logged via gstack-question-log (PostToolUse won't fire)
  *   - auto-decided marker written to ~/.gstack/sessions/<id>/.auto-decided-<tool_use_id>
  */
@@ -74,7 +74,7 @@ function runHook(stdin: object, cwd?: string, extraEnv?: Record<string, string>)
   delete env.GSTACK_HOME;
   // Strip ambient Conductor markers so these cases characterize NON-Conductor
   // behavior deterministically — otherwise running the suite inside Conductor
-  // (CONDUCTOR_WORKSPACE_PATH/PORT set) would flip every defer into the
+  // (CONDUCTOR_WORKSPACE_PATH/PORT set) would flip every pass-through into the
   // [conductor] prose deny. The Conductor cases below opt back in explicitly
   // via extraEnv.
   delete env.CONDUCTOR_WORKSPACE_PATH;
@@ -109,12 +109,18 @@ function autoDecidedEvents(): Array<Record<string, unknown>> {
     .filter((e) => e.source === 'auto-decided');
 }
 
+/** Silent pass-through: no stdout and no permissionDecision. */
+function expectNoDecision(r: { stdout: string; parsed: any }): void {
+  expect(r.stdout).toBe('');
+  expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
+}
+
 // ----------------------------------------------------------------------
-// Defer paths
+// Pass-through paths
 // ----------------------------------------------------------------------
 
-describe('defers (no enforcement)', () => {
-  test('no preference set → defer', () => {
+describe('passes through (no enforcement)', () => {
+  test('no preference set → no decision', () => {
     const r = runHook({
       session_id: 's1',
       tool_name: 'AskUserQuestion',
@@ -126,10 +132,10 @@ describe('defers (no enforcement)', () => {
       },
     });
     expect(r.status).toBe(0);
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 
-  test('marker missing → defer (D18)', () => {
+  test('marker missing → no decision (D18)', () => {
     writeProjectPref('test-q', 'never-ask');
     const r = runHook({
       session_id: 's2',
@@ -141,10 +147,10 @@ describe('defers (no enforcement)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 
-  test('always-ask preference → defer', () => {
+  test('always-ask preference → no decision', () => {
     writeProjectPref('test-q', 'always-ask');
     const r = runHook({
       session_id: 's3',
@@ -156,10 +162,10 @@ describe('defers (no enforcement)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 
-  test('empty stdin → defer (crash safety)', () => {
+  test('empty stdin → no decision (crash safety)', () => {
     const env: Record<string, string> = {};
     for (const [k, v] of Object.entries(process.env)) {
       if (v !== undefined) env[k] = v;
@@ -167,14 +173,15 @@ describe('defers (no enforcement)', () => {
     env.GSTACK_STATE_ROOT = stateRoot;
     const res = spawnSync(HOOK, [], { env, input: '', encoding: 'utf-8' });
     expect(res.status).toBe(0);
+    expect(res.stdout || '').toBe('');
     const parsed = JSON.parse(res.stdout || '{}');
-    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
-  test('non-AUQ tool_name → defer (defensive)', () => {
+  test('non-AUQ tool_name → no decision (defensive)', () => {
     writeProjectPref('test-q', 'never-ask');
     const r = runHook({ session_id: 's4', tool_name: 'Bash', tool_use_id: 'tu-4', tool_input: {} });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 });
 
@@ -204,7 +211,7 @@ describe('enforces never-ask preferences', () => {
     expect(r.parsed?.hookSpecificOutput?.permissionDecisionReason).toContain('Fix now');
   });
 
-  test('one-way door → defer even with never-ask (safety override)', () => {
+  test('one-way door → no decision even with never-ask (safety override)', () => {
     writeProjectPref('ship-test-failure-triage', 'never-ask');
     const r = runHook({
       session_id: 's6',
@@ -219,10 +226,10 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 
-  test('ambiguous recommendation (two labels) → defer (D2 refuse-on-ambiguous)', () => {
+  test('ambiguous recommendation (two labels) → no decision (D2 refuse-on-ambiguous)', () => {
     writeProjectPref('ship-pre-landing-review-fix', 'never-ask');
     const r = runHook({
       session_id: 's7',
@@ -237,10 +244,10 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 
-  test('no recommendation marker AND no prose match → defer', () => {
+  test('no recommendation marker AND no prose match → no decision', () => {
     writeProjectPref('ship-pre-landing-review-fix', 'never-ask');
     const r = runHook({
       session_id: 's8',
@@ -255,7 +262,7 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 });
 
@@ -301,7 +308,7 @@ describe('precedence: project wins over global (D8)', () => {
     expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('deny');
   });
 
-  test('project always-ask + global never-ask → defer (project wins)', () => {
+  test('project always-ask + global never-ask → no decision (project wins)', () => {
     writeProjectPref('ship-pre-landing-review-fix', 'always-ask');
     writeGlobalPref('ship-pre-landing-review-fix', 'never-ask');
     const r = runHook({
@@ -317,7 +324,7 @@ describe('precedence: project wins over global (D8)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 });
 
@@ -384,7 +391,7 @@ describe('Conductor prose redirect', () => {
     expect(r.parsed?.hookSpecificOutput?.permissionDecisionReason).toContain('[conductor]');
   });
 
-  test('one-way door → deny with prose directive (NOT defer — destructive must reach human via prose)', () => {
+  test('one-way door → deny with prose directive (NOT pass-through — destructive must reach human via prose)', () => {
     const r = runHook({
       session_id: 'c3',
       tool_name: 'AskUserQuestion',
@@ -437,13 +444,13 @@ describe('Conductor prose redirect', () => {
     expect(r.parsed?.hookSpecificOutput?.permissionDecisionReason).not.toContain('[conductor]');
   });
 
-  test('non-AUQ tool in Conductor → still defer (no redirect on unrelated tools)', () => {
+  test('non-AUQ tool in Conductor → still no decision (no redirect on unrelated tools)', () => {
     const r = runHook(
       { session_id: 'c6', tool_name: 'Bash', tool_use_id: 'tu-c6', tool_input: {} },
       undefined,
       CONDUCTOR,
     );
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expectNoDecision(r);
   });
 });
 

--- a/test/question-preference-hook.test.ts
+++ b/test/question-preference-hook.test.ts
@@ -173,9 +173,10 @@ describe('passes through (no enforcement)', () => {
     env.GSTACK_STATE_ROOT = stateRoot;
     const res = spawnSync(HOOK, [], { env, input: '', encoding: 'utf-8' });
     expect(res.status).toBe(0);
-    expect(res.stdout || '').toBe('');
-    const parsed = JSON.parse(res.stdout || '{}');
-    expect(parsed.hookSpecificOutput?.permissionDecision).toBeUndefined();
+    // Same shape as runHook so expectNoDecision applies (strict empty stdout).
+    let parsed: any = null;
+    try { parsed = JSON.parse(res.stdout || '{}'); } catch {}
+    expectNoDecision({ stdout: res.stdout ?? '', parsed });
   });
 
   test('non-AUQ tool_name → no decision (defensive)', () => {
@@ -349,6 +350,26 @@ describe('MCP variant', () => {
       },
     });
     expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  // Real failure shape for #2006/#2035/#2292/#2310: non-interactive MCP AUQ
+  // with no preference must be silent pass-through (not permissionDecision).
+  test('mcp__conductor__AskUserQuestion + no preference → no decision', () => {
+    const r = runHook({
+      session_id: 's12-passthrough',
+      tool_name: 'mcp__conductor__AskUserQuestion',
+      tool_use_id: 'tu-12-passthrough',
+      tool_input: {
+        questions: [
+          {
+            question: '<gstack-qid:test-q> Need approval?',
+            options: ['A) Yes (recommended)', 'B) No'],
+          },
+        ],
+      },
+    });
+    expect(r.status).toBe(0);
+    expectNoDecision(r);
   });
 });
 

--- a/test/question-preference-hook.test.ts
+++ b/test/question-preference-hook.test.ts
@@ -174,7 +174,7 @@ describe('passes through (no enforcement)', () => {
     const res = spawnSync(HOOK, [], { env, input: '', encoding: 'utf-8' });
     expect(res.status).toBe(0);
     // Crash-safety pass-through: empty stdout only (no permissionDecision).
-    expect(res.stdout ?? '').toBe('');
+    expect(res.stdout).toBe('');
   });
 
   test('non-AUQ tool_name → no decision (defensive)', () => {

--- a/test/skill-e2e-plan-tune-cathedral.test.ts
+++ b/test/skill-e2e-plan-tune-cathedral.test.ts
@@ -263,7 +263,7 @@ describeIfSelected('PlanTune cathedral E2E: annotation', ['plan-tune-annotation'
     cleanupFixture(fixture.workDir);
   });
 
-  testConcurrentIfSelected('PreToolUse hook surfaces memory nugget on defer', async () => {
+  testConcurrentIfSelected('PreToolUse hook surfaces memory nugget while passing through', async () => {
     const hookPath = path.join(
       fixture.workDir,
       'hosts',
@@ -296,7 +296,7 @@ describeIfSelected('PlanTune cathedral E2E: annotation', ['plan-tune-annotation'
     });
     expect(res.status).toBe(0);
     const parsed = JSON.parse(res.stdout || '{}');
-    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(parsed.hookSpecificOutput?.additionalContext).toContain('verbose explanations');
   });
 });


### PR DESCRIPTION
Picking up the handoff from #2165. @time-attack asked there on 2026-07-15:

> Please rewrite this version to include the accurate documentation and strict output coverage from PR 1924. Its implementation is otherwise the best current foundation.

Neither PR has moved since, so this branch does that merge. Credit belongs to @dpnascimento (#2165) and @jacksondc (#1924); every commit here carries both as co-authors. If either of them would rather carry it forward, I am happy to close this in favour of theirs.

## The bug

`hosts/claude/hooks/question-preference-hook.ts` emitted `permissionDecision: "defer"` on its no-opinion path. `defer` is a real Claude Code value meaning "pause this tool call and hand control back", and it is honored in print/non-interactive mode. So in any non-interactive session, every `AskUserQuestion` the hook did not auto-decide got parked and never executed. On my machine one such call was replayed several times across resumes, and no `tool_result` was ever written for it.

## What changed

- `defer()` becomes `passThrough()`: silent `exit 0`, or `hookSpecificOutput.additionalContext` alone when plan-tune has context to inject. No `permissionDecision` on that path.
- The `deny` paths (never-ask auto-decide, Conductor prose redirect) are untouched.
- Spike doc corrections, going a little beyond #1924: it restores the `deny > ask > allow` precedence fact that #1924 deleted outright, moves "No output" out of the `permissionDecision values:` list where it is not a value, and rewrites the Auto-decide example from the never-implemented `allow` + `updatedInput` to the `deny` + reason shape the hook actually emits.
- Tests: `expectNoDecision` (from #1924) now covers about ten pass-through cases, plus two cases #1924 lacked. One is `mcp__conductor__AskUserQuestion` with no preference, which is the exact shape the bug reports fire on. The other asserts `hookEventName === 'PreToolUse'` on the `additionalContext`-only output.

## Scope

Fixes the root cause behind #2006, #2035, #2292 and #2310.

#2207 is not fixed here. That one is the Conductor auto-install of the hook, owned by #2208. An early commit body on this branch listed #2207 among the root-cause issues; that wording was too broad, and this PR body is authoritative on claim surface.

## Verification

```
bun test test/question-preference-hook.test.ts test/memory-cache-injection.test.ts
  28 pass / 0 fail / 67 expect()      (upstream/main: 27 pass / 52 expect)

bun run test
  2 failures: spec-template-sync, session-runner observability
  Both also fail on untouched upstream/main. Zero new failures.

bun run slop:diff
  no new findings in 5 changed files
```

## Two things I could not verify

The cathedral e2e assertion never executed locally. `test/skill-e2e-plan-tune-cathedral.test.ts` is `EVALS=1`-gated. Forcing it with `EVALS_ALL=1 EVALS=1` gives 0 pass / 5 fail, because the fixture scaffold does not copy `lib/`, so the hook dies with `Cannot find module '../../../lib/is-conductor'` at `expect(res.status).toBe(0)`, before the pass-through assertion runs. That fixture gap predates this branch and is not fixed here. Gate coverage for this behaviour is the two unit test files above.

The Conductor deny reason carries a premise I could not confirm. In Conductor the hook still denies with a prose redirect whose reason cites the MCP variant being flaky. That premise was tied to the same `defer` path this PR removes, and I have not re-proven it under current Claude Code. The behaviour is deliberately unchanged, since it is out of scope, but that wording is now a historical claim this PR does not confirm.

I can rebase or reshape this however suits the review.