### PR TITLE
redact: block Google OAuth client secrets and Telegram bot tokens

### DIFF
--- a/lib/redact-patterns.ts
+++ b/lib/redact-patterns.ts
@@ -328,6 +328,25 @@ export const PATTERNS: RedactPattern[] = [
     nearWindow: 200,
   },
   {
+    id: "google.oauth_client_secret",
+    tier: "HIGH",
+    category: "secret",
+    // Distinct from google.api_key (MEDIUM): an AIza key is often a public
+    // client key, but a GOCSPX- client secret is never publishable — leaking
+    // it lets anyone impersonate the OAuth app's token exchange.
+    description: "Google OAuth client secret (GOCSPX-…)",
+    regex: /\b(GOCSPX-[A-Za-z0-9_-]{20,40})(?![A-Za-z0-9_-])/,
+    validate: (span) => !isPlaceholderSpan(span),
+  },
+  {
+    id: "telegram.bot_token",
+    tier: "HIGH",
+    category: "secret",
+    description: "Telegram bot token (<bot-id>:AA…)",
+    regex: /\b([0-9]{6,16}:A[A-Za-z0-9_-]{34})(?![A-Za-z0-9_-])/,
+    validate: (span) => !isPlaceholderSpan(span),
+  },
+  {
     id: "pem.private_key",
     tier: "HIGH",
     category: "secret",

--- a/test/redact-engine.test.ts
+++ b/test/redact-engine.test.ts
@@ -54,6 +54,8 @@ describe("HIGH credential patterns", () => {
       "gcp.service_account",
       '{"private_key_id": "abc123", "private_key": "-----BEGIN PRIVATE KEY-----\\nMIIE..."}',
     ],
+    ["google.oauth_client_secret", 'client_secret: "GOCSPX-' + "Ab3xQ9zLmNp2RtVw7YkD1sHf" + '"'],
+    ["telegram.bot_token", "TELEGRAM_TOKEN=8326208591:AA" + "HdqRy9Lm2ZpXvKb4NcQw8TuEr6YoP1sVg"],
   ];
   for (const [id, text] of cases) {
     test(`flags ${id}`, () => {
@@ -164,6 +166,22 @@ describe("#1946 pattern negatives (placeholders never fire)", () => {
     expect(ids("dop_v1_short")).not.toContain("digitalocean.token");
     // pem header WITHOUT the GCP JSON shape stays pem.private_key only.
     expect(ids("-----BEGIN PRIVATE KEY-----")).not.toContain("gcp.service_account");
+  });
+});
+
+describe("google.oauth_client_secret / telegram.bot_token negatives", () => {
+  test("undersized and placeholder shapes never fire", () => {
+    // Length floor keeps short repo fixtures quiet (e.g. the 19-char body in
+    // openclaw's extensions/google/oauth.test.ts).
+    expect(ids("GOCSPX-FakeSecretValue123")).not.toContain("google.oauth_client_secret");
+    expect(ids("GOCSPX-short")).not.toContain("google.oauth_client_secret");
+    // Placeholder suppression on an otherwise correctly-sized body.
+    expect(ids("GOCSPX-example" + "a".repeat(17))).not.toContain("google.oauth_client_secret");
+    expect(ids("1234567890:AAexample" + "a".repeat(26))).not.toContain("telegram.bot_token");
+    // A plain number pair must not read as a bot token.
+    expect(ids("1234567890:1234567890")).not.toContain("telegram.bot_token");
+    // The AIza key stays MEDIUM (google.api_key); it is not promoted here.
+    expect(ids("AIza" + "a".repeat(35))).not.toContain("google.oauth_client_secret");
   });
 });
 


### PR DESCRIPTION
## What

Adds two `HIGH` patterns to the redaction taxonomy:

| id | shape | why HIGH |
|---|---|---|
| `google.oauth_client_secret` | `GOCSPX-…` | Never publishable. Leaking it lets anyone impersonate the OAuth app's token exchange. |
| `telegram.bot_token` | `<bot-id>:AA…` | Full control of the bot, including message history. |

## Why

I hit this for real. A live Google OAuth client secret went through `git push` with the pre-push guard installed and enabled, and the only output was:

```
gstack-redact-prepush: 1 MEDIUM finding(s) in pushed diff (PII/internal). Not blocking.
```

The `GOCSPX-` shape has no pattern in the taxonomy today, so the secret was only caught incidentally by `env.kv`. Telegram bot tokens have no pattern either.

## This respects the existing calibration, it doesn't fight it

`redact-patterns.ts` is explicit that "Stripe publishable keys, Google AIza keys, JWTs, and env-style KV are MEDIUM, not HIGH (they are context-variable / high-FP). Only genuinely-secret credentials block." I agree, and **this PR deliberately leaves `google.api_key` (AIza) at MEDIUM** — those are frequently referrer-restricted public client keys, and promoting them would cry wolf.

A `GOCSPX-` client secret is the opposite case: there is no publishable variant. Same for a bot token. They fit the existing HIGH bar rather than widening it.

## False positives

Handled the same way `db.url_with_password` does it — a length floor plus `validate: (span) => !isPlaceholderSpan(span)`:

- `GOCSPX-FakeSecretValue123` (a real fixture in another repo of mine) — below the 20-char body floor, no finding.
- `GOCSPX-example…`, `1234567890:AAexample…` — suppressed by `isPlaceholderSpan`.
- `1234567890:1234567890` — the `A` anchor keeps plain number pairs from matching.

Both regexes are bounded (`{20,40}`, `{6,16}`/`{34}`) with a negative lookahead instead of a trailing `\b`, since `-` is not a word character and a trailing `\b` misfires on secrets ending in `-`. No nested quantifiers, so `redact-pattern-lint` stays green.

## Testing

- `bun test` across all 10 redaction suites: **190 pass, 0 fail** (`redact-engine`, `redact-pattern-lint`, `redact-prepush-hook`, `redact-engine-autoredact`, `redact-doc-resolver`, `ship-template-redaction`, `cso-spec-taxonomy-alignment`, `redact-audit-log`, `gstack-config-redact-keys`, `document-skills-redaction`).
- Added positive cases to the `HIGH credential patterns` table and a negatives block mirroring `#1946 pattern negatives`.
- Per CONTRIBUTING, also tested by actually using it — a throwaway repo with a real bare remote and `gstack-redact install-prepush-hook`, driven through real `git push`:

```
ok   google-oauth-secret   want=BLOCKED  got=BLOCKED   HIGH  google.oauth_client_secret
ok   telegram-bot-token    want=BLOCKED  got=BLOCKED   HIGH  telegram.bot_token
ok   gocspx-repo-fixture   want=ALLOWED  got=ALLOWED
ok   aiza-still-medium     want=ALLOWED  got=ALLOWED
ok   ordinary-code         want=ALLOWED  got=ALLOWED
```

I did not run the full workspace suite locally — the `browse/` and `ios-*` suites need environment setup I don't have. Happy to adjust the length bounds or naming if you'd prefer different thresholds.
