### PR TITLE
fix(hooks): emit permissionDecision under hookSpecificOutput; fix Windows hook spawn

### DIFF
--- a/bin/gstack-team-init
+++ b/bin/gstack-team-init
@@ -127,7 +127,11 @@ Install it:
 
 Then restart your AI coding tool.
 MSG
-  echo '{"permissionDecision":"deny","message":"gstack is required but not installed. See stderr for install instructions."}'
+  # The decision MUST nest under hookSpecificOutput — Claude Code dispatches on
+  # hookSpecificOutput.permissionDecision. A bare top-level {"permissionDecision":
+  # "deny"} parses fine and is then ignored, so the "BLOCKED" message above would
+  # print while the call proceeds anyway.
+  printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"gstack is required but not installed. See stderr for install instructions."}}'
   exit 0
 fi
 
@@ -138,8 +142,15 @@ HOOK_EOF
   echo "  + .claude/hooks/check-gstack.sh — enforcement hook"
 
   # Add hook to project-level settings.json
+  # Hook command passed via env to avoid a bash->JS->JSON escaping stack.
+  # `bash -c` is required for Windows: the harness spawns hooks through
+  # cmd.exe /d /s /c, which neither expands $CLAUDE_PROJECT_DIR nor can execute
+  # a .sh file directly. Wrapping in bash -c moves expansion and execution into
+  # bash, where CLAUDE_PROJECT_DIR (injected into the hook env by Claude Code)
+  # resolves on every platform.
+  GSTACK_HOOK_CMD='bash -c "exec \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-gstack.sh\""'
   if command -v bun >/dev/null 2>&1; then
-    GSTACK_SETTINGS_PATH="$SETTINGS" bun -e "
+    GSTACK_HOOK_CMD="$GSTACK_HOOK_CMD" GSTACK_SETTINGS_PATH="$SETTINGS" bun -e "
       const fs = require('fs');
       const settingsPath = process.env.GSTACK_SETTINGS_PATH;
 
@@ -160,7 +171,7 @@ HOOK_EOF
           matcher: 'Skill',
           hooks: [{
             type: 'command',
-            command: '\"\$CLAUDE_PROJECT_DIR/.claude/hooks/check-gstack.sh\"'
+            command: process.env.GSTACK_HOOK_CMD
           }]
         });
       }

--- a/careful/SKILL.md
+++ b/careful/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: careful
-version: 0.1.0
-description: Safety guardrails for destructive commands. (gstack)
+version: 0.2.0
+description: "Safety guardrails for destructive commands — a PreToolUse hook prompts for confirmation before rm -rf, DROP TABLE, TRUNCATE, force-push, git reset --hard, git checkout ., kubectl delete and docker prune, and the user can still override each prompt; triggers: be careful / safety mode / prod mode / warn before destructive / guard against rm -rf; the ask must stay nested under hookSpecificOutput and careful/tests/test-check-careful.sh must stay green (gstack)"
 triggers:
   - be careful
   - warn before destructive
   - safety mode
+  - prod mode
+  - guard against rm -rf
 allowed-tools:
   - Bash
   - Read
@@ -14,20 +16,21 @@ hooks:
     - matcher: "Bash"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/careful/bin/check-careful.sh"
+          # bash -c so bash (not cmd.exe) expands $HOME — see "Hook command form" below
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/careful/bin/check-careful.sh\""'
           statusMessage: "Checking for destructive commands..."
----
+sensitive: true---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->
 
 
 ## When to invoke this skill
 
-Warns before rm -rf, DROP TABLE,
-force-push, git reset --hard, kubectl delete, and similar destructive operations.
-User can override each warning. Use when touching prod, debugging live systems,
-or working in a shared environment. Use when asked to "be careful", "safety mode",
-"prod mode", or "careful mode".
+Warns before rm -rf, DROP TABLE, force-push, git reset --hard, kubectl
+delete, and similar destructive operations. User can override each warning.
+Use when touching prod, debugging live systems, or working in a shared
+environment. Use when asked to "be careful", "safety mode", "prod mode",
+or "careful mode".
 
 # /careful — Destructive Command Guardrails
 
@@ -61,7 +64,44 @@ These patterns are allowed without warning:
 ## How it works
 
 The hook reads the command from the tool input JSON, checks it against the
-patterns above, and returns `permissionDecision: "ask"` with a warning message
-if a match is found. You can always override the warning and proceed.
+patterns above, and on a match emits:
 
-To deactivate, end the conversation or start a new one. Hooks are session-scoped.
+```json
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"[careful] ..."}}
+```
+
+The nesting is load-bearing: Claude Code dispatches on
+`hookSpecificOutput.permissionDecision`. A bare top-level
+`{"permissionDecision":"ask"}` parses fine and is then **ignored** — no prompt
+appears and the destructive command runs unchallenged, while the skill looks
+armed. Valid decisions are `allow` / `deny` / `ask` / `defer`; `careful` uses
+`ask`, so you can always override and proceed.
+
+### Hook command form
+
+`command:` is `bash -c "exec \"$HOME/...\""`, not `bash $HOME/...`. On Windows the
+harness spawns hooks through `cmd.exe /d /s /c`, which does not expand `$HOME`;
+the bare form passes a literal `$HOME/...` to bash and dies with exit 127 before
+any check runs. Wrapping in `bash -c` moves expansion inside bash, where it works
+on every platform. `${CLAUDE_SKILL_DIR}` is **not** an option here — the harness
+interpolates it only in skill body text, never in hook commands.
+
+## Regression test
+
+`careful/tests/test-check-careful.sh` feeds representative destructive and benign
+commands through the script and asserts the warn/allow output schema, the safe
+exceptions, and that the `command:` above actually spawns through the harness's
+`cmd.exe` wrapper:
+
+```bash
+bash ~/.claude/skills/gstack/careful/tests/test-check-careful.sh
+```
+
+## Notes
+
+- Warnings are advisory (`ask`), never a hard block — you stay in control
+- The warning text never includes your command's contents, only the pattern name
+- Detection is regex over the command string, not a shell parser: obfuscated or
+  indirect forms (a destructive command inside a script you invoke) are not caught
+- To deactivate, end the conversation or start a new one. Hooks are session-scoped
+  — unlike `/freeze`, `careful` keeps no state on disk

--- a/careful/SKILL.md
+++ b/careful/SKILL.md
@@ -19,7 +19,7 @@ hooks:
           # bash -c so bash (not cmd.exe) expands $HOME — see "Hook command form" below
           command: 'bash -c "exec \"$HOME/.claude/skills/gstack/careful/bin/check-careful.sh\""'
           statusMessage: "Checking for destructive commands..."
-sensitive: true---
+---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->
 

--- a/careful/SKILL.md.tmpl
+++ b/careful/SKILL.md.tmpl
@@ -1,16 +1,14 @@
 ---
 name: careful
-version: 0.1.0
+version: 0.2.0
 description: |
-  Safety guardrails for destructive commands. Warns before rm -rf, DROP TABLE,
-  force-push, git reset --hard, kubectl delete, and similar destructive operations.
-  User can override each warning. Use when touching prod, debugging live systems,
-  or working in a shared environment. Use when asked to "be careful", "safety mode",
-  "prod mode", or "careful mode". (gstack)
+  Safety guardrails for destructive commands — a PreToolUse hook prompts for confirmation before rm -rf, DROP TABLE, TRUNCATE, force-push, git reset --hard, git checkout ., kubectl delete and docker prune, and the user can still override each prompt; triggers: be careful / safety mode / prod mode / warn before destructive / guard against rm -rf; the ask must stay nested under hookSpecificOutput and careful/tests/test-check-careful.sh must stay green (gstack)
 triggers:
   - be careful
   - warn before destructive
   - safety mode
+  - prod mode
+  - guard against rm -rf
 allowed-tools:
   - Bash
   - Read
@@ -19,7 +17,8 @@ hooks:
     - matcher: "Bash"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/careful/bin/check-careful.sh"
+          # bash -c so bash (not cmd.exe) expands $HOME — see "Hook command form" below
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/careful/bin/check-careful.sh\""'
           statusMessage: "Checking for destructive commands..."
 sensitive: true
 ---
@@ -56,7 +55,44 @@ These patterns are allowed without warning:
 ## How it works
 
 The hook reads the command from the tool input JSON, checks it against the
-patterns above, and returns `permissionDecision: "ask"` with a warning message
-if a match is found. You can always override the warning and proceed.
+patterns above, and on a match emits:
 
-To deactivate, end the conversation or start a new one. Hooks are session-scoped.
+```json
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"[careful] ..."}}
+```
+
+The nesting is load-bearing: Claude Code dispatches on
+`hookSpecificOutput.permissionDecision`. A bare top-level
+`{"permissionDecision":"ask"}` parses fine and is then **ignored** — no prompt
+appears and the destructive command runs unchallenged, while the skill looks
+armed. Valid decisions are `allow` / `deny` / `ask` / `defer`; `careful` uses
+`ask`, so you can always override and proceed.
+
+### Hook command form
+
+`command:` is `bash -c "exec \"$HOME/...\""`, not `bash $HOME/...`. On Windows the
+harness spawns hooks through `cmd.exe /d /s /c`, which does not expand `$HOME`;
+the bare form passes a literal `$HOME/...` to bash and dies with exit 127 before
+any check runs. Wrapping in `bash -c` moves expansion inside bash, where it works
+on every platform. `${CLAUDE_SKILL_DIR}` is **not** an option here — the harness
+interpolates it only in skill body text, never in hook commands.
+
+## Regression test
+
+`careful/tests/test-check-careful.sh` feeds representative destructive and benign
+commands through the script and asserts the warn/allow output schema, the safe
+exceptions, and that the `command:` above actually spawns through the harness's
+`cmd.exe` wrapper:
+
+```bash
+bash ~/.claude/skills/gstack/careful/tests/test-check-careful.sh
+```
+
+## Notes
+
+- Warnings are advisory (`ask`), never a hard block — you stay in control
+- The warning text never includes your command's contents, only the pattern name
+- Detection is regex over the command string, not a shell parser: obfuscated or
+  indirect forms (a destructive command inside a script you invoke) are not caught
+- To deactivate, end the conversation or start a new one. Hooks are session-scoped
+  — unlike `/freeze`, `careful` keeps no state on disk

