### PR TITLE
Fix followed_recommendation always false when option label carries (Recommended)

### DIFF
--- a/bin/gstack-question-log
+++ b/bin/gstack-question-log
@@ -168,9 +168,14 @@ if (j.recommended !== undefined) {
   if (j.recommended.length > 64) j.recommended = j.recommended.slice(0, 64);
 }
 
-// followed_recommendation — compute if both sides present.
+// followed_recommendation — compute if both sides present. The recommended
+// value arrives with its (Recommended) suffix already stripped by the
+// claude hook's extractRecommended, while user_choice is the raw option
+// label — so strip that suffix from both before comparing, else a user who
+// picks the recommended option is scored as NOT following it.
 if (j.recommended !== undefined && j.user_choice !== undefined) {
-  j.followed_recommendation = j.user_choice === j.recommended;
+  const stripRec = (s) => s.replace(/\(recommended\)\s*\$/i, '').trim();
+  j.followed_recommendation = stripRec(j.user_choice) === stripRec(j.recommended);
 }
 
 // session_id — kebab-friendly; <=64 chars


### PR DESCRIPTION
## Problem

`followed_recommendation` in the question log is computed as `j.user_choice === j.recommended` (`bin/gstack-question-log`). But the two sides are normalized differently:

- `recommended` arrives with the `(Recommended)` suffix **already stripped** — `extractRecommended` in `hosts/claude/hooks/question-log-hook.ts` does `.replace(RECOMMENDED_LABEL_RE, '').trim()`
- `user_choice` is the **raw option label**, suffix included

So a user who picks `"Option A (Recommended)"` is compared as `"Option A (Recommended)" === "Option A"` → scored as **not** following the recommendation. Since the `(recommended)` label suffix is the primary convention the extractor recognizes, the metric reads false in exactly the cases it exists to measure, skewing any downstream sensitivity/profile derivation.

## Fix

Strip the same suffix (`/\(recommended\)\s*$/i` + trim) from both sides before comparing. Genuine non-follows still compare unequal.

## Verification

Piped hook-shaped payloads through the PostToolUse hook on a live install:

- choose `Option A (Recommended)` → `followed_recommendation: true` (was `false`)
- choose `Option B` → `followed_recommendation: false`

Note for reviewers: the fix lives inside the `bun -e "..."` double-quoted heredoc region of the bash bin, so the regex `$` anchor is written `\$` to survive bash expansion, matching the file's existing idiom (e.g. `/^[a-z0-9-]+\$/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)