### PR TITLE
fix(browse): skip .gitignore append when git already ignores .gstack/ (#2385)

### DIFF
--- a/browse/src/config.ts
+++ b/browse/src/config.ts
@@ -82,9 +82,12 @@ function isIgnoredByGit(projectDir: string, relPath: string): boolean {
   try {
     const proc = Bun.spawnSync(['git', 'check-ignore', '-q', '--', relPath], {
       cwd: projectDir, stdout: 'pipe', stderr: 'pipe',
+      timeout: 2_000,
     });
     return proc.exitCode === 0;
   } catch {
+    // git not found, timed out, or not a repo (exit 128). Fall through to
+    // the text-check path — appending is the safe default when unsure.
     return false;
   }
 }

--- a/browse/src/config.ts
+++ b/browse/src/config.ts
@@ -78,6 +78,17 @@ export function resolveConfig(
   };
 }
 
+function isIgnoredByGit(projectDir: string, relPath: string): boolean {
+  try {
+    const proc = Bun.spawnSync(['git', 'check-ignore', '-q', '--', relPath], {
+      cwd: projectDir, stdout: 'pipe', stderr: 'pipe',
+    });
+    return proc.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Create the .gstack/ state directory if it doesn't exist.
  * Throws with a clear message on permission errors.
@@ -96,6 +107,9 @@ export function ensureStateDir(config: BrowseConfig): void {
   }
 
   // Ensure .gstack/ is in the project's .gitignore
+  // First, check if git already ignores .gstack/ (via global excludes, .git/info/exclude, or parent .gitignore)
+  if (isIgnoredByGit(config.projectDir, '.gstack/')) return;
+
   const gitignorePath = path.join(config.projectDir, '.gitignore');
   try {
     const content = fs.readFileSync(gitignorePath, 'utf-8');

--- a/browse/test/config.test.ts
+++ b/browse/test/config.test.ts
@@ -124,6 +124,41 @@ describe('config', () => {
       expect(fs.existsSync(path.join(tmpDir, '.gitignore'))).toBe(false);
       fs.rmSync(tmpDir, { recursive: true, force: true });
     });
+
+    test('leaves .gitignore alone when git already ignores .gstack/ globally', () => {
+      const { spawnSync } = require('child_process');
+      const tmpDir = path.join(os.tmpdir(), `browse-gitignore-global-${Date.now()}`);
+      fs.mkdirSync(tmpDir, { recursive: true });
+
+      // Set up a real git repo
+      spawnSync('git', ['init', '-q'], { cwd: tmpDir });
+      spawnSync('git', ['config', 'user.email', 'test@test.com'], { cwd: tmpDir });
+      spawnSync('git', ['config', 'user.name', 'Test'], { cwd: tmpDir });
+
+      // Write a global excludes file that ignores .gstack/
+      const excludesFile = path.join(tmpDir, 'global-gitignore');
+      fs.writeFileSync(excludesFile, '.gstack/\n');
+      spawnSync('git', ['config', 'core.excludesFile', excludesFile], { cwd: tmpDir });
+
+      // .gitignore exists but does NOT contain .gstack/
+      fs.writeFileSync(path.join(tmpDir, '.gitignore'), 'node_modules/\n');
+      spawnSync('git', ['add', '.gitignore'], { cwd: tmpDir });
+      spawnSync('git', ['commit', '-qm', 'init'], { cwd: tmpDir });
+
+      // Verify git knows .gstack/ is ignored
+      const check = spawnSync('git', ['check-ignore', '-q', '.gstack/'], { cwd: tmpDir });
+      expect(check.status).toBe(0);
+
+      const config = resolveConfig({ BROWSE_STATE_FILE: path.join(tmpDir, '.gstack', 'browse.json') });
+      ensureStateDir(config);
+
+      // .gitignore must NOT have been modified
+      const content = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf-8');
+      expect(content).toBe('node_modules/\n');
+      expect(fs.existsSync(path.join(tmpDir, '.gstack'))).toBe(true);
+
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
   });
 
   describe('getRemoteSlug', () => {


### PR DESCRIPTION
## Summary

Fixes #2385 — `ensureStateDir()` appends `.gstack/` to the project's `.gitignore` even when git already ignores the path via `core.excludesFile`, `.git/info/exclude`, or a parent `.gitignore`.

The function only checked the local `.gitignore` file text for the pattern. If the line wasn't there, it appended — regardless of whether git's full ignore machinery already covered it. This corrupts tracked `.gitignore` files on shared repos, creating spurious diffs that ride along in unrelated PRs.

The fix adds a `git check-ignore -q` call before the text check. If git already ignores `.gstack/` through any mechanism, the function returns early without touching the file. On error or non-repo environments (exit 128), it falls back to the existing behavior.

## Verification

- `bun test browse/test/config.test.ts` green (42/42)
- Regression test `browse/test/config.test.ts` ("leaves .gitignore alone when git already ignores .gstack/ globally") fails on main with:
  ```
  error: expect(received).toBe(expected)
  "node_modules/
  + .gstack/
  "
  Expected  - 0
  Received  + 1
  ```
- Passes after fix applied
- Discrimination verified: reverting only `browse/src/config.ts` causes failure

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>