### PR TITLE
fix(gbrain): stop a path case difference from destroying the source index

### DIFF
--- a/bin/gstack-gbrain-source-wireup
+++ b/bin/gstack-gbrain-source-wireup
@@ -294,18 +294,40 @@ do_wireup() {
       # brain-worktree (same basename, different parent), don't ping-pong the
       # registration. Just sync from our local worktree — gbrain stores pages
       # by content, not by local_path. The metadata is informational only.
-      local existing_path
+      # A path mismatch must never cost the index. This branch used to
+      # remove-then-re-add, which on gbrain >= 0.42 fails outright (the remove
+      # demands --confirm-destructive) and, if "fixed" by passing that flag,
+      # would permanently delete every page/chunk/embedding for the source and
+      # re-walk from scratch. Both outcomes are wrong, because the comment above
+      # is right: gbrain stores pages by CONTENT and local_path is informational
+      # metadata. A changed path does not justify dropping the index.
+      #
+      # Two things made this fire spuriously:
+      #   1. Case. On Windows gbrain may hold C:/Users/me/projects/quill while
+      #      the caller derives C:/Users/me/Projects/Quill — the same directory,
+      #      compared case-sensitively, so "the path changed".
+      #   2. jq. The multi-machine guard below parses `sources list --json` with
+      #      jq. Where jq isn't installed, existing_path comes back EMPTY, the
+      #      guard can never fire, and every mismatch falls through to the
+      #      destructive branch.
+      #
+      # So: normalise before comparing (case-fold + forward slashes), fall back
+      # to sed when jq is missing, and on a genuine mismatch warn and carry on
+      # rather than delete.
+      local existing_path norm_existing norm_worktree
       existing_path=$(gbrain sources list --json 2>/dev/null \
-        | jq -r --arg id "$id" '.sources[] | select(.id==$id) | .local_path' 2>/dev/null \
+        | { if command -v jq >/dev/null 2>&1; then
+              jq -r --arg id "$id" '.sources[] | select(.id==$id) | .local_path' 2>/dev/null
+            else
+              tr ',' '\n' | grep -A2 "\"$id\"" | sed -n 's/.*"local_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1
+            fi; } \
         | tr -d '[:space:]') || existing_path=""
-      if [ "$(basename "$existing_path")" = "$(basename "$WORKTREE")" ] \
-         && [ "$existing_path" != "$WORKTREE" ]; then
-        warn "source $id is registered at $existing_path (likely another machine's local copy of the same brain repo). Skipping re-registration; will sync from local worktree."
+      norm_existing=$(printf '%s' "$existing_path" | tr 'A-Z' 'a-z' | tr '\\' '/')
+      norm_worktree=$(printf '%s' "$WORKTREE" | tr 'A-Z' 'a-z' | tr '\\' '/')
+      if [ -n "$existing_path" ] && [ "$norm_existing" = "$norm_worktree" ]; then
+        : # same directory, different spelling (Windows case) — nothing to do
       else
-        warn "source $id registered with different path; recreating (gbrain has no 'sources update')"
-        gbrain sources remove "$id" --yes 2>&1 | prefix || die "gbrain sources remove failed" 1
-        gbrain sources add "$id" --path "$WORKTREE" --federated 2>&1 | prefix \
-          || die "gbrain sources add failed" 1
+        warn "source $id is registered at '${existing_path:-<unknown>}' but this worktree is $WORKTREE. Keeping the existing registration (gbrain stores pages by content; local_path is informational) and syncing from the local worktree. To re-point it deliberately: gbrain sources archive $id, then re-run."
       fi
       ;;
     2)

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -1147,16 +1147,25 @@ function runBrainSyncPush(args: CliArgs): StageResult {
 
   // #1731: gstack-brain-sync is a bash shebang script; Windows can't spawn it
   // without a shell, which surfaced as "brain-sync exited undefined".
-  spawnSync(brainSyncPath, ["--discover-new"], {
-    stdio: args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"],
+  //
+  // ...but `shell: true` on Windows means cmd.exe, and cmd cannot run an
+  // extensionless bash-shebang script either. It reports "'...gstack-brain-sync'
+  // is not recognized as an internal or external command" and exits 1, so this
+  // stage failed on every run. The shebang needs a real bash, which is present
+  // wherever git-for-windows is. Pass the script TO bash rather than trying to
+  // execute it, with separators normalised (bash on Windows accepts C:/... but
+  // not a bare backslash path inside a cmd-quoted string).
+  const isWindows = process.platform === "win32";
+  const runner = isWindows ? "bash" : brainSyncPath;
+  const leading = isWindows ? [brainSyncPath.replace(/\\/g, "/")] : [];
+  const spawnOpts = {
+    stdio: (args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"]) as ("ignore" | "inherit")[],
     timeout: 60 * 1000,
-    shell: NEEDS_SHELL_ON_WINDOWS,
-  });
-  const result = spawnSync(brainSyncPath, ["--once"], {
-    stdio: args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"],
-    timeout: 60 * 1000,
-    shell: NEEDS_SHELL_ON_WINDOWS,
-  });
+    // bash is a real executable, so no cmd wrapper is needed on Windows either.
+    shell: isWindows ? false : NEEDS_SHELL_ON_WINDOWS,
+  };
+  spawnSync(runner, [...leading, "--discover-new"], spawnOpts);
+  const result = spawnSync(runner, [...leading, "--once"], spawnOpts);
 
   return {
     name: "brain-sync",

--- a/lib/gbrain-sources.ts
+++ b/lib/gbrain-sources.ts
@@ -142,9 +142,29 @@ export async function ensureSourceRegistered(
   return withErrorContext(`ensureSourceRegistered:${id}`, () => {
     const probed = probeSource(id, env);
 
-    // Disambiguate match-but-different-path
+    // Disambiguate match-but-different-path.
+    //
+    // Compare paths case-insensitively, with separators normalised. A raw !==
+    // treats a case difference as drift, which on Windows happens routinely:
+    // gbrain may hold `C:/Users/me/projects/quill` while the caller derives
+    // `C:/Users/me/Projects/Quill`. Same directory, different spelling.
+    //
+    // That misread is expensive. Drift sends us into the remove-then-add path
+    // below, and on gbrain >= 0.42 `sources remove` refuses without
+    // --confirm-destructive, so /sync-gbrain fails in every mode. Passing that
+    // flag would be worse than the bug: it permanently deletes the source's
+    // pages, chunks and embeddings (129 / 627 / 627 on the repo where this was
+    // found) and re-walks from scratch, over a mismatch that was never real.
+    //
+    // Windows and macOS both default to case-insensitive filesystems, so
+    // folding case is correct there. On Linux a genuinely case-distinct pair of
+    // paths is possible, but gstack never creates one, and quietly re-using an
+    // existing index is a far cheaper failure than deleting it.
+    const samePath = (a: string | undefined, b: string): boolean =>
+      !!a && a.replace(/\\/g, "/").toLowerCase() === b.replace(/\\/g, "/").toLowerCase();
+
     let state: SourceState = probed;
-    if (probed.status === "match" && probed.registered_path !== path) {
+    if (probed.status === "match" && !samePath(probed.registered_path, path)) {
       state = { status: "drift", registered_path: probed.registered_path };
     }
 


### PR DESCRIPTION
## The bug

On Windows, `/sync-gbrain` fails on every run, in every mode:

```
ERR   code   source registration failed: gbrain sources remove <id> failed:
⚠️  This will permanently delete: 129 pages, 627 chunks, 627 embeddings
To proceed, pass --confirm-destructive (or use soft-delete: gbrain sources archive <id>)
```

The flag demand is the symptom, not the cause. In `ensureSourceRegistered`, gbrain held the source at `C:/Users/me/projects/quill` while the caller derived `C:/Users/me/Projects/Quill`. Those were compared with `!==`, so the same directory spelled differently was classified as drift, and every run took the remove-then-add path.

**Passing `--confirm-destructive` would be worse than the bug.** It really deletes the source's pages, chunks and embeddings and re-walks from scratch, over a mismatch that was never real. Anyone hitting this and following the error message's advice loses their index.

## The fix

`lib/gbrain-sources.ts` compares paths case-folded with separators normalised. Windows and macOS both default to case-insensitive filesystems, so this is correct there; on Linux a case-distinct pair is possible in principle but gstack never creates one, and re-using an existing index is a much cheaper failure than deleting it.

Two related fixes in the same area:

**`bin/gstack-gbrain-source-wireup`** carries the identical defect, plus a second trigger. Its multi-machine guard parses `sources list --json` with `jq`, so on a machine without jq `existing_path` comes back empty, the guard can never fire, and *every* mismatch falls through to remove-then-add. It now falls back to `sed`, compares normalised, and on a genuine mismatch warns and continues instead of deleting. Its own comment already states that gbrain stores pages by content and `local_path` is informational metadata, which is the argument for never deleting on a path change.

**`bin/gstack-gbrain-sync.ts`** spawned `gstack-brain-sync` with `shell: true` on Windows. The existing comment (#1731) notes Windows can't spawn a shebang script without a shell, but `shell: true` means `cmd.exe`, which can't run an extensionless bash-shebang script either. It reported `'...gstack-brain-sync' is not recognized as an internal or external command` and exited 1 on every run. It now passes the script to `bash`.

## Verification

Windows 11, gbrain 0.42.52.0, gstack 1.60.1.0.

Before: `1 ok, 2 error, 0 skipped` (the two errors above), on every run.

After:

```
gstack-gbrain-sync (incremental):
  OK    code         synced gstack-code-<repo> (page_count=129) (18.8s)
  OK    memory       gbrain import: 0 imported, 0 unchanged, 0 failed (2.4s)
  OK    brain-sync   curated artifacts pushed (1.7s)

  3 ok, 0 error, 0 skipped
```

No destructive operation attempted, index intact at 129 pages.

## Note on the dry-run

Worth flagging separately: `--dry-run` previews this as an idempotent `gbrain sources add ...` and gives no hint that a real run would attempt a `sources remove` first. That made the dry-run actively misleading while diagnosing this. Not addressed here, since it's a reporting change rather than a correctness one.