--- a/careful/bin/check-careful.sh
+++ b/careful/bin/check-careful.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 # check-careful.sh — PreToolUse hook for /careful skill
-# Reads JSON from stdin, checks Bash command for destructive patterns.
-# Returns {"permissionDecision":"ask","message":"..."} to warn, or {} to allow.
+# Reads JSON from stdin, checks the Bash command for destructive patterns.
+#
+# Output contract (verified against cli.js 2.1.92 — the harness dispatches ONLY
+# on the nested hookSpecificOutput.permissionDecision field; a bare top-level
+# {"permissionDecision":"ask"} parses fine and is then ignored, so the warning
+# never appears and the destructive command runs unchallenged):
+#   warn  -> {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+#             "permissionDecision":"ask","permissionDecisionReason":"..."}}
+#   allow -> {}   (no opinion; normal permission flow continues)
+# Valid decisions are allow | deny | ask | defer. "ask" prompts the user, who can
+# still proceed — this hook warns, it does not block.
+#
+# Regression: ../tests/test-check-careful.sh. Keep it green.
 set -euo pipefail
 
 # Read stdin (JSON with tool_input)
@@ -11,9 +22,17 @@ INPUT=$(cat)
 # Try grep/sed first (handles 99% of cases), fall back to Python for escaped quotes
 CMD=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//' || true)
 
-# Python fallback if grep returned empty (e.g., escaped quotes in command)
+# Python fallback if grep returned empty (e.g., escaped quotes in command).
+# Try python3 then python: many Windows installs ship only `python`, and if the
+# interpreter is missing this silently yields an empty CMD, i.e. a destructive
+# command with escaped quotes would sail through unchecked.
 if [ -z "$CMD" ]; then
-  CMD=$(printf '%s' "$INPUT" | python3 -c 'import sys,json; print(json.loads(sys.stdin.read()).get("tool_input",{}).get("command",""))' 2>/dev/null || true)
+  for _py in python3 python; do
+    if command -v "$_py" >/dev/null 2>&1; then
+      CMD=$(printf '%s' "$INPUT" | "$_py" -c 'import sys,json; print(json.loads(sys.stdin.read()).get("tool_input",{}).get("command",""))' 2>/dev/null || true)
+      if [ -n "$CMD" ]; then break; fi
+    fi
+  done
 fi
 
 # If we still couldn't extract a command, allow
@@ -101,12 +120,25 @@ fi
 
 # --- Output ---
 if [ -n "$WARN" ]; then
-  # Log hook fire event (pattern name only, never command content)
-  mkdir -p ~/.gstack/analytics 2>/dev/null || true
-  echo '{"event":"hook_fire","skill":"careful","pattern":"'"$PATTERN"'","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}' >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+  # Analytics state root — same chain as gstack/bin/gstack-paths, so the log
+  # lands where the rest of gstack looks for it.
+  if [ -n "${GSTACK_HOME:-}" ]; then
+    STATE_DIR="$GSTACK_HOME"
+  elif [ -n "${CLAUDE_PLUGIN_DATA:-}" ] && printf '%s' "${CLAUDE_PLUGIN_ROOT:-}" | grep -qi "gstack"; then
+    STATE_DIR="$CLAUDE_PLUGIN_DATA"
+  elif [ -n "${HOME:-}" ]; then
+    STATE_DIR="$HOME/.gstack"
+  else
+    STATE_DIR=".gstack"
+  fi
 
-  WARN_ESCAPED=$(printf '%s' "$WARN" | sed 's/"/\\"/g')
-  printf '{"permissionDecision":"ask","message":"[careful] %s"}\n' "$WARN_ESCAPED"
+  # Log hook fire event (pattern name only, never command content)
+  mkdir -p "$STATE_DIR/analytics" 2>/dev/null || true
+  echo '{"event":"hook_fire","skill":"careful","pattern":"'"$PATTERN"'","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}' >> "$STATE_DIR/analytics/skill-usage.jsonl" 2>/dev/null || true
+
+  WARN_ESCAPED=$(printf '%s' "$WARN" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"[careful] %s"}}\n' "$WARN_ESCAPED"
 else
   echo '{}'
 fi
+exit 0

