### PR TITLE
feat: add gstack-cursor-install and gstack-cloud-bootstrap for Cloud …

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,33 @@ bun run skill:check      # health dashboard for all skills
   helper resolves state roots through `CLAUDE_PLUGIN_DATA` / `GSTACK_HOME` so plugin
   installs work on every platform.
 
+## Cloud Agent bootstrap
+
+Cloud Agent VMs start fresh every session. If `.cursor/skills/gstack` is absent,
+install gstack before doing any work — **no bun required**:
+
+```bash
+# One-liner: clone gstack and install into .cursor/skills/ of the current repo
+git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.gstack/repos/gstack \
+  && ~/.gstack/repos/gstack/bin/gstack-cloud-bootstrap
+```
+
+If gstack is already cloned (common when it's a repo dependency or cached):
+
+```bash
+$GSTACK_ROOT/bin/gstack-cloud-bootstrap
+```
+
+Or use `setup --host cursor` directly from the gstack directory:
+
+```bash
+/path/to/gstack/setup --host cursor          # installs into <repo>/.cursor/skills/
+GSTACK_SKILLS_DIR=/custom/path setup --host cursor  # custom target
+```
+
+The bootstrap is idempotent — safe to run at every session start as a health check.
+Set `GSTACK_AUTOUPDATE=1` to pull the latest gstack on each run.
+
 ## Key conventions
 
 - SKILL.md files are **generated** from `.tmpl` templates. Edit the template, not the output.
@@ -135,3 +162,4 @@ bun run skill:check      # health dashboard for all skills
 - Safety skills (careful, freeze, guard) use inline advisory prose — always confirm before destructive operations.
 - State paths resolve via `bin/gstack-paths` (sourced via `eval "$(...)"`). Honors `GSTACK_HOME`, `CLAUDE_PLUGIN_DATA`, `CLAUDE_PLANS_DIR`.
 - The `claude` CLI binary resolves via `browse/src/claude-bin.ts` (`Bun.which()` + `GSTACK_CLAUDE_BIN` override). Set `GSTACK_CLAUDE_BIN=wsl` plus `GSTACK_CLAUDE_BIN_ARGS='["claude"]'` to run Claude through WSL on Windows.
+- `bin/gstack-cursor-install` and `bin/gstack-cloud-bootstrap` are bun-free and safe for Cloud Agent VMs.

--- a/bin/gstack-cloud-bootstrap
+++ b/bin/gstack-cloud-bootstrap
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# gstack-cloud-bootstrap — bootstrap gstack for a Cloud Agent VM
+#
+# Clones gstack (if not already present) and installs skills into
+# .cursor/skills/ so Cloud Agents can invoke them from session start.
+#
+# Does NOT require bun. Uses only bash, git, sed.
+# Safe to run multiple times (idempotent).
+#
+# Usage:
+#   # From within the project repo:
+#   gstack-cloud-bootstrap
+#
+#   # One-liner for a fresh VM (pipe from curl):
+#   curl -fsSL https://raw.githubusercontent.com/garrytan/gstack/main/bin/gstack-cloud-bootstrap | bash
+#
+# Environment:
+#   GSTACK_REPO          — git remote to clone from (default: garrytan/gstack on GitHub)
+#   GSTACK_CACHE_DIR     — where to cache the gstack clone (default: ~/.gstack/repos/gstack)
+#   GSTACK_AUTOUPDATE    — set to 1 to git-pull on every run (default: 0)
+#   GSTACK_SKILLS_DIR    — override target skills dir (default: <repo-root>/.cursor/skills)
+#   GSTACK_MIN_SKILLS    — minimum expected skill count for verify step (default: 10)
+
+set -e
+
+GSTACK_REPO="${GSTACK_REPO:-https://github.com/garrytan/gstack.git}"
+GSTACK_CACHE_DIR="${GSTACK_CACHE_DIR:-$HOME/.gstack/repos/gstack}"
+GSTACK_AUTOUPDATE="${GSTACK_AUTOUPDATE:-0}"
+GSTACK_MIN_SKILLS="${GSTACK_MIN_SKILLS:-10}"
+
+# ── Resolve project root and skills target ──────────────────────
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+TARGET_SKILLS="${GSTACK_SKILLS_DIR:-$REPO_ROOT/.cursor/skills}"
+
+# ── Step 1: Clone or refresh gstack ────────────────────────────
+if [ ! -d "$GSTACK_CACHE_DIR/.git" ]; then
+  echo "gstack: cloning to $GSTACK_CACHE_DIR..."
+  mkdir -p "$(dirname "$GSTACK_CACHE_DIR")"
+  git clone --single-branch --depth 1 "$GSTACK_REPO" "$GSTACK_CACHE_DIR"
+elif [ "$GSTACK_AUTOUPDATE" = "1" ]; then
+  echo "gstack: pulling latest..."
+  git -C "$GSTACK_CACHE_DIR" fetch --depth 1 origin
+  git -C "$GSTACK_CACHE_DIR" reset --hard FETCH_HEAD
+fi
+
+CURSOR_INSTALL="$GSTACK_CACHE_DIR/bin/gstack-cursor-install"
+if [ ! -x "$CURSOR_INSTALL" ]; then
+  echo "gstack: error — gstack-cursor-install not found at $CURSOR_INSTALL" >&2
+  exit 1
+fi
+
+# ── Step 2: Install into .cursor/skills/ ───────────────────────
+mkdir -p "$TARGET_SKILLS"
+"$CURSOR_INSTALL" "$TARGET_SKILLS"
+
+# ── Step 3: Verify ─────────────────────────────────────────────
+skill_count=$(find "$TARGET_SKILLS" -mindepth 2 -maxdepth 2 -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' ')
+echo "gstack: verified $skill_count skills in $TARGET_SKILLS"
+
+if [ "$skill_count" -lt "$GSTACK_MIN_SKILLS" ]; then
+  echo "gstack: warning — only $skill_count skills installed (expected ≥$GSTACK_MIN_SKILLS)" >&2
+  echo "  Run GSTACK_CURSOR_VERBOSE=1 $CURSOR_INSTALL $TARGET_SKILLS for details." >&2
+  exit 1
+fi

--- a/bin/gstack-cursor-install
+++ b/bin/gstack-cursor-install
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# gstack-cursor-install — install gstack skills into .cursor/skills/
+#
+# Works without bun. Designed for Cloud Agent VMs and Cursor IDE users
+# who want gstack available without a full bun build.
+#
+# Strategy:
+#   1. If .agents/skills/ exists (pre-generated), use those skill docs.
+#   2. Otherwise fall back to source SKILL.md files with sed path rewrites.
+#
+# Usage:
+#   gstack-cursor-install [<target-skills-dir>]
+#
+#   Default target: .cursor/skills/ in the current git repo root,
+#   or ./.cursor/skills if not in a git repo.
+#
+# Environment:
+#   GSTACK_CURSOR_QUIET=1  — suppress progress output
+
+set -e
+
+GSTACK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+QUIET="${GSTACK_CURSOR_QUIET:-0}"
+
+log() { [ "$QUIET" -eq 0 ] && echo "$@" || true; }
+
+# ── Resolve target directory ────────────────────────────────────
+if [ -n "${1:-}" ]; then
+  TARGET_SKILLS="$1"
+else
+  REPO_ROOT="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || pwd)"
+  TARGET_SKILLS="$REPO_ROOT/.cursor/skills"
+fi
+
+CURSOR_GSTACK="$TARGET_SKILLS/gstack"
+AGENTS_DIR="$GSTACK_DIR/.agents/skills"
+
+# ── Decide skill source ─────────────────────────────────────────
+# Prefer pre-generated .agents/skills/ (avoids any bun dependency);
+# fall back to source directories when .agents/ is absent or empty.
+if [ -d "$AGENTS_DIR" ] && ls "$AGENTS_DIR"/gstack-*/SKILL.md >/dev/null 2>&1; then
+  SKILL_SOURCE="agents"
+else
+  SKILL_SOURCE="source"
+fi
+
+# ── Path rewrite helper ─────────────────────────────────────────
+rewrite_cursor_paths() {
+  local src="$1"
+  local dst="$2"
+  sed \
+    -e "s|~/.claude/skills/gstack|.cursor/skills/gstack|g" \
+    -e "s|\.claude/skills/gstack|.cursor/skills/gstack|g" \
+    -e "s|\.claude/skills|.cursor/skills|g" \
+    -e "s|~/.codex/skills/gstack|.cursor/skills/gstack|g" \
+    -e "s|\$HOME/.codex/skills/gstack|.cursor/skills/gstack|g" \
+    "$src" > "$dst"
+}
+
+# ── Create gstack runtime root ──────────────────────────────────
+mkdir -p "$CURSOR_GSTACK/review"
+
+# Root SKILL.md
+if [ -f "$GSTACK_DIR/SKILL.md" ]; then
+  rewrite_cursor_paths "$GSTACK_DIR/SKILL.md" "$CURSOR_GSTACK/SKILL.md"
+fi
+
+# ETHOS.md (referenced by every skill's preamble)
+if [ -f "$GSTACK_DIR/ETHOS.md" ]; then
+  cp "$GSTACK_DIR/ETHOS.md" "$CURSOR_GSTACK/ETHOS.md"
+fi
+
+# Review support files
+for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+  if [ -f "$GSTACK_DIR/review/$f" ]; then
+    cp "$GSTACK_DIR/review/$f" "$CURSOR_GSTACK/review/$f"
+  fi
+done
+
+# ── Install individual skills ───────────────────────────────────
+LINKED=()
+
+if [ "$SKILL_SOURCE" = "agents" ]; then
+  # Use pre-generated Codex-format skill docs from .agents/skills/
+  for skill_dir in "$AGENTS_DIR"/gstack*/; do
+    [ -f "$skill_dir/SKILL.md" ] || continue
+    skill_name="$(basename "$skill_dir")"
+    # Skip the sidecar root (it's the gstack runtime root, not a skill)
+    [ "$skill_name" = "gstack" ] && continue
+    target_dir="$TARGET_SKILLS/$skill_name"
+    mkdir -p "$target_dir"
+    rewrite_cursor_paths "$skill_dir/SKILL.md" "$target_dir/SKILL.md"
+    LINKED+=("$skill_name")
+  done
+else
+  # Fall back to source SKILL.md files
+  for skill_dir in "$GSTACK_DIR"/*/; do
+    [ -f "$skill_dir/SKILL.md" ] || continue
+    skill_name="$(basename "$skill_dir")"
+    [ "$skill_name" = "node_modules" ] && continue
+    target_dir="$TARGET_SKILLS/$skill_name"
+    mkdir -p "$target_dir"
+    rewrite_cursor_paths "$skill_dir/SKILL.md" "$target_dir/SKILL.md"
+    LINKED+=("$skill_name")
+  done
+fi
+
+SKILL_COUNT="${#LINKED[@]}"
+log "gstack installed to $TARGET_SKILLS ($SKILL_COUNT skills)"
+if [ "${GSTACK_CURSOR_VERBOSE:-0}" = "1" ]; then
+  log "  skills: ${LINKED[*]}"
+fi

--- a/setup
+++ b/setup
@@ -85,7 +85,7 @@ NO_TEAM_MODE=0
 PLAN_TUNE_HOOKS_MODE=""   # "" = resolve from env/config/prompt; "yes"/"no" = explicit
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, cursor, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -102,6 +102,21 @@ done
 
 case "$HOST" in
   claude|codex|kiro|factory|opencode|auto) ;;
+  cursor)
+    # Cursor install is bun-free — delegate to gstack-cursor-install and exit.
+    _CURSOR_INSTALL="$(cd "$(dirname "$0")" && pwd)/bin/gstack-cursor-install"
+    if [ ! -x "$_CURSOR_INSTALL" ]; then
+      echo "gstack setup: error — bin/gstack-cursor-install not found at $_CURSOR_INSTALL" >&2
+      exit 1
+    fi
+    _REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    _TARGET="${GSTACK_SKILLS_DIR:-$_REPO_ROOT/.cursor/skills}"
+    mkdir -p "$_TARGET"
+    GSTACK_CURSOR_QUIET="$QUIET" "$_CURSOR_INSTALL" "$_TARGET"
+    log "gstack ready (cursor)."
+    log "  cursor skills: $_TARGET"
+    log "  Run /gstack-upgrade to update skills."
+    exit 0 ;;
   openclaw)
     echo ""
     echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
@@ -136,7 +151,7 @@ case "$HOST" in
     echo "GBrain setup and brain skills ship from the GBrain repo."
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, cursor, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────

--- a/test/cursor-install.test.ts
+++ b/test/cursor-install.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for bin/gstack-cursor-install and bin/gstack-cloud-bootstrap.
+ *
+ * gstack-cursor-install installs gstack skills into .cursor/skills/ without
+ * requiring bun — it uses sed-based path rewrites on source SKILL.md files.
+ *
+ * gstack-cloud-bootstrap wraps cursor-install with a git-clone step for use
+ * on fresh Cloud Agent VMs.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { execSync } from 'child_process';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const CURSOR_INSTALL = path.join(ROOT, 'bin', 'gstack-cursor-install');
+const CLOUD_BOOTSTRAP = path.join(ROOT, 'bin', 'gstack-cloud-bootstrap');
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function mkTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-cursor-test-'));
+}
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function run(
+  cmd: string,
+  opts: { cwd?: string; env?: Record<string, string>; timeout?: number } = {}
+): RunResult {
+  try {
+    const stdout = execSync(cmd, {
+      cwd: opts.cwd ?? ROOT,
+      env: { ...process.env, ...opts.env },
+      encoding: 'utf-8',
+      timeout: opts.timeout ?? 15_000,
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (e: any) {
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', exitCode: e.status ?? 1 };
+  }
+}
+
+// ── gstack-cursor-install ───────────────────────────────────────
+
+describe('gstack-cursor-install', () => {
+  let tmpDir: string;
+  let cursorSkills: string;
+
+  beforeEach(() => {
+    tmpDir = mkTmpDir();
+    cursorSkills = path.join(tmpDir, '.cursor', 'skills');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── Existence and executability ────────────────────────────
+
+  test('script exists at bin/gstack-cursor-install', () => {
+    expect(fs.existsSync(CURSOR_INSTALL)).toBe(true);
+  });
+
+  test('script is executable', () => {
+    const stat = fs.statSync(CURSOR_INSTALL);
+    // Owner execute bit
+    expect(stat.mode & 0o100).toBeGreaterThan(0);
+  });
+
+  test('script does not depend on bun', () => {
+    const content = fs.readFileSync(CURSOR_INSTALL, 'utf-8');
+    expect(content).not.toContain('command -v bun');
+    expect(content).not.toContain('bun run');
+    expect(content).not.toContain('bun install');
+  });
+
+  // ── Install outcome ────────────────────────────────────────
+
+  test('creates target .cursor/skills/ directory', () => {
+    const result = run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    expect(result.exitCode).toBe(0);
+    expect(fs.existsSync(cursorSkills)).toBe(true);
+  });
+
+  test('creates gstack/ runtime root inside target', () => {
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    expect(fs.existsSync(path.join(cursorSkills, 'gstack'))).toBe(true);
+  });
+
+  test('installs ETHOS.md in gstack/', () => {
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    expect(fs.existsSync(path.join(cursorSkills, 'gstack', 'ETHOS.md'))).toBe(true);
+  });
+
+  test('installs gstack/SKILL.md root descriptor', () => {
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    expect(fs.existsSync(path.join(cursorSkills, 'gstack', 'SKILL.md'))).toBe(true);
+  });
+
+  test('installs gstack/review/checklist.md', () => {
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    expect(fs.existsSync(path.join(cursorSkills, 'gstack', 'review', 'checklist.md'))).toBe(true);
+  });
+
+  test('installs at least 10 skills with SKILL.md files', () => {
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    const installed = fs.readdirSync(cursorSkills, { withFileTypes: true })
+      .filter(d => d.isDirectory() && fs.existsSync(path.join(cursorSkills, d.name, 'SKILL.md')));
+    expect(installed.length).toBeGreaterThanOrEqual(10);
+  });
+
+  // ── Path rewrites ──────────────────────────────────────────
+
+  test('root gstack/SKILL.md contains no ~/.claude/skills references', () => {
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    const content = fs.readFileSync(path.join(cursorSkills, 'gstack', 'SKILL.md'), 'utf-8');
+    expect(content).not.toContain('~/.claude/skills/gstack');
+  });
+
+  test('root gstack/SKILL.md contains .cursor/skills/gstack reference', () => {
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    const content = fs.readFileSync(path.join(cursorSkills, 'gstack', 'SKILL.md'), 'utf-8');
+    expect(content).toContain('.cursor/skills/gstack');
+  });
+
+  test('individual skill SKILL.md files contain no ~/.claude/skills references', () => {
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    const skills = fs.readdirSync(cursorSkills, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name);
+    for (const skill of skills) {
+      const skillFile = path.join(cursorSkills, skill, 'SKILL.md');
+      if (!fs.existsSync(skillFile)) continue;
+      const content = fs.readFileSync(skillFile, 'utf-8');
+      expect(content).not.toContain('~/.claude/skills/gstack');
+    }
+  });
+
+  test('no skill SKILL.md contains ~/.codex/skills references', () => {
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    const skills = fs.readdirSync(cursorSkills, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name);
+    for (const skill of skills) {
+      const skillFile = path.join(cursorSkills, skill, 'SKILL.md');
+      if (!fs.existsSync(skillFile)) continue;
+      const content = fs.readFileSync(skillFile, 'utf-8');
+      expect(content).not.toContain('~/.codex/skills');
+    }
+  });
+
+  // ── Idempotency ────────────────────────────────────────────
+
+  test('running twice does not fail', () => {
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    const result = run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('running twice leaves ETHOS.md intact', () => {
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    run(`${CURSOR_INSTALL} ${cursorSkills}`);
+    expect(fs.existsSync(path.join(cursorSkills, 'gstack', 'ETHOS.md'))).toBe(true);
+  });
+
+  // ── Quiet mode ─────────────────────────────────────────────
+
+  test('GSTACK_CURSOR_QUIET=1 suppresses stdout', () => {
+    const result = run(`${CURSOR_INSTALL} ${cursorSkills}`, {
+      env: { GSTACK_CURSOR_QUIET: '1' },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('');
+  });
+});
+
+// ── gstack-cloud-bootstrap ─────────────────────────────────────
+
+describe('gstack-cloud-bootstrap', () => {
+  test('script exists at bin/gstack-cloud-bootstrap', () => {
+    expect(fs.existsSync(CLOUD_BOOTSTRAP)).toBe(true);
+  });
+
+  test('script is executable', () => {
+    const stat = fs.statSync(CLOUD_BOOTSTRAP);
+    expect(stat.mode & 0o100).toBeGreaterThan(0);
+  });
+
+  test('script does not depend on bun', () => {
+    const content = fs.readFileSync(CLOUD_BOOTSTRAP, 'utf-8');
+    expect(content).not.toContain('command -v bun');
+    expect(content).not.toContain('bun run');
+    expect(content).not.toContain('bun install');
+  });
+
+  test('script clones gstack via git', () => {
+    const content = fs.readFileSync(CLOUD_BOOTSTRAP, 'utf-8');
+    expect(content).toContain('git clone');
+  });
+
+  test('script delegates to gstack-cursor-install', () => {
+    const content = fs.readFileSync(CLOUD_BOOTSTRAP, 'utf-8');
+    expect(content).toContain('gstack-cursor-install');
+  });
+
+  test('script verifies skill count after install', () => {
+    const content = fs.readFileSync(CLOUD_BOOTSTRAP, 'utf-8');
+    // Should check that enough skills were installed
+    expect(content).toContain('skill_count');
+    expect(content).toContain('GSTACK_MIN_SKILLS');
+  });
+
+  test('script exits non-zero when fewer than min skills installed', () => {
+    const content = fs.readFileSync(CLOUD_BOOTSTRAP, 'utf-8');
+    // Verify the guard is present
+    expect(content).toContain('exit 1');
+    expect(content).toContain('skill_count');
+  });
+
+  test('script supports GSTACK_AUTOUPDATE env var', () => {
+    const content = fs.readFileSync(CLOUD_BOOTSTRAP, 'utf-8');
+    expect(content).toContain('GSTACK_AUTOUPDATE');
+  });
+
+  test('script supports GSTACK_CACHE_DIR env var', () => {
+    const content = fs.readFileSync(CLOUD_BOOTSTRAP, 'utf-8');
+    expect(content).toContain('GSTACK_CACHE_DIR');
+  });
+
+  test('bootstrap using local repo does not require network', () => {
+    // Bootstrap with GSTACK_CACHE_DIR pointing at our local repo.
+    // This verifies the full install path without a git clone.
+    const tmpDir = mkTmpDir();
+    try {
+      const result = run(`${CLOUD_BOOTSTRAP}`, {
+        cwd: tmpDir,
+        env: {
+          GSTACK_CACHE_DIR: ROOT,
+          GSTACK_SKILLS_DIR: path.join(tmpDir, '.cursor', 'skills'),
+        },
+      });
+      expect(result.exitCode).toBe(0);
+      // Verify skills exist
+      const skillsDir = path.join(tmpDir, '.cursor', 'skills');
+      const skillCount = fs
+        .readdirSync(skillsDir, { withFileTypes: true })
+        .filter(d => d.isDirectory() && fs.existsSync(path.join(skillsDir, d.name, 'SKILL.md')))
+        .length;
+      expect(skillCount).toBeGreaterThanOrEqual(10);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── setup --host cursor ────────────────────────────────────────
+
+describe('setup --host cursor', () => {
+  const SETUP_SCRIPT = path.join(ROOT, 'setup');
+
+  test('setup script contains cursor in valid --host values', () => {
+    const content = fs.readFileSync(SETUP_SCRIPT, 'utf-8');
+    expect(content).toContain('cursor');
+  });
+
+  test('setup --host cursor exits 0 and installs skills', () => {
+    const tmpDir = mkTmpDir();
+    try {
+      const result = run(`${SETUP_SCRIPT} --host cursor --quiet`, {
+        cwd: tmpDir,
+        env: { GSTACK_SKILLS_DIR: path.join(tmpDir, '.cursor', 'skills') },
+      });
+      expect(result.exitCode).toBe(0);
+      const skillsDir = path.join(tmpDir, '.cursor', 'skills');
+      expect(fs.existsSync(skillsDir)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
…Agent VMs

Add bun-free skill installation for Cursor / Cloud Agent VMs:

- bin/gstack-cursor-install: installs gstack skills into .cursor/skills/ via sed path rewrites. No bun required. Falls back from pre-generated .agents/skills/ to source SKILL.md files automatically.

- bin/gstack-cloud-bootstrap: VM-startup bootstrap that clones gstack once and calls gstack-cursor-install. Idempotent; configurable via GSTACK_CACHE_DIR, GSTACK_AUTOUPDATE, GSTACK_SKILLS_DIR, GSTACK_MIN_SKILLS.

- setup --host cursor: new early-exit path that delegates to gstack-cursor-install and skips all bun-dependent steps.

- AGENTS.md: new 'Cloud Agent bootstrap' section with one-liner, cached-clone, and setup --host cursor variants.

- test/cursor-install.test.ts: 25 tests covering existence, executability, no-bun contract, >=10 skills, path rewrites, quiet mode, idempotency, and full bootstrap round-trip.

Closes #2322