### PR TITLE
fix(browse): keep headed daemon alive when parent shell dies (handoff dies ~15s in)

### DIFF
--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -655,6 +655,8 @@ const idleCheckInterval = setInterval(idleCheckTick, 60_000);
 // dual-instance fix` describe block for usage.
 export const __testInternals__ = {
   idleCheckTick,
+  parentWatchdogTick,
+  resetParentGone: () => { parentGone = false; },
   setTunnelActive: (v: boolean) => { tunnelActive = v; },
   setLastActivity: (t: number) => { lastActivity = t; },
   formatExplicitPortUnavailableError,
@@ -684,34 +686,56 @@ const BROWSE_PARENT_PID = parseInt(process.env.BROWSE_PARENT_PID || '0', 10);
 // the closure every 15s. The CLI's connect path sets BROWSE_HEADED=1 + PID=0,
 // so this branch is the normal path for /open-gstack-browser.
 const IS_HEADED_WATCHDOG = process.env.BROWSE_HEADED === '1';
+
+let parentGone = false;
+
+// Named (like idleCheckTick) so the parent-death branches can be driven
+// deterministically in tests instead of waiting on a 15s interval.
+// `pidOverride` exists only so tests can supply a known-dead PID; production
+// registration below passes nothing and uses BROWSE_PARENT_PID.
+function parentWatchdogTick(pidOverride?: number) {
+  const parentPid = pidOverride ?? BROWSE_PARENT_PID;
+  let parentAlive = true;
+  try {
+    process.kill(parentPid, 0); // signal 0 = existence check only, no signal sent
+  } catch {
+    parentAlive = false;
+  }
+  if (parentAlive) return;
+
+  // Parent exited. Resolution order:
+  // 1. Active cookie picker (one-time code or session live)? Stay alive
+  //    regardless of mode — tearing down the server mid-import leaves the
+  //    picker UI with a stale "Failed to fetch" error.
+  // 2. Headed mode? Stay alive. A visible window is a live user session, not
+  //    an orphan. `handoff` flips an already-running headless daemon to headed
+  //    at runtime, and THAT daemon's BROWSE_PARENT_PID is a Claude Code shell
+  //    which dies after every tool call — so shutting down here destroyed the
+  //    browser within 15s of every handoff, including while the user was being
+  //    asked to log in. Headed daemons are reaped by handleChromiumDisconnect
+  //    (user closes the window) or `$B disconnect`. This matches the
+  //    BROWSE_HEADED=1 launch path, which never registers this watchdog at all.
+  // 3. Tunnel mode? Shutdown. The idle timeout doesn't apply (see
+  //    idleCheckInterval above — it early-returns), and a remote /pair-agent
+  //    peer has no window to close, so parent death is the only cleanup signal.
+  // 4. Normal (headless) mode? Stay alive. Claude Code's Bash tool kills
+  //    the parent shell between invocations. The idle timeout (30 min)
+  //    handles eventual cleanup.
+  if (hasActivePicker()) return;
+  if (activeBrowserManager.getConnectionMode() === 'headed') return;
+  if (tunnelActive) {
+    console.log(`[browse] Parent process ${parentPid} exited in tunnel mode, shutting down`);
+    activeShutdown?.();
+    return;
+  }
+  if (!parentGone) {
+    parentGone = true;
+    console.log(`[browse] Parent process ${parentPid} exited (server stays alive, idle timeout will clean up)`);
+  }
+}
+
 if (BROWSE_PARENT_PID > 0 && !IS_HEADED_WATCHDOG) {
-  let parentGone = false;
-  setInterval(() => {
-    try {
-      process.kill(BROWSE_PARENT_PID, 0); // signal 0 = existence check only, no signal sent
-    } catch {
-      // Parent exited. Resolution order:
-      // 1. Active cookie picker (one-time code or session live)? Stay alive
-      //    regardless of mode — tearing down the server mid-import leaves the
-      //    picker UI with a stale "Failed to fetch" error.
-      // 2. Headed / tunnel mode? Shutdown. The idle timeout doesn't apply in
-      //    these modes (see idleCheckInterval above — both early-return), so
-      //    ignoring parent death here would leak orphan daemons after
-      //    /pair-agent or /open-gstack-browser sessions.
-      // 3. Normal (headless) mode? Stay alive. Claude Code's Bash tool kills
-      //    the parent shell between invocations. The idle timeout (30 min)
-      //    handles eventual cleanup.
-      if (hasActivePicker()) return;
-      const headed = activeBrowserManager.getConnectionMode() === 'headed';
-      if (headed || tunnelActive) {
-        console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited in ${headed ? 'headed' : 'tunnel'} mode, shutting down`);
-        activeShutdown?.();
-      } else if (!parentGone) {
-        parentGone = true;
-        console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited (server stays alive, idle timeout will clean up)`);
-      }
-    }
-  }, 15_000);
+  setInterval(parentWatchdogTick, 15_000);
 } else if (IS_HEADED_WATCHDOG) {
   console.log('[browse] Parent-process watchdog disabled (headed mode)');
 } else if (BROWSE_PARENT_PID === 0) {

--- a/browse/test/server-factory.test.ts
+++ b/browse/test/server-factory.test.ts
@@ -522,3 +522,104 @@ describe('idle timer + onDisconnect dual-instance fix', () => {
     expect(activeCount).toBe(3);
   });
 });
