### PR TITLE
Add vendor-neutral GSTACK_SPAWNED_SESSION marker for spawned mode

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -135,7 +135,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -320,7 +320,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -145,7 +145,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -330,7 +330,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -139,7 +139,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -324,7 +324,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -139,7 +139,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -324,7 +324,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/bin/gstack-session-kind
+++ b/bin/gstack-session-kind
@@ -22,9 +22,11 @@
 # signals that actually discriminate are the host/orchestrator/CI env markers below.
 set -euo pipefail
 
-# 1. Orchestrator-spawned session (OpenClaw). Authoritative block lives in the skill;
-#    we only surface the classification.
-if [ -n "${OPENCLAW_SESSION:-}" ]; then
+# 1. Orchestrator-spawned session. Authoritative block lives in the skill; we only
+#    surface the classification. OPENCLAW_SESSION is OpenClaw's marker;
+#    GSTACK_SPAWNED_SESSION is the vendor-neutral one any orchestrator can set to opt
+#    into spawned/autonomous mode (auto-choose, no AskUserQuestion, completion report).
+if [ -n "${OPENCLAW_SESSION:-}" ] || [ -n "${GSTACK_SPAWNED_SESSION:-}" ]; then
   echo "spawned"
   exit 0
 fi

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -137,7 +137,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -322,7 +322,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -137,7 +137,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -322,7 +322,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -140,7 +140,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -325,7 +325,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -141,7 +141,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -326,7 +326,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -140,7 +140,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -325,7 +325,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -143,7 +143,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -328,7 +328,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -163,7 +163,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -348,7 +348,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -144,7 +144,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -329,7 +329,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -141,7 +141,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -326,7 +326,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -158,7 +158,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -343,7 +343,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -143,7 +143,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -328,7 +328,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/diagram/SKILL.md
+++ b/diagram/SKILL.md
@@ -138,7 +138,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -323,7 +323,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/document-generate/SKILL.md
+++ b/document-generate/SKILL.md
@@ -143,7 +143,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -328,7 +328,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -141,7 +141,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -326,7 +326,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -139,7 +139,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -324,7 +324,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -178,7 +178,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -363,7 +363,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/ios-clean/SKILL.md
+++ b/ios-clean/SKILL.md
@@ -141,7 +141,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -326,7 +326,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/ios-design-review/SKILL.md
+++ b/ios-design-review/SKILL.md
@@ -143,7 +143,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -328,7 +328,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/ios-fix/SKILL.md
+++ b/ios-fix/SKILL.md
@@ -144,7 +144,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -329,7 +329,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/ios-qa/SKILL.md
+++ b/ios-qa/SKILL.md
@@ -147,7 +147,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -332,7 +332,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/ios-sync/SKILL.md
+++ b/ios-sync/SKILL.md
@@ -141,7 +141,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -326,7 +326,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -136,7 +136,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -321,7 +321,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -137,7 +137,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -322,7 +322,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -139,7 +139,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -324,7 +324,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -138,7 +138,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## MAKE-PDF SETUP (run this check BEFORE any make-pdf command)
@@ -359,7 +359,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -174,7 +174,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -359,7 +359,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -136,7 +136,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -321,7 +321,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -138,7 +138,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -323,7 +323,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -168,7 +168,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -353,7 +353,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -140,7 +140,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -325,7 +325,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -146,7 +146,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -331,7 +331,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -144,7 +144,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -329,7 +329,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -149,7 +149,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -334,7 +334,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -139,7 +139,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -324,7 +324,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -145,7 +145,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -330,7 +330,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -156,7 +156,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -341,7 +341,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -141,7 +141,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -326,7 +326,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/scrape/SKILL.md
+++ b/scrape/SKILL.md
@@ -137,7 +137,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -322,7 +322,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/scripts/resolvers/preamble/generate-preamble-bash.ts
+++ b/scripts/resolvers/preamble/generate-preamble-bash.ts
@@ -124,7 +124,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true${ctx.host === 'gbrain' || ctx.host === 'hermes' ? `
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true${ctx.host === 'gbrain' || ctx.host === 'hermes' ? `
 if command -v gbrain &>/dev/null; then
   _BRAIN_JSON=$(gbrain doctor --fast --json 2>/dev/null || echo '{}')
   _BRAIN_SCORE=$(echo "$_BRAIN_JSON" | grep -o '"health_score":[0-9]*' | cut -d: -f2)

--- a/scripts/resolvers/preamble/generate-spawned-session-check.ts
+++ b/scripts/resolvers/preamble/generate-spawned-session-check.ts
@@ -2,7 +2,7 @@
 
 export function generateSpawnedSessionCheck(): string {
   return `If \`SPAWNED_SESSION\` is \`"true"\`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets \`GSTACK_SPAWNED_SESSION=1\`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -133,7 +133,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -318,7 +318,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -140,7 +140,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -325,7 +325,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -139,7 +139,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -324,7 +324,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -141,7 +141,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -326,7 +326,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/skillify/SKILL.md
+++ b/skillify/SKILL.md
@@ -137,7 +137,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -322,7 +322,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -138,7 +138,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -323,7 +323,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.
@@ -1208,7 +1208,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -1393,7 +1393,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -139,7 +139,7 @@ else
   export GSTACK_PLAN_MODE="inactive"
 fi
 echo "GSTACK_PLAN_MODE: $GSTACK_PLAN_MODE"
-[ -n "$OPENCLAW_SESSION" ] && echo "SPAWNED_SESSION: true" || true
+{ [ -n "$OPENCLAW_SESSION" ] || [ -n "$GSTACK_SPAWNED_SESSION" ]; } && echo "SPAWNED_SESSION: true" || true
 ```
 
 ## Plan Mode Safe Operations
@@ -324,7 +324,7 @@ touch ~/.gstack/.vendoring-warned-${SLUG:-unknown}
 If marker exists, skip.
 
 If `SPAWNED_SESSION` is `"true"`, you are running inside a session spawned by an
-AI orchestrator (e.g., OpenClaw). In spawned sessions:
+AI orchestrator (e.g., OpenClaw, or any tool that sets `GSTACK_SPAWNED_SESSION=1`). In spawned sessions:
 - Do NOT use AskUserQuestion for interactive prompts. Auto-choose the recommended option.
 - Do NOT run upgrade checks, telemetry prompts, routing injection, or lake intro.
 - Focus on completing the task and reporting results via prose output.

--- a/test/gstack-session-kind.test.ts
+++ b/test/gstack-session-kind.test.ts
@@ -32,6 +32,12 @@ describe('gstack-session-kind', () => {
     expect(kind({ OPENCLAW_SESSION: '1', GSTACK_HEADLESS: '1', CONDUCTOR_PORT: '5' })).toBe('spawned');
   });
 
+  test('GSTACK_SPAWNED_SESSION → spawned (vendor-neutral orchestrator marker)', () => {
+    expect(kind({ GSTACK_SPAWNED_SESSION: '1' })).toBe('spawned');
+    // same top precedence as OPENCLAW_SESSION: spawned wins over headless/host markers
+    expect(kind({ GSTACK_SPAWNED_SESSION: '1', GSTACK_HEADLESS: '1', CONDUCTOR_PORT: '5' })).toBe('spawned');
+  });
+
   test('GSTACK_HEADLESS → headless', () => {
     expect(kind({ GSTACK_HEADLESS: '1' })).toBe('headless');
   });


### PR DESCRIPTION
## What

Adds `GSTACK_SPAWNED_SESSION` as a **vendor-neutral** way to opt a session into gstack's spawned/autonomous mode (auto-choose the recommended option, no `AskUserQuestion`, end with a completion report).

## Why

Today spawned mode is reachable only via `OPENCLAW_SESSION`. Any AI orchestrator that runs gstack **headlessly** — e.g. a harness spawning `claude -p` workers — needs the exact same behavior, because `gstack-session-kind` otherwise classifies those sessions as `interactive` (the degrade-safe default) and the skills stall at the first `AskUserQuestion` gate with no human to answer. Setting *another* tool's env var (`OPENCLAW_SESSION`) to get there is a semantic hack.

## Change

Recognized in the same two places as `OPENCLAW_SESSION`, mirroring the existing pattern:

- `bin/gstack-session-kind` — top-precedence spawned signal, alongside `OPENCLAW_SESSION`.
- `scripts/resolvers/preamble/generate-preamble-bash.ts` — emits `SPAWNED_SESSION: true` when either marker is set.
- `scripts/resolvers/preamble/generate-spawned-session-check.ts` — docs the new knob in the spawned-session prose.

`OPENCLAW_SESSION` behavior is unchanged. Regenerated the SKILL.md docs so the freshness check passes.

## Testing

- `bun test test/gstack-session-kind.test.ts` — added a case for `GSTACK_SPAWNED_SESSION → spawned` (incl. top-precedence over headless/host markers). 10/10 pass.
- `bun test test/auq-error-fallback-hook.test.ts` — 13/13 pass (unchanged).