### PR TITLE
fix(gbrain): bind source mutations to canonical identity

### DIFF
--- a/USING_GBRAIN_WITH_GSTACK.md
+++ b/USING_GBRAIN_WITH_GSTACK.md
@@ -130,12 +130,12 @@ Storage: `~/.gstack/gbrain-repo-policy.json`, mode 0600, schema-versioned so fut
 /sync-gbrain --dry-run      # preview what would sync; no writes
 ```
 
-The skill runs three stages — code, memory, brain-sync — independently. A failure in one doesn't block the others. State persists to `~/.gstack/.gbrain-sync-state.json` so re-running picks up cleanly.
+The skill runs three stages — code, memory, brain-sync — independently. A failure in one doesn't block the others. State persists to `~/.gstack/.gbrain-sync-state.json` so re-running picks up cleanly. Code sync and dream require GBrain `0.41.38.0` or newer; an older installed CLI stops before any source mutation. Run `gstack-gbrain-install` (or re-run `/setup-gbrain`) and then retry `/sync-gbrain`.
 
 **What it does on a fresh worktree:**
 
-1. **Pre-flight.** Checks `gbrain_local_status` (the local engine's health). If the engine is `broken-db` or `broken-config`, the skill STOPs with a remediation menu — it refuses to silently degrade. If the local engine is missing and you're in remote-MCP mode (Path 4), the code stage SKIPs cleanly and only brain-sync runs.
-2. **Code stage.** Registers the cwd as a federated source via `gbrain sources add`, writes a `.gbrain-source` pin file in the repo root (kubectl-style context — every worktree gets its own pin, so Conductor sibling worktrees don't collide), runs `gbrain sync --strategy code`.
+1. **Pre-flight.** Checks `gbrain_local_status` (the local engine's health) and requires GBrain `0.41.38.0+` before sync or dream. If the CLI is older, the run exits before mutation and tells you to run `gstack-gbrain-install`; `/setup-gbrain` is the user-facing upgrade path. If the engine is `broken-db` or `broken-config`, the skill STOPs with a remediation menu — it refuses to silently degrade. If the local engine is missing and you're in remote-MCP mode (Path 4), the code stage SKIPs cleanly and only brain-sync runs.
+2. **Code stage.** Registers the cwd as a federated source via `gbrain sources add`, writes a `.gbrain-source` pin file in the repo root (kubectl-style context — every worktree gets its own pin, so Conductor sibling worktrees don't collide), runs `gbrain sync --strategy code`. Relative, absolute, and symlink/junction paths resolving to the same directory are treated as one source. A genuine path drift is repaired only after guarded identity and registry checks; missing, ambiguous, rebound, or unverifiable paths stop before remove/add.
 3. **Memory stage.** Stages your `~/.gstack/` transcripts + curated memory. In local-stdio MCP mode, ingests into the local engine. In remote-http MCP mode, persists staged markdown to `~/.gstack/transcripts/run-<pid>-<ts>/` for the remote brain admin's pull pipeline. The ingest timeout is 30 minutes by default; raise it for a big brain with `GSTACK_INGEST_TIMEOUT_MS` (accepts 1 min–24h). On timeout the gbrain import checkpoint is preserved, so the next `/sync-gbrain` resumes instead of starting over.
 4. **Brain-sync stage.** Pushes curated artifacts (plans, designs, retros) to your private artifacts repo if you have one configured.
 5. **CLAUDE.md guidance.** Capability-checks the round-trip (write a page → search → find it). If green, writes the `## GBrain Search Guidance` block to your project's CLAUDE.md. If red, REMOVES the block — the agent should never be told to use a tool that isn't installed.
@@ -207,7 +207,7 @@ The skill re-collects a PAT (one-time, discarded after), lists every project in 
 | Bin | Purpose |
 |---|---|
 | `gstack-gbrain-detect` | Emit current state as JSON: gbrain on PATH, version, config engine, doctor status, sync mode |
-| `gstack-gbrain-install` | Detect-first installer (probes `~/git/gbrain`, `~/gbrain`, then fresh clone). Has `--dry-run` and `--validate-only` flags. PATH-shadow check exits 3 with remediation menu. |
+| `gstack-gbrain-install` | Detect-first installer (probes `~/git/gbrain`, `~/gbrain`, then fresh clone). Requires GBrain `0.41.38.0+`; older installs exit 3 before sync integration can run. Has `--dry-run` and `--validate-only` flags. PATH-shadow check exits 3 with remediation menu. |
 | `gstack-gbrain-lib.sh` | Sourced, not executed. Provides `read_secret_to_env VARNAME "prompt" [--echo-redacted "<sed-expr>"]` |
 | `gstack-gbrain-supabase-verify` | Structural URL check. Rejects direct-connection URLs (`db.*.supabase.co:5432`) with exit 3 |
 | `gstack-gbrain-supabase-provision` | Management API wrapper. Subcommands: `list-orgs`, `create`, `wait`, `pooler-url`, `list-orphans`, `delete-project`. All require `SUPABASE_ACCESS_TOKEN` in env. `create` and `pooler-url` also require `DB_PASS`. `--json` mode available on every subcommand. |
@@ -297,6 +297,23 @@ One rule for every secret this skill touches: **env var only, never argv, never 
 - Your shell's own `HISTFILE` behavior is your shell's, not ours — we never pass secrets to argv so they don't land there via our code, but nothing stops you from pasting one into a raw `curl` command yourself
 
 ## Troubleshooting
+
+### `[gbrain-sync] gbrain ... is below the required 0.41.38.0`
+
+The installed CLI predates the provenance, source-scoped dream, and pin-aware
+code-graph behavior that safe sync requires. The orchestrator exits before any
+source mutation. Upgrade and retry:
+
+```bash
+gstack-gbrain-install
+# Or use the guided setup path:
+/setup-gbrain
+
+/sync-gbrain
+```
+
+If you intentionally pin GBrain, pass a commit that provides version
+`0.41.38.0` or newer to `gstack-gbrain-install --pinned-commit <sha>`.
 
 ### "PATH SHADOWING DETECTED" during install
 

--- a/bin/gstack-gbrain-install
+++ b/bin/gstack-gbrain-install
@@ -42,10 +42,13 @@ set -euo pipefail
 # --pinned-commit <sha> overrides for reproducibility.
 PINNED_COMMIT=""
 PINNED_TAG=""
-# Minimum gbrain version gstack's integration is known to work with. The
-# `sources list --json` wrapped-object shape + federated sources landed by 0.20;
-# older predates the surface gstack drives. Hard-fail below this floor (#1744).
-MIN_GBRAIN_VERSION="0.20.0"
+# Minimum gbrain version gstack's integration is known to work with. The sync
+# safety gate needs authoritative `sources_list` provenance. GBrain
+# 0.41.38.0 is the first release where the complete promised workflow is sound:
+# source-scoped dream works and unqualified code-callers/code-callees honor the
+# per-worktree `.gbrain-source` pin. Older versions can silently use the wrong
+# source while gstack reports success, so installation fails closed.
+MIN_GBRAIN_VERSION="0.41.38.0"
 GBRAIN_REPO_URL="https://github.com/garrytan/gbrain.git"
 DEFAULT_INSTALL_DIR="${GBRAIN_INSTALL_DIR:-$HOME/gbrain}"
 INSTALL_DIR="$DEFAULT_INSTALL_DIR"