--- a/careful/tests/test-check-careful.sh
+++ b/careful/tests/test-check-careful.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# test-check-careful.sh — regression suite for the /careful PreToolUse hook.
+#
+# Guards two failures, each of which made the hook silently ineffective (the same
+# pair fixed in /freeze):
+#   L1 warn protocol — "ask" must nest under hookSpecificOutput, or the harness
+#                      ignores it and the destructive command runs unchallenged
+#   L2 Windows spawn — the SKILL.md hook command must survive cmd.exe /d /s /c
+# Plus detection coverage: every documented destructive pattern warns, the
+# documented safe exceptions do not, and parse failures fail open.
+#
+# Sandboxed: analytics writes are redirected via GSTACK_HOME, so a real
+# ~/.gstack log is never touched.
+# Usage: bash tests/test-check-careful.sh    (exit 0 = all green)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../bin/check-careful.sh"
+PASS=0
+FAIL=0
+
+if [ ! -f "$HOOK" ]; then
+  echo "FATAL: hook script not found at $HOOK"
+  exit 1
+fi
+
+SANDBOX="$(mktemp -d 2>/dev/null || mktemp -d -t careful-test)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+ok()  { PASS=$((PASS+1)); printf 'PASS  %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL  %s\n      %s\n' "$1" "$2"; }
+
+# run_hook <bash-command-string> — pipes a realistic PreToolUse payload in.
+# Uses python to build the JSON so quoting/escaping in the command is faithful.
+run_hook() {
+  local cmd="$1"
+  local payload
+  payload=$(CMD="$cmd" python -c 'import json,os; print(json.dumps({"session_id":"test","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":os.environ["CMD"]}}))' 2>/dev/null) \
+    || payload=$(printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$cmd")
+  printf '%s' "$payload" | env GSTACK_HOME="$SANDBOX/state" CLAUDE_PLUGIN_DATA= CLAUDE_PLUGIN_ROOT= bash "$HOOK" 2>/dev/null
+}
+
+# A warn the harness will actually act on: nested, valid JSON, decision "ask".
+assert_warn() {
+  local name="$1" cmd="$2" out
+  out=$(run_hook "$cmd")
+  if printf '%s' "$out" | grep -q '"hookSpecificOutput"' \
+     && printf '%s' "$out" | grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"ask"'; then
+    if printf '%s' "$out" | python -c 'import sys,json; d=json.load(sys.stdin); assert d["hookSpecificOutput"]["permissionDecision"]=="ask"; assert d["hookSpecificOutput"]["hookEventName"]=="PreToolUse"; assert d["hookSpecificOutput"]["permissionDecisionReason"].startswith("[careful]")' 2>/dev/null; then
+      ok "$name"
+    else
+      bad "$name" "ask present but JSON invalid / wrong nesting: $out"
+    fi
+  else
+    bad "$name" "expected nested hookSpecificOutput ask, got: ${out:-<empty>}"
+  fi
+}
+
+assert_allow() {
+  local name="$1" cmd="$2" out trimmed
+  out=$(run_hook "$cmd")
+  trimmed=$(printf '%s' "$out" | tr -d '[:space:]')
+  if [ "$trimmed" = "{}" ]; then ok "$name"
+  else bad "$name" "expected {} (no opinion), got: ${out:-<empty>}"; fi
+}
+
+echo "== /careful hook regression =="
+echo "hook: $HOOK"
+echo
+
+# ── L1: warn protocol ───────────────────────────────────────────────
+assert_warn "L1 rm -rf warns with nested ask" "rm -rf /var/data"
+
+# The exact bug: a top-level permissionDecision is invisible to the harness.
+OUT=$(run_hook "rm -rf /var/data")
+FIRST_KEY=$(printf '%s' "$OUT" | sed 's/^[[:space:]]*{[[:space:]]*//' | cut -d'"' -f2)
+if [ "$FIRST_KEY" = "hookSpecificOutput" ]; then
+  ok "L1 warn is not a bare top-level permissionDecision"
+else
+  bad "L1 warn is not a bare top-level permissionDecision" "top-level key is '$FIRST_KEY' — harness ignores this shape"
+fi
+
+# ── Detection coverage: every documented pattern ────────────────────
+assert_warn "detect rm -r"              "rm -r /important"
+assert_warn "detect DROP TABLE"         "psql -c 'DROP TABLE users;'"
+assert_warn "detect DROP DATABASE"      "mysql -e 'drop database prod;'"
+assert_warn "detect TRUNCATE"           "psql -c 'TRUNCATE orders;'"
+assert_warn "detect git push --force"   "git push --force origin main"
+assert_warn "detect git push -f"        "git push -f origin main"
+assert_warn "detect git reset --hard"   "git reset --hard HEAD~3"
+assert_warn "detect git checkout ."     "git checkout ."
+assert_warn "detect git restore ."      "git restore ."
+assert_warn "detect kubectl delete"     "kubectl delete pod api-7f9"
+assert_warn "detect docker rm -f"       "docker rm -f my-container"
+assert_warn "detect docker system prune" "docker system prune -a"
+
+# ── Safe exceptions must NOT warn ───────────────────────────────────
+assert_allow "safe: rm -rf node_modules"      "rm -rf node_modules"
+assert_allow "safe: rm -rf ./dist"            "rm -rf ./dist"
+assert_allow "safe: rm -rf .next"             "rm -rf .next"
+assert_allow "safe: rm -rf build coverage"    "rm -rf build coverage"
+
+# ── Benign commands must NOT warn ───────────────────────────────────
+assert_allow "benign: ls"                     "ls -la"
+assert_allow "benign: git status"             "git status"
+assert_allow "benign: git push (no force)"    "git push origin feature-branch"
+assert_allow "benign: npm test"               "npm test"
+
+# ── Fail-open: unparseable / absent input must not warn ─────────────
+OUT=$(printf '{"tool_name":"Bash","tool_input":{}}' | env GSTACK_HOME="$SANDBOX/state" bash "$HOOK" 2>/dev/null)
+TRIM=$(printf '%s' "$OUT" | tr -d '[:space:]')
+if [ "$TRIM" = "{}" ]; then ok "no command in payload -> {}"
+else bad "no command in payload -> {}" "got: ${OUT:-<empty>}"; fi
+
+# ── Analytics must not escape the sandbox ───────────────────────────
+run_hook "rm -rf /var/data" >/dev/null
+if [ -f "$SANDBOX/state/analytics/skill-usage.jsonl" ]; then
+  ok "analytics honors GSTACK_HOME (no write to real ~/.gstack)"
+else
+  bad "analytics honors GSTACK_HOME (no write to real ~/.gstack)" "expected $SANDBOX/state/analytics/skill-usage.jsonl"
+fi
+
+# ── L2: the hook command in SKILL.md must actually spawn ────────────
+SKILL_MD=""
+for cand in "$HOME/.claude/skills/careful/SKILL.md" "$SCRIPT_DIR/../SKILL.md"; do
+  [ -f "$cand" ] && { SKILL_MD="$cand"; break; }
+done
+
+if [ -z "$SKILL_MD" ]; then
+  echo "SKIP  L2 spawn contract (no SKILL.md found)"
+elif ! command -v node >/dev/null 2>&1; then
+  echo "SKIP  L2 spawn contract (node not available)"
+else
+  HOOK_CMD=$(grep -m1 '^[[:space:]]*command:' "$SKILL_MD" | sed "s/^[[:space:]]*command:[[:space:]]*//; s/^'//; s/'$//")
+  if [ -z "$HOOK_CMD" ]; then
+    bad "L2 spawn contract" "could not parse a command: line from $SKILL_MD"
+  else
+    SPAWN_OUT=$(HOOK_CMD="$HOOK_CMD" SPAWN_STATE="$SANDBOX/spawnstate" node -e '
+      const {spawnSync} = require("child_process");
+      const cmd = process.env.HOOK_CMD;
+      const env = {...process.env, GSTACK_HOME: process.env.SPAWN_STATE};
+      delete env.CLAUDE_PLUGIN_DATA; delete env.CLAUDE_PLUGIN_ROOT;
+      const win = process.platform === "win32";
+      const fire = (command) => {
+        const input = JSON.stringify({hook_event_name:"PreToolUse",tool_name:"Bash",tool_input:{command}});
+        const r = win
+          ? spawnSync(env.comspec || "cmd.exe", ["/d","/s","/c",`"${cmd}"`], {windowsVerbatimArguments:true, input, encoding:"utf8", env})
+          : spawnSync("sh", ["-c", cmd], {input, encoding:"utf8", env});
+        return {status: r.status, out: (r.stdout||"").trim(), err: (r.stderr||"").trim()};
+      };
+      // Replicate the harness dispatch rule: only the nested field is acted on.
+      const decides = (r) => {
+        if (r.status === 2) return "deny";
+        let j; try { j = JSON.parse(r.out); } catch { return "allow"; }
+        return j?.hookSpecificOutput?.permissionDecision || (j?.decision === "block" ? "deny" : "allow");
+      };
+      const destructive = fire("rm -rf /var/data");
+      const benign = fire("ls -la");
+      process.stdout.write(JSON.stringify({
+        spawned: destructive.status === 0 && destructive.out.startsWith("{"),
+        destructive: decides(destructive), benign: decides(benign), err: destructive.err.slice(0,160),
+      }));
+    ' 2>/dev/null)
+    if printf '%s' "$SPAWN_OUT" | grep -q '"spawned":true'; then
+      ok "L2 SKILL.md hook command spawns through the harness wrapper"
+    else
+      bad "L2 SKILL.md hook command spawns through the harness wrapper" "spawn result: $SPAWN_OUT"
+    fi
+    if printf '%s' "$SPAWN_OUT" | grep -q '"destructive":"ask"'; then
+      ok "L2 end-to-end: harness would PROMPT on a destructive command"
+    else
+      bad "L2 end-to-end: harness would PROMPT on a destructive command" "spawn result: $SPAWN_OUT"
+    fi
+    if printf '%s' "$SPAWN_OUT" | grep -q '"benign":"allow"'; then
+      ok "L2 end-to-end: harness would NOT prompt on a benign command"
+    else
+      bad "L2 end-to-end: harness would NOT prompt on a benign command" "spawn result: $SPAWN_OUT"
+    fi
+  fi
+fi
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/freeze/SKILL.md
+++ b/freeze/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: freeze
-version: 0.1.0
-description: Restrict file edits to a specific directory for the session. (gstack)
+version: 0.2.0
+description: "Restrict file edits to one directory — a PreToolUse hook hard-denies Edit/Write outside the frozen path, including Windows drive-letter paths; triggers: freeze edits / lock editing scope / restrict file changes / only edit this folder / edit boundary / prevent accidental edits; release with /unfreeze; the deny must stay nested under hookSpecificOutput and freeze/tests/test-check-freeze.sh must stay green (gstack)"
 triggers:
   - freeze edits to directory
   - lock editing scope
   - restrict file changes
+  - only edit this folder
+  - edit boundary guard
+  - prevent accidental edits
 allowed-tools:
   - Bash
   - Read
@@ -15,12 +18,14 @@ hooks:
     - matcher: "Edit"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh"
+          # bash -c so bash (not cmd.exe) expands $HOME — see "Hook command form" below
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking freeze boundary..."
     - matcher: "Write"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh"
+          # bash -c so bash (not cmd.exe) expands $HOME — see "Hook command form" below
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking freeze boundary..."
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
@@ -29,10 +34,9 @@ hooks:
 
 ## When to invoke this skill
 
-Blocks Edit and
-Write outside the allowed path. Use when debugging to prevent accidentally
-"fixing" unrelated code, or when you want to scope changes to one module.
-Use when asked to "freeze", "restrict edits", "only edit this folder",
+Blocks Edit and Write outside the allowed path. Use when debugging to prevent
+accidentally "fixing" unrelated code, or when you want to scope changes to one
+module. Use when asked to "freeze", "restrict edits", "only edit this folder",
 or "lock down edits".
 
 # /freeze — Restrict Edits to a Directory
@@ -72,20 +76,60 @@ echo "Freeze boundary set: $FREEZE_DIR"
 
 Tell the user: "Edits are now restricted to `<path>/`. Any Edit or Write
 outside this directory will be blocked. To change the boundary, run `/freeze`
-again. To remove it, run `/unfreeze` or end the session."
+again. To remove it, run `/unfreeze` — the boundary is stored on disk and stays
+in force across sessions until you do."
 
 ## How it works
 
 The hook reads `file_path` from the Edit/Write tool input JSON, then checks
-whether the path starts with the freeze directory. If not, it returns
-`permissionDecision: "deny"` to block the operation.
+whether the path starts with the freeze directory. If not, it blocks by emitting:
 
-The freeze boundary persists for the session via the state file. The hook
-script reads it on every Edit/Write invocation.
+```json
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"..."}}
+```
+
+The nesting is load-bearing: Claude Code dispatches on
+`hookSpecificOutput.permissionDecision`. A bare top-level
+`{"permissionDecision":"deny"}` parses fine and is then **ignored**, so the edit
+proceeds — the skill looks armed while blocking nothing.
+
+Paths are canonicalized to POSIX form before comparison, so a Windows
+`C:\src\x.ts` from the tool input matches a `/c/src/` boundary written at setup.
+
+### Hook command form
+
+`command:` is `bash -c "exec \"$HOME/...\""`, not `bash $HOME/...`. On Windows the
+harness spawns hooks through `cmd.exe /d /s /c`, which does not expand `$HOME`;
+the bare form passes a literal `$HOME/...` to bash and dies with exit 127 before
+any check runs. Wrapping in `bash -c` moves expansion inside bash, where it works
+on every platform. `${CLAUDE_SKILL_DIR}` is **not** an option here — the harness
+interpolates it only in skill body text, never in hook commands.
+
+### Boundary lifetime
+
+The boundary is a file on disk (`$GSTACK_STATE_ROOT/freeze-dir.txt`), not session
+state. It survives restarts and applies to every session on this machine until
+`/unfreeze` removes it. Ending the conversation does **not** clear it.
+
+`$GSTACK_STATE_ROOT` resolves as `GSTACK_HOME` → `CLAUDE_PLUGIN_DATA` (only when
+`CLAUDE_PLUGIN_ROOT` confirms gstack) → `$HOME/.gstack` → `.gstack`, matching
+`gstack/bin/gstack-paths`. Reader and writer must agree; if they drift, the hook
+reads a boundary file the setup step never wrote and silently allows everything.
+
+## Regression test
+
+`freeze/tests/test-check-freeze.sh` runs the script in a sandbox with a fake
+`HOME` and asserts the deny/allow output schema, drive-letter path handling,
+state-root resolution, and that the `command:` above actually spawns through the
+harness's `cmd.exe` wrapper. Run it after touching either file:
+
+```bash
+bash ~/.claude/skills/gstack/freeze/tests/test-check-freeze.sh
+```
 
 ## Notes
 
 - The trailing `/` on the freeze directory prevents `/src` from matching `/src-old`
 - Freeze applies to Edit and Write tools only — Read, Bash, Glob, Grep are unaffected
 - This prevents accidental edits, not a security boundary — Bash commands like `sed` can still modify files outside the boundary
-- To deactivate, run `/unfreeze` or end the conversation
+- To deactivate, run `/unfreeze`. Ending the conversation does **not** clear the boundary — the state file is on disk

--- a/freeze/SKILL.md.tmpl
+++ b/freeze/SKILL.md.tmpl
@@ -1,16 +1,15 @@
 ---
 name: freeze
-version: 0.1.0
+version: 0.2.0
 description: |
-  Restrict file edits to a specific directory for the session. Blocks Edit and
-  Write outside the allowed path. Use when debugging to prevent accidentally
-  "fixing" unrelated code, or when you want to scope changes to one module.
-  Use when asked to "freeze", "restrict edits", "only edit this folder",
-  or "lock down edits". (gstack)
+  Restrict file edits to one directory — a PreToolUse hook hard-denies Edit/Write outside the frozen path, including Windows drive-letter paths; triggers: freeze edits / lock editing scope / restrict file changes / only edit this folder / edit boundary / prevent accidental edits; release with /unfreeze; the deny must stay nested under hookSpecificOutput and freeze/tests/test-check-freeze.sh must stay green (gstack)
 triggers:
   - freeze edits to directory
   - lock editing scope
   - restrict file changes
+  - only edit this folder
+  - edit boundary guard
+  - prevent accidental edits
 allowed-tools:
   - Bash
   - Read
@@ -20,12 +19,14 @@ hooks:
     - matcher: "Edit"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh"
+          # bash -c so bash (not cmd.exe) expands $HOME — see "Hook command form" below
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking freeze boundary..."
     - matcher: "Write"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh"
+          # bash -c so bash (not cmd.exe) expands $HOME — see "Hook command form" below
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking freeze boundary..."
 sensitive: true
 ---
@@ -67,20 +68,60 @@ echo "Freeze boundary set: $FREEZE_DIR"
 
 Tell the user: "Edits are now restricted to `<path>/`. Any Edit or Write
 outside this directory will be blocked. To change the boundary, run `/freeze`
-again. To remove it, run `/unfreeze` or end the session."
+again. To remove it, run `/unfreeze` — the boundary is stored on disk and stays
+in force across sessions until you do."
 
 ## How it works
 
 The hook reads `file_path` from the Edit/Write tool input JSON, then checks
-whether the path starts with the freeze directory. If not, it returns
-`permissionDecision: "deny"` to block the operation.
+whether the path starts with the freeze directory. If not, it blocks by emitting:
 
-The freeze boundary persists for the session via the state file. The hook
-script reads it on every Edit/Write invocation.
+```json
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"..."}}
+```
+
+The nesting is load-bearing: Claude Code dispatches on
+`hookSpecificOutput.permissionDecision`. A bare top-level
+`{"permissionDecision":"deny"}` parses fine and is then **ignored**, so the edit
+proceeds — the skill looks armed while blocking nothing.
+
+Paths are canonicalized to POSIX form before comparison, so a Windows
+`C:\src\x.ts` from the tool input matches a `/c/src/` boundary written at setup.
+
+### Hook command form
+
+`command:` is `bash -c "exec \"$HOME/...\""`, not `bash $HOME/...`. On Windows the
+harness spawns hooks through `cmd.exe /d /s /c`, which does not expand `$HOME`;
+the bare form passes a literal `$HOME/...` to bash and dies with exit 127 before
+any check runs. Wrapping in `bash -c` moves expansion inside bash, where it works
+on every platform. `${CLAUDE_SKILL_DIR}` is **not** an option here — the harness
+interpolates it only in skill body text, never in hook commands.
+
+### Boundary lifetime
+
+The boundary is a file on disk (`$GSTACK_STATE_ROOT/freeze-dir.txt`), not session
+state. It survives restarts and applies to every session on this machine until
+`/unfreeze` removes it. Ending the conversation does **not** clear it.
+
+`$GSTACK_STATE_ROOT` resolves as `GSTACK_HOME` → `CLAUDE_PLUGIN_DATA` (only when
+`CLAUDE_PLUGIN_ROOT` confirms gstack) → `$HOME/.gstack` → `.gstack`, matching
+`gstack/bin/gstack-paths`. Reader and writer must agree; if they drift, the hook
+reads a boundary file the setup step never wrote and silently allows everything.
+
+## Regression test
+
+`freeze/tests/test-check-freeze.sh` runs the script in a sandbox with a fake
+`HOME` and asserts the deny/allow output schema, drive-letter path handling,
+state-root resolution, and that the `command:` above actually spawns through the
+harness's `cmd.exe` wrapper. Run it after touching either file:
+
+```bash
+bash ~/.claude/skills/gstack/freeze/tests/test-check-freeze.sh
+```
 
 ## Notes
 
 - The trailing `/` on the freeze directory prevents `/src` from matching `/src-old`
 - Freeze applies to Edit and Write tools only — Read, Bash, Glob, Grep are unaffected
 - This prevents accidental edits, not a security boundary — Bash commands like `sed` can still modify files outside the boundary
-- To deactivate, run `/unfreeze` or end the conversation
+- To deactivate, run `/unfreeze`. Ending the conversation does **not** clear the boundary — the state file is on disk

--- a/freeze/bin/check-freeze.sh
+++ b/freeze/bin/check-freeze.sh
@@ -1,14 +1,39 @@
 #!/usr/bin/env bash
 # check-freeze.sh — PreToolUse hook for /freeze skill
-# Reads JSON from stdin, checks if file_path is within the freeze boundary.
-# Returns {"permissionDecision":"deny","message":"..."} to block, or {} to allow.
+# Reads hook JSON from stdin, checks whether tool_input.file_path falls inside
+# the freeze boundary stored in $STATE_DIR/freeze-dir.txt.
+#
+# Output contract (verified against cli.js 2.1.92 — the harness dispatches
+# ONLY on the nested hookSpecificOutput.permissionDecision field; a bare
+# top-level {"permissionDecision":"deny"} is silently ignored, which was
+# layer 1 of the 2026-07-26 three-layer blocking failure):
+#   allow -> {}   (exit 0: no opinion, normal permission flow continues)
+#   deny  -> {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+#             "permissionDecision":"deny","permissionDecisionReason":"..."}}
+#            (exit 0; exit code 2 + stderr is the legacy alternative, unused here)
+#
+# Regression: ../tests/test-check-freeze.sh (sandboxed fake HOME; deny/allow
+# schema, drive-letter paths, state-root chain). Keep it green.
 set -euo pipefail
 
-# Read stdin
 INPUT=$(cat)
 
-# Locate the freeze directory state file
-STATE_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.gstack}"
+# State root — keep in sync with gstack/bin/gstack-paths:
+#   GSTACK_HOME
+#   -> CLAUDE_PLUGIN_DATA (only when CLAUDE_PLUGIN_ROOT confirms *gstack*, so
+#      another plugin's CLAUDE_PLUGIN_DATA leaking into the session env cannot
+#      redirect where freeze state is read from)
+#   -> $HOME/.gstack
+#   -> .gstack
+if [ -n "${GSTACK_HOME:-}" ]; then
+  STATE_DIR="$GSTACK_HOME"
+elif [ -n "${CLAUDE_PLUGIN_DATA:-}" ] && printf '%s' "${CLAUDE_PLUGIN_ROOT:-}" | grep -qi "gstack"; then
+  STATE_DIR="$CLAUDE_PLUGIN_DATA"
+elif [ -n "${HOME:-}" ]; then
+  STATE_DIR="$HOME/.gstack"
+else
+  STATE_DIR=".gstack"
+fi
 FREEZE_FILE="$STATE_DIR/freeze-dir.txt"
 
 # If no freeze file exists, allow everything (not yet configured)
@@ -25,13 +50,18 @@ if [ -z "$FREEZE_DIR" ]; then
   exit 0
 fi
 
-# Extract file_path from tool_input JSON
-# Try grep/sed first, fall back to Python for escaped quotes
+# Extract file_path from tool_input JSON.
+# grep/sed fast path first; note it yields JSON-escaped content (C:\\Users\\...)
+# which _to_posix below flattens. The python fallback yields the decoded form.
 FILE_PATH=$(printf '%s' "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//' || true)
 
-# Python fallback if grep returned empty
 if [ -z "$FILE_PATH" ]; then
-  FILE_PATH=$(printf '%s' "$INPUT" | python3 -c 'import sys,json; print(json.loads(sys.stdin.read()).get("tool_input",{}).get("file_path",""))' 2>/dev/null || true)
+  for _py in python3 python; do
+    if command -v "$_py" >/dev/null 2>&1; then
+      FILE_PATH=$(printf '%s' "$INPUT" | "$_py" -c 'import sys,json; print(json.loads(sys.stdin.read()).get("tool_input",{}).get("file_path",""))' 2>/dev/null || true)
+      if [ -n "$FILE_PATH" ]; then break; fi
+    fi
+  done
 fi
 
 # If we couldn't extract a file path, allow (don't block on parse failure)
@@ -40,9 +70,30 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
-# Resolve file_path to absolute if it isn't already
+# Canonicalize to POSIX form. Claude Code on Windows passes drive-letter
+# file paths (C:\foo or C:/foo) while the boundary file stores the Git-Bash
+# pwd form (/c/foo) written at setup time. Without this the two sides can
+# never prefix-match, and the old relative-path fallback glued $(pwd) onto a
+# drive-letter path (layer 3 of the 2026-07-26 failure).
+_to_posix() {
+  local p="$1"
+  p=${p//\\//}                    # backslashes (incl. JSON-escaped \\) -> /
+  case "$p" in
+    [A-Za-z]:/*|[A-Za-z]:)        # C:/foo -> /c/foo
+      local _drive="${p%%:*}"
+      _drive=$(printf '%s' "$_drive" | tr '[:upper:]' '[:lower:]')
+      p="/${_drive}${p#?:}"
+      ;;
+  esac
+  printf '%s' "$p"
+}
+FILE_PATH=$(_to_posix "$FILE_PATH")
+FREEZE_DIR=$(_to_posix "$FREEZE_DIR")
+
+# Resolve file_path to absolute if it isn't already (drive-letter forms were
+# rewritten to /c/... above, so they correctly take the absolute branch)
 case "$FILE_PATH" in
-  /*) ;; # already absolute
+  /*) ;;
   *)
     FILE_PATH="$(pwd)/$FILE_PATH"
     ;;
@@ -62,6 +113,15 @@ _resolve_path() {
 FILE_PATH=$(_resolve_path "$FILE_PATH")
 FREEZE_DIR=$(_resolve_path "$FREEZE_DIR")
 
+# Minimal JSON string escaping for interpolated paths (backslashes are gone
+# after _to_posix; embedded double quotes are the remaining hazard)
+_json_escape() {
+  local s="$1"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '%s' "$s"
+}
+
 # Check: does the file path start with the freeze directory?
 case "$FILE_PATH" in
   "${FREEZE_DIR}/"*|"${FREEZE_DIR}")
@@ -69,11 +129,11 @@ case "$FILE_PATH" in
     echo '{}'
     ;;
   *)
-    # Outside freeze boundary — deny
-    # Log hook fire event
-    mkdir -p ~/.gstack/analytics 2>/dev/null || true
-    echo '{"event":"hook_fire","skill":"freeze","pattern":"boundary_deny","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}' >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+    # Outside freeze boundary — deny via the schema the harness dispatches on
+    mkdir -p "$STATE_DIR/analytics" 2>/dev/null || true
+    echo '{"event":"hook_fire","skill":"freeze","pattern":"boundary_deny","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}' >> "$STATE_DIR/analytics/skill-usage.jsonl" 2>/dev/null || true
 
-    printf '{"permissionDecision":"deny","message":"[freeze] Blocked: %s is outside the freeze boundary (%s). Only edits within the frozen directory are allowed."}\n' "$FILE_PATH" "$FREEZE_DIR"
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"[freeze] Blocked: %s is outside the freeze boundary (%s). Only edits within the frozen directory are allowed. Run /unfreeze to lift the boundary."}}\n' "$(_json_escape "$FILE_PATH")" "$(_json_escape "$FREEZE_DIR")"
     ;;
 esac
+exit 0

--- a/freeze/tests/test-check-freeze.sh
+++ b/freeze/tests/test-check-freeze.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# test-check-freeze.sh — regression suite for the /freeze PreToolUse hook.
+#
+# Guards three blocking failures, each of which made the hook silently ineffective:
+#   L1 deny protocol   — deny must nest under hookSpecificOutput, or the harness ignores it
+#   L2 Windows spawn   — hook command must survive a cmd.exe /d /s /c spawn
+#   L3 drive letters   — C:\... / C:/... must compare correctly against a /c/... boundary
+# Plus: state-root chain parity with gstack-paths, and no CLAUDE_PLUGIN_DATA
+# leakage from a non-gstack plugin.
+#
+# Runs fully sandboxed: every case gets a throwaway HOME, so a real freeze
+# boundary on this machine can neither be read nor written by the tests.
+# Usage: bash tests/test-check-freeze.sh    (exit 0 = all green)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../bin/check-freeze.sh"
+PASS=0
+FAIL=0
+
+if [ ! -f "$HOOK" ]; then
+  echo "FATAL: hook script not found at $HOOK"
+  exit 1
+fi
+
+SANDBOX_ROOT="$(mktemp -d 2>/dev/null || mktemp -d -t freeze-test)"
+trap 'rm -rf "$SANDBOX_ROOT"' EXIT
+
+ok()   { PASS=$((PASS+1)); printf 'PASS  %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf 'FAIL  %s\n      %s\n' "$1" "$2"; }
+
+# run_hook <boundary-or-empty> <file_path> [env assignments...]
+# Creates a fresh fake HOME, seeds freeze-dir.txt (unless boundary is ""), and
+# pipes a realistic PreToolUse payload through the hook. Echoes stdout.
+run_hook() {
+  local boundary="$1" file_path="$2"; shift 2
+  local home; home="$(mktemp -d "$SANDBOX_ROOT/home.XXXXXX")"
+  if [ -n "$boundary" ]; then
+    mkdir -p "$home/.gstack"
+    printf '%s\n' "$boundary" > "$home/.gstack/freeze-dir.txt"
+  fi
+  local payload
+  payload=$(printf '{"session_id":"test","hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"a","new_string":"b"}}' "$file_path")
+  printf '%s' "$payload" | env HOME="$home" GSTACK_HOME= CLAUDE_PLUGIN_DATA= CLAUDE_PLUGIN_ROOT= "$@" bash "$HOOK" 2>/dev/null
+}
+
+# assert_deny <case> <output>  — must be a deny the harness will actually honor
+assert_deny() {
+  local name="$1" out="$2"
+  if printf '%s' "$out" | grep -q '"hookSpecificOutput"' \
+     && printf '%s' "$out" | grep -q '"hookEventName"[[:space:]]*:[[:space:]]*"PreToolUse"' \
+     && printf '%s' "$out" | grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"deny"'; then
+    # and it must be valid JSON with the decision at the nested path
+    if command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1; then
+      local py; py=$(command -v python3 || command -v python)
+      if ! printf '%s' "$out" | "$py" -c 'import sys,json; d=json.load(sys.stdin); assert d["hookSpecificOutput"]["permissionDecision"]=="deny"' 2>/dev/null; then
+        bad "$name" "deny present but JSON invalid or wrong nesting: $out"; return
+      fi
+    fi
+    ok "$name"
+  else
+    bad "$name" "expected nested hookSpecificOutput deny, got: ${out:-<empty>}"
+  fi
+}
+
+assert_allow() {
+  local name="$1" out="$2"
+  local trimmed; trimmed=$(printf '%s' "$out" | tr -d '[:space:]')
+  if [ "$trimmed" = "{}" ]; then ok "$name"
+  else bad "$name" "expected {} (no opinion), got: ${out:-<empty>}"; fi
+}
+
+echo "== /freeze hook regression =="
+echo "hook: $HOOK"
+echo
+
+# ── L1: deny protocol ───────────────────────────────────────────────
+assert_deny "L1 outside boundary -> nested deny" \
+  "$(run_hook "/tmp/frozen/" "/tmp/elsewhere/evil.ts")"
+
+# The exact bug: a top-level permissionDecision is invisible to the harness.
+OUT=$(run_hook "/tmp/frozen/" "/tmp/elsewhere/evil.ts")
+FIRST_KEY=$(printf '%s' "$OUT" | sed 's/^[[:space:]]*{[[:space:]]*//' | cut -d'"' -f2)
+if [ "$FIRST_KEY" = "hookSpecificOutput" ]; then
+  ok "L1 deny is not a bare top-level permissionDecision"
+else
+  bad "L1 deny is not a bare top-level permissionDecision" "top-level key is '$FIRST_KEY' — harness ignores this shape"
+fi
+
+assert_allow "L1 inside boundary -> {}" \
+  "$(run_hook "/tmp/frozen/" "/tmp/frozen/src/ok.ts")"
+
+# ── L3: Windows drive-letter paths ──────────────────────────────────
+assert_deny "L3 C:/ path outside /c/ boundary -> deny" \
+  "$(run_hook "/c/repo/frozen/" "C:/repo/other/evil.ts")"
+
+assert_allow "L3 C:/ path inside /c/ boundary -> {}" \
+  "$(run_hook "/c/repo/frozen/" "C:/repo/frozen/src/ok.ts")"
+
+# Claude Code sends JSON-escaped backslashes for Windows paths
+assert_allow "L3 backslash path inside boundary -> {}" \
+  "$(run_hook "/c/repo/frozen/" "C:\\\\repo\\\\frozen\\\\src\\\\ok.ts")"
+
+assert_deny "L3 backslash path outside boundary -> deny" \
+  "$(run_hook "/c/repo/frozen/" "C:\\\\repo\\\\other\\\\evil.ts")"
+
+assert_allow "L3 lowercase drive matches uppercase boundary" \
+  "$(run_hook "C:/repo/frozen/" "c:/repo/frozen/src/ok.ts")"
+
+# Prefix-collision guard: /src must not match /src-old
+assert_deny "L3 sibling prefix (/frozen-old) is outside /frozen" \
+  "$(run_hook "/c/repo/frozen/" "C:/repo/frozen-old/evil.ts")"
+
+# ── Fail-open cases (must not block) ────────────────────────────────
+assert_allow "no boundary configured -> {}" \
+  "$(run_hook "" "/anywhere/x.ts")"
+
+EMPTY_HOME="$(mktemp -d "$SANDBOX_ROOT/home.XXXXXX")"
+mkdir -p "$EMPTY_HOME/.gstack"; : > "$EMPTY_HOME/.gstack/freeze-dir.txt"
+OUT=$(printf '{"tool_input":{"file_path":"/anywhere/x.ts"}}' | env HOME="$EMPTY_HOME" GSTACK_HOME= CLAUDE_PLUGIN_DATA= CLAUDE_PLUGIN_ROOT= bash "$HOOK" 2>/dev/null)
+assert_allow "empty boundary file -> {}" "$OUT"
+
+NP_HOME="$(mktemp -d "$SANDBOX_ROOT/home.XXXXXX")"
+mkdir -p "$NP_HOME/.gstack"; printf '/tmp/frozen/\n' > "$NP_HOME/.gstack/freeze-dir.txt"
+OUT=$(printf '{"tool_name":"Edit","tool_input":{}}' | env HOME="$NP_HOME" GSTACK_HOME= CLAUDE_PLUGIN_DATA= CLAUDE_PLUGIN_ROOT= bash "$HOOK" 2>/dev/null)
+assert_allow "no file_path in payload -> {}" "$OUT"
+
+# ── State-root chain parity with gstack/bin/gstack-paths ────────────
+GH="$(mktemp -d "$SANDBOX_ROOT/gstackhome.XXXXXX")"
+H2="$(mktemp -d "$SANDBOX_ROOT/home.XXXXXX")"
+mkdir -p "$GH"; printf '/tmp/frozen/\n' > "$GH/freeze-dir.txt"
+OUT=$(printf '{"tool_input":{"file_path":"/tmp/elsewhere/evil.ts"}}' | env HOME="$H2" GSTACK_HOME="$GH" CLAUDE_PLUGIN_DATA= CLAUDE_PLUGIN_ROOT= bash "$HOOK" 2>/dev/null)
+assert_deny "GSTACK_HOME wins over \$HOME/.gstack" "$OUT"
+
+# CLAUDE_PLUGIN_DATA is honored only when CLAUDE_PLUGIN_ROOT says gstack
+PD="$(mktemp -d "$SANDBOX_ROOT/plugindata.XXXXXX")"
+H3="$(mktemp -d "$SANDBOX_ROOT/home.XXXXXX")"
+printf '/tmp/frozen/\n' > "$PD/freeze-dir.txt"
+OUT=$(printf '{"tool_input":{"file_path":"/tmp/elsewhere/evil.ts"}}' | env HOME="$H3" GSTACK_HOME= CLAUDE_PLUGIN_DATA="$PD" CLAUDE_PLUGIN_ROOT="/plugins/gstack" bash "$HOOK" 2>/dev/null)
+assert_deny "CLAUDE_PLUGIN_DATA honored when PLUGIN_ROOT=gstack" "$OUT"
+
+# ...and ignored when another plugin's data dir leaks into the env
+H4="$(mktemp -d "$SANDBOX_ROOT/home.XXXXXX")"
+OUT=$(printf '{"tool_input":{"file_path":"/tmp/elsewhere/evil.ts"}}' | env HOME="$H4" GSTACK_HOME= CLAUDE_PLUGIN_DATA="$PD" CLAUDE_PLUGIN_ROOT="/plugins/codex" bash "$HOOK" 2>/dev/null)
+assert_allow "foreign CLAUDE_PLUGIN_DATA ignored (no gstack in PLUGIN_ROOT)" "$OUT"
+
+# ── L2: the hook command in SKILL.md must actually spawn ────────────
+# Reproduces the harness spawn (cmd.exe /d /s /c "<command>" with verbatim args
+# on Windows; sh -c elsewhere) using the command string parsed out of the
+# installed SKILL.md — catches a regression to `bash $HOME/...`, which cmd.exe
+# leaves unexpanded, and to ${CLAUDE_SKILL_DIR}, which is interpolated only in
+# skill body text and never in hook commands.
+SKILL_MD=""
+for cand in "$HOME/.claude/skills/freeze/SKILL.md" "$SCRIPT_DIR/../SKILL.md"; do
+  [ -f "$cand" ] && { SKILL_MD="$cand"; break; }
+done
+
+if [ -z "$SKILL_MD" ]; then
+  echo "SKIP  L2 spawn contract (no SKILL.md found)"
+elif ! command -v node >/dev/null 2>&1; then
+  echo "SKIP  L2 spawn contract (node not available)"
+else
+  HOOK_CMD=$(grep -m1 '^[[:space:]]*command:' "$SKILL_MD" | sed "s/^[[:space:]]*command:[[:space:]]*//; s/^'//; s/'$//")
+  if [ -z "$HOOK_CMD" ]; then
+    bad "L2 spawn contract" "could not parse a command: line from $SKILL_MD"
+  else
+    # Sandbox the boundary via GSTACK_HOME, never HOME: the hook command itself
+    # resolves the script through $HOME, so a fake HOME would only make bash miss
+    # the script and prove nothing. This leaves any real boundary untouched.
+    SPAWN_STATE="$(mktemp -d "$SANDBOX_ROOT/spawnstate.XXXXXX")"
+    printf '/definitely/frozen/\n' > "$SPAWN_STATE/freeze-dir.txt"
+    SPAWN_OUT=$(HOOK_CMD="$HOOK_CMD" SPAWN_STATE="$SPAWN_STATE" node -e '
+      const {spawnSync} = require("child_process");
+      const cmd = process.env.HOOK_CMD;
+      const env = {...process.env, GSTACK_HOME: process.env.SPAWN_STATE};
+      delete env.CLAUDE_PLUGIN_DATA; delete env.CLAUDE_PLUGIN_ROOT;
+      const win = process.platform === "win32";
+      const fire = (fp) => {
+        const input = JSON.stringify({hook_event_name:"PreToolUse",tool_name:"Edit",tool_input:{file_path:fp}});
+        const r = win
+          ? spawnSync(env.comspec || "cmd.exe", ["/d","/s","/c",`"${cmd}"`], {windowsVerbatimArguments:true, input, encoding:"utf8", env})
+          : spawnSync("sh", ["-c", cmd], {input, encoding:"utf8", env});
+        return {status: r.status, out: (r.stdout||"").trim(), err: (r.stderr||"").trim()};
+      };
+      // Replicate the harness dispatch rule: only the nested field is acted on.
+      const decides = (r) => {
+        if (r.status === 2) return "deny";
+        let j; try { j = JSON.parse(r.out); } catch { return "allow"; }
+        return j?.hookSpecificOutput?.permissionDecision || (j?.decision === "block" ? "deny" : "allow");
+      };
+      const outside = fire("/definitely/elsewhere/evil.ts");
+      const inside  = fire("/definitely/frozen/src/ok.ts");
+      process.stdout.write(JSON.stringify({
+        spawned: outside.status === 0 && outside.out.startsWith("{"),
+        outside: decides(outside), inside: decides(inside), err: outside.err.slice(0,160),
+      }));
+    ' 2>/dev/null)
+    if printf '%s' "$SPAWN_OUT" | grep -q '"spawned":true'; then
+      ok "L2 SKILL.md hook command spawns through the harness wrapper"
+    else
+      bad "L2 SKILL.md hook command spawns through the harness wrapper" "spawn result: $SPAWN_OUT"
+    fi
+    if printf '%s' "$SPAWN_OUT" | grep -q '"outside":"deny"'; then
+      ok "L2 end-to-end: harness would DENY an edit outside the boundary"
+    else
+      bad "L2 end-to-end: harness would DENY an edit outside the boundary" "spawn result: $SPAWN_OUT"
+    fi
+    if printf '%s' "$SPAWN_OUT" | grep -q '"inside":"allow"'; then
+      ok "L2 end-to-end: harness would ALLOW an edit inside the boundary"
+    else
+      bad "L2 end-to-end: harness would ALLOW an edit inside the boundary" "spawn result: $SPAWN_OUT"
+    fi
+  fi
+fi
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/guard/SKILL.md
+++ b/guard/SKILL.md
@@ -15,17 +15,19 @@ hooks:
     - matcher: "Bash"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/careful/bin/check-careful.sh"
+          # bash -c so bash (not cmd.exe) expands $HOME — the bare form dies
+          # exit 127 under the harness's cmd.exe /d /s /c spawn (verified).
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/careful/bin/check-careful.sh\""'
           statusMessage: "Checking for destructive commands..."
     - matcher: "Edit"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh"
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking freeze boundary..."
     - matcher: "Write"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh"
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking freeze boundary..."
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->

--- a/guard/SKILL.md.tmpl
+++ b/guard/SKILL.md.tmpl
@@ -20,17 +20,23 @@ hooks:
     - matcher: "Bash"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/careful/bin/check-careful.sh"
+          # bash -c so bash (not cmd.exe) expands $HOME — the bare form dies
+          # exit 127 under the harness's cmd.exe /d /s /c spawn (verified).
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/careful/bin/check-careful.sh\""'
           statusMessage: "Checking for destructive commands..."
     - matcher: "Edit"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh"
+          # bash -c so bash (not cmd.exe) expands $HOME — the bare form dies
+          # exit 127 under the harness's cmd.exe /d /s /c spawn (verified).
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking freeze boundary..."
     - matcher: "Write"
       hooks:
         - type: command
-          command: "bash $HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh"
+          # bash -c so bash (not cmd.exe) expands $HOME — the bare form dies
+          # exit 127 under the harness's cmd.exe /d /s /c spawn (verified).
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking freeze boundary..."
 sensitive: true
 ---

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -23,12 +23,18 @@ hooks:
     - matcher: "Edit"
       hooks:
         - type: command
-          command: 'bash -c ''S="${CLAUDE_SKILL_DIR}/../freeze/bin/check-freeze.sh"; [ -x "$S" ] || S="${CLAUDE_SKILL_DIR}/../gstack-freeze/bin/check-freeze.sh"; [ -x "$S" ] && bash "$S" || exit 0'''
+          # bash -c so bash (not cmd.exe) expands $HOME. No nested single quotes:
+          # the harness spawns via cmd.exe /d /s /c, which shreds them (verified
+          # exit 0, hook never runs). ${CLAUDE_SKILL_DIR} is body-text-only.
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking debug scope boundary..."
     - matcher: "Write"
       hooks:
         - type: command
-          command: 'bash -c ''S="${CLAUDE_SKILL_DIR}/../freeze/bin/check-freeze.sh"; [ -x "$S" ] || S="${CLAUDE_SKILL_DIR}/../gstack-freeze/bin/check-freeze.sh"; [ -x "$S" ] && bash "$S" || exit 0'''
+          # bash -c so bash (not cmd.exe) expands $HOME. No nested single quotes:
+          # the harness spawns via cmd.exe /d /s /c, which shreds them (verified
+          # exit 0, hook never runs). ${CLAUDE_SKILL_DIR} is body-text-only.
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking debug scope boundary..."
 gbrain:
   schema: 1

--- a/investigate/SKILL.md.tmpl
+++ b/investigate/SKILL.md.tmpl
@@ -30,12 +30,18 @@ hooks:
     - matcher: "Edit"
       hooks:
         - type: command
-          command: 'bash -c ''S="${CLAUDE_SKILL_DIR}/../freeze/bin/check-freeze.sh"; [ -x "$S" ] || S="${CLAUDE_SKILL_DIR}/../gstack-freeze/bin/check-freeze.sh"; [ -x "$S" ] && bash "$S" || exit 0'''
+          # bash -c so bash (not cmd.exe) expands $HOME. No nested single quotes:
+          # the harness spawns via cmd.exe /d /s /c, which shreds them (verified
+          # exit 0, hook never runs). ${CLAUDE_SKILL_DIR} is body-text-only.
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking debug scope boundary..."
     - matcher: "Write"
       hooks:
         - type: command
-          command: 'bash -c ''S="${CLAUDE_SKILL_DIR}/../freeze/bin/check-freeze.sh"; [ -x "$S" ] || S="${CLAUDE_SKILL_DIR}/../gstack-freeze/bin/check-freeze.sh"; [ -x "$S" ] && bash "$S" || exit 0'''
+          # bash -c so bash (not cmd.exe) expands $HOME. No nested single quotes:
+          # the harness spawns via cmd.exe /d /s /c, which shreds them (verified
+          # exit 0, hook never runs). ${CLAUDE_SKILL_DIR} is body-text-only.
+          command: 'bash -c "exec \"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\""'
           statusMessage: "Checking debug scope boundary..."
 gbrain:
   schema: 1

--- a/test/hook-scripts.test.ts
+++ b/test/hook-scripts.test.ts
@@ -38,6 +38,18 @@ function runHookRaw(scriptPath: string, rawInput: string, env?: Record<string, s
   return { exitCode: result.status ?? 1, output, raw };
 }
 
+// The harness dispatches ONLY on hookSpecificOutput.permissionDecision; a bare
+// top-level {"permissionDecision":...} is parsed and then ignored, so asserting
+// the top-level field would keep passing while the hook blocks nothing.
+// Assert the shape Claude Code actually reads.
+function decisionOf(output: any): string | undefined {
+  return output?.hookSpecificOutput?.permissionDecision;
+}
+
+function reasonOf(output: any): string {
+  return output?.hookSpecificOutput?.permissionDecisionReason ?? '';
+}
+
 function carefulInput(command: string) {
   return { tool_input: { command } };
 }
@@ -46,6 +58,12 @@ function freezeInput(filePath: string) {
   return { tool_input: { file_path: filePath } };
 }
 
+// check-freeze.sh resolves its state root the same way bin/gstack-paths does:
+// CLAUDE_PLUGIN_DATA is honoured only when CLAUDE_PLUGIN_ROOT confirms gstack, so
+// another plugin's data dir leaking into the session env cannot redirect where the
+// freeze boundary is read from. Callers below therefore set both - which is also
+// the only reachable real state, since cli.js sets CLAUDE_PLUGIN_ROOT first and
+// only then CLAUDE_PLUGIN_DATA.
 function withFreezeDir(freezePath: string, fn: (stateDir: string) => void) {
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-freeze-test-'));
   fs.writeFileSync(path.join(stateDir, 'freeze-dir.txt'), freezePath);
@@ -67,34 +85,34 @@ describe('check-careful.sh', () => {
     test('rm -rf /var/data warns with recursive delete message', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('rm -rf /var/data'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('recursive delete');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('recursive delete');
     });
 
     test('rm -r ./some-dir warns', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('rm -r ./some-dir'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('recursive delete');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('recursive delete');
     });
 
     test('rm -rf node_modules allows (safe exception)', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('rm -rf node_modules'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBeUndefined();
+      expect(decisionOf(output)).toBeUndefined();
     });
 
     test('rm -rf .next dist allows (multiple safe targets)', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('rm -rf .next dist'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBeUndefined();
+      expect(decisionOf(output)).toBeUndefined();
     });
 
     test('rm -rf node_modules /var/data warns (mixed safe+unsafe)', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('rm -rf node_modules /var/data'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('recursive delete');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('recursive delete');
     });
   });
 
@@ -108,22 +126,22 @@ describe('check-careful.sh', () => {
     test('psql DROP TABLE warns with DROP in message', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('psql -c DROP TABLE users;'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('DROP');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('DROP');
     });
 
     test('mysql drop database warns (case insensitive)', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('mysql -e drop database mydb'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message.toLowerCase()).toContain('drop');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output).toLowerCase()).toContain('drop');
     });
 
     test('psql TRUNCATE warns', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('psql -c TRUNCATE orders;'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('TRUNCATE');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('TRUNCATE');
     });
   });
 
@@ -133,36 +151,36 @@ describe('check-careful.sh', () => {
     test('git push --force warns with force-push', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('git push --force origin main'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('force-push');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('force-push');
     });
 
     test('git push -f warns', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('git push -f origin main'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('force-push');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('force-push');
     });
 
     test('git reset --hard warns with uncommitted', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('git reset --hard HEAD~3'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('uncommitted');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('uncommitted');
     });
 
     test('git checkout . warns', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('git checkout .'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('uncommitted');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('uncommitted');
     });
 
     test('git restore . warns', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('git restore .'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('uncommitted');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('uncommitted');
     });
   });
 
@@ -172,22 +190,22 @@ describe('check-careful.sh', () => {
     test('kubectl delete warns with kubectl in message', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('kubectl delete pod my-pod'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('kubectl');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('kubectl');
     });
 
     test('docker rm -f warns', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('docker rm -f container123'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('Docker');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('Docker');
     });
 
     test('docker system prune -a warns', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput('docker system prune -a'));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('Docker');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('Docker');
     });
   });
 
@@ -206,7 +224,7 @@ describe('check-careful.sh', () => {
       test(`"${cmd}" allows`, () => {
         const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput(cmd));
         expect(exitCode).toBe(0);
-        expect(output.permissionDecision).toBeUndefined();
+        expect(decisionOf(output)).toBeUndefined();
       });
     }
   });
