### PR TITLE
fix: preserve gbrain argv on Windows without a shell

### DIFF
--- a/.github/workflows/windows-free-tests.yml
+++ b/.github/workflows/windows-free-tests.yml
@@ -118,6 +118,8 @@ jobs:
             test/build-script-shell-compat.test.ts \
             test/docs-config-keys.test.ts \
             test/brain-sync-windows-paths.test.ts \
+            test/gbrain-exec-argv.test.ts \
+            test/gbrain-spawn-windows-shell.test.ts \
             make-pdf/test/browseClient.test.ts \
             make-pdf/test/pdftotext.test.ts
         shell: bash

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@huggingface/transformers": "^4.1.0",
         "@ngrok/ngrok": "^1.7.0",
+        "cross-spawn": "7.0.6",
         "diff": "^7.0.0",
         "html-to-docx": "1.8.0",
         "marked": "^18.0.2",

--- a/lib/gbrain-exec.ts
+++ b/lib/gbrain-exec.ts
@@ -210,13 +210,7 @@ export function spawnGbrainAsync(
  * callers that want to surface gbrain's stderr as the error message.
  */
 export function execGbrainText(args: string[], opts: SpawnGbrainOptions = {}): string {
-  const result = crossSpawn.sync("gbrain", args, {
-    encoding: "utf-8",
-    timeout: opts.timeout ?? 30_000,
-    cwd: opts.cwd,
-    stdio: opts.stdio || ["ignore", "pipe", "pipe"],
-    env: buildGbrainEnv({ baseEnv: opts.baseEnv, announce: opts.announce }),
-  }) as GbrainSpawnResult;
+  const result = spawnGbrain(args, opts);
 
   if (result.error) throw result.error;
   if (result.status !== 0) {

--- a/lib/gbrain-exec.ts
+++ b/lib/gbrain-exec.ts
@@ -34,7 +34,7 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { spawnSync, spawn, execFileSync, type SpawnSyncReturns, type ChildProcess, type SpawnOptions } from "child_process";
+import crossSpawn from "cross-spawn";
 
 interface GbrainConfig {
   database_url?: string;
@@ -125,14 +125,9 @@ export function buildGbrainEnv(opts: BuildGbrainEnvOptions = {}): NodeJS.Process
 }
 
 /**
- * Windows can't directly spawn the `gbrain` launcher (bun/npm install it as a
- * `gbrain.cmd`/`.ps1` shim) or a shebang script like the bash `gstack-brain-sync`
- * — `spawnSync`/`spawn` resolve those only through a shell's PATHEXT + interpreter
- * lookup. Without `shell: true` the child spawn fails ENOENT, which on the sync
- * orchestrator surfaced as "brain-sync exited undefined" (#1731). Gate on platform
- * so POSIX keeps the cheaper no-shell path. Exported so the static-grep tripwire
- * (test/gbrain-spawn-windows-shell.test.ts) can assert every gbrain/brain-sync
- * spawn carries it.
+ * Legacy platform gate for fixed-argument probes and the internal brain-sync
+ * script. User-controlled gbrain arguments must use the cross-spawn helpers
+ * below, which handle Windows shims without Node's shell:true command string.
  */
 export const NEEDS_SHELL_ON_WINDOWS = process.platform === "win32";
 
@@ -153,20 +148,29 @@ export interface SpawnGbrainOptions {
   announce?: boolean;
 }
 
+export interface GbrainSpawnResult {
+  pid: number;
+  output: Array<string | null>;
+  stdout: string;
+  stderr: string;
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  error?: Error;
+}
+
 /**
  * Spawn `gbrain <args>` with the seeded env. Returns the raw
- * `SpawnSyncReturns<string>` so callers can inspect `status`, `stdout`,
- * `stderr` exactly as they would with `spawnSync` directly.
+ * result so callers can inspect `status`, `stdout`, and `stderr` exactly as
+ * they would with `spawnSync` directly.
  */
-export function spawnGbrain(args: string[], opts: SpawnGbrainOptions = {}): SpawnSyncReturns<string> {
-  return spawnSync("gbrain", args, {
+export function spawnGbrain(args: string[], opts: SpawnGbrainOptions = {}): GbrainSpawnResult {
+  return crossSpawn.sync("gbrain", args, {
     encoding: "utf-8",
     timeout: opts.timeout ?? 30_000,
     cwd: opts.cwd,
     stdio: opts.stdio || ["ignore", "pipe", "pipe"],
     env: buildGbrainEnv({ baseEnv: opts.baseEnv, announce: opts.announce }),
-    shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
-  });
+  }) as GbrainSpawnResult;
 }
 
 /**
@@ -192,27 +196,34 @@ export function execGbrainJson<T = unknown>(args: string[], opts: SpawnGbrainOpt
  */
 export function spawnGbrainAsync(
   args: string[],
-  opts: { stdio?: SpawnOptions["stdio"]; cwd?: string; baseEnv?: NodeJS.ProcessEnv } = {},
-): ChildProcess {
-  return spawn("gbrain", args, {
+  opts: { stdio?: SpawnGbrainOptions["stdio"]; cwd?: string; baseEnv?: NodeJS.ProcessEnv } = {},
+): ReturnType<typeof crossSpawn> {
+  return crossSpawn("gbrain", args, {
     stdio: opts.stdio || ["ignore", "pipe", "pipe"],
     cwd: opts.cwd,
     env: buildGbrainEnv({ baseEnv: opts.baseEnv, announce: false }),
-    shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
   });
 }
 
 /**
- * Run `gbrain <args>` via execFileSync. Throws on non-zero exit. Useful
- * for callers that want to surface gbrain's stderr as the error message.
+ * Run `gbrain <args>` synchronously. Throws on non-zero exit. Useful for
+ * callers that want to surface gbrain's stderr as the error message.
  */
 export function execGbrainText(args: string[], opts: SpawnGbrainOptions = {}): string {
-  return execFileSync("gbrain", args, {
+  const result = crossSpawn.sync("gbrain", args, {
     encoding: "utf-8",
     timeout: opts.timeout ?? 30_000,
     cwd: opts.cwd,
     stdio: opts.stdio || ["ignore", "pipe", "pipe"],
     env: buildGbrainEnv({ baseEnv: opts.baseEnv, announce: opts.announce }),
-    shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
-  });
+  }) as GbrainSpawnResult;
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const error = new Error(`gbrain exited with status ${result.status ?? "unknown"}`) as Error &
+      Partial<GbrainSpawnResult>;
+    Object.assign(error, result);
+    throw error;
+  }
+  return result.stdout || "";
 }

--- a/lib/gbrain-sources.ts
+++ b/lib/gbrain-sources.ts
@@ -9,9 +9,8 @@
  * Per /plan-eng-review D3 (DRY extraction).
  */
 
-import { execFileSync, spawnSync } from "child_process";
 import { withErrorContext } from "./gstack-memory-helpers";
-import { execGbrainJson, NEEDS_SHELL_ON_WINDOWS } from "./gbrain-exec";
+import { execGbrainJson, execGbrainText, spawnGbrain } from "./gbrain-exec";
 
 export interface SourceState {
   /** "absent" — id not registered. "match" — id at expected path. "drift" — id at different path. */
@@ -83,16 +82,14 @@ export interface EnsureOptions {
 export function probeSource(id: string, env?: NodeJS.ProcessEnv): SourceState {
   let stdout: string;
   try {
-    stdout = execFileSync("gbrain", ["sources", "list", "--json"], {
-      encoding: "utf-8",
+    stdout = execGbrainText(["sources", "list", "--json"], {
       timeout: 30_000,
       stdio: ["ignore", "pipe", "pipe"],
-      env,
-      shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
+      baseEnv: env,
     });
   } catch (err) {
-    const e = err as NodeJS.ErrnoException & { stderr?: Buffer };
-    const stderr = e.stderr?.toString() || "";
+    const e = err as NodeJS.ErrnoException & { stderr?: Buffer | string };
+    const stderr = typeof e.stderr === "string" ? e.stderr : e.stderr?.toString() || "";
     if (e.code === "ENOENT" || stderr.includes("command not found")) {
       throw new Error("gbrain CLI not on PATH");
     }
@@ -158,11 +155,9 @@ export async function ensureSourceRegistered(
 
     // For drift, remove first.
     if (state.status === "drift") {
-      const rm = spawnSync("gbrain", ["sources", "remove", id, "--yes"], {
-        encoding: "utf-8",
+      const rm = spawnGbrain(["sources", "remove", id, "--yes"], {
         timeout: 30_000,
-        env,
-        shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
+        baseEnv: env,
       });
       if (rm.status !== 0) {
         throw new Error(`gbrain sources remove ${id} failed: ${rm.stderr || rm.stdout || `exit ${rm.status}`}`);
@@ -172,11 +167,9 @@ export async function ensureSourceRegistered(
     // Add.
     const addArgs = ["sources", "add", id, "--path", path];
     if (federated) addArgs.push("--federated");
-    const add = spawnSync("gbrain", addArgs, {
-      encoding: "utf-8",
+    const add = spawnGbrain(addArgs, {
       timeout: 30_000,
-      env,
-      shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
+      baseEnv: env,
     });
     if (add.status !== 0) {
       throw new Error(`gbrain sources add ${id} failed: ${add.stderr || add.stdout || `exit ${add.status}`}`);
@@ -197,12 +190,10 @@ export async function ensureSourceRegistered(
 export function sourcePageCount(id: string, env?: NodeJS.ProcessEnv): number | null {
   let stdout: string;
   try {
-    stdout = execFileSync("gbrain", ["sources", "list", "--json"], {
-      encoding: "utf-8",
+    stdout = execGbrainText(["sources", "list", "--json"], {
       timeout: 30_000,
       stdio: ["ignore", "pipe", "pipe"],
-      env,
-      shell: NEEDS_SHELL_ON_WINDOWS, // #1731: gbrain is a .cmd shim on Windows
+      baseEnv: env,
     });
   } catch {
     return null;

--- a/lib/gbrain-sources.ts
+++ b/lib/gbrain-sources.ts
@@ -64,9 +64,8 @@ export interface EnsureOptions {
   reregister_on_drift?: boolean;
   /**
    * Optional env override for the spawned `gbrain` calls. Production callers
-   * leave this unset (inherit process.env). Tests pass a custom env to point
-   * at a fake `gbrain` on PATH (Bun's execFileSync does not respect runtime
-   * mutations of process.env.PATH unless env is passed explicitly).
+   * leave this unset (inherit process.env). Tests pass a custom env to control
+   * PATH and gbrain configuration without mutating process.env.
    */
   env?: NodeJS.ProcessEnv;
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@huggingface/transformers": "^4.1.0",
     "@ngrok/ngrok": "^1.7.0",
+    "cross-spawn": "7.0.6",
     "diff": "^7.0.0",
     "html-to-docx": "1.8.0",
     "marked": "^18.0.2",

--- a/test/gbrain-exec-argv.test.ts
+++ b/test/gbrain-exec-argv.test.ts
@@ -2,47 +2,120 @@ import { describe, expect, test } from "bun:test";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { delimiter, join } from "path";
-import { spawnGbrain } from "../lib/gbrain-exec";
+import {
+  execGbrainText,
+  spawnGbrain,
+  spawnGbrainAsync,
+} from "../lib/gbrain-exec";
+
+const ARGS = [
+  "search",
+  "",
+  "space separated",
+  "ampersand&whoami",
+  "pipe|whoami",
+  "caret^value",
+  "%PATH%",
+  "!DELAYED!",
+  "single'quote",
+  'double"quote',
+  "backslash\\value",
+  "parentheses(value)",
+];
+
+function makeFakeGbrain(): { root: string; env: NodeJS.ProcessEnv } {
+  const root = mkdtempSync(join(tmpdir(), "gstack-gbrain-argv-"));
+  const capture = join(root, "capture.ts");
+  writeFileSync(
+    capture,
+    [
+      "const args = Bun.argv.slice(2);",
+      'if (args[0] === "fail") {',
+      '  console.error("expected failure");',
+      "  process.exit(17);",
+      "}",
+      "console.log(JSON.stringify(args));",
+      "",
+    ].join("\n"),
+  );
+
+  if (process.platform === "win32") {
+    writeFileSync(join(root, "gbrain.cmd"), `@echo off\r\nbun "${capture}" %*\r\n`);
+  } else {
+    const shim = join(root, "gbrain");
+    writeFileSync(shim, `#!/usr/bin/env bun\nimport "${capture}";\n`);
+    chmodSync(shim, 0o755);
+  }
+
+  return {
+    root,
+    env: {
+      ...process.env,
+      HOME: root,
+      GBRAIN_HOME: join(root, ".gbrain"),
+      PATH: `${root}${delimiter}${process.env.PATH || ""}`,
+    },
+  };
+}
+
+function captureAsync(
+  child: ReturnType<typeof spawnGbrainAsync>,
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => { stdout += chunk; });
+    child.stderr?.on("data", (chunk) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (status) => resolve({ status, stdout, stderr }));
+  });
+}
 
 describe("gbrain argv integrity", () => {
-  test("passes Windows shell metacharacters as literal argv", () => {
-    const root = mkdtempSync(join(tmpdir(), "gstack-gbrain-argv-"));
+  test("spawnGbrain passes shell metacharacters as literal argv", () => {
+    const fake = makeFakeGbrain();
     try {
-      const capture = join(root, "capture.ts");
-      writeFileSync(capture, 'console.log(JSON.stringify(Bun.argv.slice(2)));\n');
-
-      if (process.platform === "win32") {
-        writeFileSync(join(root, "gbrain.cmd"), `@echo off\r\nbun "${capture}" %*\r\n`);
-      } else {
-        const shim = join(root, "gbrain");
-        writeFileSync(shim, `#!/usr/bin/env bun\nimport "${capture}";\n`);
-        chmodSync(shim, 0o755);
-      }
-
-      const args = [
-        "search",
-        "space separated",
-        "ampersand&whoami",
-        "pipe|whoami",
-        "caret^value",
-        "%PATH%",
-        "!DELAYED!",
-        'quote"value',
-        "parentheses(value)",
-      ];
-      const result = spawnGbrain(args, {
-        baseEnv: {
-          ...process.env,
-          HOME: root,
-          GBRAIN_HOME: join(root, ".gbrain"),
-          PATH: `${root}${delimiter}${process.env.PATH || ""}`,
-        },
-      });
+      const result = spawnGbrain(ARGS, { baseEnv: fake.env });
 
       expect(result.status).toBe(0);
-      expect(JSON.parse(result.stdout)).toEqual(args);
+      expect(JSON.parse(result.stdout)).toEqual(ARGS);
     } finally {
-      rmSync(root, { recursive: true, force: true });
+      rmSync(fake.root, { recursive: true, force: true });
+    }
+  });
+
+  test("execGbrainText preserves argv and exposes non-zero child metadata", () => {
+    const fake = makeFakeGbrain();
+    try {
+      expect(JSON.parse(execGbrainText(ARGS, { baseEnv: fake.env }))).toEqual(ARGS);
+
+      let failure: (Error & { status?: number; stderr?: string }) | undefined;
+      try {
+        execGbrainText(["fail"], { baseEnv: fake.env });
+      } catch (error) {
+        failure = error as Error & { status?: number; stderr?: string };
+      }
+      expect(failure?.status).toBe(17);
+      expect(failure?.stderr).toContain("expected failure");
+    } finally {
+      rmSync(fake.root, { recursive: true, force: true });
+    }
+  });
+
+  test("spawnGbrainAsync preserves literal argv", async () => {
+    const fake = makeFakeGbrain();
+    try {
+      const result = await captureAsync(spawnGbrainAsync(ARGS, {
+        baseEnv: fake.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      }));
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(JSON.parse(result.stdout)).toEqual(ARGS);
+    } finally {
+      rmSync(fake.root, { recursive: true, force: true });
     }
   });
 });

--- a/test/gbrain-exec-argv.test.ts
+++ b/test/gbrain-exec-argv.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { delimiter, join } from "path";
+import { spawnGbrain } from "../lib/gbrain-exec";
+
+describe("gbrain argv integrity", () => {
+  test("passes Windows shell metacharacters as literal argv", () => {
+    const root = mkdtempSync(join(tmpdir(), "gstack-gbrain-argv-"));
+    try {
+      const capture = join(root, "capture.ts");
+      writeFileSync(capture, 'console.log(JSON.stringify(Bun.argv.slice(2)));\n');
+
+      if (process.platform === "win32") {
+        writeFileSync(join(root, "gbrain.cmd"), `@echo off\r\nbun "${capture}" %*\r\n`);
+      } else {
+        const shim = join(root, "gbrain");
+        writeFileSync(shim, `#!/usr/bin/env bun\nimport "${capture}";\n`);
+        chmodSync(shim, 0o755);
+      }
+
+      const args = [
+        "search",
+        "space separated",
+        "ampersand&whoami",
+        "pipe|whoami",
+        "caret^value",
+        "%PATH%",
+        "!DELAYED!",
+        'quote"value',
+        "parentheses(value)",
+      ];
+      const result = spawnGbrain(args, {
+        baseEnv: {
+          ...process.env,
+          HOME: root,
+          GBRAIN_HOME: join(root, ".gbrain"),
+          PATH: `${root}${delimiter}${process.env.PATH || ""}`,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual(args);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/gbrain-sources.test.ts
+++ b/test/gbrain-sources.test.ts
@@ -190,6 +190,27 @@ describe("ensureSourceRegistered", () => {
     expect(log).not.toContain("sources add");
     fake.cleanup();
   });
+
+  it("preserves shell metacharacters in source ids and paths", async () => {
+    const fake = makeFakeGbrain({ sources: [] });
+    const id = "source&literal";
+    const path = '/tmp/space & pipe| caret^ percent% bang! quote" parentheses(x)';
+
+    const result = await ensureSourceRegistered(id, path, { env: fake.env });
+    expect(result).toEqual({
+      changed: true,
+      state: { status: "match", registered_path: path },
+    });
+
+    const persisted = JSON.parse(readFileSync(fake.statePath, "utf-8"));
+    expect(persisted.sources).toContainEqual({
+      id,
+      local_path: path,
+      federated: false,
+      page_count: 0,
+    });
+    fake.cleanup();
+  });
 });
 
 describe("sourcePageCount", () => {

--- a/test/gbrain-spawn-windows-shell.test.ts
+++ b/test/gbrain-spawn-windows-shell.test.ts
@@ -5,34 +5,24 @@ import * as path from "path";
 const ROOT = path.resolve(import.meta.dir, "..");
 const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), "utf-8");
 
-// #1731 tripwire. Windows can't spawn the `gbrain` shim (gbrain.cmd) or the bash
-// shebang script gstack-brain-sync without a shell; the fix gates `shell: true`
-// behind NEEDS_SHELL_ON_WINDOWS. These static checks fail CI if a refactor adds
-// a gbrain/brain-sync child spawn without the Windows shell flag, since macOS/
-// Linux CI can't exercise the Windows path at runtime.
-describe("#1731 gbrain spawns carry the Windows shell flag", () => {
-  test("NEEDS_SHELL_ON_WINDOWS is platform-gated in gbrain-exec.ts", () => {
+// Windows command shims require special PATHEXT/shebang handling. cross-spawn
+// supplies that adapter without exposing gbrain arguments to `cmd.exe` through
+// Node's shell:true command-string path.
+describe("#1731 gbrain spawns use the shell-free Windows adapter", () => {
+  test("centralized gbrain execution uses cross-spawn without shell:true", () => {
     const src = read("lib/gbrain-exec.ts");
-    expect(src).toMatch(/export const NEEDS_SHELL_ON_WINDOWS\s*=\s*process\.platform === "win32"/);
+    expect(src).toContain('import crossSpawn from "cross-spawn"');
+    expect(src).not.toMatch(/^\s*shell\s*:/m);
+    expect(src.match(/crossSpawn\.sync\("gbrain"/g)?.length).toBe(2);
+    expect(src.match(/crossSpawn\("gbrain"/g)?.length).toBe(1);
   });
 
-  // Every direct `gbrain` child spawn in these files must be matched by a
-  // shell:NEEDS_SHELL_ON_WINDOWS flag. Count openers vs flags as a cheap,
-  // refactor-resistant invariant.
-  const gbrainSpawnFiles = [
-    "lib/gbrain-exec.ts",
-    "lib/gbrain-sources.ts",
-    "lib/gbrain-local-status.ts",
-  ];
-  for (const rel of gbrainSpawnFiles) {
-    test(`${rel}: every gbrain spawn has shell:NEEDS_SHELL_ON_WINDOWS`, () => {
-      const src = read(rel);
-      const spawnOpeners = src.match(/(spawnSync|spawn|execFileSync)\("gbrain"/g)?.length ?? 0;
-      const shellFlags = src.match(/shell:\s*NEEDS_SHELL_ON_WINDOWS/g)?.length ?? 0;
-      expect(spawnOpeners).toBeGreaterThan(0);
-      expect(shellFlags).toBeGreaterThanOrEqual(spawnOpeners);
-    });
-  }
+  test("gbrain source IDs and paths route through the shell-free adapter", () => {
+    const src = read("lib/gbrain-sources.ts");
+    expect(src).not.toMatch(/(spawnSync|execFileSync)\("gbrain"/);
+    expect(src).not.toContain("NEEDS_SHELL_ON_WINDOWS");
+    expect(src).toContain("spawnGbrain(addArgs");
+  });
 
   test("orchestrator brain-sync spawns carry the Windows shell flag", () => {
     const src = read("bin/gstack-gbrain-sync.ts");

--- a/test/gbrain-spawn-windows-shell.test.ts
+++ b/test/gbrain-spawn-windows-shell.test.ts
@@ -13,8 +13,9 @@ describe("#1731 gbrain spawns use the shell-free Windows adapter", () => {
     const src = read("lib/gbrain-exec.ts");
     expect(src).toContain('import crossSpawn from "cross-spawn"');
     expect(src).not.toMatch(/^\s*shell\s*:/m);
-    expect(src.match(/crossSpawn\.sync\("gbrain"/g)?.length).toBe(2);
+    expect(src.match(/crossSpawn\.sync\("gbrain"/g)?.length).toBe(1);
     expect(src.match(/crossSpawn\("gbrain"/g)?.length).toBe(1);
+    expect(src).toContain("const result = spawnGbrain(args, opts)");
   });
 
   test("gbrain source IDs and paths route through the shell-free adapter", () => {


### PR DESCRIPTION
## Summary

- run direct `gbrain` invocations through `cross-spawn` without `shell: true`
- centralize synchronous, text, and asynchronous argv handling
- preserve source IDs, paths, and search arguments as literal argv values
- exercise the regression in the existing `windows-latest` test job

## Why

On Windows, launching the `gbrain.cmd` shim through Node's shell mode can reinterpret argument metacharacters. `cross-spawn` resolves the command shim while keeping the argument vector separate from a composed shell command.

This is a focused alternative to #2272. That PR includes broader Windows runtime and release changes; this one intentionally limits scope to direct `gbrain` process creation and its regression coverage.

## Validation

- `bun run build`
- targeted gbrain tests: 38 passed, 0 failed
- full `bun run test` completed locally with exit 0; relevant targeted tests are clean

Windows CI now runs both the argv round-trip and shell-free adapter invariants.