@@ -223,7 +226,7 @@ version_lt() {
 if version_lt "$actual_norm" "$MIN_GBRAIN_VERSION"; then
   echo "" >&2
   echo "gstack-gbrain-install: gbrain $actual_version is below the minimum gstack-tested version ($MIN_GBRAIN_VERSION)." >&2
-  echo "  gstack's sync integration needs the v0.20+ source/list surface." >&2
+  echo "  gstack's sync integration needs v0.41.38.0+ provenance, source-scoped dream, and pin-aware code graph support." >&2
   echo "  Fix: update the gbrain clone at $INSTALL_DIR to a newer release (git pull), then" >&2
   echo "  re-run /setup-gbrain. Or pass --pinned-commit <sha> to install a specific newer commit." >&2
   echo "" >&2

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -29,18 +29,64 @@
  * than building a gstack-side daemon.
  */
 
-import { existsSync, statSync, mkdirSync, writeFileSync, readFileSync, unlinkSync, renameSync } from "fs";
+import {
+  existsSync,
+  lstatSync,
+  statSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  openSync,
+  fstatSync,
+  closeSync,
+  unlinkSync,
+  renameSync,
+  constants as FS_CONSTANTS,
+} from "fs";
 import { join, dirname } from "path";
 import { execSync, spawnSync } from "child_process";
 import { homedir, hostname } from "os";
-import { createHash } from "crypto";
+import { createHash, randomBytes } from "crypto";
 
 import "../lib/conductor-env-shim";
-import { detectEngineTier, withErrorContext, canonicalizeRemote } from "../lib/gstack-memory-helpers";
-import { ensureSourceRegistered, sourcePageCount, parseSourcesList, cycleCompleted, type CycleStatus } from "../lib/gbrain-sources";
-import { detectAutopilot, decideSourceRemove, decideCodeSync } from "../lib/gbrain-guards";
-import { localEngineStatus, type LocalEngineStatus } from "../lib/gbrain-local-status";
-import { buildGbrainEnv, spawnGbrain, execGbrainJson, NEEDS_SHELL_ON_WINDOWS } from "../lib/gbrain-exec";
+import {
+  detectEngineTier,
+  withErrorContext,
+  canonicalizeRemote,
+} from "../lib/gstack-memory-helpers";
+import {
+  assertCanonicalDirectoryUnchanged,
+  bindRegisteredSourcePath,
+  canonicalSourceDirectory,
+  ensureSourceRegistered,
+  registeredSourceMatchesDirectory,
+  sourcePageCount,
+  parseSourcesList,
+  cycleCompleted,
+  type CanonicalDirectory,
+  type CycleStatus,
+  type DirectoryFsOps,
+  type SourcePathBinding,
+} from "../lib/gbrain-sources";
+import {
+  detectAutopilot,
+  decideSourceRemove,
+  decidePathManagedDriftRemove,
+  decideCodeSync,
+  fetchSources,
+} from "../lib/gbrain-guards";
+import {
+  localEngineStatus,
+  readGbrainVersion,
+  resolveGbrainBin,
+  type LocalEngineStatus,
+} from "../lib/gbrain-local-status";
+import {
+  buildGbrainEnv,
+  spawnGbrain,
+  execGbrainJson,
+  NEEDS_SHELL_ON_WINDOWS,
+} from "../lib/gbrain-exec";
 import { checkOwnedStagingDir } from "../lib/staging-guard";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -94,6 +140,56 @@ const GSTACK_HOME = process.env.GSTACK_HOME || join(HOME, ".gstack");
 const STATE_PATH = join(GSTACK_HOME, ".gbrain-sync-state.json");
 const LOCK_PATH = join(GSTACK_HOME, ".sync-gbrain.lock");
 const STALE_LOCK_MS = 5 * 60 * 1000;
+const SOURCE_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/;
+export const MIN_GBRAIN_VERSION = "0.41.38.0";
+
+export interface GbrainVersionCheck {
+  ok: boolean;
+  detected: string | null;
+  reason: string;
+}
+
+/**
+ * Fail closed on an absent, malformed, or unsupported GBrain version.
+ *
+ * The four-component release floor is intentional: 0.41.38.0 is the first
+ * GBrain release where unqualified code-callers/code-callees honor the
+ * per-worktree `.gbrain-source` pin. Merely checking command availability lets
+ * older installs sync one source and silently query another.
+ */
+export function checkGbrainVersion(
+  versionOutput: string,
+  minimum = MIN_GBRAIN_VERSION,
+): GbrainVersionCheck {
+  const match = versionOutput.match(/(?:^|\s)v?(\d+(?:\.\d+){1,3})(?:\s|$)/);
+  if (!match) {
+    return {
+      ok: false,
+      detected: null,
+      reason: "could not parse `gbrain --version`",
+    };
+  }
+
+  const detected = match[1];
+  const toParts = (value: string): number[] =>
+    value.split(".").map((part) => Number(part));
+  const detectedParts = toParts(detected);
+  const minimumParts = toParts(minimum);
+  const width = Math.max(detectedParts.length, minimumParts.length);
+  for (let i = 0; i < width; i++) {
+    const actual = detectedParts[i] ?? 0;
+    const required = minimumParts[i] ?? 0;
+    if (actual > required) return { ok: true, detected, reason: "supported" };
+    if (actual < required) {
+      return {
+        ok: false,
+        detected,
+        reason: `gbrain ${detected} is below the required ${minimum}`,
+      };
+    }
+  }
+  return { ok: true, detected, reason: "supported" };
+}
 
 // Dream (call-graph build) is brain-global and runs LOCK-FREE after the sync
 // lock releases, so it can't use the sync lock to dedupe across worktrees. A
@@ -388,8 +484,7 @@ function deriveLegacyCodeSourceId(repoPath: string): string {
  * repo path: `gstack-code-<slug>-<sha1(path).slice(0,8)>`. After #1468 the
  * hash key is `${hostname}::${path}`, so every existing user's brain has a
  * legacy id that no longer matches what `deriveCodeSourceId` produces. We
- * detect this form once, attempt rename-in-place if the gbrain CLI supports
- * `sources rename`, and otherwise clean up after the new source successfully
+ * detect this form once and clean it up only after the new source successfully
  * syncs. Distinct from `deriveLegacyCodeSourceId` (pre-pathhash v1.x form);
  * both probes run.
  */
@@ -403,41 +498,6 @@ export function derivePathOnlyHashLegacyId(repoPath: string): string {
   }
   const base = repoPath.split("/").pop() || "repo";
   return constrainSourceId("gstack-code", `${base}-${pathHash}`);
-}
-
-/**
- * Feature-check whether the installed gbrain CLI ships `sources rename <old> <new>`.
- *
- * Per the v1.40.0.0 design review: probing `gbrain sources rename --help` and
- * matching for the exact argument shape catches the case where gbrain's
- * `sources` parent help mentions a `rename` subcommand but the CLI doesn't
- * accept the `<old> <new>` form (or vice versa). Cached for the lifetime
- * of the process. As of gbrain 0.35.0.0 this command does not exist, so the
- * function returns false and the migration path falls back to register-new
- * + sync-OK + remove-old.
- */
-let _gbrainSupportsRenameCache: boolean | null = null;
-export function _resetGbrainSupportsRenameCache(): void {
-  _gbrainSupportsRenameCache = null;
-}
-function gbrainSupportsSourcesRename(env?: NodeJS.ProcessEnv): boolean {
-  if (_gbrainSupportsRenameCache !== null) return _gbrainSupportsRenameCache;
-  try {
-    const r = spawnGbrain(["sources", "rename", "--help"], {
-      timeout: 5_000,
-      baseEnv: env,
-    });
-    const out = `${r.stdout || ""}\n${r.stderr || ""}`;
-    // Match the exact argument shape: `rename <old> <new>` (with literal
-    // angle brackets in usage strings) or `rename OLD NEW`.
-    const exact = /sources\s+rename\s+<old>\s+<new>/i.test(out)
-      || /sources\s+rename\s+OLD\s+NEW/.test(out)
-      || /sources\s+rename\s+<oldId>\s+<newId>/i.test(out);
-    _gbrainSupportsRenameCache = exact && r.status === 0;
-  } catch {
-    _gbrainSupportsRenameCache = false;
-  }
-  return _gbrainSupportsRenameCache;
 }
 
 /**
@@ -465,9 +525,13 @@ export function sourceLocalPath(sourceId: string, env?: NodeJS.ProcessEnv): stri
 /** Result of `planHostnameFoldMigration` — informs `runCodeImport` of next steps. */
 export type HostnameFoldMigration =
   | { kind: "none"; reason: "ids-match" | "no-legacy-source" }
-  | { kind: "skipped-path-drift"; oldId: string; oldPath: string; currentPath: string }
-  | { kind: "renamed"; oldId: string; newId: string }
-  | { kind: "pending-cleanup"; oldId: string };
+  | {
+      kind: "skipped-path-drift";
+      oldId: string;
+      oldPath: string;
+      currentPath: string;
+    }
+  | { kind: "pending-cleanup"; oldId: string; oldPath: string };
 
 /**
  * Decide how to migrate from the pre-#1468 path-only-hash source id to the
@@ -479,18 +543,24 @@ export type HostnameFoldMigration =
  *   3. local_path != currentRoot → user moved the repo or two machines share a
  *      hash slot. Skip migration; let the user clean up manually. We will NOT
  *      rename or remove anything; the new source is registered alongside.
- *   4. Otherwise: feature-check `gbrain sources rename`. If supported and the
- *      rename call exits 0 → renamed, pages preserved.
- *   5. Else: pending-cleanup. Caller registers + syncs new source first; only
+ *   4. Otherwise: pending-cleanup. Caller registers + syncs new source first; only
  *      after sync succeeds with a non-zero page count does it remove the old.
  *      This avoids a data-loss window where the old source is gone before the
- *      new one is verifiably populated.
+ *      new one is verifiably populated. We deliberately do not use a
+ *      rename-in-place command here: GBrain provides no filesystem/source-row
+ *      lease across that mutation, so the guarded add/sync/verify/remove path
+ *      is the only path whose subject can be revalidated at every boundary.
  */
 export function planHostnameFoldMigration(
   currentRoot: string,
   newSourceId: string,
   legacyPathHashId: string,
   env?: NodeJS.ProcessEnv,
+  pathIdentity?: {
+    expected: CanonicalDirectory;
+    platform?: NodeJS.Platform;
+    fsOps?: DirectoryFsOps;
+  },
 ): HostnameFoldMigration {
   if (legacyPathHashId === newSourceId) {
     return { kind: "none", reason: "ids-match" };
@@ -499,7 +569,21 @@ export function planHostnameFoldMigration(
   if (oldPath === null) {
     return { kind: "none", reason: "no-legacy-source" };
   }
-  if (oldPath !== currentRoot) {
+  let sameDirectory = oldPath === currentRoot;
+  if (pathIdentity) {
+    try {
+      sameDirectory = registeredSourceMatchesDirectory(
+        oldPath,
+        pathIdentity.expected,
+        pathIdentity.platform,
+        pathIdentity.fsOps,
+        true,
+      );
+    } catch {
+      sameDirectory = false;
+    }
+  }
+  if (!sameDirectory) {
     return {
       kind: "skipped-path-drift",
       oldId: legacyPathHashId,
@@ -507,14 +591,11 @@ export function planHostnameFoldMigration(
       currentPath: currentRoot,
     };
   }
-  if (gbrainSupportsSourcesRename(env)) {
-    const r = spawnGbrain(["sources", "rename", legacyPathHashId, newSourceId], { baseEnv: env });
-    if (r.status === 0) {
-      return { kind: "renamed", oldId: legacyPathHashId, newId: newSourceId };
-    }
-    // Rename failed at runtime — fall through to cleanup path.
-  }
-  return { kind: "pending-cleanup", oldId: legacyPathHashId };
+  return {
+    kind: "pending-cleanup",
+    oldId: legacyPathHashId,
+    oldPath,
+  };
 }
 
 export interface GuardedRemoveResult {
@@ -533,7 +614,17 @@ export interface GuardedRemoveResult {
  * caller decides whether a skip is fatal (it never is today — removes are
  * best-effort cleanup).
  */
-export function safeSourcesRemove(sourceId: string, env?: NodeJS.ProcessEnv): GuardedRemoveResult {
+export function safeSourcesRemove(
+  sourceId: string,
+  env?: NodeJS.ProcessEnv,
+): GuardedRemoveResult {
+  if (!SOURCE_ID_RE.test(sourceId)) {
+    return {
+      removed: false,
+      skipped: true,
+      reason: `unsafe source id "${sourceId}"; refusing remove before any external command`,
+    };
+  }
   const ap = detectAutopilot(env);
   if (ap.active) {
     return {
@@ -547,6 +638,17 @@ export function safeSourcesRemove(sourceId: string, env?: NodeJS.ProcessEnv): Gu
   if (!decision.allow) {
     return { removed: false, skipped: true, reason: decision.reason };
   }
+  const finalAp = detectAutopilot(env);
+  if (finalAp.active) {
+    return {
+      removed: false,
+      skipped: true,
+      reason: `autopilot became active (${finalAp.signal}); refusing destructive remove of ${sourceId}`,
+    };
+  }
+  // GBrain exposes no compare-and-delete primitive or source lease. The final
+  // authoritative reread above minimizes, but cannot eliminate, a concurrent
+  // rebind or autopilot start after the final checks and before this CLI call.
   const r = spawnGbrain(
     ["sources", "remove", sourceId, "--confirm-destructive", ...decision.extraArgs],
     { baseEnv: env },
@@ -554,13 +656,78 @@ export function safeSourcesRemove(sourceId: string, env?: NodeJS.ProcessEnv): Gu
   return { removed: r.status === 0, skipped: false, reason: decision.reason };
 }
 
+/** Guarded, snapshot-bound remove used only for canonical path-drift repair. */
+export function safePathDriftRemove(
+  sourceId: string,
+  expectedRegisteredPath: string,
+  env?: NodeJS.ProcessEnv,
+): GuardedRemoveResult {
+  if (!SOURCE_ID_RE.test(sourceId)) {
+    return {
+      removed: false,
+      skipped: true,
+      reason: `unsafe source id "${sourceId}"; refusing path-drift remove before any external command`,
+    };
+  }
+  const ap = detectAutopilot(env);
+  if (ap.active) {
+    return {
+      removed: false,
+      skipped: true,
+      reason: `autopilot active (${ap.signal}); refusing path-drift remove of ${sourceId}`,
+    };
+  }
+
+  const decision = decidePathManagedDriftRemove(
+    sourceId,
+    expectedRegisteredPath,
+    env,
+  );
+  if (!decision.allow) {
+    return { removed: false, skipped: true, reason: decision.reason };
+  }
+  const finalAp = detectAutopilot(env);
+  if (finalAp.active) {
+    return {
+      removed: false,
+      skipped: true,
+      reason: `autopilot became active (${finalAp.signal}); refusing path-drift remove of ${sourceId}`,
+    };
+  }
+  // GBrain exposes no compare-and-delete primitive or source lease. The final
+  // exact-row reread above minimizes, but cannot eliminate, a concurrent
+  // rebind or autopilot start after the final checks and before this CLI call.
+  const result = spawnGbrain(
+    [
+      "sources",
+      "remove",
+      sourceId,
+      "--confirm-destructive",
+      ...decision.extraArgs,
+    ],
+    { baseEnv: env },
+  );
+  return {
+    removed: result.status === 0,
+    skipped: false,
+    reason:
+      result.status === 0
+        ? decision.reason
+        : `gbrain sources remove exited ${result.status}`,
+  };
+}
+
 /**
- * Remove an orphaned source. Called only after new-source sync verifies pages
- * exist, so the old source is provably redundant before deletion. Routed through
- * safeSourcesRemove for the #1734 guards.
+ * Remove the exact legacy row captured by the hostname-fold migration plan.
+ * The sync between planning and cleanup can be long, so bind the destructive
+ * operation to both the old id and its original path. A concurrent rebind then
+ * fails closed instead of deleting the replacement row.
  */
-export function removeOrphanedSource(oldId: string, env?: NodeJS.ProcessEnv): boolean {
-  return safeSourcesRemove(oldId, env).removed;
+export function removePlannedHostnameLegacySource(
+  migration: Extract<HostnameFoldMigration, { kind: "pending-cleanup" }>,
+  env?: NodeJS.ProcessEnv,
+): GuardedRemoveResult {
+  return safePathDriftRemove(migration.oldId, migration.oldPath, env);
 }
 
 /**
@@ -782,10 +949,55 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
       ran: false,
       ok: true,
       duration_ms: 0,
-      summary: `would: gbrain sources add ${sourceId} --path ${root} --federated; gbrain sync --strategy code --source ${sourceId}; gbrain sources attach ${sourceId}`,
+      summary: `would: gbrain sources add ${sourceId} --path ${root} --federated; gbrain sync --strategy code --source ${sourceId}; pin .gbrain-source to ${sourceId}`,
       detail: { source_id: sourceId, source_path: root, status: "skipped" },
     };
   }
+
+  let validatedRoot: ReturnType<typeof canonicalSourceDirectory>;
+  try {
+    validatedRoot = canonicalSourceDirectory(root);
+    // Prove a non-zero stable identity before any GBrain probe, sync, or legacy
+    // source cleanup. Some filesystems report inode/file-id 0; discovering
+    // that only inside registration would be too late because Step 0a can
+    // already mutate GBrain state.
+    assertCanonicalDirectoryUnchanged(
+      validatedRoot,
+      "repository before sync preflight",
+    );
+  } catch (err) {
+    return {
+      name: "code",
+      ran: false,
+      ok: false,
+      duration_ms: Date.now() - t0,
+      summary: `source path validation failed: ${(err as Error).message}`,
+      detail: { source_id: sourceId, source_path: root, status: "failed" },
+    };
+  }
+  const canonicalRoot = validatedRoot.canonicalPath;
+  const revalidateRoot = (operation: string): StageResult | null => {
+    try {
+      assertCanonicalDirectoryUnchanged(
+        validatedRoot,
+        `expected source path before ${operation}`,
+      );
+      return null;
+    } catch (err) {
+      return {
+        name: "code",
+        ran: true,
+        ok: false,
+        duration_ms: Date.now() - t0,
+        summary: `source path validation failed before ${operation}: ${(err as Error).message}`,
+        detail: {
+          source_id: sourceId,
+          source_path: canonicalRoot,
+          status: "failed",
+        },
+      };
+    }
+  };
 
   // Split-engine pre-flight (per plan D12): when local engine is not ok, SKIP
   // code stage cleanly. Brain-sync stage still runs because it doesn't depend
@@ -814,8 +1026,15 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
   const legacyId = deriveLegacyCodeSourceId(root);
   let legacyRemoved = false;
   if (legacyId !== sourceId) {
+    const legacyCleanupPathError = revalidateRoot("legacy-source cleanup");
+    if (legacyCleanupPathError) return legacyCleanupPathError;
     // #1734: route through the data-loss guards (autopilot + source-safety).
     const rm = safeSourcesRemove(legacyId, gbrainEnv);
+    const legacyCleanupCompletionPathError = revalidateRoot(
+      "legacy-source cleanup completion",
+    );
+    if (legacyCleanupCompletionPathError)
+      return legacyCleanupCompletionPathError;
     if (rm.skipped && !args.quiet) {
       console.error(`[sync:code] legacy-source cleanup skipped: ${rm.reason}`);
     }
@@ -825,26 +1044,46 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
   // Step 0b: Hostname-fold migration (#1414).
   // Before #1468 the source id hashed only the absolute repo path. After the
   // hostname fold, every existing user has a legacy id that no longer matches
-  // what deriveCodeSourceId produces. Try rename-in-place first (preserves
-  // pages); fall back to register-new → sync-OK → remove-old. Path-drift
-  // (user moved the repo, etc.) skips migration with a warning.
+  // what deriveCodeSourceId produces. Register the new source, prove its sync,
+  // then remove the old source through the destructive-operation guards.
+  // Path drift (user moved the repo, etc.) skips migration with a warning.
   const pathOnlyHashLegacyId = derivePathOnlyHashLegacyId(root);
-  const migration = planHostnameFoldMigration(root, sourceId, pathOnlyHashLegacyId, gbrainEnv);
+  const migration = planHostnameFoldMigration(
+    canonicalRoot,
+    sourceId,
+    pathOnlyHashLegacyId,
+    gbrainEnv,
+    { expected: validatedRoot },
+  );
   if (migration.kind === "skipped-path-drift" && !args.quiet) {
     console.error(
       `[sync:code] hostname-fold migration skipped: legacy source ${migration.oldId} `
       + `points at ${migration.oldPath}, current repo is ${migration.currentPath}. `
       + `Clean up manually with: gbrain sources remove ${migration.oldId} --confirm-destructive`,
     );
-  } else if (migration.kind === "renamed" && !args.quiet) {
-    console.error(`[sync:code] hostname-fold migration: renamed ${migration.oldId} → ${migration.newId} (pages preserved)`);
   }
 
   // Step 1: Ensure source registered (idempotent). Single source of truth in lib —
   // no synchronous duplicate here (per /codex review #12).
   let registered = false;
   try {
-    const result = await ensureSourceRegistered(sourceId, root, { federated: true, env: gbrainEnv });
+    const result = await ensureSourceRegistered(sourceId, canonicalRoot, {
+      federated: true,
+      env: gbrainEnv,
+      expected_identity: validatedRoot,
+      removeSource: (driftedId, registeredPath, removeEnv) => {
+        const removal = safePathDriftRemove(
+          driftedId,
+          registeredPath,
+          removeEnv,
+        );
+        if (!removal.removed) {
+          throw new Error(
+            `guarded path-drift repair refused: ${removal.reason}`,
+          );
+        }
+      },
+    });
     registered = result.changed;
   } catch (err) {
     return {
@@ -853,7 +1092,11 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
       ok: false,
       duration_ms: Date.now() - t0,
       summary: `source registration failed: ${(err as Error).message}`,
-      detail: { source_id: sourceId, source_path: root, status: "failed" },
+      detail: {
+        source_id: sourceId,
+        source_path: canonicalRoot,
+        status: "failed",
+      },
     };
   }
 
@@ -883,7 +1126,11 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
     return {
       name: "code", ran: true, ok: false, duration_ms: Date.now() - t0,
       summary: `refused: gbrain autopilot active (${apBeforeWalk.signal}). Stop autopilot, then re-run /sync-gbrain.`,
-      detail: { source_id: sourceId, source_path: root, status: "refused-autopilot" },
+      detail: {
+        source_id: sourceId,
+        source_path: canonicalRoot,
+        status: "refused-autopilot",
+      },
     };
   }
   const reclone = decideCodeSync(sourceId, gbrainEnv, args.allowReclone);
@@ -891,15 +1138,174 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
     return {
       name: "code", ran: true, ok: false, duration_ms: Date.now() - t0,
       summary: `refused: ${reclone.reason}`,
-      detail: { source_id: sourceId, source_path: root, status: "refused-reclone" },
+      detail: {
+        source_id: sourceId,
+        source_path: canonicalRoot,
+        status: "refused-reclone",
+      },
     };
   }
 
-  const walkResult = spawnGbrain(["sync", "--strategy", "code", "--source", sourceId], {
-    stdio: args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"],
-    timeout: codeTimeoutMs,
-    baseEnv: gbrainEnv,
-  });
+  let sourceBinding: SourcePathBinding;
+  try {
+    sourceBinding = bindRegisteredSourcePath(
+      reclone.registeredPath!,
+      validatedRoot,
+    );
+  } catch (err) {
+    return {
+      name: "code",
+      ran: true,
+      ok: false,
+      duration_ms: Date.now() - t0,
+      summary: `source path binding failed before sync: ${(err as Error).message}`,
+      detail: {
+        source_id: sourceId,
+        source_path: canonicalRoot,
+        status: "failed",
+      },
+    };
+  }
+
+  // GBrain exposes no source-row lease. Every snapshot below is strict and
+  // checked immediately around source-ID consumers, but a concurrent rebind
+  // after the snapshot remains a non-zero external CLI race window.
+  const validateCurrentSourceBinding = (
+    operation: string,
+  ): StageResult | null => {
+    const decision = decideCodeSync(sourceId, gbrainEnv, args.allowReclone);
+    if (
+      !decision.allow ||
+      !decision.registeredPath ||
+      decision.mayReclone !== reclone.mayReclone
+    ) {
+      return {
+        name: "code",
+        ran: true,
+        ok: false,
+        duration_ms: Date.now() - t0,
+        summary: `source row validation failed before ${operation}: ${decision.reason}`,
+        detail: {
+          source_id: sourceId,
+          source_path: canonicalRoot,
+          status: "failed",
+        },
+      };
+    }
+    try {
+      bindRegisteredSourcePath(decision.registeredPath, validatedRoot);
+      return null;
+    } catch (err) {
+      return {
+        name: "code",
+        ran: true,
+        ok: false,
+        duration_ms: Date.now() - t0,
+        summary: `source row validation failed before ${operation}: ${(err as Error).message}`,
+        detail: {
+          source_id: sourceId,
+          source_path: canonicalRoot,
+          status: "failed",
+        },
+      };
+    }
+  };
+
+  const validateSyncCompletion = (): StageResult | null => {
+    if (reclone.mayReclone) {
+      try {
+        const refreshedRoot = canonicalSourceDirectory(canonicalRoot);
+        if (refreshedRoot.canonicalPath !== canonicalRoot) {
+          throw new Error(
+            `authorized reclone resolved to unexpected path "${refreshedRoot.canonicalPath}"`,
+          );
+        }
+        validatedRoot = refreshedRoot;
+      } catch (err) {
+        return {
+          name: "code",
+          ran: true,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: `source path validation failed after authorized reclone: ${(err as Error).message}`,
+          detail: {
+            source_id: sourceId,
+            source_path: canonicalRoot,
+            status: "failed",
+          },
+        };
+      }
+    } else {
+      const pathError = revalidateRoot("sync completion");
+      if (pathError) return pathError;
+    }
+    return validateCurrentSourceBinding("sync completion");
+  };
+
+  const syncPathError = revalidateRoot("sync");
+  if (syncPathError) return syncPathError;
+  const syncBindingError = validateCurrentSourceBinding("sync");
+  if (syncBindingError) return syncBindingError;
+  const finalSyncPathError = revalidateRoot("sync spawn");
+  if (finalSyncPathError) return finalSyncPathError;
+  const apAtSyncSpawn = detectAutopilot(gbrainEnv);
+  if (apAtSyncSpawn.active) {
+    return {
+      name: "code",
+      ran: true,
+      ok: false,
+      duration_ms: Date.now() - t0,
+      summary:
+        `refused: gbrain autopilot became active (${apAtSyncSpawn.signal}) before sync spawn. ` +
+        "Stop autopilot, then re-run /sync-gbrain.",
+      detail: {
+        source_id: sourceId,
+        source_path: canonicalRoot,
+        status: "refused-autopilot",
+      },
+    };
+  }
+
+  // cwd is an OS-level spawn option, not a shell argument. It keeps relative
+  // legacy local_path values anchored without rejecting safe Windows spaces.
+  const syncArgs = ["sync", "--strategy", "code", "--source", sourceId];
+  if (sourceBinding.useExplicitPath) syncArgs.push("--repo", canonicalRoot);
+  // Current GBrain housekeeping follows a repo-controlled `.gitignore`
+  // symlink. Disable that side effect and update the file through our atomic
+  // boundary after the primary sync succeeds.
+  const syncEnv = { ...gbrainEnv, GBRAIN_NO_GITIGNORE: "1" };
+  let walkResult: ReturnType<typeof spawnGbrain>;
+  try {
+    walkResult = spawnGbrain(syncArgs, {
+      stdio: args.quiet
+        ? ["ignore", "ignore", "ignore"]
+        : ["ignore", "inherit", "inherit"],
+      timeout: codeTimeoutMs,
+      baseEnv: syncEnv,
+      cwd: canonicalRoot,
+    });
+  } catch (err) {
+    const syncCompletionPathError = validateSyncCompletion();
+    if (syncCompletionPathError) return syncCompletionPathError;
+    return {
+      name: "code",
+      ran: true,
+      ok: false,
+      duration_ms: Date.now() - t0,
+      summary: `gbrain sync failed to start: ${(err as Error).message}`,
+      detail: {
+        source_id: sourceId,
+        source_path: canonicalRoot,
+        status: "failed",
+      },
+    };
+  }
+
+  // A proven URL-managed source may replace its checkout only behind the
+  // explicit --allow-reclone opt-in. Refresh and re-bind that new identity;
+  // every other sync must leave the original validated object in place.
+  const syncCompletionPathError = validateSyncCompletion();
+  if (syncCompletionPathError) return syncCompletionPathError;
 
   if (walkResult.status !== 0) {
     return {
@@ -908,16 +1314,64 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
       ok: false,
       duration_ms: Date.now() - t0,
       summary: `gbrain sync --strategy code --source ${sourceId} exited ${walkResult.status}`,
-      detail: { source_id: sourceId, source_path: root, status: "failed" },
+      detail: {
+        source_id: sourceId,
+        source_path: canonicalRoot,
+        status: "failed",
+      },
     };
   }
 
   if (args.mode === "full") {
-    const reindexResult = spawnGbrain(["reindex-code", "--source", sourceId, "--yes"], {
-      stdio: args.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "inherit", "inherit"],
-      timeout: codeTimeoutMs,
-      baseEnv: gbrainEnv,
-    });
+    const reindexPathError = revalidateRoot("reindex");
+    if (reindexPathError) return reindexPathError;
+    const reindexBindingError = validateCurrentSourceBinding("reindex");
+    if (reindexBindingError) return reindexBindingError;
+    let reindexResult: ReturnType<typeof spawnGbrain>;
+    try {
+      reindexResult = spawnGbrain(
+        ["reindex-code", "--source", sourceId, "--yes"],
+        {
+          stdio: args.quiet
+            ? ["ignore", "ignore", "ignore"]
+            : ["ignore", "inherit", "inherit"],
+          timeout: codeTimeoutMs,
+          baseEnv: gbrainEnv,
+          cwd: canonicalRoot,
+        },
+      );
+    } catch (err) {
+      const reindexCompletionPathError = revalidateRoot("reindex completion");
+      if (reindexCompletionPathError) return reindexCompletionPathError;
+      const reindexCompletionBindingError =
+        validateCurrentSourceBinding("reindex completion");
+      if (reindexCompletionBindingError) {
+        return {
+          ...reindexCompletionBindingError,
+          summary:
+            `gbrain reindex-code failed to start: ${(err as Error).message}; ` +
+            reindexCompletionBindingError.summary,
+        };
+      }
+      return {
+        name: "code",
+        ran: true,
+        ok: false,
+        duration_ms: Date.now() - t0,
+        summary: `gbrain reindex-code failed to start: ${(err as Error).message}`,
+        detail: {
+          source_id: sourceId,
+          source_path: canonicalRoot,
+          status: "failed",
+        },
+      };
+    }
+
+    const reindexCompletionPathError = revalidateRoot("reindex completion");
+    if (reindexCompletionPathError) return reindexCompletionPathError;
+    const reindexCompletionBindingError =
+      validateCurrentSourceBinding("reindex completion");
+    if (reindexCompletionBindingError) return reindexCompletionBindingError;
 
     if (reindexResult.status !== 0) {
       return {
@@ -926,7 +1380,11 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
         ok: false,
         duration_ms: Date.now() - t0,
         summary: `gbrain reindex-code --source ${sourceId} exited ${reindexResult.status}`,
-        detail: { source_id: sourceId, source_path: root, status: "failed" },
+        detail: {
+          source_id: sourceId,
+          source_path: canonicalRoot,
+          status: "failed",
+        },
       };
     }
   }
@@ -935,16 +1393,51 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
   // gbrain code-def / code-refs / code-callers calls from anywhere under <root>
   // route to this source by default — no --source flag needed.
   //
-  // If attach fails the whole flow has a silent correctness problem: sync
+  // If pinning fails the whole flow has a silent correctness problem: sync
   // succeeded but unqualified `gbrain code-def` from this worktree will hit
   // the wrong/default source. Treat it as a stage failure (ok=false) so the
   // verdict block surfaces ERR and the user knows to retry rather than
   // trusting stale results.
-  const attach = spawnGbrain(["sources", "attach", sourceId], {
-    timeout: 10_000,
-    cwd: root,
-    baseEnv: gbrainEnv,
-  });
+  const attachPathError = revalidateRoot("attach");
+  if (attachPathError) return attachPathError;
+  const attachBindingError = validateCurrentSourceBinding("attach");
+  if (attachBindingError) return attachBindingError;
+  try {
+    // Do not call `gbrain sources attach`: current GBrain uses writeFileSync
+    // and follows an existing `.gbrain-source` symlink. Atomic replacement
+    // changes the link itself and never writes through to its target.
+    writeGbrainSourcePin(canonicalRoot, sourceId);
+  } catch (err) {
+    const attachCompletionPathError = revalidateRoot("attach completion");
+    if (attachCompletionPathError) return attachCompletionPathError;
+    const attachCompletionBindingError =
+      validateCurrentSourceBinding("attach completion");
+    if (attachCompletionBindingError) {
+      return {
+        ...attachCompletionBindingError,
+        summary:
+          `could not pin .gbrain-source safely: ${(err as Error).message}; ` +
+          attachCompletionBindingError.summary,
+      };
+    }
+    return {
+      name: "code",
+      ran: true,
+      ok: false,
+      duration_ms: Date.now() - t0,
+      summary: `could not pin .gbrain-source safely: ${(err as Error).message}`,
+      detail: {
+        source_id: sourceId,
+        source_path: canonicalRoot,
+        status: "failed",
+      },
+    };
+  }
+  const attachCompletionPathError = revalidateRoot("attach completion");
+  if (attachCompletionPathError) return attachCompletionPathError;
+  const attachCompletionBindingError =
+    validateCurrentSourceBinding("attach completion");
+  if (attachCompletionBindingError) return attachCompletionBindingError;
   const pageCount = sourcePageCount(sourceId, gbrainEnv);
 
   // Step 4: Deferred hostname-fold cleanup.
@@ -954,44 +1447,59 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
   // wipe pages when sync silently no-op'd. This is the codex-review-flagged
   // safety: register → sync → verify → THEN delete.
   let hostnameLegacyRemoved = false;
-  if (migration.kind === "pending-cleanup" && pageCount !== null && pageCount > 0) {
-    hostnameLegacyRemoved = removeOrphanedSource(migration.oldId, gbrainEnv);
+  const cleanupPathError = revalidateRoot("legacy cleanup");
+  if (cleanupPathError) return cleanupPathError;
+  const cleanupBindingError = validateCurrentSourceBinding("legacy cleanup");
+  if (cleanupBindingError) return cleanupBindingError;
+  if (
+    migration.kind === "pending-cleanup" &&
+    pageCount !== null &&
+    pageCount > 0
+  ) {
+    const cleanupResult = removePlannedHostnameLegacySource(
+      migration,
+      gbrainEnv,
+    );
+    hostnameLegacyRemoved = cleanupResult.removed;
+    const cleanupCompletionPathError = revalidateRoot(
+      "legacy cleanup completion",
+    );
+    if (cleanupCompletionPathError) return cleanupCompletionPathError;
+    const cleanupCompletionBindingError = validateCurrentSourceBinding(
+      "legacy cleanup completion",
+    );
+    if (cleanupCompletionBindingError) return cleanupCompletionBindingError;
     if (hostnameLegacyRemoved && !args.quiet) {
       console.error(`[sync:code] hostname-fold migration: removed legacy ${migration.oldId} after new source sync verified (page_count=${pageCount})`);
+    } else if (cleanupResult.skipped && !args.quiet) {
+      console.error(
+        `[sync:code] hostname-fold migration: kept legacy ${migration.oldId}: ${cleanupResult.reason}`,
+      );
     }
   }
 
   const legacyParts: string[] = [];
   if (legacyRemoved) legacyParts.push(`removed legacy ${legacyId}`);
-  if (migration.kind === "renamed") legacyParts.push(`renamed ${migration.oldId}→${migration.newId}`);
-  if (hostnameLegacyRemoved) legacyParts.push(`removed pre-hostname-fold ${migration.kind === "pending-cleanup" ? migration.oldId : ""}`);
-  const legacyNote = legacyParts.length > 0 ? `, ${legacyParts.join(", ")}` : "";
+  if (hostnameLegacyRemoved)
+    legacyParts.push(
+      `removed pre-hostname-fold ${migration.kind === "pending-cleanup" ? migration.oldId : ""}`,
+    );
+  const legacyNote =
+    legacyParts.length > 0 ? `, ${legacyParts.join(", ")}` : "";
   const baseSummary = `${registered ? "registered + " : ""}synced ${sourceId} (page_count=${pageCount ?? "unknown"}${legacyNote})`;
-
-  if (attach.status !== 0) {
-    const reason = (attach.stderr || attach.stdout || "").trim().split("\n").pop() || `exit ${attach.status}`;
-    return {
-      name: "code",
-      ran: true,
-      ok: false,
-      duration_ms: Date.now() - t0,
-      summary: `${baseSummary}; attach FAILED (${reason}) — code-def queries from this worktree will hit the default source until /sync-gbrain succeeds`,
-      detail: {
-        source_id: sourceId,
-        source_path: root,
-        page_count: pageCount,
-        last_imported: new Date().toISOString(),
-        status: "failed",
-      },
-    };
-  }
 
   // v1.29.0.0 changelog promised the per-worktree pin would be ignored in the
   // consuming repo, but the change actually only added .gbrain-source to
   // gstack's own .gitignore. Without the consumer-side entry, the pin gets
   // committed and breaks the per-worktree promise: Conductor sibling worktrees
   // step on each other's pin every time anyone commits (#1384).
-  ensureGbrainSourceGitignored(root);
+  const gitignorePathError = revalidateRoot("gitignore update");
+  if (gitignorePathError) return gitignorePathError;
+  ensureGbrainSourceGitignored(canonicalRoot);
+  const gitignoreCompletionPathError = revalidateRoot(
+    "gitignore update completion",
+  );
+  if (gitignoreCompletionPathError) return gitignoreCompletionPathError;
 
   return {
     name: "code",
@@ -1001,7 +1509,7 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
     summary: baseSummary,
     detail: {
       source_id: sourceId,
-      source_path: root,
+      source_path: canonicalRoot,
       page_count: pageCount,
       last_imported: new Date().toISOString(),
       status: "ok",
@@ -1010,34 +1518,293 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
 }
 
 /**
+ * Atomically replace a fixed repository metadata file from a same-directory
+ * exclusive temp file. `rename` replaces a symlink leaf itself rather than
+ * following it. The root-level caller still performs identity checks around
+ * this pathname operation; Node does not expose a portable dirfd rename API,
+ * so a hostile concurrent ancestor replacement retains a documented race.
+ */
+type RepositoryLeafExpectation =
+  { kind: "absent" } | {
+    kind: "existing";
+    device: number;
+    inode: number;
+    size: number;
+    mtimeMs: number;
+    ctimeMs: number;
+  };
+
+function assertRepositoryLeafExpectation(
+  targetPath: string,
+  expected: RepositoryLeafExpectation,
+): void {
+  try {
+    const current = lstatSync(targetPath);
+    if (expected.kind === "absent") {
+      throw new Error("repository metadata file appeared during atomic update");
+    }
+    if (
+      current.isSymbolicLink() ||
+      !current.isFile() ||
+      current.dev !== expected.device ||
+      current.ino !== expected.inode ||
+      current.size !== expected.size ||
+      current.mtimeMs !== expected.mtimeMs ||
+      current.ctimeMs !== expected.ctimeMs
+    ) {
+      throw new Error("repository metadata file changed during atomic update");
+    }
+  } catch (err) {
+    if (
+      (err as NodeJS.ErrnoException).code === "ENOENT" &&
+      expected.kind === "absent"
+    )
+      return;
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(
+        "repository metadata file disappeared during atomic update",
+      );
+    }
+    throw err;
+  }
+}
+
+function atomicReplaceRepositoryFile(
+  targetPath: string,
+  content: string,
+  replaceSymlink: boolean,
+  expectedLeaf?: RepositoryLeafExpectation,
+): void {
+  let mode = 0o644;
+  try {
+    const existing = lstatSync(targetPath);
+    if (existing.isSymbolicLink()) {
+      if (!replaceSymlink)
+        throw new Error("refusing to replace a symbolic link");
+    } else if (!existing.isFile()) {
+      throw new Error("refusing to replace a non-regular file");
+    } else {
+      mode = existing.mode & 0o777;
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+
+  const tempPath = join(
+    dirname(targetPath),
+    `.gstack-metadata-${process.pid}-${randomBytes(8).toString("hex")}.tmp`,
+  );
+  let tempExists = false;
+  try {
+    writeFileSync(tempPath, content, {
+      encoding: "utf-8",
+      flag: "wx",
+      mode,
+    });
+    tempExists = true;
+    // Recheck the read snapshot after the temp write and immediately before
+    // rename so a concurrent legitimate edit is not silently overwritten.
+    // Node exposes no portable compare-and-rename primitive; a final
+    // check→rename race remains and is documented at the caller boundary.
+    if (expectedLeaf) assertRepositoryLeafExpectation(targetPath, expectedLeaf);
+    renameSync(tempPath, targetPath);
+    tempExists = false;
+
+    const beforeRead = lstatSync(targetPath);
+    if (
+      beforeRead.isSymbolicLink() ||
+      !beforeRead.isFile() ||
+      beforeRead.dev === 0 ||
+      beforeRead.ino === 0
+    ) {
+      throw new Error("atomic replacement did not leave a regular file");
+    }
+    const noFollow = typeof FS_CONSTANTS.O_NOFOLLOW === "number" ? FS_CONSTANTS.O_NOFOLLOW : 0;
+    const nonblock = typeof FS_CONSTANTS.O_NONBLOCK === "number" ? FS_CONSTANTS.O_NONBLOCK : 0;
+    let persisted = "";
+    let fd: number | null = null;
+    try {
+      fd = openSync(targetPath, FS_CONSTANTS.O_RDONLY | noFollow | nonblock);
+      const opened = fstatSync(fd);
+      if (
+        !opened.isFile() ||
+        opened.dev !== beforeRead.dev ||
+        opened.ino !== beforeRead.ino
+      ) {
+        throw new Error("atomic replacement changed before its pinned verification read");
+      }
+      persisted = readFileSync(fd, "utf-8");
+      const afterDescriptorRead = fstatSync(fd);
+      if (
+        !afterDescriptorRead.isFile() ||
+        afterDescriptorRead.dev !== opened.dev ||
+        afterDescriptorRead.ino !== opened.ino ||
+        afterDescriptorRead.size !== opened.size ||
+        afterDescriptorRead.mtimeMs !== opened.mtimeMs ||
+        afterDescriptorRead.ctimeMs !== opened.ctimeMs
+      ) {
+        throw new Error("atomic replacement changed during its pinned verification read");
+      }
+    } finally {
+      if (fd !== null) closeSync(fd);
+    }
+    const afterRead = lstatSync(targetPath);
+    if (
+      afterRead.isSymbolicLink() ||
+      !afterRead.isFile() ||
+      beforeRead.dev !== afterRead.dev ||
+      beforeRead.ino !== afterRead.ino ||
+      persisted !== content
+    ) {
+      throw new Error("atomic replacement could not be verified");
+    }
+  } finally {
+    if (tempExists) {
+      try {
+        unlinkSync(tempPath);
+      } catch {
+        /* best-effort temp cleanup */
+      }
+    }
+  }
+}
+
+/** Safely write the per-worktree source pin without following a leaf symlink. */
+export function writeGbrainSourcePin(root: string, sourceId: string): void {
+  if (!SOURCE_ID_RE.test(sourceId)) {
+    throw new Error(`invalid GBrain source id "${sourceId}"`);
+  }
+  const expectedRoot = canonicalSourceDirectory(root);
+  assertCanonicalDirectoryUnchanged(
+    expectedRoot,
+    "repository before .gbrain-source pin",
+  );
+  atomicReplaceRepositoryFile(
+    join(expectedRoot.canonicalPath, ".gbrain-source"),
+    `${sourceId}\n`,
+    true,
+  );
+  assertCanonicalDirectoryUnchanged(
+    expectedRoot,
+    "repository after .gbrain-source pin",
+  );
+}
+
+/**
  * Ensure `.gbrain-source` is listed in the consumer repo's `.gitignore`.
+ * Static symlink/non-regular leaves are refused; regular files are replaced
+ * atomically. Failures remain a visible warning so a read-only checkout does
+ * not erase an otherwise successful code-index update.
  *
- * Idempotent: only appends when the entry is not already present (matched on
- * trimmed lines so a leading/trailing whitespace difference doesn't add a
- * second copy). Wraps writes in try/catch so a read-only checkout or weird
- * perms logs a warning and lets the rest of the sync continue.
+ * The existing file is read through a pinned descriptor: lstat establishes the
+ * expected leaf, open uses nonblocking/no-follow flags where the platform
+ * exposes them, and fstat proves the descriptor still names that same regular
+ * file before any bytes are read. The atomic writer then rechecks that leaf
+ * immediately before rename. Node exposes no portable compare-and-rename
+ * primitive, so a small final check→rename race remains; this is snapshot
+ * safety, not a zero-window filesystem lease.
  */
 export function ensureGbrainSourceGitignored(root: string): void {
-  const gitignorePath = join(root, ".gitignore");
   try {
+    const expectedRoot = canonicalSourceDirectory(root);
+    assertCanonicalDirectoryUnchanged(
+      expectedRoot,
+      "repository before .gitignore update",
+    );
+    const gitignorePath = join(expectedRoot.canonicalPath, ".gitignore");
     let existing = "";
+    let expectedLeaf: RepositoryLeafExpectation = { kind: "absent" };
     try {
-      existing = readFileSync(gitignorePath, "utf-8");
-    } catch {
-      // No .gitignore yet — we'll create it.
+      const before = lstatSync(gitignorePath);
+      if (before.isSymbolicLink() || !before.isFile()) {
+        throw new Error(
+          "existing .gitignore is a symbolic link or non-regular file",
+        );
+      }
+      if (before.dev === 0 || before.ino === 0) {
+        throw new Error(
+          "existing .gitignore has no stable filesystem identity",
+        );
+      }
+      const noFollow =
+        typeof FS_CONSTANTS.O_NOFOLLOW === "number"
+          ? FS_CONSTANTS.O_NOFOLLOW
+          : 0;
+      const nonblock =
+        typeof FS_CONSTANTS.O_NONBLOCK === "number"
+          ? FS_CONSTANTS.O_NONBLOCK
+          : 0;
+      let fd: number | null = null;
+      try {
+        fd = openSync(
+          gitignorePath,
+          FS_CONSTANTS.O_RDONLY | noFollow | nonblock,
+        );
+        const opened = fstatSync(fd);
+        if (
+          !opened.isFile() ||
+          opened.dev === 0 ||
+          opened.ino === 0 ||
+          opened.dev !== before.dev ||
+          opened.ino !== before.ino
+        ) {
+          throw new Error("existing .gitignore changed before its pinned read");
+        }
+        existing = readFileSync(fd, "utf-8");
+        const afterRead = fstatSync(fd);
+        if (
+          !afterRead.isFile() ||
+          afterRead.dev !== opened.dev ||
+          afterRead.ino !== opened.ino ||
+          afterRead.size !== opened.size ||
+          afterRead.mtimeMs !== opened.mtimeMs ||
+          afterRead.ctimeMs !== opened.ctimeMs
+        ) {
+          throw new Error(
+            "existing .gitignore changed while its descriptor was being read",
+          );
+        }
+        expectedLeaf = {
+          kind: "existing",
+          device: afterRead.dev,
+          inode: afterRead.ino,
+          size: afterRead.size,
+          mtimeMs: afterRead.mtimeMs,
+          ctimeMs: afterRead.ctimeMs,
+        };
+      } finally {
+        if (fd !== null) closeSync(fd);
+      }
+      assertRepositoryLeafExpectation(gitignorePath, expectedLeaf);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      // No .gitignore yet — create it atomically below.
     }
     const alreadyIgnored = existing
       .split("\n")
       .some((line) => line.trim() === ".gbrain-source");
     if (alreadyIgnored) {
+      assertCanonicalDirectoryUnchanged(
+        expectedRoot,
+        "repository after .gitignore check",
+      );
       return;
     }
     const sep = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
-    writeFileSync(gitignorePath, existing + sep + ".gbrain-source\n");
+    atomicReplaceRepositoryFile(
+      gitignorePath,
+      existing + sep + ".gbrain-source\n",
+      false,
+      expectedLeaf,
+    );
+    assertCanonicalDirectoryUnchanged(
+      expectedRoot,
+      "repository after .gitignore update",
+    );
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(
-      `[sync:code] could not add .gbrain-source to ${gitignorePath}: ${msg}`,
+      `[sync:code] could not add .gbrain-source to ${join(root, ".gitignore")}: ${msg}`,
     );
   }
 }
@@ -1253,8 +2020,36 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
     // only when we can't derive the source id (not in a git repo).
     const root = repoRoot();
     const sourceId = root ? deriveCodeSourceId(root) : null;
-    const dreamArgs = sourceId ? ["dream", "--source", sourceId] : ["dream"];
-
+    const dreamEnv = buildGbrainEnv({ announce: !args.quiet });
+    let dreamCwd: string | undefined;
+    let validatedDreamRoot:
+      ReturnType<typeof canonicalSourceDirectory> | undefined;
+    if (root) {
+      try {
+        validatedDreamRoot = canonicalSourceDirectory(root);
+        dreamCwd = validatedDreamRoot.canonicalPath;
+      } catch (err) {
+        return {
+          name: "dream",
+          ran: false,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: `source path validation failed before dream: ${(err as Error).message}`,
+        };
+      }
+    }
+    const validateDreamBinding = (): SourcePathBinding | undefined => {
+      if (!sourceId || !validatedDreamRoot) return undefined;
+      const row = fetchSources(dreamEnv).find(
+        (candidate) => candidate.id === sourceId,
+      );
+      if (!row?.local_path) {
+        throw new Error(
+          `source ${sourceId} is not registered or has no local_path`,
+        );
+      }
+      return bindRegisteredSourcePath(row.local_path, validatedDreamRoot);
+    };
     // spawnGbrain seeds DATABASE_URL from gbrain's config via buildGbrainEnv.
     //
     // We CAPTURE output (pipe) rather than inherit because `gbrain dream` exits 0
@@ -1266,15 +2061,83 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
     if (!args.quiet) {
       process.stderr.write("[dream] running gbrain cycle (call-graph build; this can take a few minutes)...\n");
     }
+
+    const dreamArgs = sourceId ? ["dream", "--source", sourceId] : ["dream"];
+    if (sourceId && validatedDreamRoot) {
+      try {
+        const dreamBinding = validateDreamBinding()!;
+        if (dreamBinding.useExplicitPath) {
+          dreamArgs.push("--dir", dreamBinding.canonicalPath);
+        }
+      } catch (err) {
+        return {
+          name: "dream",
+          ran: false,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: `source path binding failed before dream: ${(err as Error).message}`,
+        };
+      }
+    }
+
+    if (validatedDreamRoot) {
+      try {
+        assertCanonicalDirectoryUnchanged(
+          validatedDreamRoot,
+          "expected source path before dream",
+        );
+      } catch (err) {
+        return {
+          name: "dream",
+          ran: false,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: `source path validation failed before dream: ${(err as Error).message}`,
+        };
+      }
+    }
+
     let result: ReturnType<typeof spawnGbrain>;
     try {
       result = spawnGbrain(dreamArgs, {
         stdio: ["ignore", "pipe", "pipe"],
         timeout: dreamTimeoutMs,
-        baseEnv: process.env,
+        baseEnv: dreamEnv,
         announce: !args.quiet,
+        cwd: dreamCwd,
       });
     } catch (err) {
+      if (validatedDreamRoot) {
+        try {
+          assertCanonicalDirectoryUnchanged(
+            validatedDreamRoot,
+            "expected source path after failed dream start",
+          );
+        } catch (identityErr) {
+          return {
+            name: "dream",
+            ran: true,
+            ok: false,
+            duration_ms: Date.now() - t0,
+            summary:
+              `source path validation failed after dream start error: ${(identityErr as Error).message}; ` +
+              `gbrain also failed to start: ${(err as Error).message}`,
+          };
+        }
+      }
+      try {
+        validateDreamBinding();
+      } catch (bindingErr) {
+        return {
+          name: "dream",
+          ran: true,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary:
+            `source row validation failed after dream start error: ${(bindingErr as Error).message}; ` +
+            `gbrain also failed to start: ${(err as Error).message}`,
+        };
+      }
       // Spawn-setup failure (missing binary, bad env): ERR, not a benign skip.
       return {
         name: "dream",
@@ -1282,6 +2145,34 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
         ok: false,
         duration_ms: Date.now() - t0,
         summary: `gbrain dream failed to start: ${(err as Error).message}`,
+      };
+    }
+
+    if (validatedDreamRoot) {
+      try {
+        assertCanonicalDirectoryUnchanged(
+          validatedDreamRoot,
+          "expected source path after dream",
+        );
+      } catch (err) {
+        return {
+          name: "dream",
+          ran: true,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: `source path validation failed after dream: ${(err as Error).message}`,
+        };
+      }
+    }
+    try {
+      validateDreamBinding();
+    } catch (err) {
+      return {
+        name: "dream",
+        ran: true,
+        ok: false,
+        duration_ms: Date.now() - t0,
+        summary: `source row validation failed after dream: ${(err as Error).message}`,
       };
     }
 
@@ -1471,6 +2362,29 @@ export function formatStage(s: StageResult): string {
 
 async function main(): Promise<void> {
   const args = parseArgs();
+
+  // Enforce the integration floor at the mutation boundary, not only during
+  // fresh installation. Existing and legacy installs can otherwise pass the
+  // command-level capability probes, write an index, and then silently query a
+  // different source because their call-graph commands ignore `.gbrain-source`.
+  // Dry-run remains dependency-free because it cannot mutate anything. A
+  // missing CLI also retains the existing split-engine SKIP behavior so the
+  // independent curated brain-sync stage can still proceed; a present CLI
+  // must prove a supported version here before mutation.
+  const needsPinAwareGbrain =
+    args.mode !== "dry-run" && (!args.noCode || args.dream);
+  if (needsPinAwareGbrain) {
+    const gbrainPresent = resolveGbrainBin(process.env) !== null;
+    const versionOutput = readGbrainVersion(process.env);
+    const version = checkGbrainVersion(versionOutput);
+    if (gbrainPresent && !version.ok) {
+      console.error(
+        `[gbrain-sync] ${version.reason}. GBrain ${MIN_GBRAIN_VERSION}+ is required before sync or dream; ` +
+          "run gstack-gbrain-install, then retry.",
+      );
+      process.exit(3);
+    }
+  }
 
   if (!args.quiet) {
     const engine = detectEngineTier();

--- a/lib/gbrain-guards.ts
+++ b/lib/gbrain-guards.ts
@@ -12,7 +12,11 @@
  * plus an autopilot-active check (detectAutopilot) that refuses to run destructive
  * ops concurrently with the daemon.
  *
- * Design notes grounded in the real gbrain 0.41.x surface:
+ * Design notes grounded in the real GBrain surface:
+ *   - `gbrain sources list --json` intentionally omits remote-management
+ *     provenance. Destructive-capable decisions use the read-only
+ *     `GBRAIN_SOURCE=default gbrain call sources_list` operation instead and
+ *     require an explicit top-level `remote_url` value (string or null).
  *   - There is NO `--keep-storage` flag and NO structured capability command, and
  *     subcommand `--help` is generic — so capability detection is best-effort and
  *     defaults to "unsupported". When we can't protect a user-managed source's
@@ -32,8 +36,16 @@ import { spawnSync } from "child_process";
 import { existsSync, realpathSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { join, resolve, sep } from "path";
-import { execGbrainJson, execGbrainText, NEEDS_SHELL_ON_WINDOWS } from "./gbrain-exec";
-import { parseSourcesList, type GbrainSourceRow } from "./gbrain-sources";
+import {
+  execGbrainJson,
+  execGbrainText,
+  NEEDS_SHELL_ON_WINDOWS,
+} from "./gbrain-exec";
+import {
+  parseSourcesListStrict,
+  resolveLocalPathForContainment,
+  type GbrainSourceRow,
+} from "./gbrain-sources";
 
 export function gbrainHome(env: NodeJS.ProcessEnv = process.env): string {
   return env.GBRAIN_HOME || join(homedir(), ".gbrain");
@@ -51,10 +63,18 @@ function clonesDirs(env: NodeJS.ProcessEnv = process.env): string[] {
 
 /** True if `p` resolves (symlinks + `..` collapsed) to a location inside `dir`. */
 export function isInside(p: string, dir: string): boolean {
-  let rp: string;
   let rd: string;
-  try { rp = realpathSync(p); } catch { rp = resolve(p); }
-  try { rd = realpathSync(dir); } catch { rd = resolve(dir); }
+  try {
+    rd = realpathSync(dir);
+  } catch {
+    rd = resolve(dir);
+  }
+  let rp: string;
+  try {
+    rp = resolveLocalPathForContainment(p, rd);
+  } catch {
+    return false;
+  }
   const base = rd.endsWith(sep) ? rd : rd + sep;
   return rp === rd || rp.startsWith(base);
 }
@@ -108,7 +128,9 @@ export function detectAutopilot(
     // decision function — we do NOT delete the file here; the caller may clean it.
   }
   // Primary signal: a live `gbrain autopilot` process.
-  const running = (probe.processRunning ?? defaultProcessRunning)();
+  const running = probe.processRunning
+    ? probe.processRunning()
+    : defaultProcessRunning(env);
   if (running) return { active: true, signal: "process:gbrain autopilot" };
   return { active: false, signal: null };
 }
@@ -141,10 +163,14 @@ function isPidAlive(pid: number): boolean {
   }
 }
 
-function defaultProcessRunning(): boolean {
+function defaultProcessRunning(env: NodeJS.ProcessEnv = process.env): boolean {
   // No reliable pgrep on Windows; rely on the lock-file signal there.
   if (process.platform === "win32") return false;
-  const r = spawnSync("pgrep", ["-f", "gbrain autopilot"], { encoding: "utf-8", timeout: 3_000 });
+  const r = spawnSync("pgrep", ["-f", "gbrain autopilot"], {
+    encoding: "utf-8",
+    timeout: 3_000,
+    env,
+  });
   return r.status === 0 && (r.stdout || "").trim().length > 0;
 }
 
@@ -193,14 +219,46 @@ export function _resetCapabilityMemo(): void {
 // ── Destructive-op decisions ────────────────────────────────────────────────
 
 /**
- * Fetch + normalize the source list. Throws on read/parse failure so callers can
- * distinguish "couldn't read" (fail closed) from "empty list" (source absent).
- * Injectable for hermetic tests.
+ * Require management provenance on every row before it can authorize a
+ * destructive-capable operation. A missing field is not equivalent to null:
+ * the ordinary CLI list omits it even for URL-managed sources.
  */
-export function fetchSources(env: NodeJS.ProcessEnv = process.env): GbrainSourceRow[] {
-  const raw = execGbrainJson(["sources", "list", "--json"], { baseEnv: env });
-  if (raw === null) throw new Error("gbrain sources list returned no JSON");
-  return parseSourcesList(raw);
+function requireManagementRows(rows: GbrainSourceRow[]): GbrainSourceRow[] {
+  for (const row of rows) {
+    if (!Object.hasOwn(row, "remote_url")) {
+      throw new Error(
+        "source management provenance is missing (remote_url omitted)",
+      );
+    }
+  }
+  return rows;
+}
+
+/**
+ * Fetch the authoritative read-only source registry, including remote_url.
+ * `GBRAIN_SOURCE=default` bypasses repo-controlled `.gbrain-source` resolution
+ * on versions that resolve a source for `call`; older v0.28.x versions ignore
+ * the unused env while the operation itself remains brain-wide. The call omits
+ * a JSON argv item so the Windows `.cmd` shell transport cannot strip JSON
+ * quotes. That returns active rows only; a missing row therefore fails closed
+ * rather than being treated as a safe absent no-op. GBrain v0.28.2 introduced
+ * this public operation; gstack's higher supported-version floor also covers
+ * source-scoped dream correctness. Older/unknown surfaces fail closed with an
+ * upgrade hint at the decision boundary.
+ */
+export function fetchSources(
+  env: NodeJS.ProcessEnv = process.env,
+): GbrainSourceRow[] {
+  const registryEnv = { ...env, GBRAIN_SOURCE: "default" };
+  const raw = execGbrainJson(["call", "sources_list"], {
+    baseEnv: registryEnv,
+  });
+  if (raw === null) {
+    throw new Error(
+      "gbrain sources_list returned no JSON; upgrade GBrain to gstack's minimum supported v0.41.38.0 or newer",
+    );
+  }
+  return requireManagementRows(parseSourcesListStrict(raw));
 }
 
 export interface RemoveDecision {
@@ -218,9 +276,10 @@ export interface RemoveDecision {
  *   - the row is user-managed (remote_url set AND local_path outside gbrain's
  *     clones) and gbrain has no --keep-storage to protect the files.
  *
- * Allowed: absent row (no-op), gbrain-managed (inside clones), or path-managed
- * without a remote_url (gbrain's remove won't touch an outside-clones path that
- * it didn't clone). --keep-storage is appended whenever supported, as extra armor.
+ * Allowed: gbrain-managed (inside clones), or path-managed without a remote_url
+ * (gbrain's remove won't touch an outside-clones path that it didn't clone).
+ * An absent active row is refused because the shell-safe registry call excludes
+ * archived rows. --keep-storage is appended whenever supported, as extra armor.
  */
 export interface DecideRemoveOpts {
   /** Override capability detection (tests / cached caps). */
@@ -239,19 +298,28 @@ export function decideSourceRemove(
 
   let rows: GbrainSourceRow[];
   try {
-    rows = (opts.fetchRows ?? fetchSources)(env);
+    rows = requireManagementRows((opts.fetchRows ?? fetchSources)(env));
   } catch {
     return { allow: false, extraArgs: [], reason: "could not read sources list; refusing remove (fail closed)" };
   }
 
   const row = rows.find((r) => r.id === sourceId);
-  if (!row) return { allow: true, extraArgs: extra, reason: "source absent (no-op)" };
+  if (!row) {
+    return {
+      allow: false,
+      extraArgs: [],
+      reason:
+        "source absent from active registry; archived provenance is unproven, refusing remove",
+    };
+  }
 
-  const remoteUrl = row.config?.remote_url;
-  const userManaged =
-    !!remoteUrl && !!row.local_path && !clonesDirs(env).some((d) => isInside(row.local_path!, d));
+  const remoteUrl = row.remote_url;
+  const storageUnproven =
+    remoteUrl !== null &&
+    (!row.local_path ||
+      !clonesDirs(env).some((d) => isInside(row.local_path!, d)));
 
-  if (userManaged) {
+  if (storageUnproven) {
     if (keepStorage) {
       return { allow: true, extraArgs: ["--keep-storage"], reason: "user-managed; --keep-storage protects files" };
     }
@@ -259,8 +327,9 @@ export function decideSourceRemove(
       allow: false,
       extraArgs: [],
       reason:
-        `refusing remove of user-managed source "${sourceId}" (remote_url set, local_path ` +
-        `${row.local_path} outside gbrain clones) — this gbrain has no --keep-storage to ` +
+        `refusing remove of user-managed or unlocatable source "${sourceId}" ` +
+        `(remote_url set, local_path ${row.local_path || "missing"} is not proven inside gbrain clones) — ` +
+        `this gbrain has no --keep-storage to ` +
         `protect the working tree. Upgrade gbrain or remove the source manually.`,
     };
   }
@@ -268,9 +337,75 @@ export function decideSourceRemove(
   return { allow: true, extraArgs: extra, reason: "gbrain-managed or path-managed without remote_url" };
 }
 
+/**
+ * Authorize the narrow remove used to repair a path-managed source whose
+ * registered directory genuinely drifted. The raw row must still match the
+ * snapshot already validated by the caller, and URL-managed sources are
+ * deliberately excluded: their remove path may delete a working tree.
+ *
+ * Unlike the general removal decision, this boundary never resolves the
+ * database-provided pathname, so an untrusted UNC/device spelling cannot
+ * trigger filesystem or network access during policy evaluation.
+ */
+export function decidePathManagedDriftRemove(
+  sourceId: string,
+  expectedLocalPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+  opts: DecideRemoveOpts = {},
+): RemoveDecision {
+  // Capability detection may spawn the CLI. Do it before the final source-row
+  // snapshot so the destructive call follows that snapshot as closely as the
+  // CLI permits (there is no compare-and-delete or source lease).
+  const keepStorage = opts.keepStorage ?? gbrainSupportsKeepStorage(env);
+  let rows: GbrainSourceRow[];
+  try {
+    rows = requireManagementRows((opts.fetchRows ?? fetchSources)(env));
+  } catch {
+    return {
+      allow: false,
+      extraArgs: [],
+      reason: "could not reread sources list; refusing path-drift remove",
+    };
+  }
+
+  const row = rows.find((candidate) => candidate.id === sourceId);
+  if (!row) {
+    return {
+      allow: false,
+      extraArgs: [],
+      reason: "source disappeared before path-drift repair",
+    };
+  }
+  if (row.local_path !== expectedLocalPath) {
+    return {
+      allow: false,
+      extraArgs: [],
+      reason:
+        "registered path changed after validation; refusing path-drift remove",
+    };
+  }
+  if (row.remote_url !== null) {
+    return {
+      allow: false,
+      extraArgs: [],
+      reason: "source is URL-managed; automatic path-drift removal is unsafe",
+    };
+  }
+
+  return {
+    allow: true,
+    extraArgs: keepStorage ? ["--keep-storage"] : [],
+    reason: "validated path-managed source",
+  };
+}
+
 export interface SyncDecision {
   allow: boolean;
   reason: string;
+  /** True only for a proven URL-managed row with explicit --allow-reclone. */
+  mayReclone: boolean;
+  /** Exact strict-row snapshot used for both path binding and reclone policy. */
+  registeredPath?: string;
 }
 
 /**
@@ -278,9 +413,9 @@ export interface SyncDecision {
  *
  * A source with a remote_url can trigger gbrain's auto-reclone, the ungated
  * rm-rf path behind the data loss (gbrain #1526). Require an explicit
- * --allow-reclone opt-in for URL-managed sources. Read failure here is NOT
- * itself destructive, so it fails open (proceed) — the autopilot guard, checked
- * first, is the primary protection against the race that caused the loss.
+ * --allow-reclone opt-in for URL-managed sources. If the row cannot be read,
+ * applicability is unprovable and the destructive-capable operation fails
+ * closed; retrying after the source registry recovers is safe.
  */
 export function decideCodeSync(
   sourceId: string,
@@ -290,18 +425,42 @@ export function decideCodeSync(
 ): SyncDecision {
   let rows: GbrainSourceRow[];
   try {
-    rows = fetchRows(env);
+    rows = requireManagementRows(fetchRows(env));
   } catch {
-    return { allow: true, reason: "sources unreadable; proceeding (sync read is non-destructive)" };
+    return {
+      allow: false,
+      reason:
+        "sources unreadable; refusing sync because URL-managed applicability is unprovable",
+      mayReclone: false,
+    };
   }
   const row = rows.find((r) => r.id === sourceId);
-  if (row?.config?.remote_url && !allowReclone) {
+  if (
+    !row ||
+    typeof row.local_path !== "string" ||
+    row.local_path.length === 0
+  ) {
+    return {
+      allow: false,
+      reason: `source "${sourceId}" is absent or has no readable local_path; refusing sync`,
+      mayReclone: false,
+    };
+  }
+  if (row.remote_url !== null && !allowReclone) {
     return {
       allow: false,
       reason:
         `source "${sourceId}" is URL-managed (remote_url set); sync may auto-reclone and ` +
         `delete the working tree. Re-run /sync-gbrain with --allow-reclone to proceed.`,
+      mayReclone: false,
+      registeredPath: row.local_path,
     };
   }
-  return { allow: true, reason: "no remote_url, or reclone explicitly allowed" };
+  const mayReclone = row.remote_url !== null && allowReclone;
+  return {
+    allow: true,
+    reason: "no remote_url, or reclone explicitly allowed",
+    mayReclone,
+    registeredPath: row.local_path,
+  };
 }

--- a/lib/gbrain-sources.ts
+++ b/lib/gbrain-sources.ts
@@ -10,6 +10,8 @@
  */
 
 import { execFileSync, spawnSync } from "child_process";
+import { realpathSync, statSync } from "fs";
+import { isAbsolute, resolve } from "path";
 import { withErrorContext } from "./gstack-memory-helpers";
 import { execGbrainJson, NEEDS_SHELL_ON_WINDOWS } from "./gbrain-exec";
 
@@ -72,6 +74,54 @@ export interface EnsureOptions {
   env?: NodeJS.ProcessEnv;
 }
 
+interface CanonicalDirectory {
+  rawPath: string;
+  canonicalPath: string;
+}
+
+/**
+ * Resolve and validate one directory without mutating GBrain state.
+ * Relative registered paths are anchored to the expected repository root,
+ * never to the caller's ambient cwd.
+ */
+function canonicalDirectory(
+  rawPath: string,
+  label: string,
+  relativeTo?: string,
+  recoveryHint = "Inspect the path, then rerun /sync-gbrain.",
+): CanonicalDirectory {
+  if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
+    throw new Error(
+      `${label} "${String(rawPath)}" is missing or empty; source registration unchanged. ${recoveryHint}`,
+    );
+  }
+
+  const resolvedPath = isAbsolute(rawPath)
+    ? resolve(rawPath)
+    : resolve(relativeTo ?? process.cwd(), rawPath);
+
+  try {
+    const canonicalPath = realpathSync(resolvedPath);
+    if (!statSync(canonicalPath).isDirectory()) {
+      throw new Error("not a directory");
+    }
+    return { rawPath, canonicalPath };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `${label} "${rawPath}" resolved to "${resolvedPath}" is not an existing directory: ${reason}; ` +
+      `source registration unchanged. ${recoveryHint}`,
+    );
+  }
+}
+
+function sameCanonicalPath(left: string, right: string): boolean {
+  if (process.platform === "win32") {
+    return left.toLocaleLowerCase("en-US") === right.toLocaleLowerCase("en-US");
+  }
+  return left === right;
+}
+
 /**
  * Probe the registration state of a source by id.
  *
@@ -123,9 +173,10 @@ export function probeSource(id: string, env?: NodeJS.ProcessEnv): SourceState {
  *
  * Behavior:
  *   - status=absent  → `gbrain sources add <id> --path <path> [--federated]`, returns changed=true.
- *   - status=match + same path → no-op, returns changed=false.
- *   - status=match + different path → `sources remove` + `sources add`, returns changed=true.
+ *   - status=match + same canonical directory → no-op, returns changed=false.
+ *   - status=match + different canonical directory → `sources remove` + `sources add`, returns changed=true.
  *     (Skip when reregister_on_drift=false; returns changed=false.)
+ *   - an absent/non-directory/unresolvable path → throw before remove/add.
  *
  * Caller is responsible for catching errors. The function uses withErrorContext for
  * forensic logging to ~/.gstack/.gbrain-errors.jsonl.
@@ -142,10 +193,31 @@ export async function ensureSourceRegistered(
   return withErrorContext(`ensureSourceRegistered:${id}`, () => {
     const probed = probeSource(id, env);
 
-    // Disambiguate match-but-different-path
+    // Validate the caller-owned repository before any possible add/remove.
+    const registeredContext = probed.status === "match"
+      ? ` (registered path "${String(probed.registered_path)}")`
+      : "";
+    const expected = canonicalDirectory(
+      path,
+      `expected source path${registeredContext}`,
+      undefined,
+      "Inspect or repair the repository path, then rerun /sync-gbrain.",
+    );
+
+    // Disambiguate match-but-different-path by filesystem identity. GBrain may
+    // persist a relative spelling such as "."; interpret it from the expected
+    // repository root rather than process.cwd so comparison is deterministic.
     let state: SourceState = probed;
-    if (probed.status === "match" && probed.registered_path !== path) {
-      state = { status: "drift", registered_path: probed.registered_path };
+    if (probed.status === "match") {
+      const registered = canonicalDirectory(
+        probed.registered_path ?? "",
+        `registered source path (expected root "${expected.rawPath}")`,
+        expected.canonicalPath,
+        "Inspect `gbrain sources list --json` and repair the source path deliberately, then rerun /sync-gbrain.",
+      );
+      if (!sameCanonicalPath(registered.canonicalPath, expected.canonicalPath)) {
+        state = { status: "drift", registered_path: probed.registered_path };
+      }
     }
 
     if (state.status === "match") {

--- a/lib/gbrain-sources.ts
+++ b/lib/gbrain-sources.ts
@@ -115,8 +115,13 @@ function canonicalDirectory(
   }
 }
 
-function sameCanonicalPath(left: string, right: string): boolean {
-  if (process.platform === "win32") {
+/** @internal Exported for platform-independent Windows path tests. */
+export function sameCanonicalPath(
+  left: string,
+  right: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform === "win32") {
     return left.toLocaleLowerCase("en-US") === right.toLocaleLowerCase("en-US");
   }
   return left === right;

--- a/lib/gbrain-sources.ts
+++ b/lib/gbrain-sources.ts
@@ -1,10 +1,10 @@
 /**
  * gbrain-sources — TypeScript helper for idempotent gbrain federated source registration.
  *
- * Mirrors the bash logic in bin/gstack-gbrain-source-wireup:204-310 but in a form
- * importable by other TS callers (currently bin/gstack-gbrain-sync.ts; future
- * callers welcome). gbrain has no `sources update` — drift recovery is
- * `sources remove` followed by `sources add`.
+ * Owns the TypeScript registration boundary used by bin/gstack-gbrain-sync.ts.
+ * It evolved from the legacy shell wire-up but intentionally adds canonical,
+ * fail-closed path classification before mutation. gbrain has no `sources
+ * update` — genuine drift recovery is `sources remove` followed by `sources add`.
  *
  * Per /plan-eng-review D3 (DRY extraction).
  */

--- a/lib/gbrain-sources.ts
+++ b/lib/gbrain-sources.ts
@@ -10,8 +10,8 @@
  */
 
 import { execFileSync, spawnSync } from "child_process";
-import { realpathSync, statSync } from "fs";
-import { isAbsolute, resolve } from "path";
+import { lstatSync, readlinkSync, realpathSync, statSync } from "fs";
+import { posix, win32 } from "path";
 import { withErrorContext } from "./gstack-memory-helpers";
 import { execGbrainJson, NEEDS_SHELL_ON_WINDOWS } from "./gbrain-exec";
 
@@ -29,16 +29,33 @@ export interface EnsureResult {
   state: SourceState;
 }
 
+export interface DirectoryFsOps {
+  lstat(path: string): { isSymbolicLink(): boolean };
+  readlink(path: string): string;
+  realpath(path: string): string;
+  stat(path: string): { dev: bigint; ino: bigint; isDirectory(): boolean };
+}
+
+const DEFAULT_DIRECTORY_FS_OPS: DirectoryFsOps = {
+  lstat: (path) => lstatSync(path),
+  readlink: (path) => readlinkSync(path),
+  realpath: (path) => realpathSync(path),
+  stat: (path) => statSync(path, { bigint: true }),
+};
+
 /**
- * One row of `gbrain sources list --json`. `config.remote_url` distinguishes
- * URL-managed sources (gbrain owns the clone, may auto-reclone) from
- * path-managed ones (user owns the working tree) — load-bearing for the #1734
- * destructive-op guards.
+ * One source row returned by GBrain's source-list surfaces. The ordinary
+ * `gbrain sources list --json` projection intentionally omits management
+ * provenance. The read-only `gbrain call ... sources_list` operation includes
+ * top-level `remote_url`; callers that authorize remove/reclone behavior must
+ * use that richer surface and require the field to be present.
  */
 export interface GbrainSourceRow {
   id?: string;
-  local_path?: string;
+  local_path?: string | null;
   page_count?: number;
+  remote_url?: string | null;
+  /** Legacy/foreign projection accepted for read-only compatibility only. */
   config?: { remote_url?: string | null } | null;
 }
 
@@ -48,8 +65,8 @@ export interface GbrainSourceRow {
  * gbrain has shipped two shapes: a wrapped `{ sources: [...] }` object (v0.20+)
  * and, in older/other variants, a bare top-level array. #1576 was a crash when a
  * reader assumed one shape; the parse is centralized here so every reader
- * (probeSource, sourcePageCount, sourceLocalPath, the #1734 remote_url audit)
- * agrees on the shape in ONE place. Returns [] for null/garbage rather than
+ * (probeSource, sourcePageCount, sourceLocalPath) agrees on the shape in ONE
+ * place. Returns [] for null/garbage rather than
  * throwing — callers treat "no rows" as absent.
  */
 export function parseSourcesList(raw: unknown): GbrainSourceRow[] {
@@ -58,6 +75,70 @@ export function parseSourcesList(raw: unknown): GbrainSourceRow[] {
     return (raw as { sources: GbrainSourceRow[] }).sources;
   }
   return [];
+}
+
+/** Strict variant for decisions that may authorize add/remove/reclone paths. */
+export function parseSourcesListStrict(raw: unknown): GbrainSourceRow[] {
+  const rows = Array.isArray(raw)
+    ? raw
+    : raw &&
+        typeof raw === "object" &&
+        Array.isArray((raw as { sources?: unknown }).sources)
+      ? (raw as { sources: unknown[] }).sources
+      : null;
+  if (rows === null) {
+    throw new Error("gbrain sources list returned an unknown JSON shape");
+  }
+  for (const row of rows) {
+    if (!row || typeof row !== "object") {
+      throw new Error("gbrain sources list returned a non-object source row");
+    }
+    const candidate = row as GbrainSourceRow;
+    if (typeof candidate.id !== "string" || candidate.id.length === 0) {
+      throw new Error(
+        "gbrain sources list returned a source row without a valid id",
+      );
+    }
+    if (
+      candidate.local_path !== undefined &&
+      candidate.local_path !== null &&
+      typeof candidate.local_path !== "string"
+    ) {
+      throw new Error(
+        "gbrain sources list returned a source row with a non-string local_path",
+      );
+    }
+    if (
+      candidate.config !== undefined &&
+      candidate.config !== null &&
+      (typeof candidate.config !== "object" || Array.isArray(candidate.config))
+    ) {
+      throw new Error(
+        "gbrain sources list returned a source row with invalid config",
+      );
+    }
+    const remoteUrl = candidate.remote_url;
+    if (
+      remoteUrl !== undefined &&
+      remoteUrl !== null &&
+      typeof remoteUrl !== "string"
+    ) {
+      throw new Error(
+        "gbrain sources list returned a source row with invalid remote_url",
+      );
+    }
+    const legacyRemoteUrl = candidate.config?.remote_url;
+    if (
+      legacyRemoteUrl !== undefined &&
+      legacyRemoteUrl !== null &&
+      typeof legacyRemoteUrl !== "string"
+    ) {
+      throw new Error(
+        "gbrain sources list returned a source row with invalid remote_url",
+      );
+    }
+  }
+  return rows as GbrainSourceRow[];
 }
 
 export interface EnsureOptions {
@@ -72,11 +153,305 @@ export interface EnsureOptions {
    * mutations of process.env.PATH unless env is passed explicitly).
    */
   env?: NodeJS.ProcessEnv;
+  /** @internal Platform override for path-safety tests. */
+  platform?: NodeJS.Platform;
+  /** @internal Filesystem seam for no-follow and replacement-race tests. */
+  fsOps?: DirectoryFsOps;
+  /** @internal Caller-captured identity that must remain current. */
+  expected_identity?: CanonicalDirectory;
+  /**
+   * Guarded removal boundary for true path drift. Callers must enforce the
+   * repository's destructive-operation policy; without one, drift repair
+   * fails closed before removing the existing source.
+   */
+  removeSource?: (
+    id: string,
+    registeredPath: string,
+    env?: NodeJS.ProcessEnv,
+  ) => void;
+  /** @internal Test hook invoked immediately before identity revalidation. */
+  beforeMutation?: (
+    phase: "before-remove" | "before-add" | "after-add",
+  ) => void;
 }
 
-interface CanonicalDirectory {
+export interface CanonicalDirectory {
   rawPath: string;
   canonicalPath: string;
+  device: bigint;
+  inode: bigint;
+}
+
+const SOURCE_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/;
+const WINDOWS_SHELL_META_RE = /[&|^%!()"'<>]/;
+
+function assertSafeSourceId(id: string): void {
+  if (!SOURCE_ID_RE.test(id)) {
+    throw new Error(
+      `source id "${id}" is unsafe or invalid; expected 1-32 lowercase alphanumeric characters with interior hyphens`,
+    );
+  }
+}
+
+/** Reject path spellings that are unsafe to resolve at all. */
+function assertSafePathSyntax(
+  rawPath: string,
+  label: string,
+  platform: NodeJS.Platform,
+): void {
+  if (/^[\\\\/]{2}/.test(rawPath)) {
+    throw new Error(
+      `${label} "${rawPath}" uses a remote or device path namespace; ` +
+        "refusing it before filesystem access. Use a local repository path.",
+    );
+  }
+  if (platform !== "win32") {
+    // Bun 1.3.x realpath/lstat incorrectly treats a POSIX backslash as a path
+    // separator in this execution path. Reject the valid-but-unprovable name
+    // instead of canonicalizing a different filesystem object.
+    if (rawPath.includes("\\")) {
+      throw new Error(
+        `${label} "${rawPath}" contains a POSIX backslash filename component that this Bun runtime ` +
+          "cannot canonicalize safely; refusing it before filesystem access.",
+      );
+    }
+    return;
+  }
+
+  if (
+    /^[A-Za-z]:(?![\\\\/])/.test(rawPath) ||
+    /^[\\\\/](?![\\\\/])/.test(rawPath)
+  ) {
+    throw new Error(
+      `${label} "${rawPath}" is drive-relative or root-relative on Windows; ` +
+        "refusing the ambiguous path before filesystem access.",
+    );
+  }
+}
+
+/** Until the Windows launcher is argv-native, mutation paths must be shell-safe. */
+function assertSafeMutationPath(
+  rawPath: string,
+  platform: NodeJS.Platform,
+): void {
+  if (platform !== "win32") return;
+  if (!isSafeWindowsShellPath(rawPath)) {
+    throw new Error(
+      `expected source path "${rawPath}" is unsafe for the current Windows GBrain shell transport; ` +
+        "source registration unchanged. Use a path without whitespace or cmd.exe metacharacters.",
+    );
+  }
+}
+
+function isSafeWindowsShellPath(rawPath: string): boolean {
+  return !(
+    WINDOWS_SHELL_META_RE.test(rawPath) ||
+    Array.from(rawPath).some((char) => char.trim().length === 0)
+  );
+}
+
+function pathApi(platform: NodeJS.Platform): typeof posix {
+  return platform === "win32" ? win32 : posix;
+}
+
+function splitPathComponents(
+  rawPath: string,
+  platform: NodeJS.Platform,
+): string[] {
+  return platform === "win32" ? rawPath.split(/[\\/]+/) : rawPath.split(/\/+/);
+}
+
+/** Parent traversal is ambiguous when an earlier component may be a link. */
+function hasParentTraversal(
+  rawPath: string,
+  platform: NodeJS.Platform,
+): boolean {
+  return splitPathComponents(rawPath, platform).some(
+    (component) => component === "..",
+  );
+}
+
+/** A parent segment after a path component may step out through a nested link. */
+function hasNestedParentTraversal(
+  rawPath: string,
+  platform: NodeJS.Platform,
+): boolean {
+  let sawPathComponent = false;
+  for (const component of splitPathComponents(rawPath, platform)) {
+    if (component === "" || component === ".") continue;
+    if (component === "..") {
+      if (sawPathComponent) return true;
+      continue;
+    }
+    sawPathComponent = true;
+  }
+  return false;
+}
+
+function comparableRoot(root: string, platform: NodeJS.Platform): string {
+  return platform === "win32" ? root.toLocaleLowerCase("en-US") : root;
+}
+
+/** Turn local NT junction targets into normal drive paths; leave remote/device targets rejectable. */
+function normalizeLocalLinkTarget(
+  target: string,
+  platform: NodeJS.Platform,
+): string {
+  if (platform !== "win32") return target;
+  const localNt = target.match(/^(?:\\\\\?\\|\\\?\?\\)([A-Za-z]:[\\/].*)$/);
+  return localNt ? localNt[1] : target;
+}
+
+/**
+ * Inspect an untrusted registered path one component at a time. lstat/readlink
+ * sees a symlink or Windows junction without following it, so explicit remote
+ * targets and cross-drive aliases are rejected before realpath can traverse
+ * them. OS-mounted network filesystems remain an environmental boundary.
+ * This is snapshot validation, not handle-bound traversal: a writable ancestor
+ * can still change between lstat/readlink, realpath, stat, and the external
+ * GBrain reopen; inode reuse is also theoretically possible. Rechecks shrink
+ * and diagnose that non-zero race window but cannot make it atomic.
+ */
+function preflightLocalLinkChain(
+  resolvedPath: string,
+  expectedRoot: string,
+  label: string,
+  platform: NodeJS.Platform,
+  fsOps: DirectoryFsOps,
+): string {
+  const path = pathApi(platform);
+  const expectedVolume = path.parse(expectedRoot).root;
+  const initialVolume = path.parse(resolvedPath).root;
+  if (
+    comparableRoot(initialVolume, platform) !==
+    comparableRoot(expectedVolume, platform)
+  ) {
+    throw new Error(
+      `${label} "${resolvedPath}" is on a different filesystem root from expected "${expectedRoot}"; ` +
+        "refusing it before filesystem access. Source registration unchanged.",
+    );
+  }
+
+  let currentRoot = initialVolume;
+  let pending = splitPathComponents(
+    resolvedPath.slice(initialVolume.length),
+    platform,
+  ).filter(Boolean);
+  const visited = new Set<string>();
+  let linkHops = 0;
+
+  while (pending.length > 0) {
+    const component = pending.shift()!;
+    const candidate = path.join(currentRoot, component);
+    let stat: ReturnType<DirectoryFsOps["lstat"]>;
+    try {
+      stat = fsOps.lstat(candidate);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return path.join(candidate, ...pending);
+      }
+      throw err;
+    }
+    if (!stat.isSymbolicLink()) {
+      currentRoot = candidate;
+      continue;
+    }
+
+    linkHops += 1;
+    if (linkHops > 40) {
+      throw new Error(
+        `${label} "${resolvedPath}" exceeds 40 symbolic-link hops; source registration unchanged.`,
+      );
+    }
+
+    const rawTarget = fsOps.readlink(candidate);
+    const target = normalizeLocalLinkTarget(rawTarget, platform);
+    assertSafePathSyntax(target, `${label} link target`, platform);
+    if (hasNestedParentTraversal(target, platform)) {
+      throw new Error(
+        `${label} link target "${rawTarget}" contains parent traversal after a path component; ` +
+          "refusing it before filesystem access. Source registration unchanged.",
+      );
+    }
+    const absoluteTarget = path.isAbsolute(target)
+      ? path.resolve(target)
+      : path.resolve(path.dirname(candidate), target);
+    const targetVolume = path.parse(absoluteTarget).root;
+    if (
+      comparableRoot(targetVolume, platform) !==
+      comparableRoot(expectedVolume, platform)
+    ) {
+      throw new Error(
+        `${label} link target "${rawTarget}" crosses filesystem roots; ` +
+          "refusing it before filesystem access. Source registration unchanged.",
+      );
+    }
+
+    // Preserve component case: Windows volumes can enable per-directory case
+    // sensitivity. A case-insensitive cycle may take up to the hop cap to
+    // reject, but distinct case-sensitive targets must not be conflated.
+    const cycleKey = `${absoluteTarget}\0${pending.join("/")}`;
+    if (visited.has(cycleKey)) {
+      throw new Error(
+        `${label} "${resolvedPath}" contains a symbolic-link cycle; source registration unchanged.`,
+      );
+    }
+    visited.add(cycleKey);
+    currentRoot = targetVolume;
+    pending = [
+      ...splitPathComponents(
+        absoluteTarget.slice(targetVolume.length),
+        platform,
+      ).filter(Boolean),
+      ...pending,
+    ];
+  }
+
+  return currentRoot;
+}
+
+/**
+ * Resolve a database-provided local path for containment checks without first
+ * following direct remote/device namespaces or local links to them. Missing
+ * suffixes retain their fully expanded lexical spelling; callers can still
+ * classify an already-removed managed clone without weakening link handling.
+ */
+export function resolveLocalPathForContainment(
+  rawPath: string,
+  trustedRoot: string,
+  platform: NodeJS.Platform = process.platform,
+  fsOps: DirectoryFsOps = DEFAULT_DIRECTORY_FS_OPS,
+): string {
+  if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
+    throw new Error("local path is missing or empty");
+  }
+  assertSafePathSyntax(rawPath, "local path", platform);
+  if (hasParentTraversal(rawPath, platform)) {
+    throw new Error("local path contains parent traversal");
+  }
+
+  const path = pathApi(platform);
+  const resolvedRoot = path.resolve(trustedRoot);
+  const resolvedPath = path.resolve(rawPath);
+  const inspectedPath = preflightLocalLinkChain(
+    resolvedPath,
+    resolvedRoot,
+    "local path",
+    platform,
+    fsOps,
+  );
+
+  let canonicalPath = inspectedPath;
+  try {
+    canonicalPath = normalizeLocalLinkTarget(
+      fsOps.realpath(inspectedPath),
+      platform,
+    );
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  assertSafePathSyntax(canonicalPath, "local path canonical path", platform);
+  return canonicalPath;
 }
 
 /**
@@ -89,6 +464,8 @@ function canonicalDirectory(
   label: string,
   relativeTo?: string,
   recoveryHint = "Inspect the path, then rerun /sync-gbrain.",
+  platform: NodeJS.Platform = process.platform,
+  fsOps: DirectoryFsOps = DEFAULT_DIRECTORY_FS_OPS,
 ): CanonicalDirectory {
   if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
     throw new Error(
@@ -96,16 +473,63 @@ function canonicalDirectory(
     );
   }
 
-  const resolvedPath = isAbsolute(rawPath)
-    ? resolve(rawPath)
-    : resolve(relativeTo ?? process.cwd(), rawPath);
+  assertSafePathSyntax(rawPath, label, platform);
+  const path = pathApi(platform);
+
+  const resolvedPath = path.isAbsolute(rawPath)
+    ? path.resolve(rawPath)
+    : path.resolve(relativeTo ?? process.cwd(), rawPath);
+
+  // Never collapse an untrusted `..` lexically: `link/..` is resolved by the
+  // filesystem relative to the link target and can escape or reach a UNC
+  // target even when path.resolve() appears to land back at the expected root.
+  if (relativeTo !== undefined && hasParentTraversal(rawPath, platform)) {
+    throw new Error(
+      `${label} "${rawPath}" contains parent traversal; ` +
+        `refusing it before filesystem access. Source registration unchanged. ${recoveryHint}`,
+    );
+  }
+
+  // A relative stored spelling is meaningful only inside the expected
+  // repository boundary. Permit normal aliases such as ".", but do not let a
+  // database value resolve into an arbitrary sibling before realpath.
+  if (relativeTo !== undefined && !path.isAbsolute(rawPath)) {
+    const rel = path.relative(relativeTo, resolvedPath);
+    if (
+      rel === ".." ||
+      rel.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(rel)
+    ) {
+      throw new Error(
+        `${label} "${rawPath}" escapes expected root "${relativeTo}"; ` +
+          `refusing it before filesystem access. Source registration unchanged. ${recoveryHint}`,
+      );
+    }
+  }
 
   try {
-    const canonicalPath = realpathSync(resolvedPath);
-    if (!statSync(canonicalPath).isDirectory()) {
+    let inspectedPath = resolvedPath;
+    if (relativeTo !== undefined) {
+      inspectedPath = preflightLocalLinkChain(
+        resolvedPath,
+        relativeTo,
+        label,
+        platform,
+        fsOps,
+      );
+    }
+    const canonicalPath = normalizeLocalLinkTarget(
+      fsOps.realpath(inspectedPath),
+      platform,
+    );
+    // realpath may expand a short path or traverse a symlink into characters
+    // that were absent from the raw spelling; validate what GBrain will receive.
+    assertSafePathSyntax(canonicalPath, `${label} canonical path`, platform);
+    const stat = fsOps.stat(canonicalPath);
+    if (!stat.isDirectory()) {
       throw new Error("not a directory");
     }
-    return { rawPath, canonicalPath };
+    return { rawPath, canonicalPath, device: stat.dev, inode: stat.ino };
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     throw new Error(
@@ -115,16 +539,166 @@ function canonicalDirectory(
   }
 }
 
-/** @internal Exported for platform-independent Windows path tests. */
-export function sameCanonicalPath(
-  left: string,
-  right: string,
+/** Capture the identity of the caller-owned source directory. */
+export function canonicalSourceDirectory(
+  rawPath: string,
   platform: NodeJS.Platform = process.platform,
+  fsOps: DirectoryFsOps = DEFAULT_DIRECTORY_FS_OPS,
+): CanonicalDirectory {
+  return canonicalDirectory(
+    rawPath,
+    "expected source path",
+    undefined,
+    "Inspect or repair the repository path, then rerun /sync-gbrain.",
+    platform,
+    fsOps,
+  );
+}
+
+/** Canonical, locally safe directory path for callers that need a cwd. */
+export function canonicalSourceDirectoryPath(
+  rawPath: string,
+  platform: NodeJS.Platform = process.platform,
+  fsOps: DirectoryFsOps = DEFAULT_DIRECTORY_FS_OPS,
+): string {
+  return canonicalSourceDirectory(rawPath, platform, fsOps).canonicalPath;
+}
+
+export interface SourcePathBinding {
+  /** Canonical path captured by the caller and safe to use as cwd. */
+  canonicalPath: string;
+  /** Pass the canonical path explicitly (`--repo` / `--dir`) to ignore aliases. */
+  useExplicitPath: boolean;
+}
+
+/** Safely compare one stored source spelling with a caller-captured directory. */
+export function registeredSourceMatchesDirectory(
+  registeredPath: string,
+  expected: CanonicalDirectory,
+  platform: NodeJS.Platform = process.platform,
+  fsOps: DirectoryFsOps = DEFAULT_DIRECTORY_FS_OPS,
+  requireStableIdentity = false,
 ): boolean {
-  if (platform === "win32") {
-    return left.toLocaleLowerCase("en-US") === right.toLocaleLowerCase("en-US");
+  const registered = canonicalDirectory(
+    registeredPath,
+    `registered source path (expected root "${expected.rawPath}")`,
+    expected.canonicalPath,
+    "Inspect `gbrain sources list --json` and repair the source path deliberately, then rerun /sync-gbrain.",
+    platform,
+    fsOps,
+  );
+  return requireStableIdentity
+    ? sameStableDirectoryIdentity(registered, expected)
+    : sameDirectoryIdentity(registered, expected);
+}
+
+/**
+ * Bind a previously validated source row to its canonical directory for the
+ * next GBrain filesystem operation. On POSIX, argv transport is native and an
+ * explicit canonical path is always safe. On Windows, the current `.cmd`
+ * launcher uses a shell: safe paths get the explicit override; unsafe paths
+ * may proceed only when the stored spelling is exactly `.` or the canonical
+ * absolute path, neither of which leaves a rebindable alias for GBrain to open.
+ */
+export function bindRegisteredSourcePath(
+  registeredPath: string,
+  expected: CanonicalDirectory,
+  platform: NodeJS.Platform = process.platform,
+  fsOps: DirectoryFsOps = DEFAULT_DIRECTORY_FS_OPS,
+): SourcePathBinding {
+  if (
+    !registeredSourceMatchesDirectory(registeredPath, expected, platform, fsOps)
+  ) {
+    throw new Error(
+      `registered source path "${registeredPath}" no longer identifies "${expected.canonicalPath}"; ` +
+        "refusing the filesystem operation. Rerun /sync-gbrain.",
+    );
   }
-  return left === right;
+
+  if (platform !== "win32" || isSafeWindowsShellPath(expected.canonicalPath)) {
+    return { canonicalPath: expected.canonicalPath, useExplicitPath: true };
+  }
+
+  const path = pathApi(platform);
+  const safelyCwdRelative =
+    !path.isAbsolute(registeredPath) && path.normalize(registeredPath) === ".";
+  const exactCanonicalAbsolute =
+    path.isAbsolute(registeredPath) &&
+    registeredPath === expected.canonicalPath;
+  if (!safelyCwdRelative && !exactCanonicalAbsolute) {
+    throw new Error(
+      `registered source path "${registeredPath}" is an alias, but canonical path ` +
+        `"${expected.canonicalPath}" is unsafe for the current Windows GBrain shell transport; ` +
+        "refusing to follow a rebindable alias. Repair the registration from a shell-safe path.",
+    );
+  }
+  return { canonicalPath: expected.canonicalPath, useExplicitPath: false };
+}
+
+/** Compare filesystem objects without assuming every Windows directory is case-insensitive. */
+function sameDirectoryIdentity(
+  left: CanonicalDirectory,
+  right: CanonicalDirectory,
+): boolean {
+  // Modern filesystems expose a stable (device, inode/file-id) pair. A few
+  // adapters report inode 0; fall back to realpath spelling there rather than
+  // falsely treating every directory on the device as identical.
+  if (left.inode !== 0n && right.inode !== 0n) {
+    return left.device === right.device && left.inode === right.inode;
+  }
+  return left.canonicalPath === right.canonicalPath;
+}
+
+/** Temporal checks require an identity token; a repeated pathname is not proof. */
+function sameStableDirectoryIdentity(
+  left: CanonicalDirectory,
+  right: CanonicalDirectory,
+): boolean {
+  return (
+    left.inode !== 0n &&
+    right.inode !== 0n &&
+    left.device === right.device &&
+    left.inode === right.inode
+  );
+}
+
+/**
+ * Re-stat a previously validated directory around a path-based side effect.
+ * The external process still reopens by pathname; this detects observable
+ * replacement but is not a zero-window lease or open-handle binding.
+ */
+export function assertCanonicalDirectoryUnchanged(
+  expected: CanonicalDirectory,
+  label = "expected source path",
+  fsOps: DirectoryFsOps = DEFAULT_DIRECTORY_FS_OPS,
+): void {
+  try {
+    const stat = fsOps.stat(expected.canonicalPath);
+    const current: CanonicalDirectory = {
+      rawPath: expected.rawPath,
+      canonicalPath: expected.canonicalPath,
+      device: stat.dev,
+      inode: stat.ino,
+    };
+    if (!stat.isDirectory()) {
+      throw new Error("path is no longer a directory");
+    }
+    if (expected.inode === 0n || current.inode === 0n) {
+      throw new Error(
+        "stable directory identity is unavailable (inode/file-id is zero)",
+      );
+    }
+    if (!sameStableDirectoryIdentity(current, expected)) {
+      throw new Error("directory identity changed");
+    }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `${label} "${expected.canonicalPath}" changed after validation: ${reason}; ` +
+        "stopping before any further operation. Rerun /sync-gbrain from the intended repository, " +
+        "and inspect GBrain source state if registration had already begun.",
+    );
+  }
 }
 
 /**
@@ -164,12 +738,12 @@ export function probeSource(id: string, env?: NodeJS.ProcessEnv): SourceState {
     throw new Error(`gbrain sources list returned non-JSON output: ${(err as Error).message}`);
   }
 
-  const sources = parseSourcesList(parsed);
+  const sources = parseSourcesListStrict(parsed);
   const match = sources.find((s) => s.id === id);
   if (!match) return { status: "absent" };
   return {
     status: "match",
-    registered_path: match.local_path,
+    registered_path: match.local_path ?? undefined,
   };
 }
 
@@ -189,81 +763,213 @@ export function probeSource(id: string, env?: NodeJS.ProcessEnv): SourceState {
 export async function ensureSourceRegistered(
   id: string,
   path: string,
-  options: EnsureOptions = {}
+  options: EnsureOptions = {},
 ): Promise<EnsureResult> {
   const federated = options.federated ?? false;
   const reregister_on_drift = options.reregister_on_drift ?? true;
   const env = options.env;
+  const platform = options.platform ?? process.platform;
+  const fsOps = options.fsOps ?? DEFAULT_DIRECTORY_FS_OPS;
 
-  return withErrorContext(`ensureSourceRegistered:${id}`, () => {
-    const probed = probeSource(id, env);
+  return withErrorContext(
+    `ensureSourceRegistered:${id}`,
+    () => {
+      assertSafeSourceId(id);
+      const probed = probeSource(id, env);
 
-    // Validate the caller-owned repository before any possible add/remove.
-    const registeredContext = probed.status === "match"
-      ? ` (registered path "${String(probed.registered_path)}")`
-      : "";
-    const expected = canonicalDirectory(
-      path,
-      `expected source path${registeredContext}`,
-      undefined,
-      "Inspect or repair the repository path, then rerun /sync-gbrain.",
-    );
-
-    // Disambiguate match-but-different-path by filesystem identity. GBrain may
-    // persist a relative spelling such as "."; interpret it from the expected
-    // repository root rather than process.cwd so comparison is deterministic.
-    let state: SourceState = probed;
-    if (probed.status === "match") {
-      const registered = canonicalDirectory(
-        probed.registered_path ?? "",
-        `registered source path (expected root "${expected.rawPath}")`,
-        expected.canonicalPath,
-        "Inspect `gbrain sources list --json` and repair the source path deliberately, then rerun /sync-gbrain.",
+      // Validate the caller-owned repository before any possible add/remove.
+      const registeredContext =
+        probed.status === "match"
+          ? ` (registered path "${String(probed.registered_path)}")`
+          : "";
+      const expected = canonicalDirectory(
+        path,
+        `expected source path${registeredContext}`,
+        undefined,
+        "Inspect or repair the repository path, then rerun /sync-gbrain.",
+        platform,
+        fsOps,
       );
-      if (!sameCanonicalPath(registered.canonicalPath, expected.canonicalPath)) {
-        state = { status: "drift", registered_path: probed.registered_path };
+      if (options.expected_identity) {
+        if (!sameStableDirectoryIdentity(expected, options.expected_identity)) {
+          const reason =
+            expected.inode === 0n || options.expected_identity.inode === 0n
+              ? "stable directory identity is unavailable (inode/file-id is zero)"
+              : "directory identity changed";
+          throw new Error(
+            `expected source path "${expected.canonicalPath}" changed after caller validation: ${reason}; ` +
+              "source registration unchanged. Rerun /sync-gbrain from the intended repository.",
+          );
+        }
       }
-    }
 
-    if (state.status === "match") {
-      return { changed: false, state };
-    }
-
-    if (state.status === "drift" && !reregister_on_drift) {
-      return { changed: false, state };
-    }
-
-    // For drift, remove first.
-    if (state.status === "drift") {
-      const rm = spawnSync("gbrain", ["sources", "remove", id, "--yes"], {
-        encoding: "utf-8",
-        timeout: 30_000,
-        env,
-        shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
-      });
-      if (rm.status !== 0) {
-        throw new Error(`gbrain sources remove ${id} failed: ${rm.stderr || rm.stdout || `exit ${rm.status}`}`);
+      // Disambiguate match-but-different-path by filesystem identity. GBrain may
+      // persist a relative spelling such as "."; interpret it from the expected
+      // repository root rather than process.cwd so comparison is deterministic.
+      let state: SourceState = probed;
+      if (probed.status === "match") {
+        const registered = canonicalDirectory(
+          probed.registered_path ?? "",
+          `registered source path (expected root "${expected.rawPath}")`,
+          expected.canonicalPath,
+          "Inspect `gbrain sources list --json` and repair the source path deliberately, then rerun /sync-gbrain.",
+          platform,
+          fsOps,
+        );
+        if (!sameDirectoryIdentity(registered, expected)) {
+          state = { status: "drift", registered_path: probed.registered_path };
+        }
       }
-    }
 
-    // Add.
-    const addArgs = ["sources", "add", id, "--path", path];
-    if (federated) addArgs.push("--federated");
-    const add = spawnSync("gbrain", addArgs, {
-      encoding: "utf-8",
-      timeout: 30_000,
-      env,
-      shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
-    });
-    if (add.status !== 0) {
-      throw new Error(`gbrain sources add ${id} failed: ${add.stderr || add.stdout || `exit ${add.status}`}`);
-    }
+      if (state.status === "match") {
+        return { changed: false, state };
+      }
 
-    return {
-      changed: true,
-      state: { status: "match", registered_path: path },
-    };
-  }, "gbrain-sources");
+      if (state.status === "drift" && !reregister_on_drift) {
+        return { changed: false, state };
+      }
+
+      // Only mutation needs to transport the path through cmd.exe on Windows.
+      // Exact no-op sources continue to work from ordinary paths with spaces.
+      assertSafeMutationPath(expected.canonicalPath, platform);
+
+      // For drift, remove first.
+      let removedForDrift = false;
+      if (state.status === "drift") {
+        if (!options.removeSource) {
+          throw new Error(
+            `source ${id} is registered to a different directory, but no guarded removal policy was provided; ` +
+              "source registration unchanged. Repair the source deliberately, then rerun /sync-gbrain.",
+          );
+        }
+        options.beforeMutation?.("before-remove");
+        assertCanonicalDirectoryUnchanged(
+          expected,
+          "expected source path before remove",
+          fsOps,
+        );
+        try {
+          options.removeSource(id, state.registered_path!, env);
+          removedForDrift = true;
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          try {
+            assertCanonicalDirectoryUnchanged(
+              expected,
+              "expected source path after failed remove",
+              fsOps,
+            );
+          } catch (identityErr) {
+            throw new Error(
+              `${(identityErr as Error).message} Guarded remove also failed (${reason}); ` +
+                "source state is ambiguous. Inspect `gbrain sources list --json` before retrying.",
+            );
+          }
+          throw new Error(
+            `guarded path-drift remove for ${id} failed: ${reason}; source state may have changed. ` +
+              "Inspect `gbrain sources list --json` before retrying.",
+          );
+        }
+        assertCanonicalDirectoryUnchanged(
+          expected,
+          "expected source path after remove",
+          fsOps,
+        );
+        let afterRemove: SourceState;
+        try {
+          afterRemove = probeSource(id, env);
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          throw new Error(
+            `guarded path-drift remove for ${id} completed, but the old registration was already removed ` +
+              `and the resulting source state could not be confirmed (${reason}). Source state is absent or ` +
+              "ambiguous; inspect `gbrain sources list --json` before retrying.",
+          );
+        }
+        if (afterRemove.status !== "absent") {
+          throw new Error(
+            `guarded path-drift remove for ${id} returned without removing the validated source; ` +
+              "source state is ambiguous. Inspect `gbrain sources list --json` before retrying.",
+          );
+        }
+      }
+
+      // Reuse the validated canonical spelling and re-check identity immediately
+      // before the path-based write. The external CLI still reopens by pathname.
+      options.beforeMutation?.("before-add");
+      assertCanonicalDirectoryUnchanged(
+        expected,
+        "expected source path before add",
+        fsOps,
+      );
+      const addArgs = ["sources", "add", id, "--path", expected.canonicalPath];
+      if (federated) addArgs.push("--federated");
+      let add: ReturnType<typeof spawnSync>;
+      try {
+        add = spawnSync("gbrain", addArgs, {
+          encoding: "utf-8",
+          timeout: 30_000,
+          env,
+          shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
+        });
+      } catch (err) {
+        options.beforeMutation?.("after-add");
+        assertCanonicalDirectoryUnchanged(
+          expected,
+          "expected source path after failed add",
+          fsOps,
+        );
+        const priorState = removedForDrift
+          ? "The previous drifted registration was already removed"
+          : "The source may not have been registered";
+        throw new Error(
+          `gbrain sources add ${id} failed to start: ${(err as Error).message}. ${priorState}; ` +
+            "source state is absent or ambiguous. Inspect `gbrain sources list --json` before retrying.",
+        );
+      }
+      options.beforeMutation?.("after-add");
+      assertCanonicalDirectoryUnchanged(
+        expected,
+        "expected source path after add",
+        fsOps,
+      );
+      if (add.status !== 0) {
+        const priorState = removedForDrift
+          ? " The previous drifted registration was already removed; source state is now absent or ambiguous."
+          : " Source state may be absent or ambiguous.";
+        throw new Error(
+          `gbrain sources add ${id} failed: ${add.stderr || add.stdout || `exit ${add.status}`}.` +
+            `${priorState} Inspect \`gbrain sources list --json\` before retrying.`,
+        );
+      }
+
+      let confirmed: SourceState;
+      try {
+        confirmed = probeSource(id, env);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `gbrain sources add ${id} returned success, but persisted state could not be confirmed (${reason}). ` +
+            "Source state is ambiguous; inspect `gbrain sources list --json` before retrying.",
+        );
+      }
+      if (
+        confirmed.status !== "match" ||
+        confirmed.registered_path !== expected.canonicalPath
+      ) {
+        throw new Error(
+          `gbrain sources add ${id} did not persist the validated path "${expected.canonicalPath}"; ` +
+            "source state is ambiguous. Inspect `gbrain sources list --json` before retrying.",
+        );
+      }
+
+      return {
+        changed: true,
+        state: { status: "match", registered_path: expected.canonicalPath },
+      };
+    },
+    "gbrain-sources",
+  );
 }
 
 /**

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -798,6 +798,13 @@ It does NOT use `gbrain import` (that path is for markdown directories).
 It does NOT touch `~/.gstack/` indexing (the existing `gstack-gbrain-source-wireup`
 owns that — never double-store).
 
+Source registration is based on canonical filesystem identity. Relative,
+absolute, and symlink/junction spellings that resolve to the same directory are
+one source. A genuine path drift is repaired only through a guarded remove/add
+after the authoritative registry row and filesystem identity remain stable.
+Missing, ambiguous, rebound, or unverifiable identity stops before destructive
+source mutation.
+
 ## User-invocable
 
 When the user types `/sync-gbrain`, run this skill. Argument modes (parsed by
@@ -1109,10 +1116,11 @@ identifier yet.
 `.gbrain-source` file in the repo root (kubectl-style context).
 `gbrain code-def`, `code-refs`, `code-callers`, `code-callees`, `search`, and
 `query` from anywhere under this worktree route to that source by default —
-no `--source` flag needed (gbrain >= 0.41.38.0; on older gbrain the call-graph
-commands need `--source "$(cat .gbrain-source)"`). Conductor sibling worktrees
-of the same repo each have their own pin and their own indexed pages, so
-semantic results match the code on disk here.
+no `--source` flag needed. This requires gbrain >= 0.41.38.0; sync and dream
+stop before mutation on an older version. Run `/setup-gbrain` (or
+`gstack-gbrain-install`) and retry `/sync-gbrain` to upgrade. Conductor sibling
+worktrees of the same repo each have their own pin and their own indexed pages,
+so semantic results match the code on disk here.
 
 Call-graph queries (`code-callers`/`code-callees`) also need the graph to be
 built first — run `/sync-gbrain --dream` (or `--full`) if they return

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -788,7 +788,10 @@ refreshed against this repo's current state, and refreshes the agent-side
 guidance in CLAUDE.md so the coding agent knows when to prefer `gbrain`
 search over Grep.
 
-**Architecture (post-codex review):** This skill uses gbrain v0.20.0+'s
+**Architecture (post-codex review):** This skill requires gbrain v0.41.38.0+ so
+the safety gate can read authoritative source-management provenance and dream
+can scope its cycle to the current source and unqualified code graph commands
+honor the per-worktree pin, and uses
 **native code surfaces** (`gbrain sources add`, `gbrain sync --strategy code`,
 `gbrain reindex-code`, `gbrain code-def/code-refs/code-callers/code-callees`).
 It does NOT use `gbrain import` (that path is for markdown directories).

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -44,6 +44,13 @@ It does NOT use `gbrain import` (that path is for markdown directories).
 It does NOT touch `~/.gstack/` indexing (the existing `gstack-gbrain-source-wireup`
 owns that — never double-store).
 
+Source registration is based on canonical filesystem identity. Relative,
+absolute, and symlink/junction spellings that resolve to the same directory are
+one source. A genuine path drift is repaired only through a guarded remove/add
+after the authoritative registry row and filesystem identity remain stable.
+Missing, ambiguous, rebound, or unverifiable identity stops before destructive
+source mutation.
+
 ## User-invocable
 
 When the user types `/sync-gbrain`, run this skill. Argument modes (parsed by
@@ -355,10 +362,11 @@ identifier yet.
 `.gbrain-source` file in the repo root (kubectl-style context).
 `gbrain code-def`, `code-refs`, `code-callers`, `code-callees`, `search`, and
 `query` from anywhere under this worktree route to that source by default —
-no `--source` flag needed (gbrain >= 0.41.38.0; on older gbrain the call-graph
-commands need `--source "$(cat .gbrain-source)"`). Conductor sibling worktrees
-of the same repo each have their own pin and their own indexed pages, so
-semantic results match the code on disk here.
+no `--source` flag needed. This requires gbrain >= 0.41.38.0; sync and dream
+stop before mutation on an older version. Run `/setup-gbrain` (or
+`gstack-gbrain-install`) and retry `/sync-gbrain` to upgrade. Conductor sibling
+worktrees of the same repo each have their own pin and their own indexed pages,
+so semantic results match the code on disk here.
 
 Call-graph queries (`code-callers`/`code-callees`) also need the graph to be
 built first — run `/sync-gbrain --dream` (or `--full`) if they return

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -34,7 +34,10 @@ refreshed against this repo's current state, and refreshes the agent-side
 guidance in CLAUDE.md so the coding agent knows when to prefer `gbrain`
 search over Grep.
 
-**Architecture (post-codex review):** This skill uses gbrain v0.20.0+'s
+**Architecture (post-codex review):** This skill requires gbrain v0.41.38.0+ so
+the safety gate can read authoritative source-management provenance and dream
+can scope its cycle to the current source and unqualified code graph commands
+honor the per-worktree pin, and uses
 **native code surfaces** (`gbrain sources add`, `gbrain sync --strategy code`,
 `gbrain reindex-code`, `gbrain code-def/code-refs/code-callers/code-callees`).
 It does NOT use `gbrain import` (that path is for markdown directories).

--- a/test/gbrain-detect-install.test.ts
+++ b/test/gbrain-detect-install.test.ts
@@ -203,16 +203,16 @@ describe('gstack-gbrain-install D19 PATH-shadow validation', () => {
     return binDir;
   }
 
-  test('passes when install-dir version matches `gbrain --version` on PATH', () => {
-    // Version must be >= MIN_GBRAIN_VERSION (0.20.0) floor (#1744).
-    const installDir = seedInstallDir('0.41.29');
-    const fakeBin = seedFakeGbrainBinary('0.41.29');
+  test("passes when install-dir version matches `gbrain --version` on PATH", () => {
+    // Version must be >= MIN_GBRAIN_VERSION (0.41.38.0) floor (#1744).
+    const installDir = seedInstallDir("0.41.38.0");
+    const fakeBin = seedFakeGbrainBinary("0.41.38.0");
     try {
       const r = run(INSTALL, ['--validate-only', '--install-dir', installDir], {
         env: { PATH: `${fakeBin}:${SAFE_PATH}` },
       });
       expect(r.status).toBe(0);
-      expect(r.stdout).toContain('installed gbrain 0.41.29');
+      expect(r.stdout).toContain("installed gbrain 0.41.38.0");
     } finally {
       fs.rmSync(installDir, { recursive: true, force: true });
       fs.rmSync(fakeBin, { recursive: true, force: true });
@@ -234,9 +234,32 @@ describe('gstack-gbrain-install D19 PATH-shadow validation', () => {
     }
   });
 
+  test("pins the pin-aware code-graph boundary: 0.41.37.0 fails and 0.41.38.0 passes", () => {
+    for (const [version, expectedStatus] of [
+      ["0.41.37.0", 3],
+      ["0.41.38.0", 0],
+    ] as const) {
+      const installDir = seedInstallDir(version);
+      const fakeBin = seedFakeGbrainBinary(version);
+      try {
+        const r = run(
+          INSTALL,
+          ["--validate-only", "--install-dir", installDir],
+          {
+            env: { PATH: `${fakeBin}:${SAFE_PATH}` },
+          },
+        );
+        expect(r.status).toBe(expectedStatus);
+      } finally {
+        fs.rmSync(installDir, { recursive: true, force: true });
+        fs.rmSync(fakeBin, { recursive: true, force: true });
+      }
+    }
+  });
+
   test('tolerates a leading "v" in `gbrain --version` output', () => {
-    const installDir = seedInstallDir('0.41.29');
-    const fakeBin = seedFakeGbrainBinary('v0.41.29');
+    const installDir = seedInstallDir("0.41.38.0");
+    const fakeBin = seedFakeGbrainBinary("v0.41.38.0");
     try {
       const r = run(INSTALL, ['--validate-only', '--install-dir', installDir], {
         env: { PATH: `${fakeBin}:${SAFE_PATH}` },

--- a/test/gbrain-guards.test.ts
+++ b/test/gbrain-guards.test.ts
@@ -4,17 +4,57 @@ import * as os from "os";
 import { join } from "path";
 import {
   detectAutopilot,
+  decidePathManagedDriftRemove,
   decideSourceRemove,
   decideCodeSync,
+  fetchSources,
   isInside,
   _resetCapabilityMemo,
-  type GbrainSourceRow,
 } from "../lib/gbrain-guards";
+import type { GbrainSourceRow } from "../lib/gbrain-sources";
 
 const HOME = os.homedir();
 const clonesPath = (name: string) => join(HOME, ".gbrain", "clones", name);
 
 afterEach(() => _resetCapabilityMemo());
+
+describe("fetchSources management registry", () => {
+  test("uses the public sources_list operation with env routing and no Windows-unsafe JSON argv", () => {
+    const tmp = fs.mkdtempSync(join(os.tmpdir(), "gbrain-managed-list-"));
+    const bin = join(tmp, "bin");
+    const log = join(tmp, "args.log");
+    fs.mkdirSync(bin);
+    const payload = JSON.stringify({
+      sources: [
+        {
+          id: "path-managed",
+          local_path: "/tmp/repo",
+          remote_url: null,
+          page_count: 1,
+        },
+      ],
+    });
+    const shim = join(bin, "gbrain");
+    fs.writeFileSync(
+      shim,
+      `#!/bin/sh\nprintf '%s|%s\\n' "$GBRAIN_SOURCE" "$*" > '${log}'\nprintf '%s' '${payload}'\n`,
+    );
+    fs.chmodSync(shim, 0o755);
+
+    try {
+      const rows = fetchSources({
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH || ""}`,
+      });
+      expect(rows[0]?.remote_url).toBeNull();
+      expect(fs.readFileSync(log, "utf-8").trim()).toBe(
+        "default|call sources_list",
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
 
 // ── #1734 autopilot detection (E1: affirmative multi-signal) ────────────────
 describe("detectAutopilot", () => {
@@ -92,17 +132,29 @@ describe("detectAutopilot", () => {
 // ── #1734 remove safety (E7: fail closed on user-managed without keep-storage) ─
 describe("decideSourceRemove", () => {
   const rows = (extra: GbrainSourceRow[] = []): GbrainSourceRow[] => [
-    { id: "gbrain-managed", local_path: clonesPath("repo"), config: { remote_url: "https://x/r.git" } },
-    { id: "user-managed", local_path: "/tmp/user-repo", config: { remote_url: "https://x/r.git" } },
-    { id: "path-managed", local_path: "/tmp/path-repo" }, // no remote_url
+    { id: "default", local_path: null, remote_url: null },
+    {
+      id: "gbrain-managed",
+      local_path: clonesPath("repo"),
+      remote_url: "https://x/r.git",
+    },
+    {
+      id: "user-managed",
+      local_path: "/tmp/user-repo",
+      remote_url: "https://x/r.git",
+    },
+    { id: "path-managed", local_path: "/tmp/path-repo", remote_url: null },
     ...extra,
   ];
   const fetchRows = (extra?: GbrainSourceRow[]) => () => rows(extra);
 
-  test("absent source → allow (no-op)", () => {
-    const d = decideSourceRemove("nope", process.env, { keepStorage: false, fetchRows: fetchRows() });
-    expect(d.allow).toBe(true);
-    expect(d.reason).toContain("absent");
+  test("absent active source → FAIL CLOSED because archived provenance is unknown", () => {
+    const d = decideSourceRemove("nope", process.env, {
+      keepStorage: false,
+      fetchRows: fetchRows(),
+    });
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain("archived provenance is unproven");
   });
 
   test("user-managed + no --keep-storage → FAIL CLOSED", () => {
@@ -127,6 +179,38 @@ describe("decideSourceRemove", () => {
     expect(d.allow).toBe(true);
   });
 
+  test("an empty but non-null remote_url remains URL-managed", () => {
+    const d = decideSourceRemove("empty-remote", process.env, {
+      keepStorage: false,
+      fetchRows: fetchRows([
+        {
+          id: "empty-remote",
+          local_path: "/tmp/user-repo",
+          remote_url: "",
+        },
+      ]),
+    });
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain("user-managed");
+  });
+
+  test("URL-managed rows with null or empty local_path fail closed", () => {
+    for (const local_path of [null, ""] as const) {
+      const d = decideSourceRemove("unlocatable", process.env, {
+        keepStorage: false,
+        fetchRows: fetchRows([
+          {
+            id: "unlocatable",
+            local_path,
+            remote_url: "https://x/r.git",
+          },
+        ]),
+      });
+      expect(d.allow).toBe(false);
+      expect(d.reason).toContain("not proven inside gbrain clones");
+    }
+  });
+
   test("sources unreadable → FAIL CLOSED", () => {
     const d = decideSourceRemove("user-managed", process.env, {
       keepStorage: false,
@@ -137,11 +221,75 @@ describe("decideSourceRemove", () => {
   });
 });
 
+describe("decidePathManagedDriftRemove", () => {
+  const expectedPath = String.raw`C:\repo`;
+
+  test("allows only an unchanged path-managed source snapshot", () => {
+    const decision = decidePathManagedDriftRemove(
+      "source-id",
+      expectedPath,
+      process.env,
+      {
+        keepStorage: false,
+        fetchRows: () => [
+          { id: "source-id", local_path: expectedPath, remote_url: null },
+        ],
+      },
+    );
+    expect(decision).toEqual({
+      allow: true,
+      extraArgs: [],
+      reason: "validated path-managed source",
+    });
+  });
+
+  test("refuses when the registered row changes after validation", () => {
+    const decision = decidePathManagedDriftRemove(
+      "source-id",
+      expectedPath,
+      process.env,
+      {
+        keepStorage: false,
+        fetchRows: () => [
+          {
+            id: "source-id",
+            local_path: String.raw`C:\replacement`,
+            remote_url: null,
+          },
+        ],
+      },
+    );
+    expect(decision.allow).toBe(false);
+    expect(decision.reason).toContain("changed after validation");
+  });
+
+  test("refuses URL-managed sources without resolving their untrusted path", () => {
+    const unsafe = String.raw`\\attacker.invalid\share`;
+    const decision = decidePathManagedDriftRemove(
+      "source-id",
+      unsafe,
+      process.env,
+      {
+        keepStorage: true,
+        fetchRows: () => [
+          {
+            id: "source-id",
+            local_path: unsafe,
+            remote_url: "https://example.invalid/repo.git",
+          },
+        ],
+      },
+    );
+    expect(decision.allow).toBe(false);
+    expect(decision.reason).toContain("URL-managed");
+  });
+});
+
 // ── #1734 reclone guard (E-level: require --allow-reclone for URL-managed) ───
 describe("decideCodeSync", () => {
   const rows: GbrainSourceRow[] = [
-    { id: "url-managed", local_path: "/tmp/u", config: { remote_url: "https://x/r.git" } },
-    { id: "plain", local_path: "/tmp/p" },
+    { id: "url-managed", local_path: "/tmp/u", remote_url: "https://x/r.git" },
+    { id: "plain", local_path: "/tmp/p", remote_url: null },
   ];
   const fetch = () => rows;
 
@@ -154,16 +302,40 @@ describe("decideCodeSync", () => {
   test("URL-managed + --allow-reclone → allow", () => {
     const d = decideCodeSync("url-managed", process.env, true, fetch);
     expect(d.allow).toBe(true);
+    expect(d.mayReclone).toBe(true);
   });
 
   test("no remote_url → allow", () => {
     const d = decideCodeSync("plain", process.env, false, fetch);
     expect(d.allow).toBe(true);
+    expect(d.mayReclone).toBe(false);
+    expect(d.registeredPath).toBe("/tmp/p");
   });
 
-  test("sources unreadable → fail OPEN (sync read is non-destructive)", () => {
-    const d = decideCodeSync("url-managed", process.env, false, () => { throw new Error("boom"); });
-    expect(d.allow).toBe(true);
+  test("missing source row → FAIL CLOSED", () => {
+    const d = decideCodeSync("missing", process.env, false, fetch);
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain("absent or has no readable local_path");
+  });
+
+  test("sources unreadable → FAIL CLOSED (reclone applicability is unprovable)", () => {
+    const d = decideCodeSync("url-managed", process.env, false, () => {
+      throw new Error("boom");
+    });
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain("applicability is unprovable");
+  });
+
+  test("ordinary list shape without top-level remote_url cannot authorize sync", () => {
+    const d = decideCodeSync("legacy-looking", process.env, false, () => [
+      {
+        id: "legacy-looking",
+        local_path: "/tmp/p",
+        config: { remote_url: null },
+      },
+    ]);
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain("applicability is unprovable");
   });
 });
 
@@ -185,5 +357,14 @@ describe("isInside", () => {
     fs.symlinkSync(outside, link);
     // link lives under base, but realpath resolves to `outside` → not inside base.
     expect(isInside(link, base)).toBe(false);
+  });
+
+  test("direct UNC/device-like paths fail closed before containment resolution", () => {
+    expect(
+      isInside(String.raw`\\attacker.invalid\share`, clonesPath("repo")),
+    ).toBe(false);
+    expect(isInside("//attacker.invalid/share", clonesPath("repo"))).toBe(
+      false,
+    );
   });
 });

--- a/test/gbrain-source-gitignore.test.ts
+++ b/test/gbrain-source-gitignore.test.ts
@@ -1,6 +1,6 @@
 /**
  * Unit tests for the `.gbrain-source` gitignore append done by
- * `runCodeImport` after a successful `gbrain sources attach`.
+ * `runCodeImport` after a successful local `.gbrain-source` pin.
  *
  * Covers #1384: v1.29.0.0 changelog promised the per-worktree pin would be
  * ignored in the consuming repo, but the change actually only added
@@ -8,12 +8,38 @@
  * entry, Conductor sibling worktrees commit the pin and clobber each other.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, statSync } from "fs";
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  readdirSync,
+  rmSync,
+  chmodSync,
+  statSync,
+  lstatSync,
+  symlinkSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { ensureGbrainSourceGitignored } from "../bin/gstack-gbrain-sync";
+import {
+  ensureGbrainSourceGitignored,
+  writeGbrainSourcePin,
+} from "../bin/gstack-gbrain-sync";
+
+function metadataTemps(root: string): string[] {
+  return readdirSync(root).filter((name) =>
+    name.startsWith(".gstack-metadata-"),
+  );
+}
 
 describe("ensureGbrainSourceGitignored", () => {
   let root: string;
@@ -93,4 +119,75 @@ describe("ensureGbrainSourceGitignored", () => {
       chmodSync(gitignorePath, originalMode);
     }
   });
+
+  it("refuses a .gitignore symlink without changing its target", () => {
+    const outside = join(root, "outside-ignore");
+    const gitignorePath = join(root, ".gitignore");
+    writeFileSync(outside, "keep-me\n");
+    symlinkSync(outside, gitignorePath);
+
+    expect(() => ensureGbrainSourceGitignored(root)).not.toThrow();
+
+    expect(readFileSync(outside, "utf-8")).toBe("keep-me\n");
+    expect(lstatSync(gitignorePath).isSymbolicLink()).toBe(true);
+  });
+
+  it("preserves the mode of an atomically updated .gitignore", () => {
+    const gitignorePath = join(root, ".gitignore");
+    writeFileSync(gitignorePath, "node_modules\n");
+    chmodSync(gitignorePath, 0o600);
+
+    ensureGbrainSourceGitignored(root);
+
+    expect(statSync(gitignorePath).mode & 0o777).toBe(0o600);
+    expect(readFileSync(gitignorePath, "utf-8")).toBe(
+      "node_modules\n.gbrain-source\n",
+    );
+    expect(metadataTemps(root)).toEqual([]);
+  });
+});
+
+describe("writeGbrainSourcePin", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "gstack-gbrain-pin-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("atomically replaces a pin symlink without writing through it", () => {
+    const outside = join(root, "outside-pin");
+    const pinPath = join(root, ".gbrain-source");
+    writeFileSync(outside, "do-not-change\n");
+    symlinkSync(outside, pinPath);
+
+    writeGbrainSourcePin(root, "gstack-code-safe-1234");
+
+    expect(readFileSync(outside, "utf-8")).toBe("do-not-change\n");
+    expect(lstatSync(pinPath).isFile()).toBe(true);
+    expect(readFileSync(pinPath, "utf-8")).toBe("gstack-code-safe-1234\n");
+  });
+
+  it("rejects an invalid source id before writing", () => {
+    expect(() => writeGbrainSourcePin(root, "../escape")).toThrow(
+      /invalid GBrain source id/,
+    );
+    expect(existsSync(join(root, ".gbrain-source"))).toBe(false);
+  });
+
+  it("preserves the mode of an atomically replaced regular pin", () => {
+    const pinPath = join(root, ".gbrain-source");
+    writeFileSync(pinPath, "gstack-code-old-1234\n");
+    chmodSync(pinPath, 0o600);
+
+    writeGbrainSourcePin(root, "gstack-code-new-1234");
+
+    expect(statSync(pinPath).mode & 0o777).toBe(0o600);
+    expect(readFileSync(pinPath, "utf-8")).toBe("gstack-code-new-1234\n");
+    expect(metadataTemps(root)).toEqual([]);
+  });
+
 });

--- a/test/gbrain-sources-parse.test.ts
+++ b/test/gbrain-sources-parse.test.ts
@@ -1,15 +1,18 @@
 import { describe, test, expect } from "bun:test";
-import { parseSourcesList } from "../lib/gbrain-sources";
+import {
+  parseSourcesList,
+  parseSourcesListStrict,
+} from "../lib/gbrain-sources";
 
 // #1576 hardening: `gbrain sources list --json` has shipped two shapes — a
 // wrapped `{ sources: [...] }` object (v0.20+) and a bare top-level array.
 // parseSourcesList is the single place that normalizes both, so every reader
-// (probeSource, sourcePageCount, sourceLocalPath, the #1734 remote_url audit)
+// (probeSource, sourcePageCount, sourceLocalPath)
 // agrees on the shape. These tests pin both shapes plus the garbage paths.
 describe("parseSourcesList", () => {
   const rows = [
     { id: "a", local_path: "/x", page_count: 3 },
-    { id: "b", local_path: "/y", config: { remote_url: "https://example.com/r.git" } },
+    { id: "b", local_path: "/y", remote_url: "https://example.com/r.git" },
   ];
 
   test("wrapped { sources: [...] } shape", () => {
@@ -42,8 +45,40 @@ describe("parseSourcesList", () => {
     expect(parseSourcesList(42)).toEqual([]);
   });
 
-  test("preserves config.remote_url for the #1734 audit", () => {
+  test("preserves top-level remote_url from the richer sources_list operation", () => {
     const parsed = parseSourcesList({ sources: rows });
-    expect(parsed.find((r) => r.id === "b")?.config?.remote_url).toBe("https://example.com/r.git");
+    expect(parsed.find((r) => r.id === "b")?.remote_url).toBe(
+      "https://example.com/r.git",
+    );
+  });
+});
+
+describe("parseSourcesListStrict", () => {
+  test("accepts the documented wrapped and legacy array shapes", () => {
+    const rows = [
+      { id: "default", local_path: null },
+      { id: "source-a", local_path: "/repo" },
+    ];
+    expect(parseSourcesListStrict({ sources: rows })).toEqual(rows);
+    expect(parseSourcesListStrict(rows)).toEqual(rows);
+  });
+
+  test("rejects unknown shapes instead of treating them as an absent source", () => {
+    for (const raw of [null, { pages: [] }, { sources: "oops" }, "nope", 42]) {
+      expect(() => parseSourcesListStrict(raw)).toThrow(/unknown JSON shape/);
+    }
+  });
+
+  test("rejects malformed rows before a destructive decision can use them", () => {
+    for (const raw of [
+      { sources: ["oops"] },
+      { sources: [{}] },
+      { sources: [{ id: "source-a", local_path: 42 }] },
+      { sources: [{ id: "source-a", remote_url: 42 }] },
+      { sources: [{ id: "source-a", config: [] }] },
+      { sources: [{ id: "source-a", config: { remote_url: 42 } }] },
+    ]) {
+      expect(() => parseSourcesListStrict(raw)).toThrow(/source row/);
+    }
   });
 });

--- a/test/gbrain-sources.test.ts
+++ b/test/gbrain-sources.test.ts
@@ -8,13 +8,22 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, rmSync, chmodSync } from "fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
 import { ensureSourceRegistered, probeSource, sourcePageCount } from "../lib/gbrain-sources";
 
 interface FakeGbrainSetup {
+  root: string;
   bindir: string;
   statePath: string;
   logPath: string;
@@ -36,7 +45,7 @@ interface FakeGbrainSetup {
  *   gbrain --version                                  → echo "gbrain 0.25.1"
  * Anything else exits 1.
  */
-function makeFakeGbrain(initialState: { sources: Array<{ id: string; local_path: string; federated?: boolean; page_count?: number }> }): FakeGbrainSetup {
+function makeFakeGbrain(initialState: { sources: Array<{ id: string; local_path?: string; federated?: boolean; page_count?: number }> }): FakeGbrainSetup {
   const tmp = mkdtempSync(join(tmpdir(), "gbrain-sources-test-"));
   const bindir = join(tmp, "bin");
   mkdirSync(bindir, { recursive: true });
@@ -93,6 +102,7 @@ exit 1
   const env: NodeJS.ProcessEnv = { ...process.env, PATH: `${bindir}:${process.env.PATH || ""}` };
 
   return {
+    root: tmp,
     bindir,
     statePath,
     logPath,
@@ -101,6 +111,18 @@ exit 1
       rmSync(tmp, { recursive: true, force: true });
     },
   };
+}
+
+function makeDirectory(fake: FakeGbrainSetup, name: string): string {
+  const path = join(fake.root, name);
+  mkdirSync(path, { recursive: true });
+  return path;
+}
+
+function expectNoMutation(fake: FakeGbrainSetup): void {
+  const log = readFileSync(fake.logPath, "utf-8");
+  expect(log).not.toContain("sources remove");
+  expect(log).not.toContain("sources add");
 }
 
 describe("probeSource", () => {
@@ -126,68 +148,228 @@ describe("probeSource", () => {
 describe("ensureSourceRegistered", () => {
   it("adds source when absent, returns changed=true", async () => {
     const fake = makeFakeGbrain({ sources: [] });
-    const result = await ensureSourceRegistered("gstack-code-foo", "/Users/me/repo", {
+    const repo = makeDirectory(fake, "repo");
+    const result = await ensureSourceRegistered("gstack-code-foo", repo, {
       federated: true,
       env: fake.env,
     });
     expect(result.changed).toBe(true);
     expect(result.state.status).toBe("match");
-    expect(result.state.registered_path).toBe("/Users/me/repo");
+    expect(result.state.registered_path).toBe(repo);
 
     const log = readFileSync(fake.logPath, "utf-8");
-    expect(log).toContain("sources add gstack-code-foo --path /Users/me/repo --federated");
+    expect(log).toContain(`sources add gstack-code-foo --path ${repo} --federated`);
     expect(log).not.toContain("sources remove");
     fake.cleanup();
   });
 
   it("is a no-op when source is already at the correct path, returns changed=false", async () => {
-    const fake = makeFakeGbrain({
-      sources: [{ id: "gstack-code-foo", local_path: "/Users/me/repo" }],
-    });
-    const result = await ensureSourceRegistered("gstack-code-foo", "/Users/me/repo", { env: fake.env });
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    writeFileSync(fake.statePath, JSON.stringify({
+      sources: [{ id: "gstack-code-foo", local_path: repo }],
+    }));
+    const result = await ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env });
     expect(result.changed).toBe(false);
     expect(result.state.status).toBe("match");
 
     const log = readFileSync(fake.logPath, "utf-8");
     expect(log).toContain("sources list --json");
-    expect(log).not.toContain("sources add");
-    expect(log).not.toContain("sources remove");
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("treats stored dot as the expected repository without re-registering", async () => {
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: "." }],
+    });
+    const repo = makeDirectory(fake, "repo");
+
+    const result = await ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env });
+
+    expect(result).toEqual({
+      changed: false,
+      state: { status: "match", registered_path: "." },
+    });
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("treats a symlink or junction and its real directory as the same source", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    const alias = join(fake.root, "repo-alias");
+    symlinkSync(repo, alias, process.platform === "win32" ? "junction" : "dir");
+    writeFileSync(fake.statePath, JSON.stringify({
+      sources: [{ id: "gstack-code-foo", local_path: alias }],
+    }));
+
+    const result = await ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env });
+
+    expect(result.changed).toBe(false);
+    expect(result.state).toEqual({ status: "match", registered_path: alias });
+    expectNoMutation(fake);
     fake.cleanup();
   });
 
   it("recreates source when path differs (gbrain has no `sources update`), returns changed=true", async () => {
-    const fake = makeFakeGbrain({
-      sources: [{ id: "gstack-code-foo", local_path: "/old/path" }],
-    });
-    const result = await ensureSourceRegistered("gstack-code-foo", "/new/path", {
+    const fake = makeFakeGbrain({ sources: [] });
+    const oldPath = makeDirectory(fake, "old-path");
+    const newPath = makeDirectory(fake, "new-path");
+    writeFileSync(fake.statePath, JSON.stringify({
+      sources: [{ id: "gstack-code-foo", local_path: oldPath }],
+    }));
+    const result = await ensureSourceRegistered("gstack-code-foo", newPath, {
       federated: true,
       env: fake.env,
     });
     expect(result.changed).toBe(true);
     expect(result.state.status).toBe("match");
-    expect(result.state.registered_path).toBe("/new/path");
+    expect(result.state.registered_path).toBe(newPath);
 
     const log = readFileSync(fake.logPath, "utf-8");
     expect(log).toContain("sources remove gstack-code-foo --yes");
-    expect(log).toContain("sources add gstack-code-foo --path /new/path --federated");
+    expect(log).toContain(`sources add gstack-code-foo --path ${newPath} --federated`);
+    expect(log.indexOf("sources remove")).toBeLessThan(log.indexOf("sources add"));
     fake.cleanup();
   });
 
   it("when reregister_on_drift=false and source is at different path, returns changed=false", async () => {
-    const fake = makeFakeGbrain({
-      sources: [{ id: "gstack-code-foo", local_path: "/old/path" }],
-    });
-    const result = await ensureSourceRegistered("gstack-code-foo", "/new/path", {
+    const fake = makeFakeGbrain({ sources: [] });
+    const oldPath = makeDirectory(fake, "old-path");
+    const newPath = makeDirectory(fake, "new-path");
+    writeFileSync(fake.statePath, JSON.stringify({
+      sources: [{ id: "gstack-code-foo", local_path: oldPath }],
+    }));
+    const result = await ensureSourceRegistered("gstack-code-foo", newPath, {
       reregister_on_drift: false,
       env: fake.env,
     });
     expect(result.changed).toBe(false);
     expect(result.state.status).toBe("drift");
-    expect(result.state.registered_path).toBe("/old/path");
+    expect(result.state.registered_path).toBe(oldPath);
 
-    const log = readFileSync(fake.logPath, "utf-8");
-    expect(log).not.toContain("sources remove");
-    expect(log).not.toContain("sources add");
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects a missing expected directory before adding an absent source", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const missing = join(fake.root, "missing-repo");
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", missing, { env: fake.env }),
+    ).rejects.toThrow(/expected source path.*source registration unchanged.*rerun \/sync-gbrain/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects a non-directory expected path before adding an absent source", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const file = join(fake.root, "repo.txt");
+    writeFileSync(file, "not a directory");
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", file, { env: fake.env }),
+    ).rejects.toThrow(/expected source path.*not a directory.*source registration unchanged/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("names the stored path when the expected path is invalid and leaves registration unchanged", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const registered = makeDirectory(fake, "registered-repo");
+    const missingExpected = join(fake.root, "missing-expected-repo");
+    writeFileSync(fake.statePath, JSON.stringify({
+      sources: [{ id: "gstack-code-foo", local_path: registered }],
+    }));
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", missingExpected, { env: fake.env }),
+    ).rejects.toThrow(
+      new RegExp(`expected source path.*${registered}.*${missingExpected}.*source registration unchanged`),
+    );
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects a missing registered directory before remove or add", async () => {
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: "/missing/registered/repo" }],
+    });
+    const repo = makeDirectory(fake, "repo");
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+    ).rejects.toThrow(/registered source path.*source registration unchanged.*sources list --json.*rerun \/sync-gbrain/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects an empty registered path before remove or add", async () => {
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: "" }],
+    });
+    const repo = makeDirectory(fake, "repo");
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+    ).rejects.toThrow(/registered source path.*is missing or empty.*source registration unchanged/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects a missing registered path before remove or add", async () => {
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo" }],
+    });
+    const repo = makeDirectory(fake, "repo");
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+    ).rejects.toThrow(/registered source path.*expected root.*missing or empty.*source registration unchanged/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects a registered regular file before remove or add", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    const file = join(fake.root, "registered.txt");
+    writeFileSync(file, "not a directory");
+    writeFileSync(fake.statePath, JSON.stringify({
+      sources: [{ id: "gstack-code-foo", local_path: file }],
+    }));
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+    ).rejects.toThrow(/registered source path.*not a directory.*source registration unchanged/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects a broken registered symlink before remove or add", async () => {
+    if (process.platform === "win32") return;
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    const broken = join(fake.root, "broken-alias");
+    symlinkSync(join(fake.root, "missing-target"), broken, "dir");
+    writeFileSync(fake.statePath, JSON.stringify({
+      sources: [{ id: "gstack-code-foo", local_path: broken }],
+    }));
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+    ).rejects.toThrow(/registered source path.*source registration unchanged/);
+
+    expectNoMutation(fake);
     fake.cleanup();
   });
 });

--- a/test/gbrain-sources.test.ts
+++ b/test/gbrain-sources.test.ts
@@ -7,13 +7,18 @@
  * invocations. The same trick `test/gstack-gbrain-source-wireup.test.ts` uses.
  */
 
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, spyOn } from "bun:test";
+import * as childProcess from "child_process";
+import { spawnSync } from "child_process";
 import {
   chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
+  renameSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "fs";
@@ -21,10 +26,14 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 import {
+  bindRegisteredSourcePath,
+  canonicalSourceDirectory,
+  canonicalSourceDirectoryPath,
   ensureSourceRegistered,
   probeSource,
-  sameCanonicalPath,
+  registeredSourceMatchesDirectory,
   sourcePageCount,
+  type DirectoryFsOps,
 } from "../lib/gbrain-sources";
 
 interface FakeGbrainSetup {
@@ -71,6 +80,10 @@ case "$1 $2" in
     exit 0
     ;;
   "sources add")
+    if [ "\${FAKE_GBRAIN_FAIL_ADD:-}" = "1" ]; then
+      echo "simulated add failure" >&2
+      exit 9
+    fi
     ID="$3"
     shift 3
     PATH_VAL=""
@@ -85,12 +98,18 @@ case "$1 $2" in
     NEW=$(jq --arg id "$ID" --arg path "$PATH_VAL" --argjson fed "$FED" \
       '.sources += [{id: $id, local_path: $path, federated: $fed, page_count: 0}]' "${statePath}")
     echo "$NEW" > "${statePath}"
+    if [ "\${FAKE_GBRAIN_MALFORM_AFTER_ADD:-}" = "1" ]; then
+      echo '{"pages":[]}' > "${statePath}"
+    fi
     exit 0
     ;;
   "sources remove")
     ID="$3"
     NEW=$(jq --arg id "$ID" '.sources = (.sources | map(select(.id != $id)))' "${statePath}")
     echo "$NEW" > "${statePath}"
+    if [ "\${FAKE_GBRAIN_MALFORM_AFTER_REMOVE:-}" = "1" ]; then
+      echo '{"pages":[]}' > "${statePath}"
+    fi
     exit 0
     ;;
 esac
@@ -130,6 +149,55 @@ function expectNoMutation(fake: FakeGbrainSetup): void {
   expect(log).not.toContain("sources add");
 }
 
+function readLog(fake: FakeGbrainSetup): string[] {
+  return readFileSync(fake.logPath, "utf-8").trim().split("\n").filter(Boolean);
+}
+
+function readMutationLog(fake: FakeGbrainSetup): string[] {
+  return readLog(fake).filter((line) => /^sources (?:add|remove)\b/.test(line));
+}
+
+function fakeGuardedRemove(
+  fake: FakeGbrainSetup,
+): (id: string, registeredPath: string, env?: NodeJS.ProcessEnv) => void {
+  return (id, _registeredPath, env) => {
+    const result = spawnSync(
+      "gbrain",
+      ["sources", "remove", id, "--confirm-destructive"],
+      { encoding: "utf-8", env: env ?? fake.env },
+    );
+    if (result.status !== 0) {
+      throw new Error(
+        `guarded test remove failed: ${result.stderr || result.stdout}`,
+      );
+    }
+  };
+}
+
+function fakeWindowsFsOps(
+  options: {
+    links?: Record<string, string>;
+    canonical?: Record<string, string>;
+    onRealpath?: (path: string) => void;
+  } = {},
+): DirectoryFsOps {
+  const links = options.links ?? {};
+  const canonical = options.canonical ?? {};
+  return {
+    lstat: (path) => ({ isSymbolicLink: () => Object.hasOwn(links, path) }),
+    readlink: (path) => links[path],
+    realpath: (path) => {
+      options.onRealpath?.(path);
+      return canonical[path] ?? path;
+    },
+    stat: (path) => ({
+      dev: 1n,
+      ino: BigInt([...path].reduce((sum, char) => sum + char.charCodeAt(0), 1)),
+      isDirectory: () => true,
+    }),
+  };
+}
+
 describe("probeSource", () => {
   it("returns absent when source id is not in the list", () => {
     const fake = makeFakeGbrain({ sources: [{ id: "other-source", local_path: "/x" }] });
@@ -148,9 +216,36 @@ describe("probeSource", () => {
     expect(state.registered_path).toBe("/Users/me/repo");
     fake.cleanup();
   });
+
+  it("accepts an unrelated default source with null local_path", () => {
+    const fake = makeFakeGbrain({
+      sources: [
+        { id: "default-source", local_path: null as unknown as string },
+        { id: "gstack-code-foo", local_path: "/Users/me/repo" },
+      ],
+    });
+    const state = probeSource("gstack-code-foo", fake.env);
+    expect(state).toEqual({
+      status: "match",
+      registered_path: "/Users/me/repo",
+    });
+    fake.cleanup();
+  });
 });
 
 describe("ensureSourceRegistered", () => {
+  it("fails closed on a malformed registry shape without mutation", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    writeFileSync(fake.statePath, JSON.stringify({ pages: [] }));
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+    ).rejects.toThrow(/unknown JSON shape/);
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
   it("adds source when absent, returns changed=true", async () => {
     const fake = makeFakeGbrain({ sources: [] });
     const repo = makeDirectory(fake, "repo");
@@ -158,13 +253,73 @@ describe("ensureSourceRegistered", () => {
       federated: true,
       env: fake.env,
     });
+    const canonicalRepo = realpathSync(repo);
     expect(result.changed).toBe(true);
     expect(result.state.status).toBe("match");
-    expect(result.state.registered_path).toBe(repo);
+    expect(result.state.registered_path).toBe(canonicalRepo);
 
     const log = readFileSync(fake.logPath, "utf-8");
-    expect(log).toContain(`sources add gstack-code-foo --path ${repo} --federated`);
+    expect(log).toContain(
+      `sources add gstack-code-foo --path ${canonicalRepo} --federated`,
+    );
     expect(log).not.toContain("sources remove");
+    fake.cleanup();
+  });
+
+  it("persists the validated canonical directory when the expected path is relative", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    const previousCwd = process.cwd();
+
+    try {
+      process.chdir(fake.root);
+      const result = await ensureSourceRegistered("gstack-code-foo", "repo", {
+        env: fake.env,
+      });
+      expect(result).toEqual({
+        changed: true,
+        state: { status: "match", registered_path: realpathSync(repo) },
+      });
+      expect(readMutationLog(fake)).toEqual([
+        `sources add gstack-code-foo --path ${realpathSync(repo)}`,
+      ]);
+    } finally {
+      process.chdir(previousCwd);
+      fake.cleanup();
+    }
+  });
+
+  it("binds a drift repair to the validated symlink target", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const oldPath = makeDirectory(fake, "old-path");
+    const target = makeDirectory(fake, "new-path");
+    const alias = join(fake.root, "new-path-alias");
+    symlinkSync(
+      target,
+      alias,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    writeFileSync(
+      fake.statePath,
+      JSON.stringify({
+        sources: [{ id: "gstack-code-foo", local_path: oldPath }],
+      }),
+    );
+
+    const result = await ensureSourceRegistered("gstack-code-foo", alias, {
+      env: fake.env,
+      removeSource: fakeGuardedRemove(fake),
+    });
+    const canonicalTarget = realpathSync(target);
+
+    expect(result.state).toEqual({
+      status: "match",
+      registered_path: canonicalTarget,
+    });
+    expect(readMutationLog(fake)).toEqual([
+      "sources remove gstack-code-foo --confirm-destructive",
+      `sources add gstack-code-foo --path ${canonicalTarget}`,
+    ]);
     fake.cleanup();
   });
 
@@ -237,6 +392,295 @@ describe("ensureSourceRegistered", () => {
     fake.cleanup();
   });
 
+  it("fails closed on a POSIX backslash filename this Bun runtime cannot canonicalize", async () => {
+    if (process.platform === "win32") return;
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, String.raw`foo\bar`);
+    writeFileSync(
+      fake.statePath,
+      JSON.stringify({
+        sources: [{ id: "gstack-code-foo", local_path: repo }],
+      }),
+    );
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+    ).rejects.toThrow(
+      /POSIX backslash filename component.*cannot canonicalize safely/,
+    );
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("accepts a common relative symlink target whose parent traversal is leading", async () => {
+    if (process.platform === "win32") return;
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    const aliases = makeDirectory(fake, "aliases");
+    const alias = join(aliases, "repo");
+    symlinkSync("../repo", alias, "dir");
+    writeFileSync(
+      fake.statePath,
+      JSON.stringify({
+        sources: [{ id: "gstack-code-foo", local_path: alias }],
+      }),
+    );
+
+    const result = await ensureSourceRegistered("gstack-code-foo", repo, {
+      env: fake.env,
+    });
+
+    expect(result.changed).toBe(false);
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects a registered path after more than 40 real symbolic-link hops", async () => {
+    if (process.platform === "win32") return;
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    const links = Array.from({ length: 41 }, (_, index) =>
+      join(fake.root, `hop-${index}`),
+    );
+
+    try {
+      for (let index = 0; index < links.length - 1; index += 1) {
+        symlinkSync(`hop-${index + 1}`, links[index], "dir");
+      }
+      symlinkSync(repo, links.at(-1)!, "dir");
+      writeFileSync(
+        fake.statePath,
+        JSON.stringify({
+          sources: [{ id: "gstack-code-foo", local_path: links[0] }],
+        }),
+      );
+
+      await expect(
+        ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+      ).rejects.toThrow(/exceeds 40 symbolic-link hops/);
+      expectNoMutation(fake);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it("rejects a real symbolic-link cycle before mutation", async () => {
+    if (process.platform === "win32") return;
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    const first = join(fake.root, "cycle-a");
+    const second = join(fake.root, "cycle-b");
+
+    try {
+      symlinkSync("cycle-b", first, "dir");
+      symlinkSync("cycle-a", second, "dir");
+      writeFileSync(
+        fake.statePath,
+        JSON.stringify({
+          sources: [{ id: "gstack-code-foo", local_path: first }],
+        }),
+      );
+
+      await expect(
+        ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+      ).rejects.toThrow(/contains a symbolic-link cycle/);
+      expectNoMutation(fake);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it("accepts a local Windows junction only after a no-follow link inspection", async () => {
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: String.raw`C:\alias` }],
+    });
+    const expected = String.raw`C:\repo`;
+    const alias = String.raw`C:\alias`;
+    const fsOps = fakeWindowsFsOps({
+      links: { [alias]: String.raw`\\?\C:\repo` },
+      canonical: { [alias]: expected },
+    });
+
+    const result = await ensureSourceRegistered("gstack-code-foo", expected, {
+      env: fake.env,
+      platform: "win32",
+      fsOps,
+    });
+
+    expect(result.changed).toBe(false);
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("does not conflate case-distinct Windows link targets into a false cycle", async () => {
+    const expected = String.raw`C:\Repo`;
+    const alias = String.raw`C:\Alias`;
+    const upperTarget = String.raw`C:\Foo\B`;
+    const lowerTarget = String.raw`C:\foo\b`;
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: alias }],
+    });
+    const fsOps = fakeWindowsFsOps({
+      links: {
+        [alias]: upperTarget,
+        [upperTarget]: lowerTarget,
+      },
+      canonical: { [lowerTarget]: expected },
+    });
+
+    const result = await ensureSourceRegistered("gstack-code-foo", expected, {
+      env: fake.env,
+      platform: "win32",
+      fsOps,
+    });
+
+    expect(result.changed).toBe(false);
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects a Windows junction to UNC before realpath follows it", async () => {
+    const alias = String.raw`C:\repo\alias`;
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: alias }],
+    });
+    let realpathCalls = 0;
+    const fsOps = fakeWindowsFsOps({
+      links: { [alias]: String.raw`\\attacker.invalid\share` },
+      onRealpath: () => {
+        realpathCalls += 1;
+      },
+    });
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", String.raw`C:\repo`, {
+        env: fake.env,
+        platform: "win32",
+        fsOps,
+      }),
+    ).rejects.toThrow(
+      /link target.*remote or device path namespace.*before filesystem access/,
+    );
+
+    expect(realpathCalls).toBe(1); // trusted expected root only
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects a nested link/.. target before it can hide another link", async () => {
+    const alias = String.raw`C:\Repo\alias`;
+    const hiddenLink = String.raw`C:\Repo\link`;
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: alias }],
+    });
+    let hiddenLinkInspections = 0;
+    const base = fakeWindowsFsOps({
+      links: {
+        [alias]: String.raw`link\..`,
+        [hiddenLink]: String.raw`\\attacker.invalid\share`,
+      },
+    });
+    const fsOps: DirectoryFsOps = {
+      ...base,
+      lstat: (path) => {
+        if (path === hiddenLink) hiddenLinkInspections += 1;
+        return base.lstat(path);
+      },
+    };
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", String.raw`C:\Repo`, {
+        env: fake.env,
+        platform: "win32",
+        fsOps,
+      }),
+    ).rejects.toThrow(
+      /link target.*parent traversal after a path component.*before filesystem access/,
+    );
+
+    expect(hiddenLinkInspections).toBe(0);
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects an untrusted Windows path on another drive before filesystem access", async () => {
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: String.raw`Z:\repo` }],
+    });
+    let lstatCalls = 0;
+    const base = fakeWindowsFsOps();
+    const fsOps: DirectoryFsOps = {
+      ...base,
+      lstat: (path) => {
+        lstatCalls += 1;
+        return base.lstat(path);
+      },
+    };
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", String.raw`C:\repo`, {
+        env: fake.env,
+        platform: "win32",
+        fsOps,
+      }),
+    ).rejects.toThrow(/different filesystem root.*before filesystem access/);
+
+    expect(lstatCalls).toBe(0);
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("preserves an exact Windows no-op source under a path with spaces", async () => {
+    const repo = String.raw`C:\Users\Jane Doe\repo`;
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: repo }],
+    });
+
+    const result = await ensureSourceRegistered("gstack-code-foo", repo, {
+      env: fake.env,
+      platform: "win32",
+      fsOps: fakeWindowsFsOps(),
+    });
+
+    expect(result.changed).toBe(false);
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("uses filesystem identity for paths that differ only by case", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const upper = makeDirectory(fake, "CaseRepo");
+    const lower = makeDirectory(fake, "caserepo");
+    writeFileSync(
+      fake.statePath,
+      JSON.stringify({
+        sources: [{ id: "gstack-code-foo", local_path: upper }],
+      }),
+    );
+
+    const upperStat = statSync(upper, { bigint: true });
+    const lowerStat = statSync(lower, { bigint: true });
+    const sameIdentity =
+      upperStat.ino !== 0n && lowerStat.ino !== 0n
+        ? upperStat.dev === lowerStat.dev && upperStat.ino === lowerStat.ino
+        : realpathSync(upper) === realpathSync(lower);
+    const result = await ensureSourceRegistered("gstack-code-foo", lower, {
+      env: fake.env,
+      removeSource: fakeGuardedRemove(fake),
+    });
+
+    expect(result.changed).toBe(!sameIdentity);
+    if (sameIdentity) {
+      expectNoMutation(fake);
+    } else {
+      expect(readMutationLog(fake)).toEqual([
+        "sources remove gstack-code-foo --confirm-destructive",
+        `sources add gstack-code-foo --path ${realpathSync(lower)}`,
+      ]);
+    }
+    fake.cleanup();
+  });
+
   it("recreates source when path differs (gbrain has no `sources update`), returns changed=true", async () => {
     const fake = makeFakeGbrain({ sources: [] });
     const oldPath = makeDirectory(fake, "old-path");
@@ -247,15 +691,200 @@ describe("ensureSourceRegistered", () => {
     const result = await ensureSourceRegistered("gstack-code-foo", newPath, {
       federated: true,
       env: fake.env,
+      removeSource: fakeGuardedRemove(fake),
     });
+    const canonicalNewPath = realpathSync(newPath);
     expect(result.changed).toBe(true);
     expect(result.state.status).toBe("match");
-    expect(result.state.registered_path).toBe(newPath);
+    expect(result.state.registered_path).toBe(canonicalNewPath);
 
     const log = readFileSync(fake.logPath, "utf-8");
-    expect(log).toContain("sources remove gstack-code-foo --yes");
-    expect(log).toContain(`sources add gstack-code-foo --path ${newPath} --federated`);
-    expect(log.indexOf("sources remove")).toBeLessThan(log.indexOf("sources add"));
+    expect(log).toContain(
+      "sources remove gstack-code-foo --confirm-destructive",
+    );
+    expect(log).toContain(
+      `sources add gstack-code-foo --path ${canonicalNewPath} --federated`,
+    );
+    expect(log.indexOf("sources remove")).toBeLessThan(
+      log.indexOf("sources add"),
+    );
+    fake.cleanup();
+  });
+
+  it("refuses true drift before removal when no guarded policy is provided", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const oldPath = makeDirectory(fake, "old-path");
+    const newPath = makeDirectory(fake, "new-path");
+    writeFileSync(
+      fake.statePath,
+      JSON.stringify({
+        sources: [{ id: "gstack-code-foo", local_path: oldPath }],
+      }),
+    );
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", newPath, { env: fake.env }),
+    ).rejects.toThrow(
+      /no guarded removal policy was provided.*registration unchanged/,
+    );
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("reports a guarded-remove refusal without starting the replacement add", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const oldPath = makeDirectory(fake, "old-path");
+    const newPath = makeDirectory(fake, "new-path");
+    writeFileSync(
+      fake.statePath,
+      JSON.stringify({
+        sources: [{ id: "gstack-code-foo", local_path: oldPath }],
+      }),
+    );
+
+    try {
+      await expect(
+        ensureSourceRegistered("gstack-code-foo", newPath, {
+          env: fake.env,
+          removeSource: () => {
+            throw new Error("owner guard refused removal");
+          },
+        }),
+      ).rejects.toThrow(
+        /guarded path-drift remove.*owner guard refused removal.*state may have changed/,
+      );
+
+      expect(readMutationLog(fake)).toEqual([]);
+      expect(JSON.parse(readFileSync(fake.statePath, "utf-8"))).toEqual({
+        sources: [{ id: "gstack-code-foo", local_path: oldPath }],
+      });
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it("fails closed when a guarded remove returns but the source row remains", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const oldPath = makeDirectory(fake, "old-path");
+    const newPath = makeDirectory(fake, "new-path");
+    const phases: string[] = [];
+    let removeCalls = 0;
+    writeFileSync(
+      fake.statePath,
+      JSON.stringify({
+        sources: [{ id: "gstack-code-foo", local_path: oldPath }],
+      }),
+    );
+
+    try {
+      await expect(
+        ensureSourceRegistered("gstack-code-foo", newPath, {
+          env: fake.env,
+          removeSource: () => {
+            removeCalls += 1;
+          },
+          beforeMutation: (phase) => phases.push(phase),
+        }),
+      ).rejects.toThrow(/returned without removing the validated source/);
+
+      expect(removeCalls).toBe(1);
+      expect(phases).toEqual(["before-remove"]);
+      expect(readMutationLog(fake)).toEqual([]);
+      expect(JSON.parse(readFileSync(fake.statePath, "utf-8"))).toEqual({
+        sources: [{ id: "gstack-code-foo", local_path: oldPath }],
+      });
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it("reports partial state when add fails after guarded drift removal", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const oldPath = makeDirectory(fake, "old-path");
+    const newPath = makeDirectory(fake, "new-path");
+    writeFileSync(
+      fake.statePath,
+      JSON.stringify({
+        sources: [{ id: "gstack-code-foo", local_path: oldPath }],
+      }),
+    );
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", newPath, {
+        env: { ...fake.env, FAKE_GBRAIN_FAIL_ADD: "1" },
+        removeSource: fakeGuardedRemove(fake),
+      }),
+    ).rejects.toThrow(
+      /previous drifted registration was already removed.*absent or ambiguous/,
+    );
+
+    expect(readMutationLog(fake)).toEqual([
+      "sources remove gstack-code-foo --confirm-destructive",
+      `sources add gstack-code-foo --path ${realpathSync(newPath)}`,
+    ]);
+    fake.cleanup();
+  });
+
+  it("reports a spawn exception before an absent source add can start", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    const spawn = spyOn(childProcess, "spawnSync").mockImplementation(() => {
+      throw new Error("simulated spawn exception");
+    });
+
+    try {
+      await expect(
+        ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+      ).rejects.toThrow(
+        /failed to start: simulated spawn exception.*may not have been registered/i,
+      );
+      expectNoMutation(fake);
+    } finally {
+      spawn.mockRestore();
+      fake.cleanup();
+    }
+  });
+
+  it("reports that the old row was removed when the post-remove registry read is malformed", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    const old = makeDirectory(fake, "old");
+    writeFileSync(
+      fake.statePath,
+      JSON.stringify({
+        sources: [{ id: "gstack-code-foo", local_path: old }],
+      }),
+    );
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, {
+        env: { ...fake.env, FAKE_GBRAIN_MALFORM_AFTER_REMOVE: "1" },
+        removeSource: fakeGuardedRemove(fake),
+      }),
+    ).rejects.toThrow(
+      /old registration was already removed.*could not be confirmed.*absent or ambiguous/,
+    );
+    expect(readMutationLog(fake)).toEqual([
+      "sources remove gstack-code-foo --confirm-destructive",
+    ]);
+    fake.cleanup();
+  });
+
+  it("reports an unconfirmed persisted state when add succeeds but the registry read is malformed", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, {
+        env: { ...fake.env, FAKE_GBRAIN_MALFORM_AFTER_ADD: "1" },
+      }),
+    ).rejects.toThrow(
+      /returned success.*persisted state could not be confirmed.*ambiguous/,
+    );
+    expect(readMutationLog(fake)).toEqual([
+      `sources add gstack-code-foo --path ${realpathSync(repo)}`,
+    ]);
     fake.cleanup();
   });
 
