### PR TITLE
fix: raise gbrain version-probe timeout to 10s on Windows

### DIFF
--- a/lib/gbrain-local-status.ts
+++ b/lib/gbrain-local-status.ts
@@ -140,6 +140,10 @@ function hashPath(p: string): string {
  * call share one fork-exec (~200ms saved per skill preamble).
  */
 const _gbrainBinCache = new Map<string, string | null>();
+// On Windows the shim is `gbrain.cmd` → `bun run cli.ts`; a cold spawn can
+// exceed 2s, and a false negative here poisons the 60s status cache with
+// "no-cli". Give the shim headroom; POSIX keeps the tight timeout.
+const VERSION_PROBE_TIMEOUT_MS = NEEDS_SHELL_ON_WINDOWS ? 10_000 : 2_000;
 export function resolveGbrainBin(env?: NodeJS.ProcessEnv): string | null {
   const e = env ?? process.env;
   const key = e.PATH || "";
@@ -148,7 +152,7 @@ export function resolveGbrainBin(env?: NodeJS.ProcessEnv): string | null {
   try {
     execFileSync("gbrain", ["--version"], {
       encoding: "utf-8",
-      timeout: 2_000,
+      timeout: VERSION_PROBE_TIMEOUT_MS,
       stdio: ["ignore", "ignore", "ignore"],
       env: e,
       shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
@@ -171,7 +175,7 @@ export function readGbrainVersion(env?: NodeJS.ProcessEnv): string {
   try {
     const out = execFileSync("gbrain", ["--version"], {
       encoding: "utf-8",
-      timeout: 2_000,
+      timeout: VERSION_PROBE_TIMEOUT_MS,
       stdio: ["ignore", "pipe", "ignore"],
       env: e,
       shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows


### PR DESCRIPTION
## Problem

On Windows the gbrain CLI is a `.cmd` shim that runs `bun run cli.ts`. A cold spawn takes over 2s (warm runs are ~700ms). `resolveGbrainBin` in `lib/gbrain-local-status.ts` probes `gbrain --version` with a 2s timeout, so the cold probe times out and `localEngineStatus` returns `no-cli`. The 60s status cache then serves that false negative to every skill preamble and sync run. Net effect: `/sync-gbrain` skips the memory stage with "gbrain CLI not on PATH; install via /setup-gbrain" on a machine where the CLI works.

## Fix

Add `VERSION_PROBE_TIMEOUT_MS`: 10s when `NEEDS_SHELL_ON_WINDOWS`, 2s otherwise. Used by both `resolveGbrainBin` and `readGbrainVersion`. POSIX keeps the cheap 2s probe; only the Windows shim path gets headroom.

## Verification

On Windows 11 (bun 1.3.14, gbrain 0.42.59.0):
- Before: `gstack-gbrain-detect` reported `gbrain_on_path: false`, `gbrain_local_status: "no-cli"`; sync skipped the memory stage.
- After: detect reports `gbrain_on_path: true`, `gbrain_local_status: "ok"`; memory stage runs (`OK memory — persisted 23 pages`).
- `bun test test/gbrain-local-status.test.ts` shows the same 7 pass / 17 fail before and after the patch on this Windows machine — the 17 failures are pre-existing environment issues (the tests build fake POSIX shims on PATH), not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)