### PR TITLE
fix(land-and-deploy): correct the --auto failure diagnosis in Step 4

### DIFF
--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -1475,13 +1475,25 @@ Record the start timestamp for timing data. Also record which merge path is take
 Try auto-merge first (respects repo merge settings and merge queues):
 
 ```bash
-gh pr merge --auto --delete-branch
+gh pr merge --squash --auto --delete-branch
 ```
 
 If `--auto` succeeds: record `MERGE_PATH=auto`. This means the repo has auto-merge enabled
 and may use merge queues.
 
-If `--auto` is not available (repo doesn't have auto-merge enabled), merge directly:
+`--auto` fails for two unrelated reasons. Both fall through to the direct merge below, so
+the flow is unaffected — but do not report the second one as "auto-merge is disabled":
+
+1. **Auto-merge is disabled for the repo** — `Auto-merge is not allowed for this repository`.
+2. **The PR is not waiting on anything.** `--auto` only *queues* a merge behind pending
+   required checks. When every required check has already settled — or the repo declares
+   no required status checks at all — GitHub treats the PR as immediately mergeable and
+   rejects the mutation:
+   `Pull request is in clean status` (everything green) or
+   `Pull request is in unstable status` (something red, but nothing required).
+   A repo with zero required status checks therefore takes the direct path 100% of the
+   time no matter how auto-merge is configured, and so does any repo whose CI finishes
+   before this step runs.
 
 ```bash
 gh pr merge --squash --delete-branch

--- a/land-and-deploy/SKILL.md.tmpl
+++ b/land-and-deploy/SKILL.md.tmpl
@@ -598,13 +598,25 @@ Record the start timestamp for timing data. Also record which merge path is take
 Try auto-merge first (respects repo merge settings and merge queues):
 
 ```bash
-gh pr merge --auto --delete-branch
+gh pr merge --squash --auto --delete-branch
 ```
 
 If `--auto` succeeds: record `MERGE_PATH=auto`. This means the repo has auto-merge enabled
 and may use merge queues.
 
-If `--auto` is not available (repo doesn't have auto-merge enabled), merge directly:
+`--auto` fails for two unrelated reasons. Both fall through to the direct merge below, so
+the flow is unaffected — but do not report the second one as "auto-merge is disabled":
+
+1. **Auto-merge is disabled for the repo** — `Auto-merge is not allowed for this repository`.
+2. **The PR is not waiting on anything.** `--auto` only *queues* a merge behind pending
+   required checks. When every required check has already settled — or the repo declares
+   no required status checks at all — GitHub treats the PR as immediately mergeable and
+   rejects the mutation:
+   `Pull request is in clean status` (everything green) or
+   `Pull request is in unstable status` (something red, but nothing required).
+   A repo with zero required status checks therefore takes the direct path 100% of the
+   time no matter how auto-merge is configured, and so does any repo whose CI finishes
+   before this step runs.
 
 ```bash
 gh pr merge --squash --delete-branch


### PR DESCRIPTION
## Problem

Step 4 of `/land-and-deploy` attributes a failed `gh pr merge --auto` to one cause:

> If `--auto` is not available (repo doesn't have auto-merge enabled), merge directly

That's only one of two causes, and in practice it's the rarer one.

`--auto` only **queues** a merge behind *pending required checks*. When every required check has already settled — or the repo declares no required status checks at all — GitHub considers the PR immediately mergeable and rejects `enablePullRequestAutoMerge`:

```
GraphQL: Pull request is in clean status    (everything green)
GraphQL: Pull request is in unstable status (something red, but nothing required)
```

Whether auto-merge is *enabled* makes no difference in that case. Two common repos hit this every single time:

- a repo with **zero required status checks** — nothing is ever pending, so `--auto` is always rejected
- any repo whose **CI finishes before Step 4 runs** — a fast or cached pipeline beats the skill to the merge

## Why it's worth fixing

The flow is fine — the direct-merge fallback already handles both paths. The problem is the **recorded reason**. An operator who sees `MERGE_PATH=direct` is told to go check whether auto-merge is enabled, which points them at the wrong setting.

I lost real time to this on a repo where auto-merge had been enabled the whole time and the ruleset simply declared no required checks. The wrong explanation in the docs is what made it take as long as it did.

## Changes

- Replaces the single-cause sentence with both causes and their exact GitHub error strings, and explicitly warns against reporting the second as "auto-merge is disabled".
- Adds `--squash` to the `--auto` invocation. The fallback already squashes, so without it the two paths merge with different strategies depending on which one is taken.

Docs-only — no behavior change to the flow itself.

## Verification

Regenerated with `bun run gen:skill-docs`, and confirmed clean for `--host codex` and `--host factory` (both exit 0). Output is idempotent on re-run, so the **Skill Docs Freshness** gate stays green. The tracked diff is exactly the two expected files:

```
 land-and-deploy/SKILL.md      | 16 ++++++++++++++--
 land-and-deploy/SKILL.md.tmpl | 16 ++++++++++++++--
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
