### PR TITLE
fix(mktemp): X's must be trailing — breaks on macOS (2nd run) and Alpine (1st run) (#2370)

### DIFF
--- a/bin/gstack-developer-profile
+++ b/bin/gstack-developer-profile
@@ -55,7 +55,7 @@ do_migrate() {
 
   # Run migration in a temp file, then atomic rename.
   local TMPOUT
-  TMPOUT=$(mktemp "$GSTACK_HOME/developer-profile.json.XXXXXX.tmp")
+  TMPOUT=$(mktemp "$GSTACK_HOME/developer-profile.json.tmp.XXXXXX")
   trap 'rm -f "$TMPOUT"' EXIT
 
   cat "$LEGACY_FILE" | bun -e "
@@ -182,7 +182,7 @@ do_log_session() {
   ensure_profile
 
   local TMPOUT
-  TMPOUT=$(mktemp "$GSTACK_HOME/developer-profile.json.XXXXXX.tmp")
+  TMPOUT=$(mktemp "$GSTACK_HOME/developer-profile.json.tmp.XXXXXX")
   trap 'rm -f "$TMPOUT"' EXIT
 
   PROFILE_FILE_PATH="$PROFILE_FILE" RECORD_INPUT="$INPUT" TMPOUT_PATH="$TMPOUT" bun -e "

--- a/claude/SKILL.md.tmpl
+++ b/claude/SKILL.md.tmpl
@@ -95,8 +95,8 @@ Create temp files:
 
 ```bash
 PROMPT_FILE=$(mktemp /tmp/gstack-claude-prompt-XXXXXX)
-RESP_FILE=$(mktemp /tmp/gstack-claude-response-XXXXXX.json)
-ERR_FILE=$(mktemp /tmp/gstack-claude-error-XXXXXX.txt)
+RESP_FILE=$(mktemp /tmp/gstack-claude-response-XXXXXX)
+ERR_FILE=$(mktemp /tmp/gstack-claude-error-XXXXXX)
 ```
 
 Cleanup at the end of every mode:
@@ -151,7 +151,7 @@ Review the current branch diff with nested Claude in tool-less mode.
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 cd "$_REPO_ROOT"
-DIFF_FILE=$(mktemp /tmp/gstack-claude-diff-XXXXXX.patch)
+DIFF_FILE=$(mktemp /tmp/gstack-claude-diff-XXXXXX)
 git fetch origin <base> --quiet 2>/dev/null || true
 git diff "origin/<base>" > "$DIFF_FILE" 2>/dev/null || git diff "<base>" > "$DIFF_FILE"
 ```

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -967,7 +967,7 @@ Run Codex code review against the current branch diff.
 
 1. Create temp files for output capture:
 ```bash
-TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")
+TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX")
 ```
 
 2. Run the review (5-minute timeout). **Codex CLI ≥ 0.130.0 rejects passing a
@@ -1015,7 +1015,7 @@ when the diff content is adversarial:
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 cd "$_REPO_ROOT"
 _USER_INSTRUCTIONS="<everything after '/codex review ' in user input>"
-_PROMPT_FILE=$(mktemp "$TMP_ROOT/codex-prompt-XXXXXX.txt")
+_PROMPT_FILE=$(mktemp "$TMP_ROOT/codex-prompt-XXXXXX")
 {
   printf '%s\n' "IMPORTANT: Do NOT read or execute any files under ~/.claude/, ~/.agents/, .claude/skills/, or agents/. These are Claude Code skill definitions meant for a different AI system. Do NOT modify agents/openai.yaml. Stay focused on repository code only."
   printf '\nCustom focus: %s\n\n' "$_USER_INSTRUCTIONS"
@@ -1266,7 +1266,7 @@ if [ -z "$PYTHON_CMD" ]; then
 fi
 # Fix 1+2: wrap with timeout (gtimeout/timeout fallback chain via probe helper),
 # capture stderr to $TMPERR for auth error detection (was: 2>/dev/null).
-TMPERR=${TMPERR:-$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")}
+TMPERR=${TMPERR:-$(mktemp "$TMP_ROOT/codex-err-XXXXXX")}
 _gstack_codex_timeout_wrapper 600 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
 import sys, json
 turn_completed_count = 0
@@ -1365,8 +1365,8 @@ B) Start a new conversation
 
 2. Create temp files:
 ```bash
-TMPRESP=$(mktemp "$TMP_ROOT/codex-resp-XXXXXX.txt")
-TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")
+TMPRESP=$(mktemp "$TMP_ROOT/codex-resp-XXXXXX")
+TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX")
 ```
 
 3. **Plan review auto-detection:** If the user's prompt is about reviewing a plan,

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -158,7 +158,7 @@ Run Codex code review against the current branch diff.
 
 1. Create temp files for output capture:
 ```bash
-TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")
+TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX")
 ```
 
 2. Run the review (5-minute timeout). **Codex CLI ≥ 0.130.0 rejects passing a
@@ -206,7 +206,7 @@ when the diff content is adversarial:
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 cd "$_REPO_ROOT"
 _USER_INSTRUCTIONS="<everything after '/codex review ' in user input>"
-_PROMPT_FILE=$(mktemp "$TMP_ROOT/codex-prompt-XXXXXX.txt")
+_PROMPT_FILE=$(mktemp "$TMP_ROOT/codex-prompt-XXXXXX")
 {
   printf '%s\n' "IMPORTANT: Do NOT read or execute any files under ~/.claude/, ~/.agents/, .claude/skills/, or agents/. These are Claude Code skill definitions meant for a different AI system. Do NOT modify agents/openai.yaml. Stay focused on repository code only."
   printf '\nCustom focus: %s\n\n' "$_USER_INSTRUCTIONS"
@@ -335,7 +335,7 @@ if [ -z "$PYTHON_CMD" ]; then
 fi
 # Fix 1+2: wrap with timeout (gtimeout/timeout fallback chain via probe helper),
 # capture stderr to $TMPERR for auth error detection (was: 2>/dev/null).
-TMPERR=${TMPERR:-$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")}
+TMPERR=${TMPERR:-$(mktemp "$TMP_ROOT/codex-err-XXXXXX")}
 _gstack_codex_timeout_wrapper 600 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
 import sys, json
 turn_completed_count = 0
@@ -434,8 +434,8 @@ B) Start a new conversation
 
 2. Create temp files:
 ```bash
-TMPRESP=$(mktemp "$TMP_ROOT/codex-resp-XXXXXX.txt")
-TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX.txt")
+TMPRESP=$(mktemp "$TMP_ROOT/codex-resp-XXXXXX")
+TMPERR=$(mktemp "$TMP_ROOT/codex-err-XXXXXX")
 ```
 
 3. **Plan review auto-detection:** If the user's prompt is about reviewing a plan,

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -1329,7 +1329,7 @@ If B: skip Phase 3.5 entirely. Remember that the second opinion did NOT run (aff
 2. **Write the assembled prompt to a temp file** (prevents shell injection from user-derived content):
 
 ```bash
-CODEX_PROMPT_FILE=$(mktemp /tmp/gstack-codex-oh-XXXXXXXX.txt)
+CODEX_PROMPT_FILE=$(mktemp /tmp/gstack-codex-oh-XXXXXXXX)
 ```
 
 Write the full prompt to this file. **Always start with the filesystem boundary:**

--- a/scripts/resolvers/review.ts
+++ b/scripts/resolvers/review.ts
@@ -351,7 +351,7 @@ If B: skip Phase 3.5 entirely. Remember that the second opinion did NOT run (aff
 2. **Write the assembled prompt to a temp file** (prevents shell injection from user-derived content):
 
 \`\`\`bash
-CODEX_PROMPT_FILE=$(mktemp /tmp/gstack-codex-oh-XXXXXXXX.txt)
+CODEX_PROMPT_FILE=$(mktemp /tmp/gstack-codex-oh-XXXXXXXX)
 \`\`\`
 
 Write the full prompt to this file. **Always start with the filesystem boundary:**


### PR DESCRIPTION
Fixes #2370.

## Scope

The issue reports the five `mktemp` templates in `codex/SKILL.md.tmpl`. The same
mistake exists in three more places it doesn't mention, so this PR fixes all of them:

| file | sites | template |
|---|---|---|
| `codex/SKILL.md.tmpl` | 5 | `codex-{err,prompt,resp}-XXXXXX.txt` ← #2370 |
| `claude/SKILL.md.tmpl` | 3 | `…-response-XXXXXX.json`, `…-error-XXXXXX.txt`, `…-diff-XXXXXX.patch` |
| `scripts/resolvers/review.ts` | 1 | `gstack-codex-oh-XXXXXXXX.txt` → `office-hours/SKILL.md` |
| `bin/gstack-developer-profile` | 2 | `developer-profile.json.XXXXXX.tmp` |

`claude/SKILL.md.tmpl` is the clearest tell — line 97 is already correct and the two
lines directly under it are not:

```bash
PROMPT_FILE=$(mktemp /tmp/gstack-claude-prompt-XXXXXX)        # correct
RESP_FILE=$(mktemp /tmp/gstack-claude-response-XXXXXX.json)   # broken
ERR_FILE=$(mktemp /tmp/gstack-claude-error-XXXXXX.txt)        # broken
```

## Measured behaviour

Three platforms, same two templates:

| | `codex-err-XXXXXX.txt` (old) | `codex-err-XXXXXX` (new) |
|---|---|---|
| **macOS** (BSD mktemp) | run 1 creates a file named literally `codex-err-XXXXXX.txt`; run 2+ → `mkstemp failed … File exists` | fresh name every run |
| **Alpine** (busybox mktemp) | **`mktemp: : Invalid argument` on every run**, including the first | fresh name every run |
| **Debian** (GNU coreutils 9.7) | works — substitutes and keeps the suffix | works |

```console
# macOS
run 1: /var/…/codex-err-XXXXXX.txt
run 2: mktemp: mkstemp failed on /var/…/codex-err-XXXXXX.txt: File exists
run 3: mktemp: mkstemp failed on /var/…/codex-err-XXXXXX.txt: File exists

# Alpine
run 1: mktemp: : Invalid argument
run 2: mktemp: : Invalid argument
```

Only GNU tolerates a suffix, which is why this survived — Linux CI is green while
macOS and Alpine users hit it. Note Alpine fails on the *first* run, so it's not even
the delayed failure mode the issue describes.

`bin/gstack-developer-profile` fails differently: its `trap 'rm -f "$TMPOUT"' EXIT`
usually cleans the literal file up, so single runs look fine. But the name is constant,
so two concurrent invocations collide on the same path and one process's trap deletes
the other's temp file — exactly the guarantee `mktemp` exists to provide:

```console
old: A → /…/developer-profile.json.XXXXXX.tmp
     B → mktemp: mkstemp failed … File exists
new: A → developer-profile.json.tmp.hpkoP3
     B → developer-profile.json.tmp.JHnL0U
```

## Fix

Move the X's to the end. The suffixes aren't load-bearing — nothing globs on them and
every cleanup is `rm -f "$VAR"` — so they're dropped. `developer-profile` keeps its
`.tmp` marker, moved ahead of the X's.

## Verification

- Generated docs rebuilt with `bun run gen:skill-docs`; the tracked diff is exactly
  6 files / 17 lines and **every changed line is a `mktemp` line** (`git diff -U0`
  filtered on non-`mktemp` content comes back empty).
- `bun test test/gen-skill-docs.test.ts test/gen-skill-docs-idempotency.test.ts
  test/gen-skill-docs-out-dir.test.ts test/codex-hardening.test.ts` → **436 pass, 0 fail**.

## Not included

The issue also notes the temp files are never cleaned up (`rm -f "$TMPERR"` missing on
some paths) and that stale `codex-err-review-XXXXXX.txt` artifacts from older revisions
linger. That's a separate change to the skill's control flow — happy to follow up if
you want it in the same pass.
