### PR TITLE
fix(paths): shell-quote gstack-paths output so eval round-trips values

### DIFF
--- a/bin/gstack-paths
+++ b/bin/gstack-paths
@@ -13,9 +13,15 @@
 #   PLAN_ROOT:         GSTACK_PLAN_DIR -> CLAUDE_PLANS_DIR -> $HOME/.claude/plans -> .claude/plans
 #   TMP_ROOT:          TMPDIR -> TMP -> .gstack/tmp (and mkdir -p, best-effort)
 #
-# Security: output values are not sanitized — callers may receive paths with
-# shell-special characters if env vars contain them. Skills should always quote
-# expansions ("$GSTACK_STATE_ROOT", not $GSTACK_STATE_ROOT).
+# Output: values are emitted shell-quoted (printf %q) so `eval` round-trips them
+# byte-for-byte. This matters on Windows, where $TMP is a backslash path like
+# C:\Users\me\AppData\Local\Temp — with a bare `echo`, eval consumes the
+# backslashes as escapes and the caller gets C:UsersmeAppDataLocalTemp. A value
+# containing a space (C:\Program Files\Temp) is worse: eval word-splits it and
+# the variable ends up empty. Quoting here is the only fix that works, because
+# the corruption happens during eval, before the caller has anything to quote.
+# Callers should still quote expansions ("$GSTACK_STATE_ROOT") for the same
+# reason any path variable needs quoting.
 set -u
 
 # State root: where gstack writes projects/, sessions/, analytics/.
@@ -60,6 +66,6 @@ fi
 # will discover that on their own write attempt. Don't fail the eval here.
 mkdir -p "$_tmp_root" 2>/dev/null || true
 
-echo "GSTACK_STATE_ROOT=$_state_root"
-echo "PLAN_ROOT=$_plan_root"
-echo "TMP_ROOT=$_tmp_root"
+printf 'GSTACK_STATE_ROOT=%q\n' "$_state_root"
+printf 'PLAN_ROOT=%q\n' "$_plan_root"
+printf 'TMP_ROOT=%q\n' "$_tmp_root"

--- a/test/gstack-paths.test.ts
+++ b/test/gstack-paths.test.ts
@@ -104,6 +104,57 @@ describe('gstack-paths', () => {
     expect(got).toHaveProperty('TMP_ROOT');
   });
 
