### PR TITLE
fix(safety): unknown source exits 1 instead of documented 2 (#2390)

### DIFF
--- a/bin/gstack-question-preference
+++ b/bin/gstack-question-preference
@@ -155,8 +155,8 @@ do_write() {
       process.exit(2);
     }
     if (!ALLOWED_SOURCES.includes(j.source)) {
-      process.stderr.write('gstack-question-preference: invalid source \"' + j.source + '\"; allowed: ' + ALLOWED_SOURCES.join(', ') + '\n');
-      process.exit(1);
+      process.stderr.write('gstack-question-preference: rejected — source \"' + j.source + '\" is not user-originated (profile poisoning defense)\n');
+      process.exit(2);
     }
 
     // Optional free_text — sanitize (no injection patterns, no newlines, <=300 chars)

--- a/test/gstack-question-preference.test.ts
+++ b/test/gstack-question-preference.test.ts
@@ -281,8 +281,16 @@ describe('--write user-origin gate (profile-poisoning defense)', () => {
       '--write',
       JSON.stringify({ question_id: 'q1', preference: 'never-ask', source: 'anonymous' }),
     );
-    expect(r.status).not.toBe(0);
-    expect(r.stderr).toContain('invalid source');
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('profile poisoning defense');
+  });
+
+  test('unknown source exits 2 (user-origin rejection), not 1 (validation error)', () => {
+    const r = run(
+      '--write',
+      JSON.stringify({ question_id: 'q1', preference: 'never-ask', source: 'tool-output' }),
+    );
+    expect(r.status).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #2390 — the user-origin gate in `gstack-question-preference --write` exits with code 1 (validation error) instead of code 2 (poisoning rejection) when a source value is not in ALLOWED_SOURCES but also not in the hardcoded REJECTED_SOURCES list.

The gate has three branches: missing source (exit 1), explicitly rejected source like `inline-tool-output` (exit 2), and anything else not in ALLOWED_SOURCES (was exit 1, should be exit 2). The third branch is semantically a user-origin rejection — the source is not user-originated — but was incorrectly using the validation-error exit code. This matters because callers distinguish exit 1 (retry with corrected input) from exit 2 (do not retry, this is a security rejection). The fix aligns the exit code and error message with the REJECTED_SOURCES branch.

## Verification

- `bun test` green (60 tests across 2 related files)
- Regression test `test/gstack-question-preference.test.ts` fails on main with:
  ```
  error: expect(received).toBe(expected)
  Expected: 2
  Received: 1
  ```
- Passes after fix applied
- Discrimination verified: reverting only `bin/gstack-question-preference` while keeping the test causes failure

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>