+
+// ─── Parent watchdog vs. runtime headed mode ($B handoff) ───────────
+//
+// #994 inverted "kill on parent death" for headless mode because Claude Code's
+// Bash tool kills the spawning shell after EVERY tool invocation. The headed
+// branch was left shutting down, on the assumption that headed daemons are
+// always launched headed (BROWSE_HEADED=1 + BROWSE_PARENT_PID=0), which never
+// registers this watchdog at all.
+//
+// `handoff` breaks that assumption: it flips an ALREADY-RUNNING headless daemon
+// to headed at runtime. That daemon was spawned with a real BROWSE_PARENT_PID
+// belonging to a Claude Code shell that is already dead, so the next 15s tick
+// saw "parent gone + headed" and tore down the browser the user was actively
+// being asked to log into. Observed: window dies ~15s after every handoff.
+//
+// Headed cleanup is the browser-disconnect handler (handleChromiumDisconnect,
+// which exits the daemon when the window closes) or `$B disconnect`.
+//
+// NOTE: shutdown is fire-and-forget async and ends in a real process.exit, so
+// these tests use NON-throwing exit mocks and drain microtasks before both the
+// assertion and the restore. Throwing (or restoring early) lets the real
+// process.exit run and kills the test runner silently.
+describe('parent watchdog: runtime headed mode survives parent death (handoff)', () => {
+  const DEAD_PID = 999999; // never a live PID; process.kill throws ESRCH
+
+  async function drain() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise<void>(r => setImmediate(r));
+    await new Promise<void>(r => setImmediate(r));
+  }
+
+  beforeEach(() => {
+    __resetRegistry();
+    __testInternals__.setTunnelActive(false);
+    __testInternals__.resetParentGone();
+    __testInternals__.resetShutdownState();
+  });
+
+  test('CRITICAL — REGRESSION: headed daemon does NOT shut down when parent shell dies', async () => {
+    const exitMock = mock((_code?: number) => {});
+    const originalExit = process.exit;
+    (process as any).exit = exitMock;
+    try {
+      const mockBM = makeMockBrowserManager('headed');
+      buildFetchHandler(makeMinimalConfig({ browserManager: mockBM as any }));
+      __testInternals__.parentWatchdogTick(DEAD_PID);
+      await drain();
+      expect(exitMock).not.toHaveBeenCalled();
+    } finally {
+      (process as any).exit = originalExit;
+    }
+  });
+
+  test('headless daemon also survives parent death (#994, paired control)', async () => {
+    const exitMock = mock((_code?: number) => {});
+    const originalExit = process.exit;
+    (process as any).exit = exitMock;
+    try {
+      const mockBM = makeMockBrowserManager('launched');
+      buildFetchHandler(makeMinimalConfig({ browserManager: mockBM as any }));
+      __testInternals__.parentWatchdogTick(DEAD_PID);
+      await drain();
+      expect(exitMock).not.toHaveBeenCalled();
+    } finally {
+      (process as any).exit = originalExit;
+    }
+  });
+
+  test('tunnel mode still shuts down on parent death (unchanged)', async () => {
+    const exitMock = mock((_code?: number) => {});
+    const originalExit = process.exit;
+    (process as any).exit = exitMock;
+    try {
+      const mockBM = makeMockBrowserManager('launched');
+      buildFetchHandler(makeMinimalConfig({ browserManager: mockBM as any }));
+      __testInternals__.setTunnelActive(true);
+      __testInternals__.parentWatchdogTick(DEAD_PID);
+      await drain();
+      expect(exitMock).toHaveBeenCalled();
+    } finally {
+      (process as any).exit = originalExit;
+      __testInternals__.setTunnelActive(false);
+    }
+  });
+
+  test('live parent is a no-op regardless of mode', async () => {
+    const exitMock = mock((_code?: number) => {});
+    const originalExit = process.exit;
+    (process as any).exit = exitMock;
+    try {
+      const mockBM = makeMockBrowserManager('headed');
+      buildFetchHandler(makeMinimalConfig({ browserManager: mockBM as any }));
+      __testInternals__.parentWatchdogTick(process.pid); // alive
+      await drain();
+      expect(exitMock).not.toHaveBeenCalled();
+    } finally {
+      (process as any).exit = originalExit;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`$B handoff` opens a visible browser for the user to take over — CAPTCHA, MFA, login. Under Claude Code that window is destroyed ~15 seconds later, every time, usually while the user is still typing their password.

Root cause is the parent-process watchdog in `browse/src/server.ts`. It polls the spawning shell every 15s and, on parent death, shuts the daemon down whenever `connectionMode` is `'headed'`. Claude Code's Bash tool kills the parent shell after **every** tool invocation, so the parent is always dead within seconds.

`handoff` flips an already-running *headless* daemon to headed at runtime. That daemon was spawned with a real `BROWSE_PARENT_PID` belonging to a long-dead shell, so the next tick tears down the browser.

## Why the headed branch was never load-bearing

Its stated purpose is avoiding orphan daemons after `/pair-agent` and `/open-gstack-browser`. But those paths launch with `BROWSE_HEADED=1` + `BROWSE_PARENT_PID=0`, which skips watchdog registration entirely at the outer gate:

```ts
if (BROWSE_PARENT_PID > 0 && !IS_HEADED_WATCHDOG) { ... }
```

So the branch never fired for the case it was written for, and only ever fired for `handoff`.

This is also a re-run of #994, which inverted "kill on parent death" for headless mode for exactly this reason. The headed branch was left behind, and `handoff`'s runtime transition walks straight into it.

## Change

- Headed mode now stays alive on parent death, matching the `BROWSE_HEADED=1` launch path. Cleanup is unchanged: `handleChromiumDisconnect` exits the daemon when the user closes the window, or `$B disconnect`.
- Tunnel mode still shuts down — a remote peer has no window to close, so parent death is its only cleanup signal.
- Extracted the watchdog body into `parentWatchdogTick()` behind `__testInternals__`, mirroring the existing `idleCheckTick` seam, so the branches can be driven deterministically instead of waiting on a 15s interval.

## Verification

Reproduced end-to-end before the fix:

```
T+0   daemon 28145 alive
T+2   handoff -> daemon alive
T+20  daemon GONE, chromium GONE
```

After:

```
T+5   daemon ALIVE
T+25  daemon ALIVE
T+45  daemon ALIVE, chromium ALIVE, session URL intact
```

Four new tests in `browse/test/server-factory.test.ts` covering headed / headless / tunnel / live-parent. The headed test fails on `main` (`Received number of calls: 1`) and passes here.

`browse` suite: 0 failures across two full runs. Repo-root `bun test` shows 6 failures in `gbrain-detect-install` and `user-slug-fallback` (`status 127` under restricted PATH) — reproduced identically on a clean `origin/main` worktree, so they are pre-existing and environmental, unrelated to this change.

Found while using `/browse` for real work, per the CONTRIBUTING workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)