### PR TITLE
fix(redact): stop the E.164 phone pattern flagging compact timestamps

### DIFF
--- a/lib/redact-patterns.ts
+++ b/lib/redact-patterns.ts
@@ -138,6 +138,36 @@ function looksLikeWallet(span: string): boolean {
   return span.length >= 26 && span.length <= 62;
 }
 
+// Compact log/backup stamps (`20260727202423` = YYYYMMDDHHMMSS) are bare digit
+// runs that the phone regex happily eats. Only a SEPARATOR-FREE 14-digit span
+// qualifies: E.164 tops out at 15 digits and real numbers carry a + or spacing,
+// so rejecting this shape costs no phone coverage.
+function looksLikeCompactTimestamp(span: string): boolean {
+  if (!/^\d{14}$/.test(span)) {
+    return false;
+  }
+  const n = (from: number, to: number) => Number(span.slice(from, to));
+  const [year, month, day, hour, minute, second] = [
+    n(0, 4),
+    n(4, 6),
+    n(6, 8),
+    n(8, 10),
+    n(10, 12),
+    n(12, 14),
+  ];
+  return (
+    year >= 1900 &&
+    year <= 2999 &&
+    month >= 1 &&
+    month <= 12 &&
+    day >= 1 &&
+    day <= 31 &&
+    hour <= 23 &&
+    minute <= 59 &&
+    second <= 59
+  );
+}
+
 // ── Placeholder suppression (per-matched-span, NOT per-line) ─────────────────
 
 /**
@@ -431,7 +461,8 @@ export const PATTERNS: RedactPattern[] = [
     regex: /(?<![\w.])(\+?[1-9]\d{0,2}[ \-.]?\(?\d{2,4}\)?[ \-.]?\d{3,4}[ \-.]?\d{3,4})(?![\w.])/,
     autoRedactable: true,
     redactToken: "<REDACTED-PHONE>",
-    validate: (span) => span.replace(/\D/g, "").length >= 10,
+    validate: (span) =>
+      span.replace(/\D/g, "").length >= 10 && !looksLikeCompactTimestamp(span),
   },
   {
     id: "pii.ssn",

--- a/test/redact-engine.test.ts
+++ b/test/redact-engine.test.ts
@@ -185,8 +185,9 @@ describe("PII patterns", () => {
       scan("bob@acme.co", { repoVisibility: "private", repoPublicEmails: ["bob@acme.co"] }).findings,
     ).toHaveLength(0);
   });
-  test("phone E.164", () => {
+  test("phone E.164 flags, skips compact timestamps", () => {
     expect(ids("call +14155550123 now")).toContain("pii.phone.e164");
+    expect(ids("backup stamp 20260727202423 ran late")).not.toContain("pii.phone.e164");
   });
   test("ssn flags valid, skips 000 octet", () => {
     expect(ids("ssn 123-45-6789")).toContain("pii.ssn");


### PR DESCRIPTION
## What

`pii.phone.e164` flags compact timestamps. A bare 14-digit run such as `20260727202423` (a `YYYYMMDDHHMMSS` backup or log stamp) matches the phone regex and clears the `>= 10 digits` validate, so any document quoting one raises a MEDIUM finding.

## How it showed up

A real `gstack-redact` pre-push on a private ops repo raised 2 MEDIUM `pii.phone.e164` findings against a report that cited a PostgreSQL dump stamp twice:

> the PostgreSQL backup from 27-jul carries stamp `20260727202423` — it ran at 20:24 instead of its window

No PII was involved; both were false positives. And because the finding is `autoRedactable`, the offered remedy was to rewrite a legitimate timestamp as `<REDACTED-PHONE>`.

## Fix

Reject **only** separator-free 14-digit spans whose halves parse as a plausible date and time (year 1900-2999, month 1-12, day 1-31, 23:59:59). Deliberately narrow:

- E.164 tops out at 15 digits, and real numbers in prose carry a `+` or separators — either keeps the span out of this branch, so no phone coverage is lost.
- 12-digit stamps (`YYYYMMDDHHMM`) are **not** covered on purpose: 12 consecutive digits is a plausible national number in several countries, so excluding them would trade a false positive for a false negative.

## Testing

- `test/redact-engine.test.ts` — the existing `phone E.164` case gains a skip assertion, following the shape already used by `ssn` and `ip_public`. Confirmed failing before the fix, passing after.
- Full Tier 1 (`bun test test/*.test.ts` — 4246 tests across 280 files) run on this branch and on `main`: identical failure set, all pre-existing and environmental.
- End to end: the pre-push that originally raised 2 MEDIUM now reports 0.

## Unrelated observation

`test/redact-prepush-hook.test.ts` → *"install creates a managed hook; existing hook preserved + chained"* fails on any machine with a global `core.hooksPath` set: the hook lands in the global path instead of the test's temp repo. It passes with `GIT_CONFIG_GLOBAL=/dev/null`. Pre-existing on `main` and out of scope here — happy to send a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
