### PR TITLE
fix: normalise git_remote fallback so --include-unattributed guard fires (#2353)

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -744,7 +744,9 @@ function buildTranscriptPage(path: string, session: ParsedSession): PageRecord {
     source_path: path,
     session_id: session.session_id,
     cwd: session.cwd,
-    git_remote: remote,
+    // Normalise at the source so the --include-unattributed guard sees the
+    // same fallback the frontmatter and slug already use (#2353).
+    git_remote: remote || "_unattributed",
     start_time: session.start_time,
     end_time: session.end_time,
     partial: session.partial,

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -470,6 +470,39 @@ describe("gstack-memory-ingest writer (gbrain v0.20+ batch `import` interface)",
     expect(stagedList).toMatch(/^\.\/transcripts\/claude-code\/.+\.md$/m);
   });
 
+  // #2353 regression: buildTranscriptPage stored the RAW remote ("" on
+  // failure) in page.git_remote while the skip guard compares against the
+  // "_unattributed" fallback, so `"" === "_unattributed"` never matched and
+  // unattributable sessions imported despite the default policy.
+  it("skips unattributable sessions by default and counts them in skipped (unattrib)", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir, stagingListFile } = installFakeGbrain(home);
+
+    // Same fixture as above: cwd has no resolvable git remote. WITHOUT
+    // --include-unattributed the session must be skipped, not imported.
+    const session =
+      `{"type":"user","message":{"role":"user","content":"hi"},"timestamp":"2026-05-01T00:00:00Z","cwd":"/tmp/foo"}\n` +
+      `{"type":"assistant","message":{"role":"assistant","content":"hello"},"timestamp":"2026-05-01T00:00:01Z"}\n`;
+    writeClaudeCodeSession(home, "tmp-foo", "def456", session);
+
+    const r = runScript(["--bulk", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.exitCode).toBe(0);
+    // The user-facing counter must report the skip (was silently 0).
+    expect(r.stdout).toMatch(/skipped \(unattrib\):\s+1/);
+    // Nothing transcript-shaped may reach the gbrain staging dir.
+    if (existsSync(stagingListFile)) {
+      const stagedList = readFileSync(stagingListFile, "utf-8");
+      expect(stagedList).not.toMatch(/transcripts\//);
+    }
+  });
+
   // Originally landed in v1.32.0.0 (PR #1411) on the per-file `gbrain put`
   // path. Postgres rejects 0x00 in UTF-8 text columns. Some Claude Code
   // transcripts contain NUL inside user-pasted content or tool output. The


### PR DESCRIPTION
## Problem

`buildTranscriptPage` stores the **raw** git remote (`""` when resolution fails) in `page.git_remote`, while the frontmatter and slug already apply the `"_unattributed"` fallback. The skip guard compares against the fallback string:

```ts
if (!args.includeUnattributed && page.git_remote === "_unattributed") {
```

`"" === "_unattributed"` is always false, so the branch is dead: unattributable sessions import despite the default policy, and the `skipped (unattrib)` counter always reads 0.

## Fix

Normalise once at the source (`bin/gstack-memory-ingest.ts`), matching what `buildArtifactPage` already does:

```ts
git_remote: remote || "_unattributed",
```

## Test

Regression test in `test/gstack-memory-ingest.test.ts`: an unattributable session (cwd with no resolvable remote) run **without** `--include-unattributed` is skipped, reported as `skipped (unattrib): 1`, and never reaches the gbrain staging dir.

- Verified the new test fails on main without the fix and passes with it.
- Full `test/gstack-memory-ingest.test.ts` suite: 24 pass, 0 fail (bun 1.3.14, macOS).

The issue's optional suggestion (recovering attribution from the encoded transcript path) is left as a follow-up — this PR only fixes the dead guard.

Fixes #2353

🤖 Generated with [Claude Code](https://claude.com/claude-code)