### PR TITLE
Fix: resolveSlug silently returns "unknown" on Windows

### DIFF
--- a/lib/bin-context.ts
+++ b/lib/bin-context.ts
@@ -1,5 +1,5 @@
 /**
- * bin-context — tiny shared helpers for non-interactive gstack bins that need the
+ * bin-context -- tiny shared helpers for non-interactive gstack bins that need the
  * project slug, current branch, and argv flags. Extracted from the decision bins
  * (gstack-decision-log / gstack-decision-search) so the slug/branch/flag plumbing
  * lives in one audited place instead of being copy-pasted per bin.
@@ -9,9 +9,44 @@ import { spawnSync } from "child_process";
 
 /** Resolve the project slug via the `gstack-slug` helper (parses `SLUG=...`). */
 export function resolveSlug(slugBinPath: string): string {
-  const r = spawnSync(slugBinPath, { encoding: "utf-8" });
-  const m = (r.stdout || "").match(/^SLUG=(.+)$/m);
-  return m ? m[1].trim() : "unknown";
+  const parse = (out: string | null): string | undefined =>
+    (out || "").match(/^SLUG=(.+)$/m)?.[1].trim();
+
+  // Direct call first, so POSIX behaviour is unchanged.
+  const direct = spawnSync(slugBinPath, { encoding: "utf-8" });
+  const fromDirect = parse(direct.stdout);
+  if (fromDirect) return fromDirect;
+
+  // `gstack-slug` is an extension-less bash script. On Windows, spawnSync
+  // without a shell goes through CreateProcess, which does not honour
+  // shebangs: the call fails with ENOENT and stdout is null. `shell: true`
+  // does not help either -- cmd.exe has no association for an extension-less
+  // file. Naming the interpreter is what works. Retry whenever the direct
+  // call yielded no slug rather than only on ENOENT, so a shim that exits
+  // non-zero without output is covered too. bash specifically, not sh:
+  // gstack-slug uses `[[ ]]` and `set -o pipefail`.
+  const viaBash = spawnSync("bash", [slugBinPath], { encoding: "utf-8" });
+  const fromBash = parse(viaBash.stdout);
+  if (fromBash) return fromBash;
+
+  // A tooling failure is not an anonymous project, and a mute fallback is what
+  // let this live: callers then read and write ~/.gstack/projects/unknown/ --
+  // one shared bucket for every repo on the machine on the write side, and on
+  // the read side a directory that does not exist, so the search returns an
+  // empty list and exits 0. The session is told there are no prior decisions
+  // and re-litigates settled calls in good faith. Keep the fallback; never
+  // keep it quiet.
+  const reason = (r: typeof direct): string =>
+    (r.error as NodeJS.ErrnoException | undefined)?.code ??
+    r.error?.message ??
+    `exited ${r.status}`;
+  process.stderr.write(
+    `gstack: could not resolve the project slug from ${slugBinPath} ` +
+      `(direct: ${reason(direct)}; via bash: ${reason(viaBash)}). ` +
+      `Falling back to "unknown" -- decisions will read and write ` +
+      `~/.gstack/projects/unknown/ instead of this project.\n`,
+  );
+  return "unknown";
 }
 
 /** Current git branch, or undefined on detached HEAD / outside a repo. */

