### PR TITLE
feat: add Cua Driver desktop QA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Invoke them by name (e.g., `/office-hours`).
 | `/devex-review` | Live developer experience audit (TTHW measured against the real flow). |
 | `/qa` | Open a real browser, find bugs, fix them, re-verify. |
 | `/qa-only` | Same methodology as /qa but report only — no code changes. |
+| `/desktop-qa` | Report-only QA for an already-running native or Electron app through Cua Driver. |
 | `/scrape` | Pull data from a web page. First call prototypes; codified call runs in ~200ms. |
 | `/skillify` | Codify the most recent successful `/scrape` flow into a permanent browser-skill. |
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Fork it. Improve it. Make it yours. And if you want to hate on free open source 
 
 Open Claude Code and paste this. Claude does the rest.
 
-> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /document-generate, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.
+> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a "gstack" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\_\_claude-in-chrome\_\_\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /desktop-qa, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /document-generate, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.
 
 ### Step 2: Team mode — auto-update for shared repos (recommended)
 
@@ -192,6 +192,7 @@ Each skill feeds into the next. `/office-hours` writes a design doc that `/plan-
 | `/design-html` | **Design Engineer** | Turn a mockup into production HTML that actually works. Pretext computed layout: text reflows, heights adjust, layouts are dynamic. 30KB, zero deps. Detects React/Svelte/Vue. Smart API routing per design type (landing page vs dashboard vs form). The output is shippable, not a demo. |
 | `/qa` | **QA Lead** | Test your app, find bugs, fix them with atomic commits, re-verify. Auto-generates regression tests for every fix. |
 | `/qa-only` | **QA Reporter** | Same methodology as /qa but report only. Pure bug report without code changes. |
+| `/desktop-qa` | **Desktop QA Reporter** | Report-only testing of one already-running native or Electron window through optional Cua Driver. |
 | `/pair-agent` | **Multi-Agent Coordinator** | Share your browser with any AI agent. One command, one paste, connected. Works with OpenClaw, Hermes, Codex, Cursor, or anything that can curl. Each agent gets its own tab. Auto-launches headed mode so you watch everything. Auto-starts ngrok tunnel for remote agents. Scoped tokens, tab isolation, rate limiting, activity attribution. |
 | `/cso` | **Chief Security Officer** | OWASP Top 10 + STRIDE threat model. Zero-noise: 17 false positive exclusions, 8/10+ confidence gate, independent finding verification. Each finding includes a concrete exploit scenario. |
 | `/ship` | **Release Engineer** | Sync main, run tests, audit coverage, push, open PR. Bootstraps test frameworks if you don't have one. |
@@ -480,7 +481,7 @@ On Windows without Developer Mode (MSYS2 / Git Bash), `setup` falls back to file
 Use /browse from gstack for all web browsing. Never use mcp__claude-in-chrome__* tools.
 Available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review,
 /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy,
-/canary, /benchmark, /browse, /open-gstack-browser, /qa, /qa-only, /design-review,
+/canary, /benchmark, /browse, /open-gstack-browser, /qa, /qa-only, /desktop-qa, /design-review,
 /setup-browser-cookies, /setup-deploy, /setup-gbrain, /sync-gbrain, /retro, /investigate,
 /document-release, /document-generate, /codex, /cso, /autoplan, /pair-agent, /careful, /freeze,
 /guard, /unfreeze, /gstack-upgrade, /learn.

--- a/SKILL.md
+++ b/SKILL.md
@@ -279,6 +279,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
@@ -535,9 +536,10 @@ Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXI
 
 This is the gstack router. Its one job is to send the request to the right skill.
 
-1. If the request is about a browser, QA, dogfooding, screenshots, or inspecting a page
+1. If the request is QA for an already-running native or Electron desktop app → invoke `/desktop-qa`.
+2. If the request is about a browser, website QA, dogfooding, screenshots, or inspecting a page
    (open a site, test a deploy, take a screenshot, check a flow visually) → invoke `/browse`.
-2. Otherwise, route by the rules below. If nothing matches, answer directly.
+3. Otherwise, route by the rules below. If nothing matches, answer directly.
 
 Best-effort, record which way you routed (never block on it). Set `ROUTE_OUTCOME` to
 `browse` (sent to /browse), `routed` (sent to another skill), or `direct` (answered
@@ -567,6 +569,7 @@ quality gates that produce better results than answering inline.
 - User reports a bug, error, broken behavior, "why is this broken", "this doesn't work", "wtf", "something's wrong" → invoke `/investigate`
 - User asks to test the site, find bugs, QA, "does this work", "check the deploy" → invoke `/qa`
 - User asks to just report bugs without fixing → invoke `/qa-only`
+- User asks to test an already-running native or Electron desktop app → invoke `/desktop-qa`
 - User asks to review code, check the diff, pre-landing review, "look at my changes" → invoke `/review`
 - User asks about visual polish, design audit of a live site, "this looks off" → invoke `/design-review`
 - User asks to audit the live developer experience, time-to-hello-world → invoke `/devex-review`

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -24,9 +24,10 @@ triggers:
 
 This is the gstack router. Its one job is to send the request to the right skill.
 
-1. If the request is about a browser, QA, dogfooding, screenshots, or inspecting a page
+1. If the request is QA for an already-running native or Electron desktop app → invoke `/desktop-qa`.
+2. If the request is about a browser, website QA, dogfooding, screenshots, or inspecting a page
    (open a site, test a deploy, take a screenshot, check a flow visually) → invoke `/browse`.
-2. Otherwise, route by the rules below. If nothing matches, answer directly.
+3. Otherwise, route by the rules below. If nothing matches, answer directly.
 
 Best-effort, record which way you routed (never block on it). Set `ROUTE_OUTCOME` to
 `browse` (sent to /browse), `routed` (sent to another skill), or `direct` (answered
@@ -56,6 +57,7 @@ quality gates that produce better results than answering inline.
 - User reports a bug, error, broken behavior, "why is this broken", "this doesn't work", "wtf", "something's wrong" → invoke `/investigate`
 - User asks to test the site, find bugs, QA, "does this work", "check the deploy" → invoke `/qa`
 - User asks to just report bugs without fixing → invoke `/qa-only`
+- User asks to test an already-running native or Electron desktop app → invoke `/desktop-qa`
 - User asks to review code, check the diff, pre-landing review, "look at my changes" → invoke `/review`
 - User asks about visual polish, design audit of a live site, "this looks off" → invoke `/design-review`
 - User asks to audit the live developer experience, time-to-hello-world → invoke `/devex-review`

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -289,6 +289,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -283,6 +283,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -283,6 +283,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -281,6 +281,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -281,6 +281,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -284,6 +284,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -285,6 +285,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -284,6 +284,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -287,6 +287,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -307,6 +307,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -288,6 +288,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -285,6 +285,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -302,6 +302,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/desktop-qa/SKILL.md
+++ b/desktop-qa/SKILL.md
@@ -1,16 +1,17 @@
 ---
-name: setup-browser-cookies
+name: desktop-qa
 preamble-tier: 1
 version: 1.0.0
-description: Import cookies from your real Chromium browser into the headless browse session. (gstack)
-triggers:
-  - import browser cookies
-  - login to test site
-  - setup authenticated session
+description: Report-only QA for an already-running native or Electron desktop app through Cua Driver. (gstack)
 allowed-tools:
   - Bash
   - Read
+  - Write
   - AskUserQuestion
+triggers:
+  - desktop qa
+  - test desktop app
+  - qa native app
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->
@@ -18,9 +19,10 @@ allowed-tools:
 
 ## When to invoke this skill
 
-Opens an interactive picker UI where you select which cookie domains to import.
-Use before QA testing authenticated pages. Use when asked to "import cookies",
-"login to the site", or "authenticate the browser".
+Use when asked to test a macOS, Windows, or Linux desktop window
+without changing source code. For browser sites, use /qa or /qa-only.
+
+Voice triggers (speech-to-text aliases): "test this desktop app", "qa this native app".
 
 ## Preamble (run first)
 
@@ -78,7 +80,7 @@ _QUESTION_TUNING=$(~/.claude/skills/gstack/bin/gstack-config get question_tuning
 echo "QUESTION_TUNING: $_QUESTION_TUNING"
 mkdir -p ~/.gstack/analytics
 if [ "$_TEL" != "off" ]; then
-echo '{"skill":"setup-browser-cookies","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(_repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null | tr -cd 'a-zA-Z0-9._-'); echo "${_repo:-unknown}")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+echo '{"skill":"desktop-qa","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(_repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null | tr -cd 'a-zA-Z0-9._-'); echo "${_repo:-unknown}")'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 fi
 for _PF in $(find ~/.gstack/analytics -maxdepth 1 -name '.pending-*' 2>/dev/null); do
   if [ -f "$_PF" ]; then
@@ -100,7 +102,7 @@ if [ -f "$_LEARN_FILE" ]; then
 else
   echo "LEARNINGS: 0"
 fi
-~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"setup-browser-cookies","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
+~/.claude/skills/gstack/bin/gstack-timeline-log '{"skill":"desktop-qa","event":"started","branch":"'"$_BRANCH"'","session":"'"$_SESSION_ID"'"}' 2>/dev/null &
 _HAS_ROUTING="no"
 if [ -f CLAUDE.md ] && grep -q "## Skill routing" CLAUDE.md 2>/dev/null; then
   _HAS_ROUTING="yes"
@@ -530,104 +532,171 @@ Replace `SKILL_NAME`, `OUTCOME`, and `USED_BROWSE` before running.
 
 Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXIT PLAN MODE GATE blocking checklist at the end of the skill, which verifies the plan file ends with `## GSTACK REVIEW REPORT` before ExitPlanMode is called. Skills that don't run plan reviews (operational skills like `/ship`, `/qa`, `/review`) typically don't operate in plan mode and have no review report to verify; this footer is a no-op for them. Writing the plan file is the one edit allowed in plan mode.
 
