### PR TITLE
fix(slop-diff): redirect slop-scan stdout to a file — piped capture truncates on large reports

### DIFF
--- a/scripts/slop-diff.ts
+++ b/scripts/slop-diff.ts
@@ -31,19 +31,49 @@ if (changedFiles.size === 0) {
   process.exit(0);
 }
 
+
+/**
+ * Run `npx slop-scan scan <target> --json` with stdout redirected to a temp
+ * FILE and return the report text.
+ *
+ * Why not capture the pipe: slop-scan@0.3.0 writes its report with async
+ * stdout writes and then calls process.exit(), so on a PIPED stdout the
+ * output is truncated at the first ~8KB chunk (a full-repo report is
+ * multi-MB). File writes are synchronous, so redirecting to a file yields
+ * the complete report regardless of size. Returns null when slop-scan is
+ * unavailable or produced no output.
+ */
+function runSlopScan(target: string): string | null {
+  const outFile = path.join(
+    os.tmpdir(),
+    `slop-scan-out-${process.pid}-${Date.now()}.json`,
+  );
+  const outFd = fs.openSync(outFile, "w");
+  try {
+    spawnSync("npx", ["slop-scan", "scan", target, "--json"], {
+      stdio: ["ignore", outFd, "pipe"],
+      timeout: 120000,
+      shell: process.platform === "win32",
+    });
+    fs.closeSync(outFd);
+    const raw = fs.readFileSync(outFile, "utf-8");
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  } finally {
+    fs.rmSync(outFile, { force: true });
+  }
+}
+
 // 2. Run slop-scan on HEAD
-const scanHead = spawnSync("npx", ["slop-scan", "scan", ".", "--json"], {
-  encoding: "utf-8",
-  timeout: 120000,
-  shell: process.platform === "win32",
-});
-if (!scanHead.stdout) {
+const scanHeadOut = runSlopScan(".");
+if (!scanHeadOut) {
   console.log("slop-scan not available. Install: npm i -g slop-scan");
   process.exit(0);
 }
 let headReport: any;
 try {
-  headReport = JSON.parse(scanHead.stdout);
+  headReport = JSON.parse(scanHeadOut);
 } catch {
   console.log("slop-scan returned invalid JSON.");
   process.exit(0);
@@ -86,19 +116,11 @@ if (mergeBase) {
       } catch {}
     }
 
-    const scanBase = spawnSync(
-      "npx",
-      ["slop-scan", "scan", tmpWorktree, "--json"],
-      {
-        encoding: "utf-8",
-        timeout: 120000,
-        shell: process.platform === "win32",
-      },
-    );
+    const scanBaseOut = runSlopScan(tmpWorktree);
 
-    if (scanBase.stdout) {
+    if (scanBaseOut) {
       try {
-        const baseReport = JSON.parse(scanBase.stdout);
+        const baseReport = JSON.parse(scanBaseOut);
         for (const f of baseReport.findings) {
           // Remap worktree paths back to repo-relative
           const realPath = f.path.replace(tmpWorktree + "/", "");


### PR DESCRIPTION
## Problem

`scripts/slop-diff.ts` captures `npx slop-scan scan … --json` via `spawnSync` pipes. slop-scan (0.3.0) emits its JSON report with async stdout writes and then exits without flushing, so whether the report survives depends entirely on the *consumer's* pipe-draining behavior:

| Consumer | Captured (same repo, real report = 536,666 bytes) |
|---|---|
| `bun` `spawnSync` | 536,666 bytes ✓ |
| `node` `spawnSync` (any `maxBuffer`) | **8,192 bytes** |
| shell pipe (`… --json \| wc -c`) | **65,536 bytes** |

Under `bun run slop:diff` the wrapper works today — by luck of bun's pipe implementation. Any node-based execution (running the script with `tsx`/`node`, CI runners, or ports of this wrapper into other repos) silently truncates: `JSON.parse` fails and the script reports *"slop-scan returned invalid JSON"* — or worse, the **base** scan silently parses as nothing and the diff runs against an empty baseline, marking every pre-existing finding as "new". I hit this porting the wrapper into a monorepo whose report is ~6.9 MB, where it fails 100% of the time under node.

## Fix

Both scan sites go through one `runSlopScan()` helper that redirects the child's stdout to a temp **file** (`stdio: ["ignore", fd, "pipe"]`) and reads it back. File writes are synchronous, so the full report survives regardless of size, runtime, or slop-scan's exit behavior. Temp file is removed in `finally`. No behavior change otherwise.

## Verification

- Patched wrapper on this repo: full HEAD scan + merge-base worktree scan complete; delta over the branch's changed file reports `no new findings` (this fix adds no slop).
- Same fd-redirect approach verified in a downstream port against a 6.9 MB report (previously: 8 KB truncation, 100% failure under node).

## Note

The root cause is arguably in slop-scan itself (exit before flush — worth an upstream issue there too), but this wrapper-level fix makes slop-diff robust regardless of the CLI's version or the runtime it's executed with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