@@ -217,13 +235,13 @@ describe('check-careful.sh', () => {
     test('empty command allows gracefully', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, carefulInput(''));
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBeUndefined();
+      expect(decisionOf(output)).toBeUndefined();
     });
 
     test('missing command field allows gracefully', () => {
       const { exitCode, output } = runHook(CAREFUL_SCRIPT, { tool_input: {} });
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBeUndefined();
+      expect(decisionOf(output)).toBeUndefined();
     });
 
     test('malformed JSON input allows gracefully (exit 0, output {})', () => {
@@ -240,8 +258,8 @@ describe('check-careful.sh', () => {
       const rawJson = '{"tool_input":{"command":\n"rm -rf /tmp/important"}}';
       const { exitCode, output } = runHookRaw(CAREFUL_SCRIPT, rawJson);
       expect(exitCode).toBe(0);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.message).toContain('recursive delete');
+      expect(decisionOf(output)).toBe('ask');
+      expect(reasonOf(output)).toContain('recursive delete');
     });
   });
 });
@@ -257,10 +275,10 @@ describe('check-freeze.sh', () => {
         const { exitCode, output } = runHook(
           FREEZE_SCRIPT,
           freezeInput('/Users/dev/project/src/index.ts'),
-          { CLAUDE_PLUGIN_DATA: stateDir },
+          { CLAUDE_PLUGIN_DATA: stateDir, CLAUDE_PLUGIN_ROOT: '/plugins/gstack' },
         );
         expect(exitCode).toBe(0);
-        expect(output.permissionDecision).toBeUndefined();
+        expect(decisionOf(output)).toBeUndefined();
       });
     });
 
