### PR TITLE
test(memory-ingest): cover the --include-unattributed skip counter (#2353)

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -744,7 +744,10 @@ function buildTranscriptPage(path: string, session: ParsedSession): PageRecord {
     source_path: path,
     session_id: session.session_id,
     cwd: session.cwd,
-    git_remote: remote,
+    // Apply the same "_unattributed" fallback the frontmatter and repoSlug use.
+    // The unattributed skip guard reads this field, so leaving the raw "" here
+    // makes `--include-unattributed` inert (`"" === "_unattributed"` is never true).
+    git_remote: remote || "_unattributed",
     start_time: session.start_time,
     end_time: session.end_time,
     partial: session.partial,

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -296,6 +296,64 @@ describe("internal: parseTranscriptJsonl + buildTranscriptPage shape", () => {
   });
 });
 
+// ── unattributed skip policy ───────────────────────────────────────────────
+
+describe("gstack-memory-ingest unattributed skip", () => {
+  function sessionIn(cwd: string): string {
+    return (
+      `{"type":"user","message":{"role":"user","content":"hi"},"timestamp":"2026-05-01T00:00:00Z","cwd":"${cwd}"}\n` +
+      `{"type":"assistant","message":{"role":"assistant","content":"hello"},"timestamp":"2026-05-01T00:00:01Z"}\n`
+    );
+  }
+
+  it("skips a session whose cwd is not a git repo", () => {
+    const home = makeTestHome();
+    const work = join(home, "work");
+    mkdirSync(work, { recursive: true });
+    writeClaudeCodeSession(home, "not-a-repo", "sess1", sessionIn(work));
+
+    const r = runScript(["--bulk", "--no-write"], { HOME: home, GSTACK_HOME: join(home, ".gstack") });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("written:               0");
+    expect(r.stdout).toContain("skipped (unattrib):    1");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("imports that same session when --include-unattributed is passed", () => {
+    const home = makeTestHome();
+    const work = join(home, "work");
+    mkdirSync(work, { recursive: true });
+    writeClaudeCodeSession(home, "not-a-repo", "sess1", sessionIn(work));
+
+    const r = runScript(["--bulk", "--no-write", "--include-unattributed"], {
+      HOME: home,
+      GSTACK_HOME: join(home, ".gstack"),
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("written:               1");
+    expect(r.stdout).toContain("skipped (unattrib):    0");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("still imports a session whose cwd does resolve to a git remote", () => {
+    const home = makeTestHome();
+    const repo = join(home, "repo");
+    mkdirSync(repo, { recursive: true });
+    spawnSync("git", ["-C", repo, "init", "-q"]);
+    spawnSync("git", ["-C", repo, "remote", "add", "origin", "https://github.com/foo/bar.git"]);
+    writeClaudeCodeSession(home, "real", "sess2", sessionIn(repo));
+
+    const r = runScript(["--bulk", "--no-write"], { HOME: home, GSTACK_HOME: join(home, ".gstack") });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("written:               1");
+    expect(r.stdout).toContain("skipped (unattrib):    0");
+
+    rmSync(home, { recursive: true, force: true });
+  });
+});
+
 // ── --limit shortcut for smoke tests ───────────────────────────────────────
 
 describe("gstack-memory-ingest --limit", () => {


### PR DESCRIPTION
Fixes #2353.

## Root cause

`buildTranscriptPage` applies the `_unattributed` fallback in two of the three
places it computes it, and the one it skips is the one the guard reads:

```ts
const remote = resolveGitRemote(session.cwd);   // "" when the remote can't be resolved
const slug_repo = repoSlug(remote);             // → "_unattributed"
…
`git_remote: ${remote || "_unattributed"}`,     // :729 frontmatter — defaulted
…
git_remote: remote,                             // :750 page record — RAW
```

```ts
if (!args.includeUnattributed && page.git_remote === "_unattributed") {   // :1173
```

`page.git_remote` is `""`, so the comparison is never true, the branch is dead, and
`--include-unattributed` has no effect in either direction. The earlier `!session.cwd`
guard doesn't cover it — these sessions have a `cwd`, it just no longer resolves to a
remote (deleted directories, ephemeral worktrees).

`buildArtifactPage` already stores the defaulted value (`git_remote: slug_repo`, :787),
so this is the transcript builder catching up.

## Fix

One line, plus a comment noting the guard depends on it:

```ts
git_remote: remote || "_unattributed",
```

Taking the fix at the source rather than loosening the guard to `!page.git_remote ||
… === "_unattributed"` keeps the field consistent with the frontmatter and the slug,
which is what `buildArtifactPage` already does.

## Verification

Reproduced with a real session JSONL whose `cwd` is a directory that isn't a git repo,
run through `--bulk --no-write`:

| | written | skipped (unattrib) |
|---|---|---|
| before | **1** | **0** |
| after | 0 | 1 |
| after, `--include-unattributed` | 1 | 0 |
| after, cwd *is* a repo with a remote | 1 | 0 |

Three regression tests added to `test/gstack-memory-ingest.test.ts`, in the existing
`runScript` / `writeClaudeCodeSession` style. Confirmed they actually bite — reverting
just the one-line change makes the first one fail:

```
(fail) unattributed skip > skips a session whose cwd is not a git repo
Expected to contain: "written:               0"
Received: "… written:               1 … skipped (unattrib):    0 …"
```

Suites run clean with the fix in place:

```
bun test test/gstack-memory-ingest.test.ts                  26 pass  0 fail
bun test test/memory-ingest-no-put_page.test.ts \
         test/memory-ingest-timeout.test.ts \
         test/gstack-memory-helpers.test.ts                 34 pass  0 fail
```

## Note on scope

The issue also suggests recovering attribution from the Claude Code project-directory
encoding rather than discarding it. That's a behaviour change with its own design
questions, so it's left out — this PR only makes the existing flag do what it says.
