### PR TITLE
fix(browse): guard browser.process() in resolveDisconnectCause

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -91,7 +91,11 @@ export function shouldEnableChromiumSandbox(): boolean {
  * restarts on backoff.
  */
 export async function resolveDisconnectCause(browser: Browser | null): Promise<'clean' | 'crash'> {
-  const proc = browser?.process();
+  // `.process()` only exists on browsers we launched ourselves. A browser
+  // obtained via connectOverCDP() (or a stub in tests) has no such method —
+  // calling it blind throws inside the disconnect handler, which killed the
+  // whole daemon with "browser?.process is not a function".
+  const proc = typeof browser?.process === 'function' ? browser.process() : null;
   if (proc && proc.exitCode === null && proc.signalCode === null) {
     await new Promise<void>((resolve) => {
       const timer = setTimeout(resolve, 1000);


### PR DESCRIPTION
## Problem

`resolveDisconnectCause` calls `browser?.process()` unconditionally. `.process()` only exists on browsers the daemon launched itself — a browser obtained via `connectOverCDP()` (e.g. connect-chrome flows) or a stub in tests has no such method. When such a browser disconnects, the disconnect handler itself throws:

```
browser?.process is not a function
```

…which kills the entire browse daemon on what should be a routine disconnect event. Everything depending on the daemon (/browse, /qa, make-pdf) goes down with it.

## Fix

Guard with a `typeof` check and fall through to the default branch when the process handle is unavailable:

```ts
const proc = typeof browser?.process === 'function' ? browser.process() : null;
```

Found and patched locally while debugging a daemon crash; carrying it as a local patch across upgrades since, so upstreaming it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)