@@ -275,6 +904,146 @@ describe("ensureSourceRegistered", () => {
     expect(result.state.registered_path).toBe(oldPath);
 
     expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("fails before mutation when a Windows add path needs unsafe shell transport", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = String.raw`C:\Users\Jane Doe\repo`;
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, {
+        env: fake.env,
+        platform: "win32",
+        fsOps: fakeWindowsFsOps(),
+      }),
+    ).rejects.toThrow(/unsafe for the current Windows GBrain shell transport/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("revalidates directory identity immediately before destructive drift repair", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const oldPath = makeDirectory(fake, "old-path");
+    const expected = makeDirectory(fake, "expected");
+    const moved = join(fake.root, "expected-before-replacement");
+    writeFileSync(
+      fake.statePath,
+      JSON.stringify({
+        sources: [{ id: "gstack-code-foo", local_path: oldPath }],
+      }),
+    );
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", expected, {
+        env: fake.env,
+        removeSource: fakeGuardedRemove(fake),
+        beforeMutation: (phase) => {
+          if (phase !== "before-remove") return;
+          renameSync(expected, moved);
+          mkdirSync(expected);
+        },
+      }),
+    ).rejects.toThrow(/changed after validation/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects a caller-captured expected identity after the path is replaced", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    const captured = canonicalSourceDirectory(repo);
+    const moved = join(fake.root, "repo-before-replacement");
+    renameSync(repo, moved);
+    mkdirSync(repo);
+
+    try {
+      await expect(
+        ensureSourceRegistered("gstack-code-foo", repo, {
+          env: fake.env,
+          expected_identity: captured,
+        }),
+      ).rejects.toThrow(
+        /changed after caller validation: directory identity changed.*registration unchanged/,
+      );
+      expectNoMutation(fake);
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it("fails visibly when the validated directory changes after add", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const expected = makeDirectory(fake, "expected");
+    const canonicalExpected = realpathSync(expected);
+    const moved = join(fake.root, "expected-before-replacement");
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", expected, {
+        env: fake.env,
+        beforeMutation: (phase) => {
+          if (phase !== "after-add") return;
+          renameSync(expected, moved);
+          mkdirSync(expected);
+        },
+      }),
+    ).rejects.toThrow(/changed after validation/);
+
+    expect(readMutationLog(fake)).toEqual([
+      `sources add gstack-code-foo --path ${canonicalExpected}`,
+    ]);
+    fake.cleanup();
+  });
+
+  it("fails closed when the filesystem cannot provide a stable identity token", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = String.raw`C:\repo`;
+    let device = 1n;
+    const base = fakeWindowsFsOps();
+    const fsOps: DirectoryFsOps = {
+      ...base,
+      stat: () => ({
+        dev: device,
+        ino: 0n,
+        isDirectory: () => true,
+      }),
+    };
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, {
+        env: fake.env,
+        platform: "win32",
+        fsOps,
+        beforeMutation: (phase) => {
+          if (phase === "before-add") device = 2n;
+        },
+      }),
+    ).rejects.toThrow(/stable directory identity is unavailable/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("fails visibly when a successful add does not persist the validated source row", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const expected = makeDirectory(fake, "expected");
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", expected, {
+        env: fake.env,
+        beforeMutation: (phase) => {
+          if (phase === "after-add") {
+            writeFileSync(fake.statePath, JSON.stringify({ sources: [] }));
+          }
+        },
+      }),
+    ).rejects.toThrow(/did not persist the validated path/);
+
+    expect(readMutationLog(fake)).toEqual([
+      `sources add gstack-code-foo --path ${realpathSync(expected)}`,
+    ]);
     fake.cleanup();
   });
 