-# Setup Browser Cookies
+# /desktop-qa: Report-Only Desktop App QA
 
-Import logged-in sessions from your real Chromium browser into the headless browse session.
+Test one already-running native or Electron desktop-app window through Cua Driver. Follow realistic user flows, verify every claimed effect from fresh window state, and write an evidence-backed bug report. **Never edit source code or fix the bugs you find.**
 
-## CDP mode check
+Use this skill for macOS, Windows, and Linux desktop applications. For browser pages or web deployments, use `/qa` or `/qa-only`. For mobile apps, use the platform-specific mobile skill.
 
-First, check if browse is already connected to the user's real browser:
-```bash
-$B status 2>/dev/null | grep -q "Mode: cdp" && echo "CDP_MODE=true" || echo "CDP_MODE=false"
-```
-If `CDP_MODE=true`: tell the user "Not needed — you're connected to your real browser via CDP. Your cookies and sessions are already available." and stop. No cookie import needed.
+## Hard boundaries
 
-## How it works
+These boundaries define the skill, not optional preferences:
 
-1. Find the browse binary
-2. Run `cookie-import-browser` to detect installed browsers and open the picker UI
-3. User selects which cookie domains to import in their browser
-4. Cookies are decrypted and loaded into the Playwright session
+1. **Attach only to an app the user already launched.** Never launch, quit, restart, install, update, or replace an application.
+2. **Bind one exact window.** Use its `pid` and `window_id` for every snapshot and action. Never capture the desktop or another app.
+3. **Use strict window capture.** Start Cua Driver with `capture_scope:"window"`. Do not escalate the session or bring the target to the foreground.
+4. **Use the standard Cua Driver permission model.** Never bypass approvals, grant OS permissions, or alter driver configuration for the user.
+5. **Stay report-only.** Do not inspect or edit source code, create regression tests, or attempt fixes.
+6. **Protect real data.** Use synthetic or disposable test data. Obtain explicit user approval immediately before any action that sends a message, publishes content, makes a purchase, deletes data, changes account or security settings, or commits persistent external state.
+7. **Keep evidence narrow.** Save only target-window screenshots needed to prove a finding. Never include secrets, credentials, personal data, or unrelated app content in the report.
 
