### PR TITLE
Fix question-log hook silently failing on Windows

### DIFF
--- a/hosts/claude/hooks/question-log-hook.ts
+++ b/hosts/claude/hooks/question-log-hook.ts
@@ -205,12 +205,28 @@ function detectSkill(cwd: string | undefined): string {
 }
 
 function spawnLog(payload: Record<string, unknown>, cwd?: string): void {
-  // Locate the bin relative to this script's directory.
-  const here = path.dirname(new URL(import.meta.url).pathname);
+  // Locate the bin relative to this script's directory. On Windows the URL
+  // pathname is "/C:/Users/..."; the leading slash makes path.resolve treat it
+  // as drive-relative and emit a doubled "C:\C:\Users\...", so strip it first.
+  const here = path.dirname(
+    new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1'),
+  );
   // hosts/claude/hooks/ -> ../../../bin/
   const repoRoot = path.resolve(here, '..', '..', '..');
   const bin = path.join(repoRoot, 'bin', 'gstack-question-log');
-  const res = spawnSync(bin, [JSON.stringify(payload)], {
+  // Windows cannot CreateProcess a shebang script directly, so spawnSync(bin)
+  // fails to launch at all (status undefined). Invoke it through bash there;
+  // POSIX keeps the original direct-exec path unchanged.
+  const isWindows = process.platform === 'win32';
+  // Git Bash reads a Windows path (C:\a\b) as relative and prefixes cwd, so
+  // translate the drive letter to a POSIX mount point: C:\a\b -> /c/a/b.
+  const toPosixPath = (p: string): string =>
+    p.replace(/\\/g, '/').replace(/^([A-Za-z]):/, (_m, d) => `/${d.toLowerCase()}`);
+  const cmd = isWindows ? 'bash' : bin;
+  const args = isWindows
+    ? [toPosixPath(bin), JSON.stringify(payload)]
+    : [JSON.stringify(payload)];
+  const res = spawnSync(cmd, args, {
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
     timeout: 3000,


### PR DESCRIPTION
## Problem

On Windows, the plan-tune PostToolUse question-log hook never records anything. Because the hook always exits 0 by design (errors go to `~/.gstack/hook-errors.log`), the failure is invisible — question logging simply doesn't happen, and plan-tune's profile/preference pipeline gets no data.

## Root causes (two, independent)

1. **Doubled drive letter.** `new URL(import.meta.url).pathname` yields `/C:/Users/...` on Windows. The leading slash makes `path.resolve` treat it as drive-relative, producing a bin path of `C:\C:\Users\...\bin\gstack-question-log`, which doesn't exist.

2. **Shebang spawn.** Even with a correct path, `spawnSync(bin, ...)` cannot launch a `#!/usr/bin/env bash` script on Windows — `CreateProcess` doesn't understand shebangs, so the spawn fails before producing an exit code (`status: undefined`, logged as `gstack-question-log exited undefined: null`).

## Fix

- Strip the leading slash from the URL pathname before `path.dirname` (POSIX pathnames are unaffected by the regex).
- On `win32`, invoke the bin through `bash` with the path translated to a POSIX mount (`C:\a\b` → `/c/a/b`), since Git Bash reads a Windows-style path as cwd-relative. Non-Windows platforms keep the original direct-exec path unchanged.

## Verification

Tested on Windows 11 (Git Bash + bun) by piping a Claude Code hook-shaped payload into the hook: before the fix, `hook-errors.log` showed the spawn failure and no log was written; after, the hook exits 0 with no errors and the event lands in `~/.gstack/projects/<slug>/question-log.jsonl` with question, id, options count, and recommendation extraction all correct.

Related: the `cygpath` workaround for #1950 in `bin/gstack-question-log` handles the same path-translation class of problem for `bun -e` imports; this PR applies the equivalent handling to the hook's spawn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)