@@ -373,7 +1142,7 @@ describe("ensureSourceRegistered", () => {
 
     await expect(
       ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
-    ).rejects.toThrow(/registered source path.*"42".*missing or empty.*source registration unchanged/);
+    ).rejects.toThrow(/source row with a non-string local_path/);
 
     expectNoMutation(fake);
     fake.cleanup();
@@ -413,12 +1182,221 @@ describe("ensureSourceRegistered", () => {
     expectNoMutation(fake);
     fake.cleanup();
   });
+
+  it("rejects a stored relative path that escapes the expected repository", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    makeDirectory(fake, "outside");
+    writeFileSync(
+      fake.statePath,
+      JSON.stringify({
+        sources: [{ id: "gstack-code-foo", local_path: "../outside" }],
+      }),
+    );
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+    ).rejects.toThrow(/parent traversal.*before filesystem access/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects a Windows case-variant sibling escape before filesystem access", async () => {
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: String.raw`..\repo` }],
+    });
+    let lstatCalls = 0;
+    const base = fakeWindowsFsOps();
+    const fsOps: DirectoryFsOps = {
+      ...base,
+      lstat: (path) => {
+        lstatCalls += 1;
+        return base.lstat(path);
+      },
+    };
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", String.raw`C:\Repo`, {
+        env: fake.env,
+        platform: "win32",
+        fsOps,
+      }),
+    ).rejects.toThrow(/parent traversal.*before filesystem access/);
+
+    expect(lstatCalls).toBe(0);
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects POSIX link/.. before collapsing the link target", async () => {
+    if (process.platform === "win32") return;
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: "link/.." }],
+    });
+    const repo = makeDirectory(fake, "repo");
+    const outside = makeDirectory(fake, "outside");
+    symlinkSync(outside, join(repo, "link"), "dir");
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+    ).rejects.toThrow(/link\/\.\..*parent traversal.*before filesystem access/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects Windows junction/.. before inspecting a UNC target", async () => {
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: String.raw`link\..` }],
+    });
+    let lstatCalls = 0;
+    let registeredRealpathCalls = 0;
+    const base = fakeWindowsFsOps({
+      links: {
+        [String.raw`C:\Repo\link`]: String.raw`\\attacker.invalid\share`,
+      },
+      onRealpath: (path) => {
+        if (path !== String.raw`C:\Repo`) registeredRealpathCalls += 1;
+      },
+    });
+    const fsOps: DirectoryFsOps = {
+      ...base,
+      lstat: (path) => {
+        lstatCalls += 1;
+        return base.lstat(path);
+      },
+    };
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", String.raw`C:\Repo`, {
+        env: fake.env,
+        platform: "win32",
+        fsOps,
+      }),
+    ).rejects.toThrow(/parent traversal.*before filesystem access/);
+
+    expect(lstatCalls).toBe(0);
+    expect(registeredRealpathCalls).toBe(0);
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
+  it("rejects unsafe source ids before invoking GBrain", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+
+    await expect(
+      ensureSourceRegistered("bad&id", repo, { env: fake.env }),
+    ).rejects.toThrow(/source id.*unsafe or invalid/);
+
+    expect(readLog(fake)).toEqual([]);
+    fake.cleanup();
+  });
 });
 
