### PR TITLE
fix(preamble): probe gbrain engine liveness before recommending it

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -356,10 +356,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -491,10 +491,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -360,10 +360,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -360,10 +360,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -358,10 +358,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -483,10 +483,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -486,10 +486,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -487,10 +487,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -486,10 +486,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -489,10 +489,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -509,10 +509,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -490,10 +490,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -487,10 +487,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -504,10 +504,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -489,10 +489,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/diagram/SKILL.md
+++ b/diagram/SKILL.md
@@ -484,10 +484,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/document-generate/SKILL.md
+++ b/document-generate/SKILL.md
@@ -489,10 +489,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -487,10 +487,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -485,10 +485,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -524,10 +524,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/ios-clean/SKILL.md
+++ b/ios-clean/SKILL.md
@@ -487,10 +487,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/ios-design-review/SKILL.md
+++ b/ios-design-review/SKILL.md
@@ -489,10 +489,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/ios-fix/SKILL.md
+++ b/ios-fix/SKILL.md
@@ -490,10 +490,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/ios-qa/SKILL.md
+++ b/ios-qa/SKILL.md
@@ -493,10 +493,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/ios-sync/SKILL.md
+++ b/ios-sync/SKILL.md
@@ -487,10 +487,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -482,10 +482,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -483,10 +483,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -485,10 +485,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -395,10 +395,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -520,10 +520,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -482,10 +482,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -484,10 +484,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -514,10 +514,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -486,10 +486,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -492,10 +492,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -490,10 +490,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -495,10 +495,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -485,10 +485,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -491,10 +491,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -502,10 +502,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -487,10 +487,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/scrape/SKILL.md
+++ b/scrape/SKILL.md
@@ -483,10 +483,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/scripts/resolvers/preamble/generate-brain-sync-block.ts
+++ b/scripts/resolvers/preamble/generate-brain-sync-block.ts
@@ -61,10 +61,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + \`--version\` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \\\`gbrain search\\\`/\\\`gbrain query\\\` over Grep for"
       echo "semantic questions; use \\\`gbrain code-def\\\`/\\\`code-refs\\\`/\\\`code-callers\\\` for"
       echo "symbol-aware code lookup. See \\"## GBrain Search Guidance\\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \\\`gbrain search\\\`/\\\`code-def\\\`"
+        echo "this session; use Grep instead. Diagnose with \\\`gbrain doctor --fast\\\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \\\`/sync-gbrain --full\\\`"
       echo "before relying on \\\`gbrain search\\\` for code questions in this worktree."

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -354,10 +354,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -486,10 +486,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -485,10 +485,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -487,10 +487,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/skillify/SKILL.md
+++ b/skillify/SKILL.md
@@ -483,10 +483,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -484,10 +484,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -1554,10 +1573,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -485,10 +485,29 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      # Liveness probe. A config file + `--version` + a pin only prove gbrain is
+      # INSTALLED; none of them prove its engine is reachable. When the engine is
+      # down (disk full, container stopped, pooler unreachable, autopilot wedged)
+      # this block would still tell the agent to "prefer gbrain search" — so the
+      # agent keeps reaching for a tool whose every query fails, instead of
+      # falling back to Grep. One bounded probe closes that gap; the timeout
+      # keeps a hung engine from stalling the preamble of every skill.
+      _GBRAIN_ALIVE=0
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      else
+        gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
+      fi
+      if [ "$_GBRAIN_ALIVE" -eq 1 ]; then
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      else
+        echo "GBrain DOWN — this worktree is pinned, but a probe query failed, so"
+        echo "the engine is unreachable. Do NOT rely on \`gbrain search\`/\`code-def\`"
+        echo "this session; use Grep instead. Diagnose with \`gbrain doctor --fast\`."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."


### PR DESCRIPTION
## Problem

The gbrain block in the skill preamble decides whether to tell the agent "prefer `gbrain search` over Grep". Today it checks three things:

1. `~/.gbrain/config.json` exists
2. `gbrain --version` responds
3. the worktree has a `.gbrain-source` pin

All three can pass while the engine is completely unreachable — **none of them opens a connection**. They prove gbrain is *installed*, not that it *works*.

So when the engine goes down (disk full, container stopped, pooler unreachable, autopilot wedged), every skill preamble keeps printing:

> GBrain configured. Prefer `gbrain search`/`gbrain query` over Grep for semantic questions…

The agent then reaches for a tool whose every query fails, instead of falling back to Grep. Nothing errors, nothing is surfaced — the guidance actively asserts health it never verified, so the outage is silent and can persist indefinitely.

I hit exactly this: the local Postgres engine was crash-looping on a full Docker disk for well over a day. The preamble recommended gbrain the entire time.

## Fix

Add a bounded liveness probe and branch on the result:

```bash
_GBRAIN_ALIVE=0
if command -v timeout >/dev/null 2>&1; then
  timeout 5 gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
else
  gbrain sources list >/dev/null 2>&1 && _GBRAIN_ALIVE=1
fi
```

When it fails, the preamble now says so and redirects to Grep:

```
GBrain DOWN — this worktree is pinned, but a probe query failed, so
the engine is unreachable. Do NOT rely on `gbrain search`/`code-def`
this session; use Grep instead. Diagnose with `gbrain doctor --fast`.
```

Design notes:

- **Bounded.** `timeout 5` means a hung engine can't stall the preamble of every skill. Falls back to an unbounded call only where `timeout` isn't available (rare on macOS/Linux; the alternative is skipping the check entirely).
- **Engine-agnostic.** Points at `gbrain doctor --fast` rather than assuming any particular backend (PGLite / Postgres / Supabase).
- **Zero cost when gbrain isn't in play.** The probe runs only inside the existing "pin is present" branch, so non-gbrain users and unpinned worktrees are untouched.
- **Cheap.** One `sources list` per skill invocation.

## Changes

- `scripts/resolvers/preamble/generate-brain-sync-block.ts` — the actual change
- 49 generated `SKILL.md` files — regenerated via `bun run gen:skill-docs`

Insertions only; no existing lines modified.

## Verification

Tested against a genuinely stopped engine, from a pinned worktree:

| engine state | preamble output |
|---|---|
| up | normal "prefer `gbrain search`" guidance |
| **stopped** | **`GBrain DOWN` + use Grep + diagnose hint`** |
| restarted | normal guidance again |

Also confirmed the unpinned-worktree branch still prints its existing "isn't pinned yet" message and never runs the probe.
