### PR TITLE
fix(settings): include command in add-event dedup key (#2382)

### DIFF
--- a/bin/gstack-settings-hook
+++ b/bin/gstack-settings-hook
@@ -171,8 +171,9 @@ case "$ACTION" in
 
       const matchesEntry = (entry) => {
         const sameMatcher = (entry.matcher || "") === matcher;
+        const sameCommand = entry.hooks && entry.hooks[0] && entry.hooks[0].command === cmd;
         const sameSource = entry._gstack_source === source;
-        return sameMatcher && sameSource;
+        return sameMatcher && (sameSource || sameCommand);
       };
 
       let existing = settings.hooks[event].find(matchesEntry);
@@ -184,6 +185,7 @@ case "$ACTION" in
 
       if (existing) {
         existing.hooks = [hookEntry];
+        existing._gstack_source = source;
       } else {
         const newEntry = { _gstack_source: source, hooks: [hookEntry] };
         if (matcher) newEntry.matcher = matcher;

--- a/test/gstack-settings-hook-schema-aware.test.ts
+++ b/test/gstack-settings-hook-schema-aware.test.ts
@@ -111,6 +111,55 @@ describe('add-event', () => {
     expect(s.hooks.PreToolUse[0].hooks[0].command).toBe('/v2');
   });
 
+  test('dedup includes command: same (event, matcher, command) with different source updates in place', () => {
+    run([
+      'add-event',
+      '--event', 'PostToolUse',
+      '--matcher', '(AskUserQuestion|mcp__.*__AskUserQuestion)',
+      '--command', '/abs/path/to/question-log-hook',
+      '--source', 'source-A',
+      '--timeout', '5',
+    ]);
+    run([
+      'add-event',
+      '--event', 'PostToolUse',
+      '--matcher', '(AskUserQuestion|mcp__.*__AskUserQuestion)',
+      '--command', '/abs/path/to/question-log-hook',
+      '--source', 'source-B',
+      '--timeout', '5',
+    ]);
+    const s = settings();
+    expect(s.hooks.PostToolUse).toHaveLength(1);
+    expect(s.hooks.PostToolUse[0]._gstack_source).toBe('source-B');
+  });
+
+  test('dedup includes command: untagged entry with same command is updated not duplicated', () => {
+    fs.writeFileSync(
+      settingsFile,
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: '(AskUserQuestion|mcp__.*__AskUserQuestion)',
+              hooks: [{ type: 'command', command: '/abs/path/to/question-log-hook', timeout: 5 }],
+            },
+          ],
+        },
+      }, null, 2),
+    );
+    run([
+      'add-event',
+      '--event', 'PostToolUse',
+      '--matcher', '(AskUserQuestion|mcp__.*__AskUserQuestion)',
+      '--command', '/abs/path/to/question-log-hook',
+      '--source', 'plan-tune-cathedral',
+      '--timeout', '5',
+    ]);
+    const s = settings();
+    expect(s.hooks.PostToolUse).toHaveLength(1);
+    expect(s.hooks.PostToolUse[0]._gstack_source).toBe('plan-tune-cathedral');
+  });
+
   test('preserves unrelated existing hooks', () => {
     fs.writeFileSync(
       settingsFile,


### PR DESCRIPTION
## Summary

Fixes #2382 — `gstack-settings-hook add-event` deduplicates on `(event, matcher, _gstack_source)` but ignores the `command` field. When an entry loses its `_gstack_source` tag (or is re-registered under a different source), the same hook command is appended as a duplicate — firing N times per matching tool call.

The fix adds `command` to the match predicate: an entry with the same `(event, matcher, command)` is now treated as the same hook regardless of source tag. On match, the existing entry is updated in place (including refreshing its `_gstack_source`), preventing duplication and making `add-event` self-healing for untagged entries.

## Verification

- `bun test test/gstack-settings-hook-schema-aware.test.ts` green (15/15)
- Two regression tests fail on main:
  - "dedup includes command: same (event, matcher, command) with different source updates in place"
  - "dedup includes command: untagged entry with same command is updated not duplicated"
  ```
  error: expect(received).toHaveLength(expected)
  Expected length: 1
  Received length: 2
  ```
- Both pass after fix applied
- Discrimination verified: reverting only `bin/gstack-settings-hook` causes both failures

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>