### PR TITLE
fix: Windows build and ACL issues

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -8,6 +8,11 @@
 set -e
 
 GSTACK_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+# Windows (MSYS/Git Bash): convert to a Windows-style path — Bun cannot open
+# MSYS /c/... absolute paths ("FileNotFound opening root directory").
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) GSTACK_DIR="$(cygpath -m "$GSTACK_DIR")" ;;
+esac
 SRC_DIR="$GSTACK_DIR/browse/src"
 DIST_DIR="$GSTACK_DIR/browse/dist"
 

--- a/browse/src/file-permissions.ts
+++ b/browse/src/file-permissions.ts
@@ -42,6 +42,28 @@ import * as os from 'os';
 
 let warnedOnce = false;
 
+/**
+ * Resolve an unambiguous icacls principal for the current user.
+ * Bare usernames can resolve to the machine account when the hostname
+ * equals the username (e.g. host CHIRAG, user chirag) — icacls then grants
+ * the machine SID and the real user loses access. Prefer the fully
+ * qualified `DOMAIN\user` env form (always set on Windows); fall back to
+ * the `*S-1-5-21-...` SID form via whoami.
+ */
+function currentUserPrincipal(): string {
+  const domain = process.env.USERDOMAIN;
+  const user = process.env.USERNAME || os.userInfo().username;
+  if (domain && user) return `${domain}\\${user}`;
+  try {
+    const out = execFileSync('whoami', ['/user'], { encoding: 'utf8' });
+    const m = out.match(/S-1-5-21-\d+-\d+-\d+-\d+/);
+    if (m) return `*${m[0]}`;
+  } catch {
+    /* fall through */
+  }
+  return user;
+}
+
 function warnIcaclsFailure(fsPath: string, err: unknown): void {
   if (warnedOnce) return;
   warnedOnce = true;
@@ -67,10 +89,9 @@ function warnIcaclsFailure(fsPath: string, err: unknown): void {
 export function restrictFilePermissions(filePath: string): void {
   if (process.platform === 'win32') {
     try {
-      const user = os.userInfo().username;
       execFileSync(
         'icacls',
-        [filePath, '/inheritance:r', '/grant:r', `${user}:(F)`],
+        [filePath, '/inheritance:r', '/grant:r', `${currentUserPrincipal()}:(F)`],
         { stdio: 'ignore' },
       );
     } catch (err) {
@@ -97,10 +118,9 @@ export function restrictFilePermissions(filePath: string): void {
 export function restrictDirectoryPermissions(dirPath: string): void {
   if (process.platform === 'win32') {
     try {
-      const user = os.userInfo().username;
       execFileSync(
         'icacls',
-        [dirPath, '/inheritance:r', '/grant:r', `${user}:(OI)(CI)(F)`],
+        [dirPath, '/inheritance:r', '/grant:r', `${currentUserPrincipal()}:(OI)(CI)(F)`],
         { stdio: 'ignore' },
       );
     } catch (err) {


### PR DESCRIPTION
Fixes two Windows-specific issues that prevented gstack from working out-of-the-box:

1. **Build failure for browse/server-node.mjs**
   - On Windows (MSYS/Git Bash), Bun cannot resolve MSYS-style `/c/...` absolute paths.
   - The build-node-server.sh script now converts the GSTACK_DIR to a Windows-style path via `cygpath -m` when running under MINGW/MSYS/CYGWIN.

2. **ACL lockout on .gstack directory**
   - gstack's file-permissions.ts used bare username (`chirag`) for icacls grants.
   - When the hostname equals the username (e.g., host `CHIRAG`, user `chirag`), the bare name resolves to the *machine SID* instead of the user SID.
   - This left the real user without access to the .gstack directory, causing EPERM on reads/writes and the "Another instance is starting the server, waiting..." loop.
   - Changed to use the fully-qualified `%USERDOMAIN%\%USERNAME%` (with fallback to the SID via `whoami /user`) so the correct user gets access.

After applying these patches:
- A fresh `.gstack` directory is created with the correct `CHIRAG\chirag:(OI)(CI)(F)` ACL.
- The browse server starts successfully (tested with `browse goto https://example.com` → text extraction).
- Both the Bun-compiled `browse.exe` and the Node.js compatibility bundle (`server-node.mjs`) are built and functional.

Tested on:
- Windows 10 (MSYS2/Git Bash from git-bash)
- Bun 1.3.14
- Node 24.18.0

Fixes:
- "FileNot able to build browse/server-node.mjs on Windows (FileNotFound opening root directory)"
- Browse server fails with EPERM on .gstack directory due to mistaken ACL granting machine SID

Related to: https://github.com/garrytan/gstack/issues/997 (the codesign note is unrelated, but same class of Windows-specific issues)