-describe("sameCanonicalPath", () => {
-  it("folds case on Windows but preserves case sensitivity on POSIX", () => {
-    expect(sameCanonicalPath("C:\\Repo", "c:\\repo", "win32")).toBe(true);
-    expect(sameCanonicalPath("/Repo", "/repo", "linux")).toBe(false);
+describe("canonicalSourceDirectoryPath", () => {
+  it("rejects UNC and device namespaces before filesystem access", () => {
+    for (const unsafe of [
+      String.raw`\\attacker.invalid\share`,
+      String.raw`\\?\C:\repo`,
+      String.raw`\\.\PhysicalDrive0`,
+      "//attacker.invalid/share",
+    ]) {
+      expect(() => canonicalSourceDirectoryPath(unsafe, "win32")).toThrow(
+        /remote or device path namespace.*before filesystem access/,
+      );
+    }
+  });
+
+  it("rejects ambiguous Windows-relative paths before filesystem access", () => {
+    for (const unsafe of [String.raw`C:repo`, String.raw`\repo`]) {
+      expect(() => canonicalSourceDirectoryPath(unsafe, "win32")).toThrow(
+        /drive-relative or root-relative.*before filesystem access/,
+      );
+    }
+  });
+
+  it("allows a Windows path with spaces when it is used as an OS-level cwd", () => {
+    const repo = String.raw`C:\Users\Jane Doe\repo`;
+    expect(
+      canonicalSourceDirectoryPath(repo, "win32", fakeWindowsFsOps()),
+    ).toBe(repo);
+  });
+});
+
+describe("bindRegisteredSourcePath", () => {
+  it("uses an explicit canonical override for an equivalent POSIX symlink", () => {
+    if (process.platform === "win32") return;
+    const root = mkdtempSync(join(tmpdir(), "gbrain-binding-"));
+    const repo = join(root, "repo");
+    const alias = join(root, "alias");
+    mkdirSync(repo);
+    symlinkSync(repo, alias, "dir");
+    try {
+      const expected = canonicalSourceDirectory(repo);
+      expect(bindRegisteredSourcePath(alias, expected)).toEqual({
+        canonicalPath: realpathSync(repo),
+        useExplicitPath: true,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for an unsafe Windows absolute alias", () => {
+    const expectedPath = String.raw`C:\Users\Jane Doe\repo`;
+    const alias = String.raw`C:\Users\Jane Doe\alias`;
+    const fsOps = fakeWindowsFsOps({ canonical: { [alias]: expectedPath } });
+    const expected = canonicalSourceDirectory(expectedPath, "win32", fsOps);
+
+    expect(() =>
+      bindRegisteredSourcePath(alias, expected, "win32", fsOps),
+    ).toThrow(
+      /alias.*unsafe for the current Windows GBrain shell transport.*rebindable alias/,
+    );
+  });
+
+  it("uses cwd for a stored dot under an unsafe Windows canonical path", () => {
+    const expectedPath = String.raw`C:\Users\Jane Doe\repo`;
+    const fsOps = fakeWindowsFsOps({
+      canonical: { [expectedPath]: expectedPath },
+    });
+    const expected = canonicalSourceDirectory(expectedPath, "win32", fsOps);
+
+    expect(bindRegisteredSourcePath(".", expected, "win32", fsOps)).toEqual({
+      canonicalPath: expectedPath,
+      useExplicitPath: false,
+    });
+  });
+
+  it("compares Windows case variants by filesystem identity", () => {
+    const expectedPath = String.raw`C:\Repo`;
+    const storedPath = String.raw`C:\repo`;
+    const fsOps = fakeWindowsFsOps({
+      canonical: { [storedPath]: expectedPath },
+    });
+    const expected = canonicalSourceDirectory(expectedPath, "win32", fsOps);
+
+    expect(
+      registeredSourceMatchesDirectory(storedPath, expected, "win32", fsOps),
+    ).toBe(true);
+  });
+
+  it("can require stable identity before a legacy source-id mutation", () => {
+    const repo = String.raw`C:\repo`;
+    const fsOps: DirectoryFsOps = {
+      ...fakeWindowsFsOps(),
+      stat: () => ({ dev: 1n, ino: 0n, isDirectory: () => true }),
+    };
+    const expected = canonicalSourceDirectory(repo, "win32", fsOps);
+
+    expect(
+      registeredSourceMatchesDirectory(repo, expected, "win32", fsOps),
+    ).toBe(true);
+    expect(
+      registeredSourceMatchesDirectory(repo, expected, "win32", fsOps, true),
+    ).toBe(false);
   });
 });
 

--- a/test/gbrain-sources.test.ts
+++ b/test/gbrain-sources.test.ts
@@ -322,10 +322,12 @@ describe("ensureSourceRegistered", () => {
   });
 
   it("rejects a missing registered directory before remove or add", async () => {
-    const fake = makeFakeGbrain({
-      sources: [{ id: "gstack-code-foo", local_path: "/missing/registered/repo" }],
-    });
+    const fake = makeFakeGbrain({ sources: [] });
     const repo = makeDirectory(fake, "repo");
+    const missingRegistered = join(fake.root, "missing-registered-repo");
+    writeFileSync(fake.statePath, JSON.stringify({
+      sources: [{ id: "gstack-code-foo", local_path: missingRegistered }],
+    }));
 
     await expect(
       ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),

--- a/test/gbrain-sources.test.ts
+++ b/test/gbrain-sources.test.ts
@@ -20,7 +20,12 @@ import {
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { ensureSourceRegistered, probeSource, sourcePageCount } from "../lib/gbrain-sources";
+import {
+  ensureSourceRegistered,
+  probeSource,
+  sameCanonicalPath,
+  sourcePageCount,
+} from "../lib/gbrain-sources";
 
 interface FakeGbrainSetup {
   root: string;
@@ -177,6 +182,26 @@ describe("ensureSourceRegistered", () => {
     expect(log).toContain("sources list --json");
     expectNoMutation(fake);
     fake.cleanup();
+  });
+
+  it("resolves a relative expected path from the caller's working directory", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const repo = makeDirectory(fake, "repo");
+    const previousCwd = process.cwd();
+    writeFileSync(fake.statePath, JSON.stringify({
+      sources: [{ id: "gstack-code-foo", local_path: repo }],
+    }));
+
+    try {
+      process.chdir(fake.root);
+      const result = await ensureSourceRegistered("gstack-code-foo", "repo", { env: fake.env });
+      expect(result.changed).toBe(false);
+      expect(result.state).toEqual({ status: "match", registered_path: repo });
+      expectNoMutation(fake);
+    } finally {
+      process.chdir(previousCwd);
+      fake.cleanup();
+    }
   });
 
   it("treats stored dot as the expected repository without re-registering", async () => {
@@ -338,6 +363,20 @@ describe("ensureSourceRegistered", () => {
     fake.cleanup();
   });
 
+  it("rejects a non-string registered path before remove or add", async () => {
+    const fake = makeFakeGbrain({
+      sources: [{ id: "gstack-code-foo", local_path: 42 as unknown as string }],
+    });
+    const repo = makeDirectory(fake, "repo");
+
+    await expect(
+      ensureSourceRegistered("gstack-code-foo", repo, { env: fake.env }),
+    ).rejects.toThrow(/registered source path.*"42".*missing or empty.*source registration unchanged/);
+
+    expectNoMutation(fake);
+    fake.cleanup();
+  });
+
   it("rejects a registered regular file before remove or add", async () => {
     const fake = makeFakeGbrain({ sources: [] });
     const repo = makeDirectory(fake, "repo");
@@ -371,6 +410,13 @@ describe("ensureSourceRegistered", () => {
 
     expectNoMutation(fake);
     fake.cleanup();
+  });
+});
+
+describe("sameCanonicalPath", () => {
+  it("folds case on Windows but preserves case sensitivity on POSIX", () => {
+    expect(sameCanonicalPath("C:\\Repo", "c:\\repo", "win32")).toBe(true);
+    expect(sameCanonicalPath("/Repo", "/repo", "linux")).toBe(false);
   });
 });
 

--- a/test/gbrain-sync-skip.test.ts
+++ b/test/gbrain-sync-skip.test.ts
@@ -85,7 +85,7 @@ function makeEnv(opts: {
             }
   exit 1`;
     const fake = `#!/bin/sh
-if [ "$1" = "--version" ]; then echo "gbrain 0.33.1.0"; exit 0; fi
+if [ "$1" = "--version" ]; then echo "gbrain 0.41.38.0"; exit 0; fi
 if [ "$1 $2" = "sources list" ]; then
 ${sourcesBlock}
 fi

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -12,12 +12,16 @@ import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, mkdirSync
 import { tmpdir } from "os";
 import { join } from "path";
 import { spawnSync } from "child_process";
+import { canonicalSourceDirectory } from "../lib/gbrain-sources";
 
 import {
   derivePathOnlyHashLegacyId,
   planHostnameFoldMigration,
+  removePlannedHostnameLegacySource,
+  safePathDriftRemove,
+  safeSourcesRemove,
   sourceLocalPath,
-  _resetGbrainSupportsRenameCache,
+  checkGbrainVersion,
 } from "../bin/gstack-gbrain-sync";
 
 const SCRIPT = join(import.meta.dir, "..", "bin", "gstack-gbrain-sync.ts");
@@ -40,6 +44,85 @@ function runScript(args: string[], env: Record<string, string> = {}): { stdout: 
 }
 
 describe("gstack-gbrain-sync CLI", () => {
+  it("enforces the pin-aware GBrain release boundary", () => {
+    expect(checkGbrainVersion("gbrain 0.41.37.0")).toMatchObject({
+      ok: false,
+      detected: "0.41.37.0",
+    });
+    expect(checkGbrainVersion("gbrain v0.41.38.0")).toEqual({
+      ok: true,
+      detected: "0.41.38.0",
+      reason: "supported",
+    });
+    expect(checkGbrainVersion("gbrain 0.42.0")).toMatchObject({
+      ok: true,
+      detected: "0.42.0",
+    });
+    expect(checkGbrainVersion("not-a-version")).toMatchObject({
+      ok: false,
+      detected: null,
+    });
+  });
+
+  it("rejects an installed pre-floor GBrain before any sync mutation", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    const bindir = join(home, "bin");
+    const mutationMarker = join(home, "unexpected-gbrain-command");
+    mkdirSync(gstackHome, { recursive: true });
+    mkdirSync(bindir, { recursive: true });
+    writeFileSync(
+      join(bindir, "gbrain"),
+      `#!/bin/sh\nif [ "$1" = "--version" ]; then echo "gbrain 0.41.37.0"; exit 0; fi\n: > '${mutationMarker}'\nexit 0\n`,
+    );
+    chmodSync(join(bindir, "gbrain"), 0o755);
+
+    try {
+      const r = runScript(["--incremental", "--code-only", "--quiet"], {
+        HOME: home,
+        GSTACK_HOME: gstackHome,
+        PATH: `${bindir}:${process.env.PATH || ""}`,
+      });
+      expect(r.exitCode).toBe(3);
+      expect(r.stderr).toContain("below the required 0.41.38.0");
+      expect(existsSync(mutationMarker)).toBe(false);
+      expect(existsSync(join(gstackHome, ".sync-gbrain.lock"))).toBe(false);
+      expect(existsSync(join(gstackHome, ".gbrain-sync-state.json"))).toBe(
+        false,
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a present GBrain with unverifiable version output before mutation", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    const bindir = join(home, "bin");
+    const mutationMarker = join(home, "unexpected-gbrain-command");
+    mkdirSync(gstackHome, { recursive: true });
+    mkdirSync(bindir, { recursive: true });
+    writeFileSync(
+      join(bindir, "gbrain"),
+      `#!/bin/sh\nif [ "$1" = "--version" ]; then echo "gbrain development-build"; exit 0; fi\n: > '${mutationMarker}'\nexit 0\n`,
+    );
+    chmodSync(join(bindir, "gbrain"), 0o755);
+
+    try {
+      const r = runScript(["--incremental", "--code-only", "--quiet"], {
+        HOME: home,
+        GSTACK_HOME: gstackHome,
+        PATH: `${bindir}:${process.env.PATH || ""}`,
+      });
+      expect(r.exitCode).toBe(3);
+      expect(r.stderr).toContain("could not parse `gbrain --version`");
+      expect(existsSync(mutationMarker)).toBe(false);
+      expect(existsSync(join(gstackHome, ".sync-gbrain.lock"))).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("--help exits 0 with usage text", () => {
     const r = runScript(["--help"]);
     expect(r.exitCode).toBe(0);
@@ -60,6 +143,54 @@ describe("gstack-gbrain-sync CLI", () => {
 
     expect(source).not.toContain('command -v gbrain');
     expect(source).toContain("localEngineStatus");
+    expect(source).toMatch(/syncArgs\.push\("--repo", canonicalRoot\)/);
+    expect(source).toMatch(
+      /spawnGbrain\(syncArgs, \{[\s\S]*?cwd: canonicalRoot/,
+    );
+    expect(source).toMatch(
+      /dreamArgs\.push\("--dir", dreamBinding\.canonicalPath\)/,
+    );
+    expect(source).toMatch(/spawnGbrain\(dreamArgs, \{[\s\S]*?cwd: dreamCwd/);
+
+    const rootCapture = source.indexOf(
+      "validatedRoot = canonicalSourceDirectory(root)",
+    );
+    const stableRootProof = source.indexOf(
+      '"repository before sync preflight"',
+      rootCapture,
+    );
+    const engineProbe = source.indexOf(
+      "const localStatus = localEngineStatus",
+      stableRootProof,
+    );
+    const legacyCleanup = source.indexOf(
+      "safeSourcesRemove(legacyId",
+      engineProbe,
+    );
+    expect(rootCapture).toBeGreaterThan(-1);
+    expect(stableRootProof).toBeGreaterThan(rootCapture);
+    expect(engineProbe).toBeGreaterThan(stableRootProof);
+    expect(legacyCleanup).toBeGreaterThan(engineProbe);
+
+    const finalBindingCheck = source.indexOf(
+      'validateCurrentSourceBinding("sync")',
+    );
+    const finalRootCheck = source.indexOf(
+      'revalidateRoot("sync spawn")',
+      finalBindingCheck,
+    );
+    const finalAutopilotCheck = source.indexOf(
+      "const apAtSyncSpawn = detectAutopilot",
+      finalRootCheck,
+    );
+    const syncSpawn = source.indexOf(
+      "walkResult = spawnGbrain(syncArgs",
+      finalAutopilotCheck,
+    );
+    expect(finalBindingCheck).toBeGreaterThan(-1);
+    expect(finalRootCheck).toBeGreaterThan(finalBindingCheck);
+    expect(finalAutopilotCheck).toBeGreaterThan(finalRootCheck);
+    expect(syncSpawn).toBeGreaterThan(finalAutopilotCheck);
   });
 
   it("--dry-run with --code-only reports the code import preview only", () => {
@@ -486,7 +617,7 @@ describe("gstack-gbrain-sync CLI", () => {
     rmSync(home, { recursive: true, force: true });
   });
 
-  it("dry-run preview includes legacy-source removal + attach (post-codex-review hardening)", () => {
+  it("dry-run preview includes legacy-source removal + safe pin (post-codex-review hardening)", () => {
     // Codex adversarial flagged: pre-pathhash `gstack-code-<slug>` sources stay
     // orphaned forever after the new pathhash id ships. Dry-run preview must
     // surface the legacy cleanup so the user knows it'll happen.
@@ -511,18 +642,20 @@ describe("gstack-gbrain-sync CLI", () => {
     // string lists what it would do, but the legacy removal is gated on the
     // legacy id being registered (which we can't probe in a sandboxed test
     // without a real gbrain CLI). Instead, assert the preview still includes
-    // the new flow (sources add + sync + attach) at minimum.
+    // the new flow (sources add + sync + safe local pin) at minimum.
     expect(r.stdout).toMatch(/gbrain sources add gstack-code-/);
-    expect(r.stdout).toMatch(/gbrain sync --strategy code --source gstack-code-/);
-    expect(r.stdout).toMatch(/gbrain sources attach gstack-code-/);
+    expect(r.stdout).toMatch(
+      /gbrain sync --strategy code --source gstack-code-/,
+    );
+    expect(r.stdout).toMatch(/pin \.gbrain-source to gstack-code-/);
 
     rmSync(repo, { recursive: true, force: true });
     rmSync(home, { recursive: true, force: true });
   });
 
-  it("dry-run preview includes the `sources attach` step (kubectl-style CWD pin)", () => {
+  it("dry-run preview includes the symlink-safe local CWD pin", () => {
     // Post-spike redesign: after sources add + sync, /sync-gbrain calls
-    // `gbrain sources attach <id>` so subsequent gbrain code-def / code-refs
+    // a `.gbrain-source` pin so subsequent gbrain code-def / code-refs
     // calls from anywhere under the worktree route to this source by default.
     // The dry-run preview must surface that step so the user knows what we
     // would do.
@@ -540,10 +673,133 @@ describe("gstack-gbrain-sync CLI", () => {
       env: { ...process.env, HOME: home, GSTACK_HOME: gstackHome },
     });
     expect(r.status).toBe(0);
-    expect(r.stdout).toMatch(/gbrain sources attach gstack-code-/);
+    expect(r.stdout).toMatch(/pin \.gbrain-source to gstack-code-/);
 
     rmSync(repo, { recursive: true, force: true });
     rmSync(home, { recursive: true, force: true });
+  });
+});
+
+describe("guarded remove source-id sink", () => {
+  it("rejects unsafe ids before spawning pgrep or gbrain", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "gstack-remove-id-"));
+    const marker = join(tmp, "spawned");
+    for (const name of ["pgrep", "gbrain"]) {
+      const shim = join(tmp, name);
+      writeFileSync(shim, `#!/bin/sh\ntouch '${marker}'\nexit 1\n`);
+      chmodSync(shim, 0o755);
+    }
+    const env = { ...process.env, PATH: tmp };
+
+    try {
+      const general = safeSourcesRemove("bad&id", env);
+      const drift = safePathDriftRemove("../bad", "/tmp/repo", env);
+      expect(general.skipped).toBe(true);
+      expect(general.reason).toContain("unsafe source id");
+      expect(drift.skipped).toBe(true);
+      expect(drift.reason).toContain("unsafe source id");
+      expect(existsSync(marker)).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("rechecks autopilot after policy I/O and refuses a late start", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "gstack-remove-pilot-race-"));
+    const count = join(tmp, "pgrep-count");
+    const removed = join(tmp, "removed");
+    writeFileSync(count, "0\n");
+    const pgrep = join(tmp, "pgrep");
+    writeFileSync(
+      pgrep,
+      `#!/bin/sh\nN=$(/bin/cat '${count}')\nN=$((N + 1))\nprintf '%s\\n' "$N" > '${count}'\nif [ "$N" -ge 2 ]; then printf '%s\\n' 'gbrain autopilot'; exit 0; fi\nexit 1\n`,
+    );
+    chmodSync(pgrep, 0o755);
+    const gbrain = join(tmp, "gbrain");
+    const registry = JSON.stringify({
+      sources: [
+        { id: "safe-source", local_path: "/tmp/repo", remote_url: null },
+      ],
+    });
+    writeFileSync(
+      gbrain,
+      `#!/bin/sh\ncase "$*" in\n  "--version") printf '%s\\n' 'gbrain 9.9.9-race' ;;\n  "call sources_list") printf '%s' '${registry}' ;;\n  "sources remove safe-source --confirm-destructive"*) : > '${removed}' ;;\n  *) exit 0 ;;\nesac\n`,
+    );
+    chmodSync(gbrain, 0o755);
+    const env = {
+      ...process.env,
+      PATH: tmp,
+      GBRAIN_HOME: join(tmp, "home"),
+    };
+
+    try {
+      const general = safeSourcesRemove("safe-source", env);
+      expect(general.skipped).toBe(true);
+      expect(general.reason).toContain("became active");
+      expect(existsSync(removed)).toBe(false);
+
+      writeFileSync(count, "0\n");
+      const drift = safePathDriftRemove("safe-source", "/tmp/repo", env);
+      expect(drift.skipped).toBe(true);
+      expect(drift.reason).toContain("became active");
+      expect(existsSync(removed)).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("executes both guarded remove paths with exact argv for a proven non-empty path", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "gstack-remove-success-"));
+    const repo = join(tmp, "repo");
+    const callLog = join(tmp, "gbrain-calls.log");
+    mkdirSync(repo);
+    const pgrep = join(tmp, "pgrep");
+    writeFileSync(pgrep, "#!/bin/sh\nexit 1\n");
+    chmodSync(pgrep, 0o755);
+    const registry = JSON.stringify({
+      sources: [
+        { id: "general-source", local_path: repo, remote_url: null },
+        { id: "drift-source", local_path: repo, remote_url: null },
+      ],
+    });
+    makeShim(tmp, {
+      "--version": { stdout: "gbrain 99.100.101-remove-success" },
+      "sources remove --help": { stdout: "usage: sources remove" },
+      "--help": { stdout: "usage: gbrain" },
+      "call sources_list": { stdout: registry },
+      "sources remove general-source --confirm-destructive": {},
+      "sources remove drift-source --confirm-destructive": {},
+    });
+    const env = {
+      ...envWithBindir(tmp),
+      GBRAIN_HOME: join(tmp, "gbrain-home"),
+      GBRAIN_SHIM_LOG: callLog,
+    };
+
+    try {
+      expect(repo.length).toBeGreaterThan(0);
+      expect(safeSourcesRemove("general-source", env)).toMatchObject({
+        removed: true,
+        skipped: false,
+      });
+      expect(safePathDriftRemove("drift-source", repo, env)).toMatchObject({
+        removed: true,
+        skipped: false,
+      });
+      const mutationCalls = readFileSync(callLog, "utf-8")
+        .trim()
+        .split("\n")
+        .filter((line) =>
+          line === "sources remove general-source --confirm-destructive" ||
+          line === "sources remove drift-source --confirm-destructive"
+        );
+      expect(mutationCalls).toEqual([
+        "sources remove general-source --confirm-destructive",
+        "sources remove drift-source --confirm-destructive",
+      ]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
 
@@ -574,7 +830,7 @@ function makeShim(bindir: string, responses: Record<string, { stdout?: string; s
     return `  "${key}") printf '%s' '${stdout}'; printf '%s' '${stderr}' >&2; exit ${exit} ;;`;
   }).join("\n");
   // Match on the full argument string, joined with literal spaces.
-  const script = `#!/bin/sh\nARGS="$*"\ncase "$ARGS" in\n${cases}\n  *) echo "shim: no match for [$ARGS]" >&2; exit 1 ;;\nesac\n`;
+  const script = `#!/bin/sh\nARGS="$*"\nif [ -n "$GBRAIN_SHIM_LOG" ]; then printf '%s\\n' "$ARGS" >> "$GBRAIN_SHIM_LOG"; fi\ncase "$ARGS" in\n${cases}\n  *) echo "shim: no match for [$ARGS]" >&2; exit 1 ;;\nesac\n`;
   writeFileSync(shim, script);
   chmodSync(shim, 0o755);
   return shim;
@@ -655,16 +911,306 @@ function envWithBindir(bindir: string): NodeJS.ProcessEnv {
   return { ...process.env, PATH: `${bindir}:${process.env.PATH || ""}` };
 }
 
+function previewCodeSourceId(
+  repo: string,
+  env: NodeJS.ProcessEnv,
+): string {
+  const preview = spawnSync(
+    "bun",
+    [SCRIPT, "--dry-run", "--code-only", "--quiet"],
+    { cwd: repo, env, encoding: "utf-8", timeout: 60000 },
+  );
+  expect(preview.status).toBe(0);
+  const sourceId = (preview.stdout || "").match(
+    /gbrain sources add (\S+)/,
+  )?.[1];
+  if (!sourceId) throw new Error("dry-run did not report a code source id");
+  return sourceId;
+}
+
+describe("executable source-bound orchestration", () => {
+  it("registers, rereads, syncs with the canonical repo, pins, counts pages, then removes the exact legacy row", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    const gbrainHome = join(home, ".gbrain");
+    const bindir = join(home, "bin");
+    const repo = join(home, "repo");
+    const callLog = join(home, "gbrain-calls.jsonl");
+    const registered = join(home, "registered");
+    const synced = join(home, "synced");
+    const pageCountObserved = join(home, "page-count-observed");
+    const legacyRemoved = join(home, "legacy-removed");
+    mkdirSync(gstackHome, { recursive: true });
+    mkdirSync(gbrainHome, { recursive: true });
+    mkdirSync(bindir, { recursive: true });
+    mkdirSync(repo, { recursive: true });
+    writeFileSync(join(gbrainHome, "config.json"), '{"engine":"postgres"}\n');
+    spawnSync("git", ["init", "--quiet", "-b", "main"], { cwd: repo });
+    spawnSync(
+      "git",
+      ["remote", "add", "origin", "https://github.com/example/orchestration.git"],
+      { cwd: repo },
+    );
+    const env = {
+      ...process.env,
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      GBRAIN_HOME: gbrainHome,
+      GSTACK_HOSTNAME: "orchestration-test-host",
+      PATH: `${bindir}:${process.env.PATH || ""}`,
+    };
+    const sourceId = previewCodeSourceId(repo, env);
+    const reportedRoot = spawnSync(
+      "git",
+      ["rev-parse", "--show-toplevel"],
+      { cwd: repo, encoding: "utf-8" },
+    ).stdout.trim();
+    const canonicalRoot = canonicalSourceDirectory(reportedRoot).canonicalPath;
+    const previousCwd = process.cwd();
+    let legacyId: string;
+    try {
+      process.chdir(repo);
+      legacyId = derivePathOnlyHashLegacyId(reportedRoot);
+    } finally {
+      process.chdir(previousCwd);
+    }
+
+    const gbrain = join(bindir, "gbrain");
+    writeFileSync(
+      gbrain,
+      `#!/usr/bin/env bun
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "fs";
+const callLog = ${JSON.stringify(callLog)};
+const registered = ${JSON.stringify(registered)};
+const synced = ${JSON.stringify(synced)};
+const pageCountObserved = ${JSON.stringify(pageCountObserved)};
+const legacyRemoved = ${JSON.stringify(legacyRemoved)};
+const sourceId = ${JSON.stringify(sourceId)};
+const legacyId = ${JSON.stringify(legacyId)};
+const root = ${JSON.stringify(canonicalRoot)};
+const pinPath = root + "/.gbrain-source";
+const args = process.argv.slice(2);
+const key = args.join(" ");
+const pin = existsSync(pinPath) ? readFileSync(pinPath, "utf-8").trim() : null;
+appendFileSync(callLog, JSON.stringify({ args, cwd: process.cwd(), noGitignore: process.env.GBRAIN_NO_GITIGNORE || "", pin }) + "\\n");
+const same = (expected) => JSON.stringify(args) === JSON.stringify(expected);
+const list = () => {
+  const sources = [];
+  if (!existsSync(legacyRemoved)) {
+    sources.push({ id: legacyId, local_path: root, remote_url: null, page_count: 9 });
+  }
+  if (existsSync(registered)) {
+    sources.push({ id: sourceId, local_path: root, remote_url: null, page_count: existsSync(synced) ? 4 : 0 });
+  }
+  return JSON.stringify({ sources });
+};
+if (same(["--version"])) {
+  console.log("gbrain 0.41.38.0");
+} else if (same(["sources", "list", "--json"])) {
+  if (existsSync(synced) && pin === sourceId) writeFileSync(pageCountObserved, "yes");
+  process.stdout.write(list());
+} else if (same(["call", "sources_list"])) {
+  process.stdout.write(list());
+} else if (same(["sources", "remove", "--help"])) {
+  process.stdout.write("usage: sources remove");
+} else if (same(["--help"])) {
+  process.stdout.write("usage: gbrain");
+} else if (same(["sources", "add", sourceId, "--path", root, "--federated"])) {
+  writeFileSync(registered, "yes");
+} else if (same(["sync", "--strategy", "code", "--source", sourceId, "--repo", root])) {
+  if (process.cwd() !== root || process.env.GBRAIN_NO_GITIGNORE !== "1" || !existsSync(registered)) process.exit(41);
+  writeFileSync(synced, "yes");
+} else if (same(["sources", "remove", legacyId, "--confirm-destructive"])) {
+  if (!existsSync(pageCountObserved) || pin !== sourceId) process.exit(42);
+  writeFileSync(legacyRemoved, "yes");
+} else {
+  console.error("unexpected gbrain argv: " + key);
+  process.exit(90);
+}
+`,
+    );
+    chmodSync(gbrain, 0o755);
+    writeFileSync(join(bindir, "pgrep"), "#!/bin/sh\nexit 1\n");
+    chmodSync(join(bindir, "pgrep"), 0o755);
+
+    try {
+      const result = spawnSync(
+        "bun",
+        [SCRIPT, "--incremental", "--code-only", "--quiet"],
+        { cwd: repo, env, encoding: "utf-8", timeout: 60000 },
+      );
+      expect({
+        status: result.status,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      }).toMatchObject({ status: 0 });
+      expect(readFileSync(join(canonicalRoot, ".gbrain-source"), "utf-8")).toBe(
+        `${sourceId}\n`,
+      );
+      expect(existsSync(pageCountObserved)).toBe(true);
+      expect(existsSync(legacyRemoved)).toBe(true);
+
+      const calls = readFileSync(callLog, "utf-8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as {
+          args: string[];
+          cwd: string;
+          noGitignore: string;
+          pin: string | null;
+        });
+      const addArgs = [
+        "sources", "add", sourceId, "--path", canonicalRoot, "--federated",
+      ];
+      const syncArgs = [
+        "sync", "--strategy", "code", "--source", sourceId, "--repo", canonicalRoot,
+      ];
+      const removeArgs = [
+        "sources", "remove", legacyId, "--confirm-destructive",
+      ];
+      const addIndex = calls.findIndex((call) =>
+        JSON.stringify(call.args) === JSON.stringify(addArgs)
+      );
+      const syncIndex = calls.findIndex((call) =>
+        JSON.stringify(call.args) === JSON.stringify(syncArgs)
+      );
+      const pageCountIndex = calls.findIndex(
+        (call, index) =>
+          index > syncIndex &&
+          JSON.stringify(call.args) ===
+            JSON.stringify(["sources", "list", "--json"]) &&
+          call.pin === sourceId,
+      );
+      const removeIndex = calls.findIndex((call) =>
+        JSON.stringify(call.args) === JSON.stringify(removeArgs)
+      );
+      expect(addIndex).toBeGreaterThan(-1);
+      expect(syncIndex).toBeGreaterThan(addIndex);
+      expect(
+        calls.slice(addIndex + 1, syncIndex).some((call) =>
+          JSON.stringify(call.args) === JSON.stringify(["call", "sources_list"])
+        ),
+      ).toBe(true);
+      expect(calls[syncIndex]).toMatchObject({
+        cwd: canonicalRoot,
+        noGitignore: "1",
+      });
+      expect(pageCountIndex).toBeGreaterThan(syncIndex);
+      expect(removeIndex).toBeGreaterThan(pageCountIndex);
+      expect(
+        calls.filter((call) => call.args[0] === "sources" && call.args[1] === "remove" && call.args[2] !== "--help")
+          .map((call) => call.args),
+      ).toEqual([removeArgs]);
+      expect(readFileSync(join(canonicalRoot, ".gitignore"), "utf-8")).toContain(
+        ".gbrain-source",
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("runs source-bound dream in the canonical repo and preserves its non-zero failure", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    const gbrainHome = join(home, ".gbrain");
+    const bindir = join(home, "bin");
+    const repo = join(home, "repo");
+    const callLog = join(home, "dream-calls.jsonl");
+    mkdirSync(gstackHome, { recursive: true });
+    mkdirSync(gbrainHome, { recursive: true });
+    mkdirSync(bindir, { recursive: true });
+    mkdirSync(repo, { recursive: true });
+    writeFileSync(join(gbrainHome, "config.json"), '{"engine":"postgres"}\n');
+    spawnSync("git", ["init", "--quiet", "-b", "main"], { cwd: repo });
+    spawnSync(
+      "git",
+      ["remote", "add", "origin", "https://github.com/example/dream.git"],
+      { cwd: repo },
+    );
+    const env = {
+      ...process.env,
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      GBRAIN_HOME: gbrainHome,
+      GSTACK_HOSTNAME: "dream-test-host",
+      PATH: `${bindir}:${process.env.PATH || ""}`,
+    };
+    const sourceId = previewCodeSourceId(repo, env);
+    const reportedRoot = spawnSync(
+      "git",
+      ["rev-parse", "--show-toplevel"],
+      { cwd: repo, encoding: "utf-8" },
+    ).stdout.trim();
+    const canonicalRoot = canonicalSourceDirectory(reportedRoot).canonicalPath;
+    const dreamArgs = [
+      "dream", "--source", sourceId, "--dir", canonicalRoot,
+    ];
+    const gbrain = join(bindir, "gbrain");
+    writeFileSync(
+      gbrain,
+      `#!/usr/bin/env bun
+import { appendFileSync } from "fs";
+const callLog = ${JSON.stringify(callLog)};
+const sourceId = ${JSON.stringify(sourceId)};
+const root = ${JSON.stringify(canonicalRoot)};
+const args = process.argv.slice(2);
+appendFileSync(callLog, JSON.stringify({ args, cwd: process.cwd() }) + "\\n");
+const same = (expected) => JSON.stringify(args) === JSON.stringify(expected);
+const list = JSON.stringify({ sources: [{ id: sourceId, local_path: root, remote_url: null, page_count: 4 }] });
+if (same(["--version"])) console.log("gbrain 0.41.38.0");
+else if (same(["sources", "list", "--json"]) || same(["call", "sources_list"])) process.stdout.write(list);
+else if (same(["dream", "--source", sourceId, "--dir", root])) process.exit(17);
+else process.exit(90);
+`,
+    );
+    chmodSync(gbrain, 0o755);
+
+    try {
+      const result = spawnSync(
+        "bun",
+        [
+          SCRIPT,
+          "--incremental",
+          "--no-code",
+          "--no-memory",
+          "--no-brain-sync",
+          "--dream",
+          "--quiet",
+        ],
+        { cwd: repo, env, encoding: "utf-8", timeout: 60000 },
+      );
+      expect(result.status).toBe(1);
+      const calls = readFileSync(callLog, "utf-8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { args: string[]; cwd: string });
+      const dreamCalls = calls.filter((call) =>
+        JSON.stringify(call.args) === JSON.stringify(dreamArgs)
+      );
+      expect(dreamCalls).toEqual([{ args: dreamArgs, cwd: canonicalRoot }]);
+      const state = JSON.parse(
+        readFileSync(join(gstackHome, ".gbrain-sync-state.json"), "utf-8"),
+      ) as { last_stages?: Array<{ name: string; ok: boolean; summary: string }> };
+      expect(state.last_stages?.find((stage) => stage.name === "dream"))
+        .toMatchObject({
+          ok: false,
+          summary: "gbrain dream exited 17",
+        });
+      expect(existsSync(join(gstackHome, ".dream-in-progress"))).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("planHostnameFoldMigration", () => {
   let bindir: string;
 
   beforeEach(() => {
     bindir = mkdtempSync(join(tmpdir(), "gstack-mig-plan-bin-"));
-    _resetGbrainSupportsRenameCache();
   });
   afterEach(() => {
     rmSync(bindir, { recursive: true, force: true });
-    _resetGbrainSupportsRenameCache();
   });
 
   it("returns ids-match when legacy == new (degenerate case)", () => {
@@ -695,43 +1241,136 @@ describe("planHostnameFoldMigration", () => {
     }
   });
 
-  it("returns renamed when rename is supported and exits 0", () => {
+  it("treats stored dot as the same legacy source by canonical identity", () => {
+    const repo = mkdtempSync(join(tmpdir(), "gstack-mig-dot-"));
+    makeShim(bindir, {
+      "sources list --json": {
+        stdout: JSON.stringify([{ id: "legacy-id", local_path: "." }]),
+      },
+    });
+
+    try {
+      const expected = canonicalSourceDirectory(repo);
+      const result = planHostnameFoldMigration(
+        repo,
+        "new-id",
+        "legacy-id",
+        envWithBindir(bindir),
+        { expected },
+      );
+      expect(result).toEqual({
+        kind: "pending-cleanup",
+        oldId: "legacy-id",
+        oldPath: ".",
+      });
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("never mutates with rename even when a CLI advertises it", () => {
+    const callLog = join(bindir, "calls.log");
     makeShim(bindir, {
       "sources list --json": {
         stdout: JSON.stringify([{ id: "legacy-id", local_path: "/repo/here" }]),
       },
       "sources rename --help": {
-        stdout: "Usage: gbrain sources rename <old> <new>\n",
+        exit: 99,
+        stderr: "rename capability probe must not run",
       },
-      "sources rename legacy-id new-id": { exit: 0 },
+      "sources rename legacy-id new-id": {
+        exit: 99,
+        stderr: "rename mutation must not run",
+      },
     });
-    const result = planHostnameFoldMigration("/repo/here", "new-id", "legacy-id", envWithBindir(bindir));
-    expect(result).toEqual({ kind: "renamed", oldId: "legacy-id", newId: "new-id" });
+    const result = planHostnameFoldMigration(
+      "/repo/here",
+      "new-id",
+      "legacy-id",
+      { ...envWithBindir(bindir), GBRAIN_SHIM_LOG: callLog },
+    );
+    expect(result).toEqual({
+      kind: "pending-cleanup",
+      oldId: "legacy-id",
+      oldPath: "/repo/here",
+    });
+    expect(readFileSync(callLog, "utf-8").trim()).toBe("sources list --json");
   });
 
-  it("returns pending-cleanup when rename is unsupported (current gbrain 0.35.0.0)", () => {
+  it("returns pending-cleanup for a matching legacy source", () => {
     makeShim(bindir, {
       "sources list --json": {
         stdout: JSON.stringify([{ id: "legacy-id", local_path: "/repo/here" }]),
       },
-      // No `sources rename --help` match → shim falls into the catch-all and exits 1.
     });
     const result = planHostnameFoldMigration("/repo/here", "new-id", "legacy-id", envWithBindir(bindir));
-    expect(result).toEqual({ kind: "pending-cleanup", oldId: "legacy-id" });
+    expect(result).toEqual({
+      kind: "pending-cleanup",
+      oldId: "legacy-id",
+      oldPath: "/repo/here",
+    });
   });
 
-  it("returns pending-cleanup when rename is supported but the rename call itself fails", () => {
+  it("refuses cleanup when the planned legacy id is rebound during sync", () => {
+    const callLog = join(bindir, "calls.log");
     makeShim(bindir, {
       "sources list --json": {
-        stdout: JSON.stringify([{ id: "legacy-id", local_path: "/repo/here" }]),
+        stdout: JSON.stringify([
+          { id: "legacy-id", local_path: "/repo/original" },
+        ]),
       },
-      "sources rename --help": {
-        stdout: "Usage: gbrain sources rename <old> <new>\n",
-      },
-      "sources rename legacy-id new-id": { exit: 1, stderr: "rename failed: db locked" },
     });
-    const result = planHostnameFoldMigration("/repo/here", "new-id", "legacy-id", envWithBindir(bindir));
-    expect(result).toEqual({ kind: "pending-cleanup", oldId: "legacy-id" });
+    const env = {
+      ...envWithBindir(bindir),
+      GBRAIN_SHIM_LOG: callLog,
+      GBRAIN_HOME: join(bindir, "gbrain-home"),
+    };
+    const migration = planHostnameFoldMigration(
+      "/repo/original",
+      "new-id",
+      "legacy-id",
+      env,
+    );
+    expect(migration).toEqual({
+      kind: "pending-cleanup",
+      oldId: "legacy-id",
+      oldPath: "/repo/original",
+    });
+    if (migration.kind !== "pending-cleanup") {
+      throw new Error("expected a pending hostname-fold cleanup");
+    }
+
+    makeShim(bindir, {
+      "call sources_list": {
+        stdout: JSON.stringify({
+          sources: [
+            {
+              id: "legacy-id",
+              local_path: "/repo/replacement",
+              remote_url: null,
+            },
+          ],
+        }),
+      },
+      "--version": { stdout: "gbrain 0.41.38.0" },
+      "sources remove --help": { stdout: "--keep-storage" },
+      "sources remove legacy-id --confirm-destructive": {
+        exit: 99,
+        stderr: "replacement row must not be removed",
+      },
+      "sources remove legacy-id --confirm-destructive --keep-storage": {
+        exit: 99,
+        stderr: "replacement row must not be removed",
+      },
+    });
+
+    const cleanup = removePlannedHostnameLegacySource(migration, env);
+    expect(cleanup.removed).toBe(false);
+    expect(cleanup.skipped).toBe(true);
+    expect(cleanup.reason).toContain("changed after validation");
+    expect(readFileSync(callLog, "utf-8")).not.toContain(
+      "sources remove legacy-id --confirm-destructive",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- compare registered GBrain sources by canonical filesystem identity, so equivalent relative, absolute, symlink, junction, and case-variant spellings remain a no-op
- bind every source remove/add, legacy cleanup, sync, pin, and dream operation to authoritative source provenance plus stable pre/post identity checks
- fail closed before destructive mutation when a path is missing, ambiguous, rebound, cross-volume, remotely managed, or no longer matches the recorded source row
- require GBrain 0.41.38.0+, the first release with the provenance, source-scoped dream, and pin-aware code graph behavior this workflow relies on
- document the version recovery path and source-identity safety contract

This is the source-identity and destructive-safety slice split from #2377. The adjacent docs-aware `sync --strategy auto` work remains a separate PR.

## Why the diff is larger than a path helper

The initial equivalence fix exposed two destructive seams during independent correctness and security review: a source row could change between planning and cleanup, and local pin/gitignore writes could follow a replaced filesystem object. Keeping the fix safe required carrying the proven path through orchestration, rereading the authoritative registry around mutations, and making local writes atomic and symlink-safe. The expanded diff stays on one concern: a source operation must act only on the exact filesystem and registry identity it proved.

## Verification

Current HEAD: `46ba3aa2412ed399dc2d5645e47f7f20950903ad`

- `bun test test/gbrain-sources-parse.test.ts test/gbrain-sources.test.ts test/gbrain-guards.test.ts test/gstack-gbrain-sync.test.ts test/gbrain-dream-stage.test.ts test/gbrain-source-gitignore.test.ts test/gbrain-detect-install.test.ts test/gbrain-sync-skip.test.ts test/gbrain-exec-invariant.test.ts test/gbrain-spawn-windows-shell.test.ts` — 217 passed, 0 failed, 596 assertions
- `bun test test/gstack-gbrain-source-wireup.test.ts test/gen-skill-docs.test.ts` — 421 passed, 0 failed, 6,464 assertions
- `bun test test/gbrain-detect-install.test.ts test/gstack-gbrain-sync.test.ts` — 63 passed, 0 failed, 239 assertions
- `bun run build` — passed; the existing Factory `gstack-ship` token-ceiling warning remains non-fatal
- `git diff --check origin/main...HEAD` — passed
- independent correctness and security reviews — no remaining findings

`bun run test:evals` selected 11 broad LLM routing scenarios, but this environment has no Claude credentials. Every failure artifact reports `Not logged in`, zero tool calls, zero tokens, and $0.00; the failing suites and runners are unchanged from `origin/main`, and the changed `sync-gbrain` skill is not installed by those journey fixtures. Deterministic branch-owned tests above are green.

## Documentation

- `sync-gbrain/SKILL.md.tmpl` and generated `sync-gbrain/SKILL.md`: document canonical identity, fail-closed drift handling, and the hard 0.41.38.0 floor
- `USING_GBRAIN_WITH_GSTACK.md`: add operator recovery, code-stage safety semantics, installer reference, and troubleshooting
- no VERSION or CHANGELOG change: upstream batches release metadata separately

Coverage: the changed source-identity and minimum-version surfaces have reference, how-to, and explanation coverage. No architecture diagram drift or new documentation debt was found.

## Tracking

Basecamp: https://3.basecamp.com/4058523/buckets/34718435/card_tables/cards/10157486137
