### PR TITLE
fix(plan-tune): stop deferring AskUserQuestion in non-interactive sessions

### DIFF
--- a/docs/spikes/claude-code-hook-mutation.md
+++ b/docs/spikes/claude-code-hook-mutation.md
@@ -107,14 +107,25 @@ required for our hook to fire there.
 ```
 
 **Pass-through (no preference, or one-way safety override):**
+
+Emit **no** `permissionDecision` — absence is "no opinion". Either write nothing to
+stdout, or emit only `additionalContext`:
 ```json
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "defer"
+    "additionalContext": "…optional…"
   }
 }
 ```
+
+> ⚠️ **Do not use `permissionDecision: "defer"` here.** (This spike originally
+> recommended it; that was wrong and shipped a real bug — see the AskUserQuestion
+> note in `~/.claude/CLAUDE.md`.) The documented set is `allow | deny | ask`.
+> `defer` is an undocumented print-mode-only value: interactive Claude Code logs
+> "defer is print-mode only" and ignores it, but non-interactive sessions (Cowork,
+> Agent SDK, `claude -p`) honor it and leave the tool_use **unresolved with no
+> result**, which the agent sees as `[Tool result missing due to internal error]`.
 
 **PostToolUse capture (always):**
 ```json

--- a/hosts/claude/hooks/question-preference-hook.ts
+++ b/hosts/claude/hooks/question-preference-hook.ts
@@ -92,13 +92,29 @@ function readStdin(): Promise<string> {
   });
 }
 
+/**
+ * Pass the tool through untouched. Emits NO `permissionDecision` — absence is
+ * the correct "no opinion" signal, and the only one that is safe in both modes.
+ *
+ * Do NOT emit `permissionDecision: 'defer'` here. It is an undocumented
+ * print-mode-only value (the documented set is allow | deny | ask): interactive
+ * Claude Code logs "defer is print-mode only" and ignores it, but a
+ * non-interactive / print session — Cowork, the Agent SDK, `claude -p` — honors
+ * it and leaves the tool_use unresolved with no result, which surfaces to the
+ * agent as "[Tool result missing due to internal error]". That made
+ * AskUserQuestion permanently dead in Cowork while looking fine in the terminal.
+ */
 function defer(additionalContext?: string): void {
-  const out: Record<string, unknown> = {
-    hookEventName: 'PreToolUse',
-    permissionDecision: 'defer',
-  };
-  if (additionalContext) out.additionalContext = additionalContext;
-  process.stdout.write(JSON.stringify({ hookSpecificOutput: out }));
+  if (additionalContext) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          additionalContext,
+        },
+      }),
+    );
+  }
   process.exit(0);
 }
 

--- a/test/memory-cache-injection.test.ts
+++ b/test/memory-cache-injection.test.ts
@@ -91,7 +91,7 @@ describe('memory injection', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toContain('verbose explanations');
   });
 
@@ -115,7 +115,7 @@ describe('memory injection', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toBeUndefined();
   });
 
@@ -219,7 +219,7 @@ describe('per-session memory cache', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toBeUndefined();
   });
 });

--- a/test/question-preference-hook.test.ts
+++ b/test/question-preference-hook.test.ts
@@ -126,7 +126,7 @@ describe('defers (no enforcement)', () => {
       },
     });
     expect(r.status).toBe(0);
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('marker missing → defer (D18)', () => {
@@ -141,7 +141,7 @@ describe('defers (no enforcement)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('always-ask preference → defer', () => {
@@ -156,7 +156,7 @@ describe('defers (no enforcement)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('empty stdin → defer (crash safety)', () => {
@@ -168,13 +168,13 @@ describe('defers (no enforcement)', () => {
     const res = spawnSync(HOOK, [], { env, input: '', encoding: 'utf-8' });
     expect(res.status).toBe(0);
     const parsed = JSON.parse(res.stdout || '{}');
-    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('non-AUQ tool_name → defer (defensive)', () => {
     writeProjectPref('test-q', 'never-ask');
     const r = runHook({ session_id: 's4', tool_name: 'Bash', tool_use_id: 'tu-4', tool_input: {} });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 
@@ -219,7 +219,7 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('ambiguous recommendation (two labels) → defer (D2 refuse-on-ambiguous)', () => {
@@ -237,7 +237,7 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('no recommendation marker AND no prose match → defer', () => {
@@ -255,7 +255,7 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 
@@ -317,7 +317,7 @@ describe('precedence: project wins over global (D8)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 
@@ -443,7 +443,7 @@ describe('Conductor prose redirect', () => {
       undefined,
       CONDUCTOR,
     );
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 

--- a/test/skill-e2e-plan-tune-cathedral.test.ts
+++ b/test/skill-e2e-plan-tune-cathedral.test.ts
@@ -296,7 +296,7 @@ describeIfSelected('PlanTune cathedral E2E: annotation', ['plan-tune-annotation'
     });
     expect(res.status).toBe(0);
     const parsed = JSON.parse(res.stdout || '{}');
-    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(parsed.hookSpecificOutput?.additionalContext).toContain('verbose explanations');
   });
 });


### PR DESCRIPTION
## Summary

The `AskUserQuestion` `PreToolUse` hook emits `permissionDecision: "defer"` on its pass-through path — no preference set, no `<gstack-qid:…>` marker, i.e. the common case. This makes `AskUserQuestion` **silently fail in every non-interactive host** while working perfectly in the terminal.

## Root cause

`defer` is an undocumented, **print-mode-only** value. The documented set is `allow | deny | ask`. From the Claude Code 2.1.216 binary:

```
- `permissionDecision` - "allow", "deny", or "ask" (PreToolUse only)
Hook … returned permissionDecision=defer in interactive mode; ignoring (defer is print-mode only)
Unknown hook permissionDecision type: … Valid types are: allow, deny, ask, defer
```

So:

| Host | Behavior |
|---|---|
| Interactive terminal | Value parsed, warning logged, **ignored** → tool works |
| Non-interactive (Cowork, Agent SDK, `claude -p`) | Value **honored** → tool_use left unresolved, no result |

In the non-interactive case the agent receives `[Tool result missing due to internal error]` and the question never reaches the user.

The failure mode is nasty precisely because it's mode-split: 100% broken in one host, 100% fine in another. That reads as flaky transport, so it gets misattributed to the platform rather than the hook. It also defeats the existing `auq-error-fallback-hook` mitigation, since a deferred tool never produces the error response that hook keys on.

## Fix

Emit **no** `permissionDecision` on pass-through. Absence is the correct "no opinion" signal and the only form that is safe in both modes.

Unchanged:
- `additionalContext` (plan-tune memory injection) still emitted when present.
- The `deny` paths — `never-ask` auto-decide and the Conductor prose redirect — are untouched.

Also corrects `docs/spikes/claude-code-hook-mutation.md`, which documented `defer` as *the* pass-through shape. That's where the bug originated, so leaving it would re-seed the regression.

## Testing

- **89 pass / 0 fail** across the 7 `AskUserQuestion` hook test files.
- Updated 11 assertions across 3 test files that pinned the old `defer` contract; they now assert absence.
- Verified live: `AskUserQuestion` confirmed working in a Cowork session where it had consistently returned no result.
- The 5 `skill-e2e-plan-tune-cathedral` eval scenarios fail identically on `main` and on this branch (pre-existing, unrelated — per the repo's E2E blame protocol).

Health check — empty stdout is correct:

```bash
echo '{"hook_event_name":"PreToolUse","tool_name":"AskUserQuestion","tool_input":{"questions":[]}}' \
  | hosts/claude/hooks/question-preference-hook
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