@@ -269,10 +287,10 @@ describe('check-freeze.sh', () => {
         const { exitCode, output } = runHook(
           FREEZE_SCRIPT,
           freezeInput('/Users/dev/project/src/components/Button.tsx'),
-          { CLAUDE_PLUGIN_DATA: stateDir },
+          { CLAUDE_PLUGIN_DATA: stateDir, CLAUDE_PLUGIN_ROOT: '/plugins/gstack' },
         );
         expect(exitCode).toBe(0);
-        expect(output.permissionDecision).toBeUndefined();
+        expect(decisionOf(output)).toBeUndefined();
       });
     });
   });
@@ -283,12 +301,12 @@ describe('check-freeze.sh', () => {
         const { exitCode, output } = runHook(
           FREEZE_SCRIPT,
           freezeInput('/Users/dev/other-project/index.ts'),
-          { CLAUDE_PLUGIN_DATA: stateDir },
+          { CLAUDE_PLUGIN_DATA: stateDir, CLAUDE_PLUGIN_ROOT: '/plugins/gstack' },
         );
         expect(exitCode).toBe(0);
-        expect(output.permissionDecision).toBe('deny');
-        expect(output.message).toContain('freeze');
-        expect(output.message).toContain('outside');
+        expect(decisionOf(output)).toBe('deny');
+        expect(reasonOf(output)).toContain('freeze');
+        expect(reasonOf(output)).toContain('outside');
       });
     });
 