-## Steps
+If a required test cannot be completed inside these boundaries, mark it **unverified** and explain the limitation. Do not silently widen scope.
 
-### 1. Find the browse binary
+## 1. Parse the request
 
-## SETUP (run this check BEFORE any browse command)
+Resolve these parameters before interacting:
 
-```bash
-_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-B=""
-[ -n "$_ROOT" ] && [ -x "$_ROOT/.claude/skills/gstack/browse/dist/browse" ] && B="$_ROOT/.claude/skills/gstack/browse/dist/browse"
-[ -z "$B" ] && B="$HOME/.claude/skills/gstack/browse/dist/browse"
-if [ -x "$B" ]; then
-  echo "READY: $B"
-else
-  echo "NEEDS_SETUP"
-fi
-```
+| Parameter | Default | Example override |
+|-----------|---------|------------------|
+| Target | Required app and exact window | `Test the Settings window in MyApp` |
+| Mode | Standard: 3-5 representative flows | `--quick` for one smoke flow |
+| Scope | Visible behavior in the named window | `Focus on onboarding and keyboard navigation` |
+| Test data | Synthetic, local, disposable | `Use the provided staging account` |
+| Output | `.gstack/desktop-qa-reports/<app>-<timestamp>/` | `Write the report under artifacts/qa/` |
 
-If `NEEDS_SETUP`:
-1. Tell the user: "gstack browse needs a one-time build (~10 seconds). OK to proceed?" Then STOP and wait.
-2. Run: `cd <SKILL_DIR> && ./setup`
-3. If `bun` is not installed:
-   ```bash
-   if ! command -v bun >/dev/null 2>&1; then
-     BUN_VERSION="1.3.10"
-     BUN_INSTALL_SHA="bab8acfb046aac8c72407bdcce903957665d655d7acaa3e11c7c4616beae68dd"
-     tmpfile=$(mktemp)
-     curl -fsSL "https://bun.sh/install" -o "$tmpfile"
-     actual_sha=$(shasum -a 256 "$tmpfile" | awk '{print $1}')
-     if [ "$actual_sha" != "$BUN_INSTALL_SHA" ]; then
-       echo "ERROR: bun install script checksum mismatch" >&2
-       echo "  expected: $BUN_INSTALL_SHA" >&2
-       echo "  got:      $actual_sha" >&2
-       rm "$tmpfile"; exit 1
-     fi
-     BUN_VERSION="$BUN_VERSION" bash "$tmpfile"
-     rm "$tmpfile"
-   fi
-   ```
+If the request names multiple apps or windows, ask the user to choose one. If it asks for browser or mobile QA, route to the appropriate skill instead.
 
-### 2. Open the cookie picker
+## 2. Verify Cua Driver without changing the system
+
+Run read-only preflight checks:
 
 ```bash
-$B cookie-import-browser
+cua-driver --version
+cua-driver doctor --json
+cua-driver list-tools
 ```
 
-This auto-detects installed Chromium browsers and opens
-an interactive picker UI in your default browser where you can:
-- Switch between installed browsers
-- Search domains
-- Click "+" to import a domain's cookies
-- Click trash to remove imported cookies
+Confirm that `start_session`, `list_windows`, `get_window_state`, `click`, `type_text`, `press_key`, `scroll`, and `end_session` are available.
 
