### PR TITLE
fix(bin): PreToolUse hook schema in gstack-team-init required mode (#2413)

### DIFF
--- a/bin/gstack-team-init
+++ b/bin/gstack-team-init
@@ -127,8 +127,8 @@ Install it:
 
 Then restart your AI coding tool.
 MSG
-  echo '{"permissionDecision":"deny","message":"gstack is required but not installed. See stderr for install instructions."}'
-  exit 0
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"gstack is required but not installed. See stderr for install instructions."}}'
+  exit 2
 fi
 
 echo '{}'

--- a/test/gstack-team-init-hook-schema.test.ts
+++ b/test/gstack-team-init-hook-schema.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { execSync, execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// Regression guard for #2413: gstack-team-init required generated a
+// PreToolUse hook that emitted a flat {"permissionDecision":...} payload and
+// exited 0. Claude Code only nests decisions under hookSpecificOutput, and
+// only exit code 2 reliably blocks a PreToolUse call. The old shape was
+// silently ignored as a non-blocking error, so `required` mode enforced
+// nothing — the BLOCKED text printed to stderr but the tool call proceeded.
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const TEAM_INIT = path.join(ROOT, 'bin', 'gstack-team-init');
+
+let repoDir: string;
+let fakeHomeAbsent: string;
+let fakeHomePresent: string;
+
+describe('gstack-team-init required: PreToolUse hook schema (#2413)', () => {
+  beforeEach(() => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-team-init-repo-'));
+    execFileSync('git', ['init', '-q'], { cwd: repoDir });
+    execFileSync(TEAM_INIT, ['required'], { cwd: repoDir, encoding: 'utf-8' });
+
+    fakeHomeAbsent = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-team-init-home-absent-'));
+
+    fakeHomePresent = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-team-init-home-present-'));
+    fs.mkdirSync(path.join(fakeHomePresent, '.claude', 'skills', 'gstack', 'bin'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    fs.rmSync(fakeHomeAbsent, { recursive: true, force: true });
+    fs.rmSync(fakeHomePresent, { recursive: true, force: true });
+  });
+
+  function runHook(home: string): { status: number; stdout: string; stderr: string } {
+    const hookPath = path.join(repoDir, '.claude', 'hooks', 'check-gstack.sh');
+    try {
+      const stdout = execSync(`bash "${hookPath}"`, {
+        env: { ...process.env, HOME: home },
+        encoding: 'utf-8',
+      });
+      return { status: 0, stdout, stderr: '' };
+    } catch (err) {
+      const e = err as { status: number; stdout: string; stderr: string };
+      return { status: e.status, stdout: e.stdout, stderr: e.stderr };
+    }
+  }
+
+  test('generates the hook and registers it in settings.json', () => {
+    expect(fs.existsSync(path.join(repoDir, '.claude', 'hooks', 'check-gstack.sh'))).toBe(true);
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(repoDir, '.claude', 'settings.json'), 'utf-8'),
+    );
+    expect(JSON.stringify(settings)).toContain('check-gstack.sh');
+  });
+
+  test('gstack absent: exits 2 (blocking) with schema-valid deny JSON', () => {
+    const { status, stdout, stderr } = runHook(fakeHomeAbsent);
+    expect(status).toBe(2);
+    expect(stderr).toContain('BLOCKED: gstack is not installed globally.');
+
+    const payload = JSON.parse(stdout.trim());
+    expect(payload.hookSpecificOutput.hookEventName).toBe('PreToolUse');
+    expect(payload.hookSpecificOutput.permissionDecision).toBe('deny');
+    expect(typeof payload.hookSpecificOutput.permissionDecisionReason).toBe('string');
+    // The old top-level shape must be gone, not just supplemented.
+    expect(payload.permissionDecision).toBeUndefined();
+    expect(payload.message).toBeUndefined();
+  });
+
+  test('gstack present: exits 0 with an empty (no-opinion) payload', () => {
+    const { status, stdout, stderr } = runHook(fakeHomePresent);
+    expect(status).toBe(0);
+    expect(stderr).toBe('');
+    expect(JSON.parse(stdout.trim())).toEqual({});
+  });
+});


### PR DESCRIPTION
## What was broken (plain English)
`gstack-team-init required` writes a Claude Code hook meant to block AI-assisted work when gstack isn't installed globally. The hook prints the right warning to the terminal, but the machine-readable part of its answer was in a shape Claude Code doesn't recognize, and it said "everything's fine" (exit code 0) even on the deny path. So the block never actually happened — the warning showed up, then the tool call ran anyway.

## How it was fixed (plain English)
The hook's answer is now wrapped in the shape Claude Code actually expects, and it exits with the code that means "actually stop this." The allow path (when gstack is installed) is untouched.

Fixes #2413

## Technical detail
`.claude/hooks/check-gstack.sh` (generated by `bin/gstack-team-init required`) emitted:
```
{"permissionDecision":"deny","message":"..."}
exit 0
```
Per the [hooks reference](https://code.claude.com/docs/en/hooks), a PreToolUse hook must nest the decision inside `hookSpecificOutput`, and JSON is only parsed on exit 0 — an exit-0 JSON payload that doesn't match the expected schema is treated as a non-blocking error, so the tool call proceeds regardless. Fix:
```
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"..."}}
exit 2
```
Exit code 2 blocks the call even if a future schema change makes the JSON invalid again, so the gate holds defensively.

## Verification
- Manual repro matching the issue's exact steps: `HOME=/tmp/no-gstack bash .claude/hooks/check-gstack.sh; echo "exit: $?"` now prints the nested JSON and `exit: 2` (was `exit: 0` before this fix, confirmed against `main`).
- gstack-present path still returns `{}` / `exit: 0` (unchanged, verified).
- Added `test/gstack-team-init-hook-schema.test.ts`: generates the hook via `gstack-team-init required` in a temp repo and asserts both the absent-gstack (exit 2, schema-valid deny) and present-gstack (exit 0, `{}`) branches.
- `bun test` full suite run on this branch and compared against `main`: no new failures introduced by this change (pre-existing failures — Playwright browser binary not installed, gbrain/Xcode/auth-dependent tests, and sidebar tests referencing already-ripped functionality — are identical/superset on `main`).

## Scope note
The same flat, non-nested `permissionDecision` pattern this issue reports also exists in `freeze/bin/check-freeze.sh` and `careful/bin/check-careful.sh` (both currently rely on implicit exit 0 via `set -euo pipefail`). Left out of this PR to keep the diff scoped to the exact file/line #2413 reports — happy to send a follow-up if that's wanted.