@@ -297,12 +315,12 @@ describe('check-freeze.sh', () => {
         const { exitCode, output } = runHook(
           FREEZE_SCRIPT,
           freezeInput('/etc/hosts'),
-          { CLAUDE_PLUGIN_DATA: stateDir },
+          { CLAUDE_PLUGIN_DATA: stateDir, CLAUDE_PLUGIN_ROOT: '/plugins/gstack' },
         );
         expect(exitCode).toBe(0);
-        expect(output.permissionDecision).toBe('deny');
-        expect(output.message).toContain('freeze');
-        expect(output.message).toContain('outside');
+        expect(decisionOf(output)).toBe('deny');
+        expect(reasonOf(output)).toContain('freeze');
+        expect(reasonOf(output)).toContain('outside');
       });
     });
   });
@@ -313,11 +331,11 @@ describe('check-freeze.sh', () => {
         const { exitCode, output } = runHook(
           FREEZE_SCRIPT,
           freezeInput('/Users/dev/project/src-old/index.ts'),
-          { CLAUDE_PLUGIN_DATA: stateDir },
+          { CLAUDE_PLUGIN_DATA: stateDir, CLAUDE_PLUGIN_ROOT: '/plugins/gstack' },
         );
         expect(exitCode).toBe(0);
-        expect(output.permissionDecision).toBe('deny');
-        expect(output.message).toContain('outside');
+        expect(decisionOf(output)).toBe('deny');
+        expect(reasonOf(output)).toContain('outside');
       });
     });
   });
