### PR TITLE
fix(setup): link lib/ beside bin/ in runtime sidecars (#2305)

### DIFF
--- a/setup
+++ b/setup
@@ -796,6 +796,9 @@ create_codex_runtime_root() {
   if [ -d "$gstack_dir/bin" ]; then
     _link_or_copy "$gstack_dir/bin" "$codex_gstack/bin"
   fi
+  if [ -d "$gstack_dir/lib" ]; then
+    _link_or_copy "$gstack_dir/lib" "$codex_gstack/lib"
+  fi
   if [ -d "$gstack_dir/browse/dist" ]; then
     _link_or_copy "$gstack_dir/browse/dist" "$codex_gstack/browse/dist"
   fi
@@ -836,6 +839,9 @@ create_factory_runtime_root() {
   if [ -d "$gstack_dir/bin" ]; then
     _link_or_copy "$gstack_dir/bin" "$factory_gstack/bin"
   fi
+  if [ -d "$gstack_dir/lib" ]; then
+    _link_or_copy "$gstack_dir/lib" "$factory_gstack/lib"
+  fi
   if [ -d "$gstack_dir/browse/dist" ]; then
     _link_or_copy "$gstack_dir/browse/dist" "$factory_gstack/browse/dist"
   fi
@@ -873,6 +879,9 @@ create_opencode_runtime_root() {
   fi
   if [ -d "$gstack_dir/bin" ]; then
     _link_or_copy "$gstack_dir/bin" "$opencode_gstack/bin"
+  fi
+  if [ -d "$gstack_dir/lib" ]; then
+    _link_or_copy "$gstack_dir/lib" "$opencode_gstack/lib"
   fi
   if [ -d "$gstack_dir/browse/dist" ]; then
     _link_or_copy "$gstack_dir/browse/dist" "$opencode_gstack/browse/dist"

--- a/test/setup-lib-sidecar.test.ts
+++ b/test/setup-lib-sidecar.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Static invariant: runtime sidecar roots (codex, factory, opencode) that link
+ * bin/ MUST also link lib/, because bin/ scripts import from ../lib/ via
+ * relative paths (e.g. gstack-learnings-log imports lib/jsonl-store.ts).
+ *
+ * Without lib/ beside bin/ in the sidecar, those imports resolve to nothing and
+ * the script crashes at runtime.
+ *
+ * Issue: #2305
+ */
+
+import { describe, test, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SETUP = fs.readFileSync(path.join(import.meta.dir, '..', 'setup'), 'utf-8');
+
+describe('setup links lib/ beside bin/ in runtime sidecars', () => {
+  const SIDECAR_VARS = ['codex_gstack', 'factory_gstack', 'opencode_gstack'];
+
+  for (const sidecar of SIDECAR_VARS) {
+    test(`${sidecar} links lib/ when bin/ is linked`, () => {
+      const binPattern = new RegExp(
+        `_link_or_copy "\\$gstack_dir/bin" "\\$${sidecar}/bin"`,
+      );
+      const libPattern = new RegExp(
+        `_link_or_copy "\\$gstack_dir/lib" "\\$${sidecar}/lib"`,
+      );
+
+      const hasBin = binPattern.test(SETUP);
+      const hasLib = libPattern.test(SETUP);
+
+      expect(hasBin).toBe(true);
+      expect(hasLib).toBe(true);
+    });
+  }
+
+  test('lib/ link uses _link_or_copy (not raw ln)', () => {
+    const libLines = SETUP.split('\n').filter(
+      (l) => l.includes('/lib"') && /\bln\s+-/.test(l),
+    );
+    expect(libLines).toEqual([]);
+  });
+
+  test('lib/ link is guarded by -d check', () => {
+    const libGuards = SETUP.split('\n').filter((l) =>
+      l.includes('if [ -d "$gstack_dir/lib" ]'),
+    );
+    expect(libGuards.length).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2305 — `bin/` scripts that import from `../lib/` (e.g. `gstack-learnings-log`, `gstack-gbrain-sync`, `gstack-redact-prepush`) crash at runtime in codex, factory, and opencode sidecars because setup links `bin/` but omits `lib/`.

The fix adds `_link_or_copy "$gstack_dir/lib" "$<host>_gstack/lib"` after each `bin/` link block in the three affected sidecar sections, guarded by the same `-d` check pattern used for `bin/` and `browse/dist`.

## Verification

- `bun test` green (full Tier 1 suite)
- Regression test `test/setup-lib-sidecar.test.ts` fails on main with:
  ```
  error: expect(received).toBe(expected)
  Expected: true
  Received: false
  (fail) codex_gstack links lib/ when bin/ is linked
  (fail) factory_gstack links lib/ when bin/ is linked
  (fail) opencode_gstack links lib/ when bin/ is linked
  (fail) lib/ link is guarded by -d check
  ```
- Passes after fix applied

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>