### PR TITLE
Fix browse daemon ownership across handoff

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -74,7 +74,8 @@ export function shouldEnableChromiumSandbox(): boolean {
 }
 
 /**
- * Resolve why the underlying Chromium ChildProcess is going away.
+ * Resolve why the underlying Chromium ChildProcess is going away when the
+ * Browser implementation exposes a process accessor.
  *
  * The 'disconnected' Playwright event fires before the child process emits
  * its own 'exit' in most cases, so .exitCode is null at that moment. Wait
@@ -82,6 +83,10 @@ export function shouldEnableChromiumSandbox(): boolean {
  *
  *   exitCode === 0 && no signal  → 'clean'  (user Cmd+Q, normal shutdown)
  *   anything else                → 'crash'  (signal-kill, SIGSEGV, OOM, non-zero exit)
+ *
+ * Playwright's public Browser API does not expose the child process. In that
+ * case return the defensive `crash` result instead of throwing inside the
+ * disconnect handler.
  *
  * Process supervisors (gbrowser's gbd HealthMonitor in cmd/gbd/health.go)
  * read our exit code to decide whether to restart. The two callers in this
@@ -91,7 +96,19 @@ export function shouldEnableChromiumSandbox(): boolean {
  * restarts on backoff.
  */
 export async function resolveDisconnectCause(browser: Browser | null): Promise<'clean' | 'crash'> {
-  const proc = browser?.process();
+  // Playwright's public Browser API does not expose process(); some embedders
+  // provide a Puppeteer-compatible accessor, so use it when available without
+  // crashing the disconnect handler for ordinary Playwright Browser objects.
+  const processAccessor = (browser as Browser & {
+    process?: () => {
+      exitCode: number | null;
+      signalCode: NodeJS.Signals | null;
+      once: (event: 'exit', listener: () => void) => unknown;
+    };
+  } | null)?.process;
+  if (typeof processAccessor !== 'function') return 'crash';
+
+  const proc = processAccessor.call(browser);
   if (proc && proc.exitCode === null && proc.signalCode === null) {
     await new Promise<void>((resolve) => {
       const timer = setTimeout(resolve, 1000);

--- a/browse/src/daemon-ownership-policy.ts
+++ b/browse/src/daemon-ownership-policy.ts
@@ -1,0 +1,18 @@
+export type TerminationAction = 'retain' | 'shutdown';
+
+export interface DaemonOwnership {
+  startedHeaded: boolean;
+  tunnelActive: boolean;
+}
+
+/**
+ * Decide whether an external lifecycle signal owns the daemon.
+ *
+ * Browser mode can change from headless to headed during `handoff`. That
+ * transition must not transfer ownership back to the already-exited one-shot
+ * CLI process. Only a daemon launched headed, or one serving an active tunnel,
+ * should shut down when its launch parent disappears or sends SIGTERM.
+ */
+export function terminationAction(ownership: DaemonOwnership): TerminationAction {
+  return ownership.startedHeaded || ownership.tunnelActive ? 'shutdown' : 'retain';
+}

--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -52,6 +52,7 @@ import { parseProxyConfig, toUpstreamConfig, ProxyConfigError } from './proxy-co
 import { redactProxyUrl } from './proxy-redact';
 import { shouldSpawnXvfb, pickFreeDisplay, spawnXvfb, xvfbInstallHint, type XvfbHandle } from './xvfb';
 import { logTunnelDenial } from './tunnel-denial-log';
+import { terminationAction } from './daemon-ownership-policy';
 import {
   mintSseSessionToken, validateSseSessionToken, extractSseCookie,
   buildSseSetCookie, SSE_COOKIE_NAME,
@@ -694,21 +695,24 @@ if (BROWSE_PARENT_PID > 0 && !IS_HEADED_WATCHDOG) {
       // 1. Active cookie picker (one-time code or session live)? Stay alive
       //    regardless of mode — tearing down the server mid-import leaves the
       //    picker UI with a stale "Failed to fetch" error.
-      // 2. Headed / tunnel mode? Shutdown. The idle timeout doesn't apply in
-      //    these modes (see idleCheckInterval above — both early-return), so
-      //    ignoring parent death here would leak orphan daemons after
-      //    /pair-agent or /open-gstack-browser sessions.
-      // 3. Normal (headless) mode? Stay alive. Claude Code's Bash tool kills
-      //    the parent shell between invocations. The idle timeout (30 min)
-      //    handles eventual cleanup.
+      // 2. Daemon launched headed, or active tunnel? Shutdown. Those lifecycles
+      //    are externally owned and the idle timeout does not apply.
+      // 3. Daemon launched headless? Stay alive, even if `handoff` later made
+      //    the browser headed. The dead one-shot CLI must not regain ownership
+      //    merely because the browser changed modes.
       if (hasActivePicker()) return;
       const headed = activeBrowserManager.getConnectionMode() === 'headed';
-      if (headed || tunnelActive) {
-        console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited in ${headed ? 'headed' : 'tunnel'} mode, shutting down`);
+      const action = terminationAction({
+        startedHeaded: IS_HEADED_WATCHDOG,
+        tunnelActive,
+      });
+      if (action === 'shutdown') {
+        console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited in ${tunnelActive ? 'tunnel' : 'headed-launch'} mode, shutting down`);
         activeShutdown?.();
       } else if (!parentGone) {
         parentGone = true;
-        console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited (server stays alive, idle timeout will clean up)`);
+        const transition = headed ? ' after handoff' : '';
+        console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited${transition} (server stays alive, idle timeout/user window will clean up)`);
       }
     }
   }, 15_000);
@@ -1361,9 +1365,11 @@ if (import.meta.main) {
   // - Normal (headless) mode: Claude Code's Bash sandbox fires SIGTERM when the
   //   parent shell exits between tool invocations. Ignoring it keeps the server
   //   alive across $B calls. Idle timeout (30 min) handles eventual cleanup.
-  // - Headed / tunnel mode: idle timeout doesn't apply in these modes. Respect
-  //   SIGTERM so external tooling (systemd, supervisord, CI) can shut cleanly
-  //   without waiting forever. Ctrl+C and /stop still work either way.
+  // - Daemon launched headed / active tunnel: idle timeout doesn't apply.
+  //   Respect SIGTERM so external tooling can shut it down cleanly.
+  // - Headless daemon promoted by `handoff`: retain the original headless
+  //   ownership policy. A short-lived agent shell must not close the user's
+  //   newly visible browser.
   // - Active cookie picker: never tear down mid-import regardless of mode —
   //   would strand the picker UI with "Failed to fetch."
   process.on('SIGTERM', () => {
@@ -1371,9 +1377,12 @@ if (import.meta.main) {
       console.log('[browse] Received SIGTERM but cookie picker is active, ignoring to avoid stranding the picker UI');
       return;
     }
-    const headed = activeBrowserManager.getConnectionMode() === 'headed';
-    if (headed || tunnelActive) {
-      console.log(`[browse] Received SIGTERM in ${headed ? 'headed' : 'tunnel'} mode, shutting down`);
+    const action = terminationAction({
+      startedHeaded: IS_HEADED_WATCHDOG,
+      tunnelActive,
+    });
+    if (action === 'shutdown') {
+      console.log(`[browse] Received SIGTERM in ${tunnelActive ? 'tunnel' : 'headed-launch'} mode, shutting down`);
       activeShutdown?.();
     } else {
       console.log('[browse] Received SIGTERM (ignoring — use /stop or Ctrl+C for intentional shutdown)');

--- a/browse/test/browser-manager-unit.test.ts
+++ b/browse/test/browser-manager-unit.test.ts
@@ -190,6 +190,11 @@ describe('resolveDisconnectCause', () => {
     const { resolveDisconnectCause } = await import('../src/browser-manager');
     expect(await resolveDisconnectCause(null)).toBe('crash');
   });
+
+  it('crash: Playwright Browser without a process accessor does not throw', async () => {
+    const { resolveDisconnectCause } = await import('../src/browser-manager');
+    expect(await resolveDisconnectCause({} as never)).toBe('crash');
+  });
 });
 
 // ─── onDisconnect exit-code propagation (regression test) ──────────

--- a/browse/test/daemon-ownership-policy.test.ts
+++ b/browse/test/daemon-ownership-policy.test.ts
@@ -1,0 +1,28 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, test } from 'bun:test';
+import { terminationAction } from '../src/daemon-ownership-policy';
+
+describe('daemon ownership across browser-mode transitions', () => {
+  test('headless launch remains alive after a later user handoff', () => {
+    expect(terminationAction({ startedHeaded: false, tunnelActive: false })).toBe('retain');
+  });
+
+  test('a daemon launched headed remains owned by external lifecycle signals', () => {
+    expect(terminationAction({ startedHeaded: true, tunnelActive: false })).toBe('shutdown');
+  });
+
+  test('an active tunnel remains owned by external lifecycle signals', () => {
+    expect(terminationAction({ startedHeaded: false, tunnelActive: true })).toBe('shutdown');
+  });
+
+  test('watchdog and SIGTERM handlers use launch ownership, not current browser mode', () => {
+    const server = fs.readFileSync(
+      path.join(import.meta.dir, '..', 'src', 'server.ts'),
+      'utf-8',
+    );
+    const calls = server.match(/terminationAction\(\{/g) || [];
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(server).not.toContain('if (headed || tunnelActive)');
+  });
+});

--- a/browse/test/watchdog.test.ts
+++ b/browse/test/watchdog.test.ts
@@ -14,8 +14,10 @@ import * as os from 'os';
 //   3. Default headless mode + parent dies: server STAYS ALIVE. The original
 //      "kill on parent death" was inverted by #994 because Claude Code's Bash
 //      sandbox kills the parent shell between every tool invocation, and #994
-//      makes browse persist across $B calls. Idle timeout (30 min) handles
-//      eventual cleanup.
+//      makes browse persist across $B calls. This launch ownership remains
+//      stable if `handoff` later changes the browser to headed mode; the dead
+//      one-shot CLI must not close the user's visible browser. Idle timeout or
+//      the user window handles eventual cleanup.
 //
 // Tunnel mode coverage (parent dies → shutdown because idle timeout doesn't
 // apply) is not covered by an automated test here — tunnelActive is a runtime


### PR DESCRIPTION
## What changed

- Keep daemon termination ownership tied to the mode it was launched in.
- Prevent a headless daemon promoted by `handoff` from shutting down when the short-lived launch CLI exits.
- Use the same ownership policy for the parent watchdog and `SIGTERM`.
- Avoid throwing when Playwright's public `Browser` object has no `process()` accessor.

## Root cause

The parent watchdog and `SIGTERM` handler derived lifecycle ownership from the browser's current mode. After `handoff` changed a headless browser to headed mode, the already-exited one-shot CLI appeared to own the now-visible browser. The next watchdog tick shut the daemon and browser down.

Separately, disconnect handling assumed a Puppeteer-style `Browser.process()` method that Playwright's public API does not provide.

## Impact

Headless-to-headed handoff remains alive until the user closes it or explicit cleanup runs. Ordinary Playwright disconnects no longer throw from the exit-classification path.

## Validation

```text
32 pass
0 fail
```

Covered by:

- `browse/test/daemon-ownership-policy.test.ts`
- `browse/test/watchdog.test.ts`
- `browse/test/browser-manager-unit.test.ts`

The original lifecycle reproduction was also repeated across the 15-second watchdog boundary: the same daemon PID and URL remained healthy after handoff.
