### PR TITLE
fix(redact): chained pre-push.local silently fails open (stdin newline stripped)

### DIFF
--- a/bin/gstack-redact
+++ b/bin/gstack-redact
@@ -73,10 +73,15 @@ function installPrepushHook(): void {
   }
 
   // stdin is single-consume: capture it once, feed both the chained hook and ours.
+  // The `printf x` sentinel preserves the trailing newline that `$(cat)` strips.
+  // Without it, a chained shell pre-push.local built on `while read` silently
+  // drops the final (often only) ref line and exits 0 — the guard reports
+  // success having scanned nothing, i.e. it fails OPEN.
   const wrapper = `#!/usr/bin/env bash
 ${MANAGED_MARKER}
 set -euo pipefail
-_input="$(cat)"
+_input="$(cat; printf x)"
+_input="\${_input%x}"
 _local="$(git rev-parse --git-path hooks/pre-push.local)"
 if [ -x "$_local" ]; then
   printf '%s' "$_input" | "$_local" "$@" || exit $?

--- a/test/redact-prepush-hook.test.ts
+++ b/test/redact-prepush-hook.test.ts
@@ -216,6 +216,54 @@ describe("install / chaining", () => {
     expect(fs.readFileSync(path.join(hookDir, "pre-push.local"), "utf8")).toContain("echo mine");
   });
 
+  // Regression: `_input="$(cat)"` strips the trailing newline, so a chained
+  // shell hook using `while read` never entered its loop body for the final
+  // (usually only) ref line — it saw zero refs and exited 0, failing OPEN.
+  test("chained pre-push.local receives the final ref line (trailing newline preserved)", () => {
+    const hookDir = path.join(repo, ".git", "hooks");
+    fs.mkdirSync(hookDir, { recursive: true });
+    spawnSync("bun", [REDACT, "install-prepush-hook"], { cwd: repo });
+
+    const seen = path.join(repo, "seen.txt");
+    fs.writeFileSync(
+      path.join(hookDir, "pre-push.local"),
+      `#!/usr/bin/env bash\nwhile read -r a b c d; do echo "$a $b $c $d" >> ${JSON.stringify(seen)}; done\nexit 0\n`,
+      { mode: 0o755 },
+    );
+
+    const sha = "a".repeat(40);
+    const line = `refs/heads/main ${sha} refs/heads/main ${ZERO}\n`;
+    const r = spawnSync("bash", [path.join(hookDir, "pre-push")], {
+      cwd: repo,
+      input: Buffer.from(line),
+      encoding: "utf8",
+      env: { ...process.env, GSTACK_REDACT_PREPUSH: "skip" },
+    });
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(seen)).toBe(true);
+    expect(fs.readFileSync(seen, "utf8").trim()).toBe(
+      `refs/heads/main ${sha} refs/heads/main ${ZERO}`,
+    );
+  });
+
+  test("a blocking pre-push.local still short-circuits the push", () => {
+    const hookDir = path.join(repo, ".git", "hooks");
+    fs.mkdirSync(hookDir, { recursive: true });
+    spawnSync("bun", [REDACT, "install-prepush-hook"], { cwd: repo });
+    fs.writeFileSync(
+      path.join(hookDir, "pre-push.local"),
+      "#!/usr/bin/env bash\nwhile read -r _a _b _c _d || [ -n \"${_a:-}\" ]; do exit 1; done\nexit 0\n",
+      { mode: 0o755 },
+    );
+    const r = spawnSync("bash", [path.join(hookDir, "pre-push")], {
+      cwd: repo,
+      input: Buffer.from(`refs/heads/main ${"b".repeat(40)} refs/heads/main ${ZERO}\n`),
+      encoding: "utf8",
+      env: { ...process.env, GSTACK_REDACT_PREPUSH: "skip" },
+    });
+    expect(r.status).toBe(1);
+  });
+
   test("uninstall restores the chained original", () => {
     const hookDir = path.join(repo, ".git", "hooks");
     fs.mkdirSync(hookDir, { recursive: true });


### PR DESCRIPTION
## The bug

The managed pre-push wrapper captures stdin with:

```bash
_input="$(cat)"
```

Command substitution strips **all** trailing newlines, and the wrapper then re-emits with `printf '%s'` — no newline. Git's pre-push protocol is line-oriented, so a chained `pre-push.local` written in shell does this:

```bash
while read -r local_ref local_sha remote_ref remote_sha; do
  ...
done
```

`read` returns non-zero at EOF on an unterminated final line, so **the loop body never runs for that line**. With a single ref being pushed — the common case — the chained hook sees zero refs, falls through, and exits 0.

**It fails open.** The local hook prints nothing, git reports a normal successful push, and the user believes their credential scan ran. Mine appeared correctly installed and executable for hours while scanning nothing.

`bin/gstack-redact-prepush` itself is unaffected because it reads stdin as a whole buffer, which is why this hasn't surfaced — but `pre-push.local` is a documented extension seam, and today it silently breaks for any shell hook that reads line-by-line (including git's own `pre-push.sample`, which is `while read` based).

## The fix

```bash
_input="$(cat; printf x)"
_input="${_input%x}"
```

The sentinel makes the capture byte-exact, so stdin is forwarded to both the chained hook and `gstack-redact-prepush` exactly as git supplied it. I chose this over `printf '%s\n'` because it round-trips precisely rather than approximately — for a security control, "approximately correct stdin" is what caused the bug.

## Testing

Two tests added to `describe("install / chaining")`:

1. **The regression test** — installs the managed hook, chains a `while read` shell `pre-push.local` that logs what it saw, drives the wrapper with a realistic ref line, and asserts the local hook received it.
2. A companion asserting a chained hook that exits non-zero still short-circuits the push (so the fix doesn't quietly break the propagation path).

Verified the regression test actually catches the bug — with the tests in place and only `bin/gstack-redact` reverted:

```
16 pass, 1 fail     # bug present
17 pass, 0 fail     # fix applied
```

Also ran the surrounding redaction suites: **160 pass, 0 fail** across `redact-prepush-hook`, `redact-engine`, `redact-pattern-lint`, `redact-engine-autoredact`, `ship-template-redaction`, `redact-audit-log`.

Note: existing installs keep the old wrapper until the hook is reinstalled, since `install-prepush-hook` returns early when it sees the managed marker. Happy to add a marker-version bump that rewrites a stale wrapper in place if you'd like that in the same PR.
