### PR TITLE
fix(browse): qualify icacls grants with USERDOMAIN (computer-name/username collision locks users out of state dirs)

### DIFF
--- a/browse/src/file-permissions.ts
+++ b/browse/src/file-permissions.ts
@@ -42,6 +42,23 @@ import * as os from 'os';
 
 let warnedOnce = false;
 
+/**
+ * Fully-qualified account name for icacls grants.
+ *
+ * An unqualified username is ambiguous when the computer shares its name
+ * with the user: LookupAccountName resolves it to the COMPUTER account (a
+ * bare machine SID nobody's token holds), so `/inheritance:r /grant:r
+ * <user>` locks the actual user out of their own state dir — and because
+ * these calls are idempotent-by-design, every invocation re-applies the
+ * lockout. Qualifying with the account domain (USERDOMAIN — the machine
+ * name for local accounts) makes the lookup unambiguous.
+ */
+function currentUserAccount(): string {
+  const user = os.userInfo().username;
+  const domain = process.env.USERDOMAIN;
+  return domain ? `${domain}\\${user}` : user;
+}
+
 function warnIcaclsFailure(fsPath: string, err: unknown): void {
   if (warnedOnce) return;
   warnedOnce = true;
@@ -67,7 +84,7 @@ function warnIcaclsFailure(fsPath: string, err: unknown): void {
 export function restrictFilePermissions(filePath: string): void {
   if (process.platform === 'win32') {
     try {
-      const user = os.userInfo().username;
+      const user = currentUserAccount();
       execFileSync(
         'icacls',
         [filePath, '/inheritance:r', '/grant:r', `${user}:(F)`],
@@ -97,7 +114,7 @@ export function restrictFilePermissions(filePath: string): void {
 export function restrictDirectoryPermissions(dirPath: string): void {
   if (process.platform === 'win32') {
     try {
-      const user = os.userInfo().username;
+      const user = currentUserAccount();
       execFileSync(
         'icacls',
         [dirPath, '/inheritance:r', '/grant:r', `${user}:(OI)(CI)(F)`],


### PR DESCRIPTION
## Bug

`restrictFilePermissions` / `restrictDirectoryPermissions` (browse/src/file-permissions.ts) pass the **unqualified** username to icacls:

```
icacls <path> /inheritance:r /grant:r <username>:(OI)(CI)(F)
```

When the computer name equals the username — common on personal machines (this repro: user `hackdiva` on a PC named `HackDiva`) — Windows' `LookupAccountName` resolves the bare name to the **computer account**: a bare machine SID (`S-1-5-21-…`, no RID) that no user token holds.

Combined with `/inheritance:r`, the directory ends up with a single ACE granting Full Control to a SID nobody has. The actual user — including the owner — is locked out of gstack's own state dir. And because these calls are documented as "idempotent, safe to re-apply", **every browse invocation re-applies the lockout**, so:

- `~/.gstack` and every project `.gstack` become unreadable/undeletable ("Permission denied" from both PowerShell and Git Bash),
- the browse daemon can never acquire its lock ("Another instance is starting the server" forever),
- repairs with `icacls /reset` or an unqualified `/grant <username>` silently fail the same way (same ambiguous lookup), which makes this maddening to diagnose — it presents as machine-level ACL corruption with a phantom "re-stamper".

## Fix

Qualify the grantee with `USERDOMAIN` (the machine name for local accounts, the domain for domain accounts), making the lookup unambiguous:

```
icacls <path> /inheritance:r /grant:r HACKDIVA\hackdiva:(OI)(CI)(F)
```

One new helper (`currentUserAccount()`), used by both call sites. No behavior change on machines without the name collision.

## Recovery note for affected users

Wedged dirs need the SID form (names stay ambiguous): `takeown /f <dir> /r /d y` then `icacls <dir> /grant:r "*<your-user-SID>:(OI)(CI)F" /t` (get the SID from `whoami /user`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