-Tell the user: **"Cookie picker opened — select the domains you want to import in your browser, then tell me when you're done."**
+If Cua Driver is missing, unhealthy, lacks required OS permissions, or lacks a required tool, stop and report the exact failed check. Point the user to the official [Cua Driver installation guide](https://cua.ai/docs/how-to-guides/driver/install). Never install or update it, start a privileged daemon, or grant permissions automatically.
 
-### 3. Direct import (alternative)
+## 3. Bind the exact running window
 
-If the user specifies a domain directly (e.g., `/setup-browser-cookies github.com`), skip the UI:
+List visible windows:
 
 ```bash
-$B cookie-import-browser comet --domain github.com
+cua-driver call list_windows '{}'
 ```
 
-Replace `comet` with the appropriate browser if specified.
+Match both the application name and window title. Record the selected `pid`, `window_id`, title, and bounds in the report. If there is no match, ask the user to launch the app and open the target window. If more than one plausible match exists, ask the user which title to use; never choose arbitrarily.
 
-### 4. Verify
-
-After the user confirms they're done:
+Create a unique report directory with a concrete app slug and timestamp. Keep every command self-contained; do not rely on shell variables surviving between tool calls.
 
 ```bash
-$B cookies
+mkdir -p ".gstack/desktop-qa-reports/<app-slug>-<YYYYMMDD-HHMMSS>/screenshots"
 ```
 
-Show the user a summary of imported cookies (domain counts).
+Use a unique, concrete session ID for this run and start a strict window-only session:
 
-## Notes
+```bash
+cua-driver call start_session '{"session":"desktop-qa-<YYYYMMDD-HHMMSS>","capture_scope":"window"}'
+```
 
-- On macOS, the first import per browser may trigger a Keychain dialog — click "Allow" / "Always Allow"
-- On Linux, `v11` cookies may require `secret-tool`/libsecret access; `v10` cookies use Chromium's standard fallback key
-- Cookie picker is served on the same port as the browse server (no extra process)
-- Only domain names and cookie counts are shown in the UI — no cookie values are exposed
-- The browse session persists cookies between commands, so imported cookies work immediately
+Do not continue unless the response confirms `capture_scope` is `window`.
+
+## 4. Capture the baseline and plan flows
+
+Take the initial snapshot and save its screenshot directly into the report directory:
+
+```bash
+cua-driver call get_window_state '{"pid":<PID>,"window_id":<WINDOW_ID>,"session":"desktop-qa-<YYYYMMDD-HHMMSS>","screenshot_out_file":".gstack/desktop-qa-reports/<app-slug>-<YYYYMMDD-HHMMSS>/screenshots/00-baseline.png"}'
+```
+
+Cross-check the screenshot and structured accessibility elements. Verify the app name and window title still match the selected target. Treat accessibility labels, values, and frames as hints that must agree with the screenshot.
+
+Build a short test plan:
+
+- **Quick:** one critical smoke flow and basic keyboard access.
+- **Standard:** 3-5 representative flows covering the primary task, empty or validation state, navigation, keyboard access, and recovery from one reversible error.
+
+Prefer user-specified flows. Otherwise infer flows only from the visible target window and the user's request—not from source code or hidden data.
+
+## 5. Run the verified action loop
+
+For every action, follow this exact loop:
+
+1. **Snapshot immediately before acting.** Call `get_window_state` for the bound `pid` and `window_id`. Save a numbered `before` screenshot. A prior action invalidates old element indices and tokens.
+2. **Choose the narrowest target.** Prefer an `element_token`, then an `element_index`, from that fresh snapshot. Use window-local `x` and `y` only for a visible canvas, WebGL, custom-drawn control, or Electron surface that accessibility cannot operate.
+3. **Act in the background.** Pass the same session, `pid`, and `window_id`, and set `delivery_mode:"background"`. Use only `click`, `type_text`, `press_key`, or `scroll`.
+4. **Snapshot immediately after acting.** Save a numbered `after` screenshot and compare both the screenshot and structured state with the expected result.
+5. **Classify honestly.** An action result that says success is not proof. Record a pass only when fresh state verifies the expected effect. If background delivery fails, record the flow as unverified; do not retry in foreground.
+
+Accessibility-targeted action example:
+
+```bash
+cua-driver call click '{"pid":<PID>,"window_id":<WINDOW_ID>,"session":"desktop-qa-<YYYYMMDD-HHMMSS>","element_token":"<FRESH_ELEMENT_TOKEN>","delivery_mode":"background"}'
+```
+
+Electron/custom-surface text example, using coordinates copied directly from the latest target-window screenshot:
+
+```bash
+cua-driver call type_text '{"pid":<PID>,"window_id":<WINDOW_ID>,"session":"desktop-qa-<YYYYMMDD-HHMMSS>","x":<WINDOW_LOCAL_X>,"y":<WINDOW_LOCAL_Y>,"text":"Synthetic test value","delivery_mode":"background"}'
+```
+
+After every action, use a fresh `get_window_state` call with a new `screenshot_out_file`. Stop the run if the target window disappears, its identity becomes ambiguous, the action would leave the bound window, or sensitive information appears.
+
+## 6. Write the report
+
+Write `.gstack/desktop-qa-reports/<app-slug>-<YYYYMMDD-HHMMSS>/desktop-qa-report.md` with:
+
+```markdown
+# Desktop QA Report: <app and window>
+
+## Scope and environment
+- Mode and requested scope
+- Cua Driver version
+- Platform
+- Target app, window title, PID, and window ID
+- Started and completed timestamps
+
+## Summary
+- Flows passed, failed, and unverified
+- Highest confirmed severity
+
+## Verified findings
+### DQA-001: <concise title>
+- Severity: Critical | High | Medium | Low
+- Flow: <tested task>
+- Reproduction: <numbered exact steps>
+- Expected: <observable outcome>
+- Actual: <observable outcome>
+- Evidence: <relative before/after screenshot paths>
+
+## Passed checks
+- <flow and observed result>
+
+## Unverified checks and limitations
+- <what could not be proven and why>
+```
+
+Include only reproducible, freshly verified findings. Do not offer speculative root causes or copy sensitive accessibility values into the report.
+
+## 7. Always end the session
+
+Whether the run passes, fails, or stops early, end only the session created for this run:
+
+```bash
+cua-driver call end_session '{"session":"desktop-qa-<YYYYMMDD-HHMMSS>"}'
+```
+
+Confirm the session ended. Do not stop the shared Cua Driver daemon, revoke permissions, or clean up another session.
+
+## Completion checklist
+
+- The exact app window stayed bound by `pid` and `window_id`.
+- Every action used a fresh before snapshot and a fresh after snapshot.
+- Every claimed pass or bug has target-window evidence.
+- Unverified behavior is labeled rather than guessed.
+- No source, app installation, driver configuration, external account, or unrelated window was changed.
+- The report contains no secrets or personal data.
+- The Cua Driver session ended.

--- a/desktop-qa/SKILL.md.tmpl
+++ b/desktop-qa/SKILL.md.tmpl
@@ -1,0 +1,192 @@
+---
+name: desktop-qa
+preamble-tier: 1
+version: 1.0.0
+description: |
+  Report-only QA for an already-running native or Electron desktop app through
+  Cua Driver. Use when asked to test a macOS, Windows, or Linux desktop window
+  without changing source code. For browser sites, use /qa or /qa-only. (gstack)
+voice-triggers:
+  - "test this desktop app"
+  - "qa this native app"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - AskUserQuestion
+triggers:
+  - desktop qa
+  - test desktop app
+  - qa native app
+---
+
+{{PREAMBLE}}
+
+# /desktop-qa: Report-Only Desktop App QA
+
+Test one already-running native or Electron desktop-app window through Cua Driver. Follow realistic user flows, verify every claimed effect from fresh window state, and write an evidence-backed bug report. **Never edit source code or fix the bugs you find.**
+
+Use this skill for macOS, Windows, and Linux desktop applications. For browser pages or web deployments, use `/qa` or `/qa-only`. For mobile apps, use the platform-specific mobile skill.
+
+## Hard boundaries
+
+These boundaries define the skill, not optional preferences:
+
+1. **Attach only to an app the user already launched.** Never launch, quit, restart, install, update, or replace an application.
+2. **Bind one exact window.** Use its `pid` and `window_id` for every snapshot and action. Never capture the desktop or another app.
+3. **Use strict window capture.** Start Cua Driver with `capture_scope:"window"`. Do not escalate the session or bring the target to the foreground.
+4. **Use the standard Cua Driver permission model.** Never bypass approvals, grant OS permissions, or alter driver configuration for the user.
+5. **Stay report-only.** Do not inspect or edit source code, create regression tests, or attempt fixes.
+6. **Protect real data.** Use synthetic or disposable test data. Obtain explicit user approval immediately before any action that sends a message, publishes content, makes a purchase, deletes data, changes account or security settings, or commits persistent external state.
+7. **Keep evidence narrow.** Save only target-window screenshots needed to prove a finding. Never include secrets, credentials, personal data, or unrelated app content in the report.
+
+If a required test cannot be completed inside these boundaries, mark it **unverified** and explain the limitation. Do not silently widen scope.
+
+## 1. Parse the request
+
+Resolve these parameters before interacting:
+
+| Parameter | Default | Example override |
+|-----------|---------|------------------|
+| Target | Required app and exact window | `Test the Settings window in MyApp` |
+| Mode | Standard: 3-5 representative flows | `--quick` for one smoke flow |
+| Scope | Visible behavior in the named window | `Focus on onboarding and keyboard navigation` |
+| Test data | Synthetic, local, disposable | `Use the provided staging account` |
+| Output | `.gstack/desktop-qa-reports/<app>-<timestamp>/` | `Write the report under artifacts/qa/` |
+
+If the request names multiple apps or windows, ask the user to choose one. If it asks for browser or mobile QA, route to the appropriate skill instead.
+
+## 2. Verify Cua Driver without changing the system
+
+Run read-only preflight checks:
+
+```bash
+cua-driver --version
+cua-driver doctor --json
+cua-driver list-tools
+```
+
+Confirm that `start_session`, `list_windows`, `get_window_state`, `click`, `type_text`, `press_key`, `scroll`, and `end_session` are available.
+
+If Cua Driver is missing, unhealthy, lacks required OS permissions, or lacks a required tool, stop and report the exact failed check. Point the user to the official [Cua Driver installation guide](https://cua.ai/docs/how-to-guides/driver/install). Never install or update it, start a privileged daemon, or grant permissions automatically.
+
+## 3. Bind the exact running window
+
+List visible windows:
+
+```bash
+cua-driver call list_windows '{}'
+```
+
+Match both the application name and window title. Record the selected `pid`, `window_id`, title, and bounds in the report. If there is no match, ask the user to launch the app and open the target window. If more than one plausible match exists, ask the user which title to use; never choose arbitrarily.
+
+Create a unique report directory with a concrete app slug and timestamp. Keep every command self-contained; do not rely on shell variables surviving between tool calls.
+
+```bash
+mkdir -p ".gstack/desktop-qa-reports/<app-slug>-<YYYYMMDD-HHMMSS>/screenshots"
+```
+
+Use a unique, concrete session ID for this run and start a strict window-only session:
+
+```bash
+cua-driver call start_session '{"session":"desktop-qa-<YYYYMMDD-HHMMSS>","capture_scope":"window"}'
+```
+
+Do not continue unless the response confirms `capture_scope` is `window`.
+
+## 4. Capture the baseline and plan flows
+
+Take the initial snapshot and save its screenshot directly into the report directory:
+
+```bash
+cua-driver call get_window_state '{"pid":<PID>,"window_id":<WINDOW_ID>,"session":"desktop-qa-<YYYYMMDD-HHMMSS>","screenshot_out_file":".gstack/desktop-qa-reports/<app-slug>-<YYYYMMDD-HHMMSS>/screenshots/00-baseline.png"}'
+```
+
+Cross-check the screenshot and structured accessibility elements. Verify the app name and window title still match the selected target. Treat accessibility labels, values, and frames as hints that must agree with the screenshot.
+
+Build a short test plan:
+
+- **Quick:** one critical smoke flow and basic keyboard access.
+- **Standard:** 3-5 representative flows covering the primary task, empty or validation state, navigation, keyboard access, and recovery from one reversible error.
+
+Prefer user-specified flows. Otherwise infer flows only from the visible target window and the user's request—not from source code or hidden data.
+
+## 5. Run the verified action loop
+
+For every action, follow this exact loop:
+
+1. **Snapshot immediately before acting.** Call `get_window_state` for the bound `pid` and `window_id`. Save a numbered `before` screenshot. A prior action invalidates old element indices and tokens.
+2. **Choose the narrowest target.** Prefer an `element_token`, then an `element_index`, from that fresh snapshot. Use window-local `x` and `y` only for a visible canvas, WebGL, custom-drawn control, or Electron surface that accessibility cannot operate.
+3. **Act in the background.** Pass the same session, `pid`, and `window_id`, and set `delivery_mode:"background"`. Use only `click`, `type_text`, `press_key`, or `scroll`.
+4. **Snapshot immediately after acting.** Save a numbered `after` screenshot and compare both the screenshot and structured state with the expected result.
+5. **Classify honestly.** An action result that says success is not proof. Record a pass only when fresh state verifies the expected effect. If background delivery fails, record the flow as unverified; do not retry in foreground.
+
+Accessibility-targeted action example:
+
+```bash
+cua-driver call click '{"pid":<PID>,"window_id":<WINDOW_ID>,"session":"desktop-qa-<YYYYMMDD-HHMMSS>","element_token":"<FRESH_ELEMENT_TOKEN>","delivery_mode":"background"}'
+```
+
+Electron/custom-surface text example, using coordinates copied directly from the latest target-window screenshot:
+
+```bash
+cua-driver call type_text '{"pid":<PID>,"window_id":<WINDOW_ID>,"session":"desktop-qa-<YYYYMMDD-HHMMSS>","x":<WINDOW_LOCAL_X>,"y":<WINDOW_LOCAL_Y>,"text":"Synthetic test value","delivery_mode":"background"}'
+```
+
+After every action, use a fresh `get_window_state` call with a new `screenshot_out_file`. Stop the run if the target window disappears, its identity becomes ambiguous, the action would leave the bound window, or sensitive information appears.
+
+## 6. Write the report
+
+Write `.gstack/desktop-qa-reports/<app-slug>-<YYYYMMDD-HHMMSS>/desktop-qa-report.md` with:
+
+```markdown
+# Desktop QA Report: <app and window>
+
+## Scope and environment
+- Mode and requested scope
+- Cua Driver version
+- Platform
+- Target app, window title, PID, and window ID
+- Started and completed timestamps
+
+## Summary
+- Flows passed, failed, and unverified
+- Highest confirmed severity
+
+## Verified findings
+### DQA-001: <concise title>
+- Severity: Critical | High | Medium | Low
+- Flow: <tested task>
+- Reproduction: <numbered exact steps>
+- Expected: <observable outcome>
+- Actual: <observable outcome>
+- Evidence: <relative before/after screenshot paths>
+
+## Passed checks
+- <flow and observed result>
+
+## Unverified checks and limitations
+- <what could not be proven and why>
+```
+
+Include only reproducible, freshly verified findings. Do not offer speculative root causes or copy sensitive accessibility values into the report.
+
+## 7. Always end the session
+
+Whether the run passes, fails, or stops early, end only the session created for this run:
+
+```bash
+cua-driver call end_session '{"session":"desktop-qa-<YYYYMMDD-HHMMSS>"}'
+```
+
+Confirm the session ended. Do not stop the shared Cua Driver daemon, revoke permissions, or clean up another session.
+
+## Completion checklist
+
+- The exact app window stayed bound by `pid` and `window_id`.
+- Every action used a fresh before snapshot and a fresh after snapshot.
+- Every claimed pass or bug has target-window evidence.
+- Unverified behavior is labeled rather than guessed.
+- No source, app installation, driver configuration, external account, or unrelated window was changed.
+- The report contains no secrets or personal data.
+- The Cua Driver session ended.

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -287,6 +287,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/diagram/SKILL.md
+++ b/diagram/SKILL.md
@@ -282,6 +282,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -17,6 +17,7 @@ Detailed guides for every gstack skill — philosophy, workflow, and examples.
 | [`/design-html`](#design-html) | **Design Engineer** | Generates production-quality Pretext-native HTML. Works with approved mockups, CEO plans, design reviews, or from scratch. Text reflows on resize, heights adjust to content. Smart API routing per design type. Framework detection for React/Svelte/Vue. |
 | [`/qa`](#qa) | **QA Lead** | Test your app, find bugs, fix them with atomic commits, re-verify. Auto-generates regression tests for every fix. |
 | [`/qa-only`](#qa) | **QA Reporter** | Same methodology as /qa but report only. Use when you want a pure bug report without code changes. |
+| [`/desktop-qa`](#desktop-qa) | **Desktop QA Reporter** | Report-only testing of one already-running native or Electron app window through Cua Driver. |
 | [`/scrape`](#scrape) | **Browser Data Extractor** | Pull data from a web page. First call prototypes via `$B`; subsequent calls on a matching intent run a codified browser-skill in ~200ms. |
 | [`/skillify`](#skillify) | **Skill Codifier** | Walks back through your conversation, finds the last `/scrape` prototype, synthesizes script + test + fixture, runs the test, asks before committing. |
 | [`/ship`](#ship) | **Release Engineer** | Sync main, run tests, audit coverage, push, open PR. Bootstraps test frameworks if you don't have one. One command. |
@@ -632,6 +633,16 @@ Claude: [Explores 12 pages, fills 3 forms, tests 2 flows]
 ```
 
 **Testing authenticated pages:** Use `/setup-browser-cookies` first to import your real browser sessions, then `/qa` can test pages behind login.
+
+---
+
+## `/desktop-qa`
+
+`/desktop-qa` gives gstack a narrow, report-only path for native and Electron desktop applications. It attaches to one app window the user has already launched, exercises representative flows through [Cua Driver](https://cua.ai/docs/how-to-guides/driver/install), and saves verified before/after evidence under `.gstack/desktop-qa-reports/`.
+
+The skill deliberately stays inside a strict window boundary: it does not capture the desktop, launch or quit apps, foreground windows, install or update Cua Driver, grant permissions, edit source, or fix findings. Every action is preceded and followed by a fresh window snapshot; behavior that cannot be verified in background mode is reported as unverified rather than widening permissions.
+
+Use `/desktop-qa --quick` for one critical smoke flow or `/desktop-qa` for 3-5 representative flows. Use synthetic or disposable data, and expect an explicit confirmation before any action that could publish, purchase, delete, send, change account settings, or persist external state. Browser QA remains under `/qa` and `/qa-only`; mobile QA remains under the platform-specific mobile skills.
 
 ---
 

--- a/document-generate/SKILL.md
+++ b/document-generate/SKILL.md
@@ -287,6 +287,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -285,6 +285,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/gstack/llms.txt
+++ b/gstack/llms.txt
@@ -25,6 +25,7 @@ Conventions:
 - [/design-html](design-html/SKILL.md): Design finalization: generates production-quality Pretext-native HTML/CSS.
 - [/design-review](design-review/SKILL.md): Designer's eye QA: finds visual inconsistency, spacing issues, hierarchy problems, AI slop patterns, and slow interactions — then fixes them.
 - [/design-shotgun](design-shotgun/SKILL.md): Design shotgun: generate multiple AI design variants, open a comparison board, collect structured feedback, and iterate.
+- [/desktop-qa](desktop-qa/SKILL.md): Report-only QA for an already-running native or Electron desktop app through Cua Driver.
 - [/devex-review](devex-review/SKILL.md): Live developer experience audit.
 - [/diagram](diagram/SKILL.md): Turn an English description (or mermaid source) into a diagram triplet: the source, an editable .excalidraw file you can open on excalidraw.com, and rendered SVG + PNG (clean mermaid style; the .excalidraw carries the hand-drawn aesthetic).
 - [/document-generate](document-generate/SKILL.md): Generate missing documentation from scratch for a feature, module, or entire project.

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -283,6 +283,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -322,6 +322,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/ios-clean/SKILL.md
+++ b/ios-clean/SKILL.md
@@ -285,6 +285,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/ios-design-review/SKILL.md
+++ b/ios-design-review/SKILL.md
@@ -287,6 +287,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/ios-fix/SKILL.md
+++ b/ios-fix/SKILL.md
@@ -288,6 +288,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/ios-qa/SKILL.md
+++ b/ios-qa/SKILL.md
@@ -291,6 +291,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/ios-sync/SKILL.md
+++ b/ios-sync/SKILL.md
@@ -285,6 +285,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -280,6 +280,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -281,6 +281,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -283,6 +283,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -318,6 +318,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -318,6 +318,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -280,6 +280,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -282,6 +282,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -312,6 +312,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -284,6 +284,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -290,6 +290,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -288,6 +288,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -293,6 +293,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -283,6 +283,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -289,6 +289,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -300,6 +300,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -285,6 +285,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/scrape/SKILL.md
+++ b/scrape/SKILL.md
@@ -281,6 +281,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/scripts/proactive-suggestions.json
+++ b/scripts/proactive-suggestions.json
@@ -73,6 +73,11 @@
       "routing": "Standalone design exploration you can\nrun anytime. Use when: \"explore designs\", \"show me options\", \"design variants\",\n\"visual brainstorm\", or \"I don't like how this looks\".\nProactively suggest when the user describes a UI feature but hasn't seen\nwhat it could look like.",
       "voice_line": null
     },
+    "desktop-qa": {
+      "lead": "Report-only QA for an already-running native or Electron desktop app through Cua Driver.",
+      "routing": "Use when asked to test a macOS, Windows, or Linux desktop window\nwithout changing source code. For browser sites, use /qa or /qa-only.",
+      "voice_line": "Voice triggers (speech-to-text aliases): \"test this desktop app\", \"qa this native app\"."
+    },
     "devex-review": {
       "lead": "Live developer experience audit.",
       "routing": "Uses the browse tool to actually TEST the\ndeveloper experience: navigates docs, tries the getting started flow, times\nTTHW, screenshots error messages, evaluates CLI help text. Produces a DX\nscorecard with evidence. Compares against /plan-devex-review scores if they\nexist (the boomerang: plan said 3 minutes, reality says 8). Use when asked to\n\"test the DX\", \"DX audit\", \"developer experience test\", or \"try the\nonboarding\". Proactively suggest after shipping a developer-facing feature.",

--- a/scripts/resolvers/preamble/generate-routing-injection.ts
+++ b/scripts/resolvers/preamble/generate-routing-injection.ts
@@ -28,6 +28,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -284,6 +284,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -283,6 +283,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -285,6 +285,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/skillify/SKILL.md
+++ b/skillify/SKILL.md
@@ -281,6 +281,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -282,6 +282,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy
@@ -1352,6 +1353,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -283,6 +283,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/test/desktop-qa-contract.test.ts
+++ b/test/desktop-qa-contract.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf-8');
+}
+
+describe('/desktop-qa safety and verification contract', () => {
+  const template = read('desktop-qa/SKILL.md.tmpl');
+
+  test('is report-only and binds one already-running window', () => {
+    expect(template).toContain('already-running native or Electron');
+    expect(template).toContain('Bind one exact window');
+    expect(template).toContain('Stay report-only');
+    expect(template).toContain('Never edit source code or fix the bugs you find');
+    expect(template).toContain('`pid` and `window_id`');
+  });
+
+  test('uses the minimum Cua Driver window tool surface', () => {
+    for (const tool of [
+      'start_session',
+      'list_windows',
+      'get_window_state',
+      'click',
+      'type_text',
+      'press_key',
+      'scroll',
+      'end_session',
+    ]) {
+      expect(template).toContain(tool);
+    }
+    expect(template).toContain('capture_scope:\"window\"');
+    expect(template).toContain('screenshot_out_file');
+    expect(template).toContain('delivery_mode:\"background\"');
+  });
+
+  test('requires fresh before/after verification and honest limitations', () => {
+    expect(template).toContain('Snapshot immediately before acting');
+    expect(template).toContain('Snapshot immediately after acting');
+    expect(template).toContain('An action result that says success is not proof');
+    expect(template).toContain('record the flow as unverified; do not retry in foreground');
+    expect(template).toContain('Whether the run passes, fails, or stops early, end only the session');
+  });
+
+  test('does not widen permissions, capture, lifecycle, or recording scope', () => {
+    const prohibited = [
+      '--dangerously-bypass-approvals',
+      'permissions grant',
+      'update --apply',
+      'launch_app',
+      'kill_app',
+      'bring_to_front',
+      'escalate_session',
+      'get_desktop_state',
+      'capture_scope:\"desktop\"',
+      'capture_scope:\"auto\"',
+      'delivery_mode:\"foreground\"',
+      'start_recording',
+      'record_video',
+    ];
+
+    for (const value of prohibited) {
+      expect(template).not.toContain(value);
+    }
+  });
+
+  test('routes desktop QA separately from browser QA', () => {
+    const router = read('SKILL.md.tmpl');
+    const routingInjection = read('scripts/resolvers/preamble/generate-routing-injection.ts');
+
+    expect(router).toContain('already-running native or Electron desktop app → invoke `/desktop-qa`');
+    expect(router).toContain('browser, website QA');
+    expect(routingInjection).toContain('native or Electron desktop app → invoke /desktop-qa');
+  });
+
+  test('generated skill preserves the contract', () => {
+    const generated = read('desktop-qa/SKILL.md');
+
+    expect(generated).toContain('AUTO-GENERATED from SKILL.md.tmpl');
+    expect(generated).toContain('capture_scope:\"window\"');
+    expect(generated).toContain('Snapshot immediately before acting');
+    expect(generated).toContain('Snapshot immediately after acting');
+    expect(generated).toContain('cua-driver call end_session');
+  });
+});

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -285,6 +285,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -271,6 +271,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -273,6 +273,7 @@ Key routing rules:
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate
 - QA/testing site behavior → invoke /qa or /qa-only
+- QA/testing an already-running native or Electron desktop app → invoke /desktop-qa
 - Code review/diff check → invoke /review
 - Visual polish → invoke /design-review
 - Ship/deploy/PR → invoke /ship or /land-and-deploy

--- a/test/skill-coverage-matrix.ts
+++ b/test/skill-coverage-matrix.ts
@@ -55,6 +55,11 @@ export const SKILL_COVERAGE: Record<string, SkillCoverage> = {
     periodic: [],
     rationale: 'qa-only is qa with --report-only; behavior tested via /qa coverage.',
   },
+  'desktop-qa': {
+    gate: ['test/desktop-qa-contract.test.ts', 'test/skill-coverage-floor.test.ts'],
+    periodic: [],
+    rationale: 'Deterministic contract tests pin the Cua Driver window boundary, action loop, and report-only behavior.',
+  },
   investigate: {
     gate: ['test/skill-coverage-floor.test.ts'],
     periodic: [],


### PR DESCRIPTION
## What

- add `/desktop-qa`, a report-only workflow for one already-running native or Electron desktop window
- use optional Cua Driver with strict window capture, exact PID/window binding, background-only actions, and fresh before/after verification
- route desktop QA separately from browser and mobile QA
- add documentation, cross-host generated skills, and deterministic contract coverage

## Safety boundaries

This first version deliberately does not launch or quit apps, capture the desktop, foreground windows, install or update Cua Driver, grant permissions, edit source code, or fix findings. It requires synthetic or disposable data and explicit approval before external or persistent actions. If a background action cannot be verified, the report marks it unverified instead of widening permissions.

## Prior art and overlap

Related prior art: #596. No implementation code was reused. This PR narrows the idea to an optional report-only desktop workflow and addresses the consent, full-display capture, unreviewed-app execution, and platform-scope concerns raised there. I also reviewed #604, #1574, #262, #2044, #1087, #1093, and #1754; none adds a general Cua Driver desktop QA skill.

## Validation

- `bun test test/host-config.test.ts test/desktop-qa-contract.test.ts test/skill-coverage-matrix.test.ts test/skill-coverage-floor.test.ts test/skill-validation.test.ts test/skill-collision-sentinel.test.ts` — 751 pass, 0 fail
- `bun run gen:skill-docs --host all --dry-run` — all generated outputs fresh
- `bun run skill:check` — new `gstack-desktop-qa` output accepted for every supported host and all host outputs fresh; command retains the existing top-level `claude/SKILL.md` missing-file exit on current main
- Cua Driver 0.12.3 contract smoke — doctor healthy; strict window session started with desktop access locked and ended cleanly
- full `bun test` was attempted; the change-owned golden fixture failures were fixed and retested. Remaining observed failures were unrelated environment/baseline failures, including unavailable XCTest and PATH-dependent gbrain fixtures.