--- a/test/bin-context-resolve-slug.test.ts
+++ b/test/bin-context-resolve-slug.test.ts
@@ -1,0 +1,60 @@
+/**
+ * resolveSlug portability guard (free).
+ *
+ * `bin/gstack-slug` is an extension-less bash script. On Windows, spawnSync
+ * without a shell goes through CreateProcess, which does not honour shebangs:
+ * the direct call fails with ENOENT, stdout is null, and resolveSlug used to
+ * return the literal "unknown". Both consumers -- gstack-decision-log and
+ * gstack-decision-search -- then read and write ~/.gstack/projects/unknown/.
+ * On the write side that is one anonymous bucket shared by every repo on the
+ * machine; on the read side the directory does not exist, so the search
+ * returns an empty list and exits 0. The session is told there are no prior
+ * decisions and re-litigates settled calls in good faith.
+ *
+ * Two things are pinned here, because the bug had two halves:
+ *
+ *   1. the fallback -- an extension-less shebang script must resolve on every
+ *      platform, which is what the `bash <script>` retry buys;
+ *   2. the diagnosis -- a resolution failure must be audible. A mute fallback
+ *      is what let this live long enough to corrupt sessions' reasoning.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveSlug } from '../lib/bin-context';
+
+/** A stand-in for bin/gstack-slug: shebang script, deliberately no extension. */
+function fakeSlugBin(body: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-slug-'));
+  const bin = path.join(dir, 'gstack-slug-fake');
+  fs.writeFileSync(bin, body);
+  fs.chmodSync(bin, 0o755);
+  return bin;
+}
+
+describe('resolveSlug', () => {
+  test('resolves an extension-less shebang script on every platform', () => {
+    const bin = fakeSlugBin('#!/usr/bin/env bash\necho "SLUG=demo-project"\necho "BRANCH=main"\n');
+    expect(resolveSlug(bin)).toBe('demo-project');
+  });
+
+  test('warns on stderr rather than returning "unknown" in silence', () => {
+    const missing = path.join(os.tmpdir(), 'gstack-slug-that-does-not-exist-9f3a');
+    const seen: string[] = [];
+    const original = process.stderr.write.bind(process.stderr);
+    (process.stderr as unknown as { write: unknown }).write = (chunk: unknown) => {
+      seen.push(String(chunk));
+      return true;
+    };
+    try {
+      // The fallback value is kept, so no caller breaks...
+      expect(resolveSlug(missing)).toBe('unknown');
+    } finally {
+      (process.stderr as unknown as { write: unknown }).write = original;
+    }
+    // ...but it must never be silent.
+    expect(seen.join('')).toContain('could not resolve the project slug');
+  });
+});


### PR DESCRIPTION
On Windows, `resolveSlug()` never resolves a slug. It returns the literal
`"unknown"`, with exit code 0 and no output.

`bin/gstack-slug` is an extension-less bash script. `spawnSync` without a shell
goes through `CreateProcess`, which does not honour shebangs: the call fails
with `ENOENT`, `stdout` is `null`, the `SLUG=` regex does not match, and the
`: "unknown"` branch is taken.

```js
// Windows, git-bash, bun 1.3.14
const { spawnSync } = require("child_process");
const r = spawnSync("C:/Users/<u>/.claude/skills/gstack/bin/gstack-slug",
                    { encoding: "utf-8" });
console.log(r.error && r.error.code, JSON.stringify(r.stdout));
// ENOENT null
```

## Why this is worse than a wrong path

Both consumers, `bin/gstack-decision-log` and `bin/gstack-decision-search`,
then work against `~/.gstack/projects/unknown/`.

- **Write side:** one anonymous bucket shared by every repo on the machine.
- **Read side:** the directory does not exist, so the search returns an empty
  list and exits **0**. The session reads "no prior decisions" and re-litigates
  settled calls in good faith.

Observed on a real project: `gstack-decision-search --recent 5` printed nothing
while `~/.gstack/projects/<slug>/decisions.active.json` held 3930 bytes of
decisions at the correct path. The reader was simply looking elsewhere.

The `: "unknown"` fallback turned an exec failure into a plausible value, which
is why this went unnoticed rather than surfacing as an error.

## The fix

`shell: true` does **not** work — `cmd.exe` has no association for an
extension-less file and yields `"unknown"` too. Naming the interpreter does.

- Retry via `bash <script>` when the direct call yields no slug. The direct call
  is still attempted first, so **POSIX behaviour is unchanged**. The retry is
  keyed on "no slug parsed" rather than on `ENOENT` specifically, so a shim that
  exits non-zero without output is covered as well. `bash` and not `sh`:
  `gstack-slug` uses `[[ ]]` and `set -o pipefail`.
- Warn on stderr before falling back. The fallback value is kept so no caller
  breaks, but a tooling failure is not an anonymous project.

## Tests

`test/bin-context-resolve-slug.test.ts` pins both halves — that an
extension-less shebang script resolves on every platform, and that a failure is
audible. Verified failing against the pre-fix function and passing after it.

## Notes

`gitBranch()` in the same file is unaffected: it spawns `git`, which Windows
resolves via `PATHEXT`. Only extension-less scripts break, so an audit could
look for other `spawnSync` calls targeting `bin/gstack-*`.

Verified on Windows 11 / git-bash / bun 1.3.14. Happy to adjust the approach if
you prefer a `process.platform` check over the retry-on-empty.