### PR TITLE
fix(autoplan): task aggregator silently returns zero tasks

### DIFF
--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -1666,8 +1666,12 @@ if command -v jq >/dev/null 2>&1; then
       # Filter to current branch + recent commits, then keep records for the
       # latest run_id only. (Single phase may have multiple files if the user
       # re-ran the review; aggregator takes the newest.)
+      # NOTE: bind .commit BEFORE the split pipe. Inside ($commits | split(...))
+      # the "." context is the resulting ARRAY, so a bare .commit there raises
+      # "Cannot index array with string" on every record — and the 2>/dev/null
+      # below swallows it, so the whole aggregation silently yields zero tasks.
       jq -c --arg branch "$BRANCH" --arg commits "$COMMITS_RECENT" \
-        'select(.branch == $branch and ($commits | split("|") | index(.commit) != null))' \
+        'select(.branch == $branch and ((.commit) as $c | ($commits | split("|") | index($c)) != null))' \
         "$f" 2>/dev/null >> "$ALL_JSONL" || true
     done < <(find "$TASKS_DIR" -maxdepth 1 -name "tasks-$phase-*.jsonl" 2>/dev/null | sort)
     # Reduce to latest run_id per phase

--- a/scripts/resolvers/tasks-section.ts
+++ b/scripts/resolvers/tasks-section.ts
@@ -118,8 +118,12 @@ if command -v jq >/dev/null 2>&1; then
       # Filter to current branch + recent commits, then keep records for the
       # latest run_id only. (Single phase may have multiple files if the user
       # re-ran the review; aggregator takes the newest.)
+      # NOTE: bind .commit BEFORE the split pipe. Inside ($commits | split(...))
+      # the "." context is the resulting ARRAY, so a bare .commit there raises
+      # "Cannot index array with string" on every record — and the 2>/dev/null
+      # below swallows it, so the whole aggregation silently yields zero tasks.
       jq -c --arg branch "$BRANCH" --arg commits "$COMMITS_RECENT" \\
-        'select(.branch == $branch and ($commits | split("|") | index(.commit) != null))' \\
+        'select(.branch == $branch and ((.commit) as $c | ($commits | split("|") | index($c)) != null))' \\
         "$f" 2>/dev/null >> "$ALL_JSONL" || true
     done < <(find "$TASKS_DIR" -maxdepth 1 -name "tasks-$phase-*.jsonl" 2>/dev/null | sort)
     # Reduce to latest run_id per phase


### PR DESCRIPTION
The Phase 4 **Implementation Tasks** aggregator drops every record, so `/autoplan`'s final approval gate always renders the `_No per-phase task lists found_` fallback — even when all four phases wrote valid JSONL.

## Root cause

```
select(.branch == $branch and ($commits | split("|") | index(.commit) != null))
```

Inside `($commits | split("|") | ...)` the `.` context is the resulting **array**, not the input object. So `.commit` there indexes an array with a string and raises:

```
jq: error (at <stdin>:1): Cannot index array with string "commit"
```

on **every** record.

This is not a filtering bug, it is a hard error per line — and the surrounding `2>/dev/null ... || true` swallows it. That is what makes it expensive: the failure is indistinguishable from "the phases never ran", so the gate appears to blame the producers rather than the consumer. I lost a while chasing my own JSONL writer before reading the filter.

## Fix

Bind the commit before the pipe:

```
((.commit) as $c | ($commits | split("|") | index($c)) != null)
```

## Verification

Against a real four-phase run (36 tasks across `ceo-review` / `eng-review` / `devex-review`, matching branch, HEAD inside the 5-commit window):

| | records aggregated |
|---|---|
| before | **0** |
| after | **36** (17 P1, 13 P2, 6 P3) |

Isolated reproduction, showing it errors rather than filters:

```
$ echo '{"branch":"b","commit":"abc123"}' | jq -c --arg branch b --arg commits "abc123|def456" \
    'select(.branch == $branch and ($commits | split("|") | index(.commit) != null))'
jq: error (at <stdin>:1): Cannot index array with string "commit"

$ echo '{"branch":"b","commit":"abc123"}' | jq -c --arg branch b --arg commits "abc123|def456" \
    'select(.branch == $branch and ((.commit) as $c | ($commits | split("|") | index($c)) != null))'
{"branch":"b","commit":"abc123"}
```

Negative control: a record with `commit: "zzz999"` is still correctly dropped, so the fix is not merely permissive.

## Scope

- `scripts/resolvers/tasks-section.ts` — the source of truth, plus a comment explaining the trap so it does not regress.
- `autoplan/SKILL.md` — propagated via `bun run gen:skill-docs`. Regeneration is idempotent on this base (re-running produces no further diff).

No behaviour change beyond the filter. Found while running `/autoplan` end-to-end on a ~1,400-line infrastructure plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)