@@ -329,10 +347,10 @@ describe('check-freeze.sh', () => {
         const { exitCode, output } = runHook(
           FREEZE_SCRIPT,
           freezeInput('/anywhere/at/all.ts'),
-          { CLAUDE_PLUGIN_DATA: stateDir },
+          { CLAUDE_PLUGIN_DATA: stateDir, CLAUDE_PLUGIN_ROOT: '/plugins/gstack' },
         );
         expect(exitCode).toBe(0);
-        expect(output.permissionDecision).toBeUndefined();
+        expect(decisionOf(output)).toBeUndefined();
       } finally {
         fs.rmSync(stateDir, { recursive: true, force: true });
       }
@@ -345,11 +363,52 @@ describe('check-freeze.sh', () => {
         const { exitCode, output } = runHook(
           FREEZE_SCRIPT,
           { tool_input: {} },
-          { CLAUDE_PLUGIN_DATA: stateDir },
+          { CLAUDE_PLUGIN_DATA: stateDir, CLAUDE_PLUGIN_ROOT: '/plugins/gstack' },
         );
         expect(exitCode).toBe(0);
-        expect(output.permissionDecision).toBeUndefined();
+        expect(decisionOf(output)).toBeUndefined();
       });
     });
+  });
+});
+
+describe('harness output contract', () => {
+  // Regression guard for the failure these scripts shipped with: both emitted a
+  // bare top-level {"permissionDecision":...}. That is valid JSON and is parsed,
+  // but Claude Code dispatches on hookSpecificOutput.permissionDecision, so the
+  // decision was silently discarded and the tool call proceeded. Every assertion
+  // in this file passed throughout, because running a script directly never
+  // exercises the harness's dispatch rule.
+  test('careful nests the decision and omits the legacy top-level field', () => {
+    const { output, raw } = runHook(CAREFUL_SCRIPT, {
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /var/data' },
+    });
+    expect(output.hookSpecificOutput?.hookEventName).toBe('PreToolUse');
+    expect(output.hookSpecificOutput?.permissionDecision).toBe('ask');
+    expect(output.permissionDecision).toBeUndefined();
+    expect(raw.trimStart().startsWith('{"hookSpecificOutput"')).toBe(true);
+  });
+
+  test('freeze nests the decision and omits the legacy top-level field', () => {
+    withFreezeDir('/tmp/frozen', (stateDir) => {
+      const { output, raw } = runHook(
+        FREEZE_SCRIPT,
+        { tool_name: 'Edit', tool_input: { file_path: '/tmp/elsewhere/evil.ts' } },
+        { CLAUDE_PLUGIN_DATA: stateDir, CLAUDE_PLUGIN_ROOT: '/plugins/gstack' },
+      );
+      expect(output.hookSpecificOutput?.hookEventName).toBe('PreToolUse');
+      expect(output.hookSpecificOutput?.permissionDecision).toBe('deny');
+      expect(output.permissionDecision).toBeUndefined();
+      expect(raw.trimStart().startsWith('{"hookSpecificOutput"')).toBe(true);
+    });
+  });
+
+  test('allow path stays an empty object (no opinion)', () => {
+    const { raw } = runHook(CAREFUL_SCRIPT, {
+      tool_name: 'Bash',
+      tool_input: { command: 'ls -la' },
+    });
+    expect(raw.trim()).toBe('{}');
   });
 });

