### PR TITLE
fix(redact): stop all-zero digit runs matching pii.cc

### DIFF
--- a/lib/redact-patterns.ts
+++ b/lib/redact-patterns.ts
@@ -455,7 +455,9 @@ export const PATTERNS: RedactPattern[] = [
     regex: /\b((?:\d[ \-]?){13,19})\b/,
     autoRedactable: true,
     redactToken: "<REDACTED-CC>",
-    validate: (span) => luhnValid(span),
+    // An all-zero run is Luhn-valid (checksum 0) but is never a card number.
+    // SVG <feColorMatrix values="0 0 0 ..."> hits this constantly.
+    validate: (span) => !/^0+$/.test(span.replace(/[ \-]/g, "")) && luhnValid(span),
   },
   {
     id: "pii.ip_public",

--- a/test/redact-engine.test.ts
+++ b/test/redact-engine.test.ts
@@ -196,6 +196,16 @@ describe("PII patterns", () => {
     expect(ids("card 4111111111111111")).toContain("pii.cc");
     expect(ids("num 4111111111111112")).not.toContain("pii.cc");
   });
+  test("all-zero runs are not cards", () => {
+    // Luhn-valid (checksum 0) but never a real card. SVG colour matrices are
+    // full of these: <feColorMatrix values="0 0 0 0 0 ...">.
+    expect(ids("0000000000000000")).not.toContain("pii.cc");
+    expect(ids('values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"')).not.toContain(
+      "pii.cc"
+    );
+    // A zero-leading real card must still be caught.
+    expect(ids("card 0000000000000018")).toContain("pii.cc");
+  });
   test("public IP flagged, RFC1918 skipped", () => {
     expect(ids("connect 8.8.8.8")).toContain("pii.ip_public");
     expect(ids("local 192.168.1.5")).not.toContain("pii.ip_public");


### PR DESCRIPTION
## The bug

An all-zero digit run passes Luhn trivially — the checksum is 0, and `0 % 10 === 0`. So `pii.cc` reports `0000000000000000` as a credit card.

Because the `pii.cc` regex allows spaces between digits:

```js
regex: /\b((?:\d[ \-]?){13,19})\b/
```

…anything with a long run of space-separated zeros matches. SVG is the common case:

```xml
<feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0" />
```

Every colour matrix in a repo becomes a MEDIUM finding.

## Why it matters

On a repo with a lot of vendored SVG icons, the pre-push hook reported **119 MEDIUM findings, all of them this**. They buried 7 unrelated findings that were worth looking at (CDN hashes matching `pii.wallet`, query params matching `pii.phone.e164`). The noise is what makes the signal easy to skip.

## The fix

Reject all-zero spans before the Luhn check:

```js
validate: (span) => !/^0+$/.test(span.replace(/[ \-]/g, "")) && luhnValid(span),
```

After this the same diff reports 7 instead of 119.

## Not over-corrected

Only spans that are *entirely* zeros are dropped. Cards with leading zeros still match, pinned by a test:

```js
expect(ids("card 0000000000000018")).toContain("pii.cc");
```

## Tests

Added a case to `test/redact-engine.test.ts` covering the bare run, the SVG-shaped string, and the leading-zero card above.

`bun test test/redact-engine.test.ts test/redact-pattern-lint.test.ts test/redact-engine-autoredact.test.ts test/gstack-redact-cli.test.ts` → 139 pass, 0 fail.