+  // Regression: values must survive `eval "$(gstack-paths)"`, which is the
+  // documented calling convention. A bare `echo` emits an unquoted RHS, so eval
+  // re-parses it: backslashes become escapes and spaces become word separators.
+  // On Windows $TMP is always a backslash path, so every skill that then runs
+  // mktemp "$TMP_ROOT/..." fails and the bash block dies before doing any work.
+  // These run identically on POSIX — the values are just strings.
+  function evalRoundTrip(env: Record<string, string | undefined>, varName: string): string {
+    const result = spawnSync(
+      'bash',
+      ['-c', `eval "$(bash "$1")"; printf '%s' "\${${varName}}"`, 'sh', BIN],
+      {
+        env: { PATH: process.env.PATH, USERPROFILE: '', ...env } as Record<string, string>,
+        encoding: 'utf-8',
+      },
+    );
+    if (result.status !== 0) {
+      throw new Error(`eval round-trip failed (status ${result.status}): ${result.stderr}`);
+    }
+    return result.stdout;
+  }
+
+  // Values are POSIX-shaped on purpose: MSYS/Git Bash rewrites `C:\...` env
+  // values to `/c/...` before bash sees them, so a literal Windows path would
+  // assert the translation layer rather than the quoting. A backslash is a
+  // backslash to eval either way, which is the behavior under test.
+  test('eval round-trip preserves backslashes (#2374)', () => {
+    // Skip on Windows: MSYS also rewrites backslashes to forward slashes in
+    // env values, so a literal backslash cannot be injected through the
+    // environment on a Git Bash runner. The escape-eating this guards against
+    // is pure eval semantics, so exercising it on Linux/macOS CI is sufficient
+    // — same reasoning as the HOME-unset skips above.
+    if (process.platform === 'win32') return;
+    const backslashed = '/tmp/back\\slash/dir';
+    expect(evalRoundTrip({ TMPDIR: backslashed, HOME: '/h' }, 'TMP_ROOT')).toBe(backslashed);
+  });
+
+  test('eval round-trip preserves spaces (#2374)', () => {
+    // Bare echo made eval word-split this, leaving the variable empty and
+    // emitting `<second-word>: command not found`.
+    const spaced = '/tmp/two words/dir';
+    expect(evalRoundTrip({ TMPDIR: spaced, HOME: '/h' }, 'TMP_ROOT')).toBe(spaced);
+  });
+
+  test('eval round-trip preserves quotes, and leaves plain paths alone (#2374)', () => {
+    expect(evalRoundTrip({ TMPDIR: "/tmp/o'brien", HOME: '/h' }, 'TMP_ROOT')).toBe("/tmp/o'brien");
+    expect(evalRoundTrip({ GSTACK_HOME: '/tmp/state root' }, 'GSTACK_STATE_ROOT')).toBe(
+      '/tmp/state root',
+    );
+    expect(evalRoundTrip({ HOME: '/tmp/myhome' }, 'PLAN_ROOT')).toBe('/tmp/myhome/.claude/plans');
+  });
+
   test('output is shell-evalable: only KEY=VALUE lines, no extra prose', () => {
     const result = spawnSync('bash', [BIN], {
       env: { PATH: process.env.PATH, USERPROFILE: '', HOME: '/tmp/h' } as Record<string, string>,


### PR DESCRIPTION
Fixes #2374.

> Re-filed. The original PR (#2375) was closed automatically when its head fork was
> deleted by mistake — GitHub closes any PR whose head repository goes away, and such a PR
> can't be reopened. Same commit (`0134f29e`), same tests, no content changes. Apologies for
> the duplicate notification.

### The bug

`bin/gstack-paths` is consumed as `eval "$(gstack-paths)"` (the documented contract, used
at Step 0.6 of every skill), but emits bare `KEY=VALUE` lines with an unquoted right-hand
side. `eval` re-parses those: backslashes become escape sequences, spaces become word
separators.

On Windows `$TMP` is always a backslash path, so this fires every time:

```bash
TMP='C:\Users\me\AppData\Local\Temp'
eval "$(gstack-paths)"
echo "$TMP_ROOT"
# C:UsersmeAppDataLocalTemp      <- every separator gone
```

The `mktemp "$TMP_ROOT/codex-err-XXXXXX.txt"` that follows then fails, `TMPERR` is empty,
and `2>"$TMPERR"` is a redirect to an empty filename, so the bash block exits 1 **before
Codex ever runs**:

```
mktemp: failed to create file via template 'C:Users...Temp/codex-err-XXXXXX.txt': No such file or directory
bash: line 1: : No such file or directory
exit=1
```

A value containing a space is worse — `eval` word-splits it, prints
`FilesTemp: command not found`, and leaves the variable empty, so `mktemp` targets the
filesystem root and fails with `Permission denied`.

This is the same user-visible cascade as #2091 and #2370, both filed as macOS/BSD-`mktemp`
bugs. The root cause here is different, so those fixes don't help: a Windows user searching
the symptom finds them, applies them, and is still broken.

Not Windows-only — any POSIX `TMPDIR` containing a space or a backslash corrupts the same way.

### The fix

Emit with `printf %q` so `eval` reproduces values byte-for-byte:

```diff
-echo "GSTACK_STATE_ROOT=$_state_root"
-echo "PLAN_ROOT=$_plan_root"
-echo "TMP_ROOT=$_tmp_root"
+printf 'GSTACK_STATE_ROOT=%q\n' "$_state_root"
+printf 'PLAN_ROOT=%q\n' "$_plan_root"
+printf 'TMP_ROOT=%q\n' "$_tmp_root"
```

The script is already `#!/usr/bin/env bash`, so `%q` is available. Plain POSIX paths are
unchanged by `%q`, so existing callers and the existing assertions see identical output.

I also reworded the header comment. The old note said callers should quote expansions,
which doesn't cover this failure — the corruption happens *during* `eval`, before the
caller has a variable to quote. Callers here already quote correctly and were still broken.

### Tests

Three `eval`-round-trip cases added to `test/gstack-paths.test.ts`: backslash, space, and
embedded single quote. They assert the full documented calling convention rather than the
raw stdout, which is what the existing tests check.

Verified they are real regression tests — against the old `echo` they fail, with `%q` they pass:

| | old `echo` | `printf %q` |
|---|---|---|
| `test/gstack-paths.test.ts` | 2 fail, 10 pass | **12 pass, 0 fail** |
| `test/gstack-paths.test.ts` + `test/spec-template-invariants.test.ts` | — | **60 pass, 0 fail** |

(2 rather than 3 failures on the old code because the backslash case is skipped on this
Windows runner — see below. On Linux CI all three fail without the fix.)

Test-environment note worth flagging for review: the backslash case is skipped on `win32`.
MSYS/Git Bash rewrites both `C:\...` → `/c/...` and backslashes → forward slashes in env
values, so a literal backslash cannot be injected through the environment on a Git Bash
runner. What it guards is pure `eval` semantics, so exercising it on Linux/macOS CI is
sufficient. This follows the same reasoning as the existing `HOME`-unset skips in that
file. The space and quote cases do run on Windows, and both catch the bug there.

The three test files that reference `gstack-paths` or `TMP_ROOT` are
`test/gstack-paths.test.ts`, `test/spec-template-invariants.test.ts`, and
`test/skill-e2e-plan-tune-cathedral.test.ts` (evals tier). The first two pass in full.
No templates are touched, so generated `SKILL.md` output is unaffected.

### Alternative considered

Keeping `echo` and changing the contract to `set -a; . <(gstack-paths)` also fixes it and
preserves the plain human-readable output documented on line 4. I didn't take it because
it changes Step 0.6 in every skill template plus each host variant, where this is three
lines in one file. Happy to switch if you'd rather have the unescaped display form.

Found while dogfooding `/codex review` on Windows: with a literal `TMP_ROOT=/tmp`
substituted before the `mktemp`, `/codex review` works normally on 1.60.1.0, which isolates
this as the only blocker on that path.