--- a/test/investigate-freeze-path.test.ts
+++ b/test/investigate-freeze-path.test.ts
@@ -5,21 +5,53 @@ import * as path from 'path';
 const ROOT = path.resolve(import.meta.dir, '..');
 const FILES = ['investigate/SKILL.md.tmpl', 'investigate/SKILL.md'];
 
+/**
+ * This file used to assert that the *hook command* carried a
+ * `${CLAUDE_SKILL_DIR}`-based two-way fallback ending in `|| exit 0`. That form
+ * is dead on arrival: `${CLAUDE_SKILL_DIR}` is interpolated only into skill body
+ * text, and the nested single quotes are shredded by the cmd.exe wrapper the
+ * harness spawns hooks through — verified exit 0 with the hook never running,
+ * i.e. a silent fail-open. The test was green the whole time, which is precisely
+ * why the defect survived: it locked in the broken form.
+ *
+ * The hook command form is now owned by hook-spawn-contract.test.ts, which
+ * proves by execution that each command reaches its script. What remains here is
+ * the part that was always legitimate: the dual-layout probe in the skill *body*,
+ * where ${CLAUDE_SKILL_DIR} genuinely is substituted.
+ */
 describe('investigate freeze path resolution', () => {
   for (const rel of FILES) {
     const content = fs.readFileSync(path.join(ROOT, rel), 'utf-8');
 
-    test(`${rel} hook falls back to standalone gstack-freeze install`, () => {
-      expect(content).toContain('${CLAUDE_SKILL_DIR}/../freeze/bin/check-freeze.sh');
-      expect(content).toContain('${CLAUDE_SKILL_DIR}/../gstack-freeze/bin/check-freeze.sh');
-      expect(content).toContain('[ -x "$S" ] && bash "$S" || exit 0');
-      expect(content).toContain("command: 'bash -c ''");
+    test(`${rel} hook resolves the freeze script through $HOME inside bash -c`, () => {
+      expect(content).toContain(
+        'command: \'bash -c "exec \\"$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh\\""\'',
+      );
     });
 
+    test(`${rel} hook carries none of the three dead forms`, () => {
+      const fm = content.slice(0, content.indexOf('\n---', 3));
+      const commands = [...fm.matchAll(/^\s*command:\s*(.+?)\s*$/gm)].map((m) => m[1]);
+      expect(commands.length).toBeGreaterThan(0);
+      for (const c of commands) {
+        expect(c).not.toContain('${CLAUDE_SKILL_DIR}');
+        expect(c.startsWith("'bash -c ''")).toBe(false);
+        expect(c).not.toMatch(/^"?(bash|sh)\s+\$/);
+      }
+    });
+
+    // Body text IS interpolated, so the standalone-install fallback is real here
+    // even though it could never work inside a hook command.
     test(`${rel} scope lock availability check supports standalone install`, () => {
-      expect(content).toContain('_FREEZE_SCRIPT="${CLAUDE_SKILL_DIR}/../freeze/bin/check-freeze.sh"');
-      expect(content).toContain('[ -x "$_FREEZE_SCRIPT" ] || _FREEZE_SCRIPT="${CLAUDE_SKILL_DIR}/../gstack-freeze/bin/check-freeze.sh"');
-      expect(content).toContain('[ -x "$_FREEZE_SCRIPT" ] && echo "FREEZE_AVAILABLE" || echo "FREEZE_UNAVAILABLE"');
+      expect(content).toContain(
+        '_FREEZE_SCRIPT="${CLAUDE_SKILL_DIR}/../freeze/bin/check-freeze.sh"',
+      );
+      expect(content).toContain(
+        '[ -x "$_FREEZE_SCRIPT" ] || _FREEZE_SCRIPT="${CLAUDE_SKILL_DIR}/../gstack-freeze/bin/check-freeze.sh"',
+      );
+      expect(content).toContain(
+        '[ -x "$_FREEZE_SCRIPT" ] && echo "FREEZE_AVAILABLE" || echo "FREEZE_UNAVAILABLE"',
+      );
     });
   }
 });


### PR DESCRIPTION
## Summary

Five hooks in this repo declare blocking behaviour that never takes effect. Each was verified by *running* the hook, not by reading it.

**1. The decision must nest under `hookSpecificOutput`.** Claude Code (checked against `cli.js` 2.1.92) dispatches only on `hookSpecificOutput.permissionDecision`. A bare top-level `{"permissionDecision":"deny"}` is valid JSON, is parsed, and is then ignored — the tool call proceeds while the skill looks armed. `freeze`, `careful`, and the hook generated by `gstack-team-init` all used the top-level form.

**2. On Windows the hook never starts.** The harness spawns hooks through `cmd.exe /d /s /c "<command>"`, which does not expand `$HOME`. So `bash $HOME/.claude/skills/gstack/<skill>/bin/<script>.sh` hands bash a literal `$HOME/...` and exits 127 before any check runs. Wrapping in `bash -c "exec \"$HOME/...\""` moves expansion inside bash and works on every platform.

**3. `${CLAUDE_SKILL_DIR}` does not work in hook commands.** It is interpolated only into skill *body text* (both replacement sites are inside `getPromptForCommand`) and is not injected into the hook process env — so it reaches the shell verbatim, and inside `bash -c` it expands to empty. `investigate` relied on it and was therefore broken on **every** platform, not just Windows; its trailing `|| exit 0` swallowed the failure silently. Executing it gives `resolved=[/../freeze/bin/check-freeze.sh]` → `NOTFOUND`.

## What each fix does

- **`freeze`** — nest the deny; canonicalize Windows drive-letter paths (`C:\x` / `C:/x` against a `/c/x` boundary; the old code appended `$(pwd)` to drive-letter paths, which corrupted every comparison and could even deny edits *inside* the boundary); align the state-root chain with `bin/gstack-paths`, including the guard that ignores a foreign plugin's `CLAUDE_PLUGIN_DATA`.
- **`careful`** — nest the `ask`, so destructive commands actually prompt; try `python` as well as `python3` for the JSON fallback (Windows often ships only `python`, and a missing interpreter silently yielded an empty command, skipping the check entirely).
- **`guard`** — composes `careful` + `freeze`; all three of its hook commands used the bare `$HOME` form and were dead on Windows.
- **`investigate`** — replace the `${CLAUDE_SKILL_DIR}` form with the same `bash -c` form as the others.
- **`gstack-team-init`** — nest the deny in the generated hook, and wrap the generated `settings.json` command in `bash -c`: `cmd.exe` can neither expand `$CLAUDE_PROJECT_DIR` nor execute a `.sh` directly, so the generated "gstack is required" gate was decorative on Windows. The command string is now passed via env to avoid a bash → JS → JSON escaping stack.
- **Docs** — `freeze`'s boundary is a file on disk that outlives the session; the old text said it was session-scoped and cleared when the conversation ends.

`SKILL.md` and `SKILL.md.tmpl` are both updated throughout; changing only the generated file would be reverted by the next `bun run gen:skill-docs`.

## Tests

Two new suites, fully sandboxed (throwaway `HOME`, `GSTACK_HOME`-redirected state; they never read or write a real freeze boundary or analytics log):

```bash
bash freeze/tests/test-check-freeze.sh     # 18 assertions
bash careful/tests/test-check-careful.sh   # 27 assertions
```

Both include an end-to-end check that spawns the command declared in `SKILL.md` through the same `cmd.exe` wrapper the harness uses, then applies the harness's own dispatch rule to the output — so a regression to any of the three failure modes fails loudly.

Run against the pre-fix code the same suites report **13** and **17** failures, including `"harness would ALLOW"` for an out-of-boundary edit and for `rm -rf /var/data`.

Separately, every installed `PreToolUse` hook was fired through the real spawn path: **14 live fires, 0 wrong** (`Edit`/`Write` → `deny` outside the boundary, `Bash rm -rf` → `ask`).

## Notes for review

- Verification is by equivalent reproduction of the harness spawn and dispatch rule, derived from reading `cli.js` 2.1.92 — I did not instrument a live session. If the hook output contract changes in a future release, these suites fail first, which is intentional.
- `investigate` loses its "fall through silently if freeze isn't installed" behaviour. That fallback never actually worked (see point 3), and for a safety hook failing loudly seems better than failing open — but say the word if you'd prefer it restored in a form that works.
- Tested on Windows (Git Bash + `cmd.exe` spawn). The `bash -c` form is platform-neutral, but a second pair of eyes on macOS/Linux would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)