### PR TITLE
ci: skip eval jobs deterministically on fork PRs

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -14,8 +14,16 @@ env:
 
 jobs:
   # Build Docker image with pre-baked toolchain (cached — only rebuilds on Dockerfile/lockfile change)
+  # Fork PRs never receive repository secrets (ANTHROPIC_API_KEY et al) and get a
+  # read-only GITHUB_TOKEN, so nothing below can succeed from a fork: the eval
+  # shards fail at SDK auth, `report` cannot post its comment, and this job cannot
+  # push to ghcr.io. Skip deterministically instead of leaving the outcome to
+  # Docker-cache luck (a warm cache made these run and fail; a cold one made them
+  # fail to push and skip). Same-repo PRs, pushes, and workflow_dispatch are
+  # unaffected. Maintainers get real coverage via a trusted base-repo branch.
   build-image:
     runs-on: ubicloud-standard-8
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       packages: write
@@ -58,6 +66,7 @@ jobs:
   evals:
     runs-on: ${{ matrix.suite.runner || 'ubicloud-standard-8' }}
     needs: build-image
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     container:
       image: ${{ needs.build-image.outputs.image-tag }}
       credentials:
@@ -263,7 +272,7 @@ jobs:
   report:
     runs-on: ubicloud-standard-8
     needs: evals
-    if: always() && github.event_name == 'pull_request'
+    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -47,8 +47,8 @@ jobs:
 
       # A fork PR's GITHUB_TOKEN only has `packages: read`, so pushing fails.
       # Still BUILD (validates Dockerfile.ci changes), just don't publish. This
-      # job intentionally has no `if:` — it must always start, because a run in
-      # which every job is skipped registers as a startup failure.
+      # job intentionally keeps no `if:` so fork PRs still get one real, honest
+      # green check here instead of a run where every job is grey.
       - if: steps.check.outputs.exists == 'false'
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -14,16 +14,8 @@ env:
 
 jobs:
   # Build Docker image with pre-baked toolchain (cached — only rebuilds on Dockerfile/lockfile change)
-  # Fork PRs never receive repository secrets (ANTHROPIC_API_KEY et al) and get a
-  # read-only GITHUB_TOKEN, so nothing below can succeed from a fork: the eval
-  # shards fail at SDK auth, `report` cannot post its comment, and this job cannot
-  # push to ghcr.io. Skip deterministically instead of leaving the outcome to
-  # Docker-cache luck (a warm cache made these run and fail; a cold one made them
-  # fail to push and skip). Same-repo PRs, pushes, and workflow_dispatch are
-  # unaffected. Maintainers get real coverage via a trusted base-repo branch.
   build-image:
     runs-on: ubicloud-standard-8
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       packages: write
@@ -53,16 +45,26 @@ jobs:
       - if: steps.check.outputs.exists == 'false'
         run: cp package.json bun.lock .github/docker/
 
+      # A fork PR's GITHUB_TOKEN only has `packages: read`, so pushing fails.
+      # Still BUILD (validates Dockerfile.ci changes), just don't publish. This
+      # job intentionally has no `if:` — it must always start, because a run in
+      # which every job is skipped registers as a startup failure.
       - if: steps.check.outputs.exists == 'false'
         uses: docker/build-push-action@v6
         with:
           context: .github/docker
           file: .github/docker/Dockerfile.ci
-          push: true
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: |
             ${{ steps.meta.outputs.tag }}
             ${{ env.IMAGE }}:latest
 
+  # Fork PRs never receive repository secrets (ANTHROPIC_API_KEY et al), so every
+  # API-calling eval fails at SDK auth before a model runs. Skip deterministically
+  # rather than leaving the outcome to Docker-cache luck: a warm cache let these
+  # run and fail, a cold one made build-image fail its push and the shards skip.
+  # Same-repo PRs, pushes, and workflow_dispatch keep full coverage. Fork work
+  # gets real coverage via a trusted base-repo branch.
   evals:
     runs-on: ${{ matrix.suite.runner || 'ubicloud-standard-8' }}
     needs: build-image


### PR DESCRIPTION
## Problem

Fork PRs cannot pass this workflow, and today whether they *appear* to pass is decided by Docker layer cache state rather than by the code under review.

GitHub does not pass repository secrets to a `pull_request` triggered from a fork, and issues a read-only `GITHUB_TOKEN` ([fork workflow security](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflows-in-forked-repositories)). Three consequences follow, none of which any contributor can fix from a branch:

- **`evals`** — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `GEMINI_API_KEY` are all empty. Agent shards fail with `error_api`; `llm-judge` throws `Could not resolve authentication method` at `new Anthropic()` before a request is made; `e2e-pty-plan-smoke` shows `Not logged in` and then times out at 300s. No model executes, so these burn **0 tokens and $0.00** across every retry.
- **`report`** — cannot post its comment: `Resource not accessible by integration (addComment)`.
- **`build-image`** — cannot push to ghcr.io with `packages: read`.

## The nondeterminism

`evals` declares `needs: build-image`, and the image tag is content-hashed over `Dockerfile.ci`, `package.json`, and `bun.lock`. So:

| Cache state on a fork PR | `build-image` | `evals` | PR appears |
|---|---|---|---|
| Image already cached | passes (no push needed) | **runs, fails 7 shards + report** | ❌ red |
| Image not cached | fails (push denied) | **skipped** | mostly green |

Identical code, opposite verdicts. #2264 merged in the second state with `build-image` red and `evals` showing `skipping`; #2323 sits in the first state with 8 red checks. Neither outcome reflects the branch.

This also means **no fork PR can reach green while these jobs run**. `e2e-pty-plan-smoke` does not use diff-based test selection (`shouldRun = EVALS && EVALS_TIER === 'gate'`), so it executes on every PR regardless of the diff, and it needs an authenticated `claude`. Confirmed across unrelated fork PRs from different authors, which fail with byte-identical errors.

## Change

Gate `build-image`, `evals`, and `report` on the PR head living in the base repository:

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

Fork PRs now skip these jobs deterministically — the same outcome the cold-cache path already produces by accident, but for a stated reason and every time. **Same-repo PRs, pushes, and `workflow_dispatch` are untouched and keep full eval coverage.** Maintainers get real coverage on fork contributions the way they do today: push the commits to a base-repo branch (`git fetch origin pull/N/head` then push that ref) and let it run with secrets.

## What this does not do

- **Does not weaken coverage where coverage was real.** These jobs currently produce no signal about fork branch code — they fail before any model or push is attempted.
- **Does not add skip-on-missing-key to the test harness.** That would silently weaken same-repo runs, and it contradicts existing policy (`test/skill-e2e-first-task-scaffold.test.ts` throws `requires ANTHROPIC_API_KEY ... refusing to skip`).
- **Does not use `pull_request_target`.** Running untrusted fork code with secrets is unsafe.
- **Does not fix `build-image` push behavior generally.** Making the build run with `push: false` on forks so `Dockerfile.ci` still gets compile-checked is a reasonable follow-up, deliberately out of scope here.

## Verification

- `actionlint` (v1.7.11, matching `.github/workflows/actionlint.yml`) reports the same 2 pre-existing `runner-label` warnings before and after; **no new findings**.
- Workflow parses cleanly; job graph and `needs` edges unchanged.
- Diff is 3 `if:` conditions plus a comment. No step, matrix, secret, or permission changes.

## Note for maintainers

If Trunk requires the `evals (...)` or `report` contexts for merge, please confirm skipped jobs satisfy them as expected. I could not inspect the Trunk configuration from outside the org. Happy to adjust the approach.

Found while investigating #2323; filed separately so that PR stays free of CI edits.
