### PR TITLE
fix: harden external review preflight

### DIFF
--- a/claude/SKILL.md.tmpl
+++ b/claude/SKILL.md.tmpl
@@ -42,20 +42,50 @@ CLAUDE_BIN=$(command -v claude 2>/dev/null || echo "")
 If `NOT_FOUND`, stop and tell the user:
 "Claude CLI not found. Install Claude Code, then re-run this skill."
 
-Check auth:
+Check auth. A failed CLI probe is not proof that the user is logged out: sandboxed
+hosts may be unable to read macOS Keychain or reach the provider even though the
+normal host session is authenticated.
 
 ```bash
+_CLAUDE_AUTH_JSON=""
+_CLAUDE_AUTH_EXIT=0
+_CLAUDE_AUTH_JSON=$(claude auth status --json 2>/dev/null) || _CLAUDE_AUTH_EXIT=$?
+
 if [ -f "$HOME/.claude/.credentials.json" ] \
   || [ -n "${ANTHROPIC_API_KEY:-}" ] \
-  || claude auth status --json >/dev/null 2>&1; then
+  || printf '%s' "$_CLAUDE_AUTH_JSON" | grep -Eq '"loggedIn"[[:space:]]*:[[:space:]]*true'; then
   echo "AUTH_FOUND"
 else
-  echo "AUTH_MISSING"
+  echo "AUTH_UNKNOWN: cli_exit=$_CLAUDE_AUTH_EXIT"
+  printf '%s\n' "$_CLAUDE_AUTH_JSON"
 fi
 ```
 
-If `AUTH_MISSING`, stop and tell the user:
-"No Claude authentication found. Run `claude auth login` (or `claude` interactively), or export `ANTHROPIC_API_KEY`, then re-run this skill."
+If `AUTH_UNKNOWN`, **do not report that authentication is missing.** On a sandboxed
+host, request narrowly scoped host credential/network access and rerun
+`claude auth status --json`. Classify the result only after that authoritative
+host-context check:
+
+- `"loggedIn": true` — continue.
+- `"loggedIn": false` — stop and tell the user: "Claude is logged out. Run
+  `claude auth login` (or `claude` interactively), then re-run this skill."
+- The host-context probe could not run — report authentication as unverified,
+  including the concrete access error. Never turn an access failure into a logout.
+
+---
+
+## External Data Authorization Boundary
+
+Before reading or assembling repository content for Claude, confirm that the current
+user explicitly authorized sending the specific payload to **Anthropic Claude** for
+this review. Name the payload accurately: complete diff and necessary source, a plan,
+or other repository context.
+
+Authentication, command execution approval, a configured review preference, and a
+generic request for an "independent review" are not source-export consent. If the
+current request does not name Anthropic Claude and the data scope, use
+AskUserQuestion to request that authorization and wait for the answer. Do not infer
+authorization from another provider, PR, repository, or earlier session.
 
 ---
 
@@ -140,8 +170,12 @@ if session_id:
 PY
 ```
 
-If stderr contains `auth`, `login`, or `unauthorized`, tell the user:
-"Claude authentication failed. Run `claude` interactively to authenticate or export `ANTHROPIC_API_KEY`."
+If stderr contains `auth`, `login`, or `unauthorized`, do not immediately report
+the user as logged out. Repeat the narrow authentication check from Step 0 in a
+host context with credential-store and network access. Only an authoritative
+`loggedIn: false` result is an authentication failure. If the host check cannot
+run, report authentication as **unverified** and include the access error; never
+turn a sandbox/Keychain/network denial into login instructions.
 
 ---
 
@@ -327,8 +361,9 @@ rm -f "$PROMPT_FILE" "$RESP_FILE" "$ERR_FILE"
 ## Error Handling
 
 - **Binary not found:** Stop with install instructions.
-- **Auth missing:** Stop with login/API key instructions.
-- **Auth failure from stderr:** Surface the stderr line and ask the user to re-authenticate.
+- **Auth explicitly missing after host check:** Stop with login/API key instructions.
+- **Auth unverified:** Surface the access error and request the narrow host recheck.
+- **Auth failure from stderr:** Recheck in host context before asking the user to re-authenticate.
 - **JSON parse failure:** Show raw stdout from `$RESP_FILE` and stderr from `$ERR_FILE`.
 - **Empty response:** Tell the user "Claude returned no response. Check stderr for errors."
 - **Resume failure:** Delete `.context/claude-session-id` and retry with a fresh session.

--- a/claude/SKILL.md.tmpl
+++ b/claude/SKILL.md.tmpl
@@ -45,7 +45,9 @@ If `NOT_FOUND`, stop and tell the user:
 Check auth:
 
 ```bash
-if [ -f "$HOME/.claude/.credentials.json" ] || [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+if [ -f "$HOME/.claude/.credentials.json" ] \
+  || [ -n "${ANTHROPIC_API_KEY:-}" ] \
+  || claude auth status --json >/dev/null 2>&1; then
   echo "AUTH_FOUND"
 else
   echo "AUTH_MISSING"
@@ -53,7 +55,7 @@ fi
 ```
 
 If `AUTH_MISSING`, stop and tell the user:
-"No Claude authentication found. Run `claude` interactively to log in, or export `ANTHROPIC_API_KEY`, then re-run this skill."
+"No Claude authentication found. Run `claude auth login` (or `claude` interactively), or export `ANTHROPIC_API_KEY`, then re-run this skill."
 
 ---
 

--- a/claude/SKILL.md.tmpl
+++ b/claude/SKILL.md.tmpl
@@ -96,15 +96,16 @@ Use these shell snippets in every mode.
 Create temp files:
 
 ```bash
-PROMPT_FILE=$(mktemp /tmp/gstack-claude-prompt-XXXXXX)
-RESP_FILE=$(mktemp /tmp/gstack-claude-response-XXXXXX.json)
-ERR_FILE=$(mktemp /tmp/gstack-claude-error-XXXXXX.txt)
+CLAUDE_TMP_DIR=$(mktemp -d /tmp/gstack-claude-XXXXXX)
+PROMPT_FILE="$CLAUDE_TMP_DIR/prompt.txt"
+RESP_FILE="$CLAUDE_TMP_DIR/response.json"
+ERR_FILE="$CLAUDE_TMP_DIR/error.txt"
 ```
 
 Cleanup at the end of every mode:
 
 ```bash
-rm -f "$PROMPT_FILE" "$RESP_FILE" "$ERR_FILE"
+rm -rf "$CLAUDE_TMP_DIR"
 ```
 
 Parse JSON output:
@@ -153,7 +154,7 @@ Review the current branch diff with nested Claude in tool-less mode.
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 cd "$_REPO_ROOT"
-DIFF_FILE=$(mktemp /tmp/gstack-claude-diff-XXXXXX.patch)
+DIFF_FILE="$CLAUDE_TMP_DIR/diff.patch"
 git fetch origin <base> --quiet 2>/dev/null || true
 git diff "origin/<base>" > "$DIFF_FILE" 2>/dev/null || git diff "<base>" > "$DIFF_FILE"
 ```
@@ -195,7 +196,7 @@ CLAUDE SAYS (code review):
 5. Cleanup:
 
 ```bash
-rm -f "$DIFF_FILE" "$PROMPT_FILE" "$RESP_FILE" "$ERR_FILE"
+rm -rf "$CLAUDE_TMP_DIR"
 ```
 
 ---
@@ -241,7 +242,7 @@ CLAUDE SAYS (adversarial challenge):
 5. Cleanup:
 
 ```bash
-rm -f "$DIFF_FILE" "$PROMPT_FILE" "$RESP_FILE" "$ERR_FILE"
+rm -rf "$CLAUDE_TMP_DIR"
 ```
 
 ---

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -899,6 +899,21 @@ deadlock fixed in #972.
 
 ---
 
+## Step 0.55: External data authorization
+
+Before reading or assembling repository content for Codex, confirm that the current
+user explicitly authorized sending the specific payload to the **OpenAI Codex model
+service** for this review. Name the payload accurately: complete diff and necessary
+source, a plan, or other repository context.
+
+Authentication, command execution approval, a configured review preference, and a
+generic request for an "independent review" are not source-export consent. If the
+current request does not name OpenAI Codex and the data scope, use AskUserQuestion to
+request that authorization and wait for the answer. Do not infer authorization from
+another provider, PR, repository, or earlier session.
+
+---
+
 ## Step 0.6: Resolve portable roots
 
 Before any mode runs, resolve `$PLAN_ROOT` (where plan files live) and `$TMP_ROOT`

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -90,6 +90,21 @@ deadlock fixed in #972.
 
 ---
 
+## Step 0.55: External data authorization
+
+Before reading or assembling repository content for Codex, confirm that the current
+user explicitly authorized sending the specific payload to the **OpenAI Codex model
+service** for this review. Name the payload accurately: complete diff and necessary
+source, a plan, or other repository context.
+
+Authentication, command execution approval, a configured review preference, and a
+generic request for an "independent review" are not source-export consent. If the
+current request does not name OpenAI Codex and the data scope, use AskUserQuestion to
+request that authorization and wait for the answer. Do not infer authorization from
+another provider, PR, repository, or earlier session.
+
+---
+
 ## Step 0.6: Resolve portable roots
 
 Before any mode runs, resolve `$PLAN_ROOT` (where plan files live) and `$TMP_ROOT`

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -1133,12 +1133,24 @@ Use AskUserQuestion:
 
 If user chooses B, skip this step and continue.
 
-**Check Codex availability:**
+**Check Codex availability, then authorize export:**
+
 ```bash
 command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
-**If Codex is available**, launch both voices simultaneously:
+If Codex is available, apply this gate before reading or assembling its payload:
+
+**External data authorization:** Before reading or assembling the design plan, design artifacts, and necessary source context, confirm
+the user authorized sending that payload to the **OpenAI Codex model service** for
+this invocation. Authentication, command approval, `codex_reviews=enabled`, or a
+generic request for independent review is not export consent. If OpenAI Codex and
+the payload were not both named, use AskUserQuestion and wait. Decline or inability
+to ask means skip Codex and continue locally. Never reuse consent across providers,
+repositories, pull requests, or sessions.
+
+Launch the Claude design subagent. If Codex is also authorized, launch its voice
+simultaneously:
 
 1. **Codex design voice** (via Bash):
 ```bash

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -1718,14 +1718,28 @@ Record baseline design score and AI slop score at end of Phase 6.
 
 ## Design Outside Voices (parallel)
 
-**Automatic:** Outside voices run automatically when Codex is available. No opt-in needed.
+**Configured automatically:** The in-session design voice runs as part of this review.
+The Codex voice still requires explicit OpenAI-and-payload export authorization for
+this invocation.
 
-**Check Codex availability:**
+**Check Codex availability, then authorize export:**
+
 ```bash
 command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
-**If Codex is available**, launch both voices simultaneously:
+If Codex is available, apply this gate before reading or assembling its payload:
+
+**External data authorization:** Before reading or assembling the design plan, design artifacts, and necessary source context, confirm
+the user authorized sending that payload to the **OpenAI Codex model service** for
+this invocation. Authentication, command approval, `codex_reviews=enabled`, or a
+generic request for independent review is not export consent. If OpenAI Codex and
+the payload were not both named, use AskUserQuestion and wait. Decline or inability
+to ask means skip Codex and continue locally. Never reuse consent across providers,
+repositories, pull requests, or sessions.
+
+Launch the Claude design subagent. If Codex is also authorized, launch its voice
+simultaneously:
 
 1. **Codex design voice** (via Bash):
 ```bash

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -1155,7 +1155,7 @@ Display:
 - **Eng Review (required by default):** The only review that gates shipping. Covers architecture, code quality, tests, performance. Can be disabled globally with \`gstack-config set skip_eng_review true\` (the "don't bother me" setting).
 - **CEO Review (optional):** Use your judgment. Recommend it for big product/business changes, new user-facing features, or scope decisions. Skip for bug fixes, refactors, infra, and cleanup.
 - **Design Review (optional):** Use your judgment. Recommend it for UI/UX changes. Skip for backend-only, infra, or prompt-only changes.
-- **Adversarial Review (automatic):** Always-on for every review. Every diff gets both Claude adversarial subagent and Codex adversarial challenge. Large diffs (200+ lines) additionally get Codex structured review with P1 gate. No configuration needed.
+- **Adversarial Review:** Every diff gets the in-session Claude adversarial pass. Codex cross-model passes are offered when configured and run only after explicit provider-and-payload export authorization; large authorized diffs (200+ lines) additionally get Codex structured review with a P1 gate.
 - **Outside Voice (optional):** Independent plan review from a different AI model. Offered after all review sections complete in /plan-ceo-review and /plan-eng-review. Falls back to Claude subagent if Codex is unavailable. Never gates shipping.
 
 **Verdict logic:**

--- a/document-release/sections/release-body.md
+++ b/document-release/sections/release-body.md
@@ -361,14 +361,19 @@ If all coverage is complete and no diagrams drifted, output: "Coverage: all ship
 
 ---
 
-## Codex Documentation Review (default-on)
+## Codex Documentation Review (configured by default; export consent required)
 
 After the documentation updates above are written, run an independent cross-model pass that
-checks the docs against what actually shipped. This is a standard part of /document-release,
-not an opt-in. The user turns it off only by asking explicitly
+checks the docs against what actually shipped. This is a configured standard option in
+/document-release, but it never authorizes exporting documentation or a comparison diff.
+Each invocation requires explicit provider-and-payload authorization. The user can disable
+the option with
 (`gstack-config set codex_reviews disabled`).
 
 **Preflight — decide whether and how the doc review runs:**
+
+Run this local provider/configuration preflight first. It does not export
+repository content:
 
 ```bash
 # Codex preflight: one block (functions sourced here don't persist to later blocks).
@@ -391,10 +396,23 @@ Branch on the echoed `CODEX_MODE`:
 - **`disabled`** — the user turned Codex reviews off (`codex_reviews=disabled`). Skip this section entirely; do NOT fall back to a Claude subagent — disabled means no extra review step. Print: "Codex review skipped (codex_reviews disabled). Re-enable: `gstack-config set codex_reviews enabled`."
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
-- **`ready`** — run the Codex pass below.
+- **`ready`** — do not read or assemble the provider payload yet. First confirm
+  that the current user explicitly authorized sending the specific payload to the
+  **OpenAI Codex model service** for this invocation. Name the actual payload:
+  complete diff and necessary source, a plan, documentation plus its comparison
+  diff, or other repository context. Authentication, command execution approval,
+  `codex_reviews=enabled`, and a generic request for an "independent review" are
+  not source-export consent. If the request does not name OpenAI Codex and the data
+  scope, use AskUserQuestion and wait. Never infer consent from another provider,
+  PR, repository, or earlier session. If declined, treat Codex as unavailable and
+  continue only with the caller's in-session fallback. Only after authorization is
+  confirmed may the Codex pass below read, assemble, or dispatch the payload.
 
-When the mode is `ready`, `not_installed`, or `not_authed`, print one line so the off-switch
-stays discoverable: "Running the Codex doc review automatically (standard step). Disable: `gstack-config set codex_reviews disabled`."
+When the mode is `ready` and authorization was granted, print one line so the
+off-switch stays discoverable: "Codex documentation review authorized for this
+payload. Disable future offers: `gstack-config set codex_reviews disabled`." For
+`not_installed` or `not_authed`, use the in-session fallback without describing
+OpenAI export as authorized.
 
 **Determine the release diff range (D3 — reuse the method, do not invent one).**
 Recompute the SAME range document-release used in its pre-flight / diff analysis, with the

--- a/hosts/codex.ts
+++ b/hosts/codex.ts
@@ -27,7 +27,10 @@ const codex: HostConfig = {
   pathRewrites: [
     { from: '~/.claude/skills/gstack', to: '$GSTACK_ROOT' },
     { from: '.claude/skills/gstack', to: '.agents/skills/gstack' },
-    { from: '.claude/skills/review', to: '.agents/skills/gstack/review' },
+    // Review assets must resolve from the computed runtime root. A literal
+    // project-relative sidecar path fails in repos that use only the global
+    // Codex install, even though setup installed the files correctly there.
+    { from: '.claude/skills/review', to: '$GSTACK_ROOT/review' },
     { from: '.claude/skills', to: '.agents/skills' },
   ],
 
@@ -44,7 +47,12 @@ const codex: HostConfig = {
   runtimeRoot: {
     globalSymlinks: ['bin', 'browse/dist', 'browse/bin', 'gstack-upgrade', 'ETHOS.md'],
     globalFiles: {
-      'review': ['checklist.md', 'TODOS-format.md'],
+      'review': [
+        'checklist.md',
+        'design-checklist.md',
+        'greptile-triage.md',
+        'TODOS-format.md',
+      ],
     },
   },
   sidecar: {

--- a/plan-ceo-review/sections/review-sections.md
+++ b/plan-ceo-review/sections/review-sections.md
@@ -253,15 +253,19 @@ If this plan has significant UI scope, recommend: "Consider running /plan-design
 **STOP.** AskUserQuestion once per issue. Do NOT batch. Recommend + WHY. If this section turned up zero findings, state "No issues, moving on" and proceed. If the section has findings, you MUST call AskUserQuestion as a tool_use — a finding with an "obvious fix" is still a finding and still needs user approval before any change lands in the plan. Do NOT proceed until the user responds.
 **Reminder: Do NOT make any code changes. Review only.**
 
-## Outside Voice — Independent Plan Challenge (default-on)
+## Outside Voice — Independent Plan Challenge (configured by default; export consent required)
 
-After all review sections are complete, run an independent second opinion from a
-different AI system automatically — it is a standard part of plan review, not an
-opt-in. Two models agreeing on a plan is stronger signal than one model's thorough
-review. The user turns this off only by asking explicitly
+After all review sections are complete, offer an independent second opinion from a
+different AI system. It is configured as a standard plan-review option, but it is
+never permission to export the plan: each invocation requires explicit provider-and-
+payload authorization. Two models agreeing on a plan is stronger signal than one
+model's thorough review. The user can disable the option with
 (`gstack-config set codex_reviews disabled`).
 
 **Preflight — decide whether and how the outside voice runs:**
+
+Run this local provider/configuration preflight first. It does not export
+repository content:
 
 ```bash
 # Codex preflight: one block (functions sourced here don't persist to later blocks).
@@ -284,10 +288,23 @@ Branch on the echoed `CODEX_MODE`:
 - **`disabled`** — the user turned Codex reviews off (`codex_reviews=disabled`). Skip this section entirely; do NOT fall back to a Claude subagent — disabled means no extra review step. Print: "Codex review skipped (codex_reviews disabled). Re-enable: `gstack-config set codex_reviews enabled`."
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
-- **`ready`** — run the Codex pass below.
+- **`ready`** — do not read or assemble the provider payload yet. First confirm
+  that the current user explicitly authorized sending the specific payload to the
+  **OpenAI Codex model service** for this invocation. Name the actual payload:
+  complete diff and necessary source, a plan, documentation plus its comparison
+  diff, or other repository context. Authentication, command execution approval,
+  `codex_reviews=enabled`, and a generic request for an "independent review" are
+  not source-export consent. If the request does not name OpenAI Codex and the data
+  scope, use AskUserQuestion and wait. Never infer consent from another provider,
+  PR, repository, or earlier session. If declined, treat Codex as unavailable and
+  continue only with the caller's in-session fallback. Only after authorization is
+  confirmed may the Codex pass below read, assemble, or dispatch the payload.
 
-When the mode is `ready`, `not_installed`, or `not_authed`, print one line so the off-switch
-stays discoverable: "Running the outside voice automatically (standard step). Disable: `gstack-config set codex_reviews disabled`."
+When the mode is `ready` and authorization was granted, print one line so the
+off-switch stays discoverable: "Outside voice authorized for this payload. Disable
+future offers: `gstack-config set codex_reviews disabled`." For `not_installed`
+or `not_authed`, use the in-session fallback without describing OpenAI export as
+authorized.
 
 **Construct the plan review prompt** (for `ready`, `not_installed`, and `not_authed` — skip only on `disabled`).
 Read the plan file being reviewed (the file the user pointed this review at, or the branch
@@ -659,7 +676,7 @@ Display:
 - **Eng Review (required by default):** The only review that gates shipping. Covers architecture, code quality, tests, performance. Can be disabled globally with \`gstack-config set skip_eng_review true\` (the "don't bother me" setting).
 - **CEO Review (optional):** Use your judgment. Recommend it for big product/business changes, new user-facing features, or scope decisions. Skip for bug fixes, refactors, infra, and cleanup.
 - **Design Review (optional):** Use your judgment. Recommend it for UI/UX changes. Skip for backend-only, infra, or prompt-only changes.
-- **Adversarial Review (automatic):** Always-on for every review. Every diff gets both Claude adversarial subagent and Codex adversarial challenge. Large diffs (200+ lines) additionally get Codex structured review with P1 gate. No configuration needed.
+- **Adversarial Review:** Every diff gets the in-session Claude adversarial pass. Codex cross-model passes are offered when configured and run only after explicit provider-and-payload export authorization; large authorized diffs (200+ lines) additionally get Codex structured review with a P1 gate.
 - **Outside Voice (optional):** Independent plan review from a different AI model. Offered after all review sections complete in /plan-ceo-review and /plan-eng-review. Falls back to Claude subagent if Codex is unavailable. Never gates shipping.
 
 **Verdict logic:**

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -1349,12 +1349,24 @@ Use AskUserQuestion:
 
 If user chooses B, skip this step and continue.
 
-**Check Codex availability:**
+**Check Codex availability, then authorize export:**
+
 ```bash
 command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
-**If Codex is available**, launch both voices simultaneously:
+If Codex is available, apply this gate before reading or assembling its payload:
+
+**External data authorization:** Before reading or assembling the design plan, design artifacts, and necessary source context, confirm
+the user authorized sending that payload to the **OpenAI Codex model service** for
+this invocation. Authentication, command approval, `codex_reviews=enabled`, or a
+generic request for independent review is not export consent. If OpenAI Codex and
+the payload were not both named, use AskUserQuestion and wait. Decline or inability
+to ask means skip Codex and continue locally. Never reuse consent across providers,
+repositories, pull requests, or sessions.
+
+Launch the Claude design subagent. If Codex is also authorized, launch its voice
+simultaneously:
 
 1. **Codex design voice** (via Bash):
 ```bash

--- a/plan-design-review/sections/review-sections.md
+++ b/plan-design-review/sections/review-sections.md
@@ -395,7 +395,7 @@ Display:
 - **Eng Review (required by default):** The only review that gates shipping. Covers architecture, code quality, tests, performance. Can be disabled globally with \`gstack-config set skip_eng_review true\` (the "don't bother me" setting).
 - **CEO Review (optional):** Use your judgment. Recommend it for big product/business changes, new user-facing features, or scope decisions. Skip for bug fixes, refactors, infra, and cleanup.
 - **Design Review (optional):** Use your judgment. Recommend it for UI/UX changes. Skip for backend-only, infra, or prompt-only changes.
-- **Adversarial Review (automatic):** Always-on for every review. Every diff gets both Claude adversarial subagent and Codex adversarial challenge. Large diffs (200+ lines) additionally get Codex structured review with P1 gate. No configuration needed.
+- **Adversarial Review:** Every diff gets the in-session Claude adversarial pass. Codex cross-model passes are offered when configured and run only after explicit provider-and-payload export authorization; large authorized diffs (200+ lines) additionally get Codex structured review with a P1 gate.
 - **Outside Voice (optional):** Independent plan review from a different AI model. Offered after all review sections complete in /plan-ceo-review and /plan-eng-review. Falls back to Claude subagent if Codex is unavailable. Never gates shipping.
 
 **Verdict logic:**

--- a/plan-devex-review/sections/review-sections.md
+++ b/plan-devex-review/sections/review-sections.md
@@ -239,15 +239,19 @@ Check each item. For any unchecked item, explain what's missing and suggest the 
 
 **STOP.** AskUserQuestion for any item that requires a design decision.
 
-## Outside Voice — Independent Plan Challenge (default-on)
+## Outside Voice — Independent Plan Challenge (configured by default; export consent required)
 
-After all review sections are complete, run an independent second opinion from a
-different AI system automatically — it is a standard part of plan review, not an
-opt-in. Two models agreeing on a plan is stronger signal than one model's thorough
-review. The user turns this off only by asking explicitly
+After all review sections are complete, offer an independent second opinion from a
+different AI system. It is configured as a standard plan-review option, but it is
+never permission to export the plan: each invocation requires explicit provider-and-
+payload authorization. Two models agreeing on a plan is stronger signal than one
+model's thorough review. The user can disable the option with
 (`gstack-config set codex_reviews disabled`).
 
 **Preflight — decide whether and how the outside voice runs:**
+
+Run this local provider/configuration preflight first. It does not export
+repository content:
 
 ```bash
 # Codex preflight: one block (functions sourced here don't persist to later blocks).
@@ -270,10 +274,23 @@ Branch on the echoed `CODEX_MODE`:
 - **`disabled`** — the user turned Codex reviews off (`codex_reviews=disabled`). Skip this section entirely; do NOT fall back to a Claude subagent — disabled means no extra review step. Print: "Codex review skipped (codex_reviews disabled). Re-enable: `gstack-config set codex_reviews enabled`."
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
-- **`ready`** — run the Codex pass below.
+- **`ready`** — do not read or assemble the provider payload yet. First confirm
+  that the current user explicitly authorized sending the specific payload to the
+  **OpenAI Codex model service** for this invocation. Name the actual payload:
+  complete diff and necessary source, a plan, documentation plus its comparison
+  diff, or other repository context. Authentication, command execution approval,
+  `codex_reviews=enabled`, and a generic request for an "independent review" are
+  not source-export consent. If the request does not name OpenAI Codex and the data
+  scope, use AskUserQuestion and wait. Never infer consent from another provider,
+  PR, repository, or earlier session. If declined, treat Codex as unavailable and
+  continue only with the caller's in-session fallback. Only after authorization is
+  confirmed may the Codex pass below read, assemble, or dispatch the payload.
 
-When the mode is `ready`, `not_installed`, or `not_authed`, print one line so the off-switch
-stays discoverable: "Running the outside voice automatically (standard step). Disable: `gstack-config set codex_reviews disabled`."
+When the mode is `ready` and authorization was granted, print one line so the
+off-switch stays discoverable: "Outside voice authorized for this payload. Disable
+future offers: `gstack-config set codex_reviews disabled`." For `not_installed`
+or `not_authed`, use the in-session fallback without describing OpenAI export as
+authorized.
 
 **Construct the plan review prompt** (for `ready`, `not_installed`, and `not_authed` — skip only on `disabled`).
 Read the plan file being reviewed (the file the user pointed this review at, or the branch
@@ -633,7 +650,7 @@ Display:
 - **Eng Review (required by default):** The only review that gates shipping. Covers architecture, code quality, tests, performance. Can be disabled globally with \`gstack-config set skip_eng_review true\` (the "don't bother me" setting).
 - **CEO Review (optional):** Use your judgment. Recommend it for big product/business changes, new user-facing features, or scope decisions. Skip for bug fixes, refactors, infra, and cleanup.
 - **Design Review (optional):** Use your judgment. Recommend it for UI/UX changes. Skip for backend-only, infra, or prompt-only changes.
-- **Adversarial Review (automatic):** Always-on for every review. Every diff gets both Claude adversarial subagent and Codex adversarial challenge. Large diffs (200+ lines) additionally get Codex structured review with P1 gate. No configuration needed.
+- **Adversarial Review:** Every diff gets the in-session Claude adversarial pass. Codex cross-model passes are offered when configured and run only after explicit provider-and-payload export authorization; large authorized diffs (200+ lines) additionally get Codex structured review with a P1 gate.
 - **Outside Voice (optional):** Independent plan review from a different AI model. Offered after all review sections complete in /plan-ceo-review and /plan-eng-review. Falls back to Claude subagent if Codex is unavailable. Never gates shipping.
 
 **Verdict logic:**

--- a/plan-eng-review/sections/review-sections.md
+++ b/plan-eng-review/sections/review-sections.md
@@ -329,15 +329,19 @@ For each issue found in this section, call AskUserQuestion individually. One iss
 
 **STOP.** Do NOT proceed to the next review section, edit the plan file with the proposed fix, or call ExitPlanMode until the user responds. An issue with an "obvious fix" is still an issue and still needs explicit user approval before it lands in the plan. Loading the AskUserQuestion schema via ToolSearch and then writing the recommendation as chat prose is the failure mode this gate exists to prevent.
 
-## Outside Voice — Independent Plan Challenge (default-on)
+## Outside Voice — Independent Plan Challenge (configured by default; export consent required)
 
-After all review sections are complete, run an independent second opinion from a
-different AI system automatically — it is a standard part of plan review, not an
-opt-in. Two models agreeing on a plan is stronger signal than one model's thorough
-review. The user turns this off only by asking explicitly
+After all review sections are complete, offer an independent second opinion from a
+different AI system. It is configured as a standard plan-review option, but it is
+never permission to export the plan: each invocation requires explicit provider-and-
+payload authorization. Two models agreeing on a plan is stronger signal than one
+model's thorough review. The user can disable the option with
 (`gstack-config set codex_reviews disabled`).
 
 **Preflight — decide whether and how the outside voice runs:**
+
+Run this local provider/configuration preflight first. It does not export
+repository content:
 
 ```bash
 # Codex preflight: one block (functions sourced here don't persist to later blocks).
@@ -360,10 +364,23 @@ Branch on the echoed `CODEX_MODE`:
 - **`disabled`** — the user turned Codex reviews off (`codex_reviews=disabled`). Skip this section entirely; do NOT fall back to a Claude subagent — disabled means no extra review step. Print: "Codex review skipped (codex_reviews disabled). Re-enable: `gstack-config set codex_reviews enabled`."
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
-- **`ready`** — run the Codex pass below.
+- **`ready`** — do not read or assemble the provider payload yet. First confirm
+  that the current user explicitly authorized sending the specific payload to the
+  **OpenAI Codex model service** for this invocation. Name the actual payload:
+  complete diff and necessary source, a plan, documentation plus its comparison
+  diff, or other repository context. Authentication, command execution approval,
+  `codex_reviews=enabled`, and a generic request for an "independent review" are
+  not source-export consent. If the request does not name OpenAI Codex and the data
+  scope, use AskUserQuestion and wait. Never infer consent from another provider,
+  PR, repository, or earlier session. If declined, treat Codex as unavailable and
+  continue only with the caller's in-session fallback. Only after authorization is
+  confirmed may the Codex pass below read, assemble, or dispatch the payload.
 
-When the mode is `ready`, `not_installed`, or `not_authed`, print one line so the off-switch
-stays discoverable: "Running the outside voice automatically (standard step). Disable: `gstack-config set codex_reviews disabled`."
+When the mode is `ready` and authorization was granted, print one line so the
+off-switch stays discoverable: "Outside voice authorized for this payload. Disable
+future offers: `gstack-config set codex_reviews disabled`." For `not_installed`
+or `not_authed`, use the in-session fallback without describing OpenAI export as
+authorized.
 
 **Construct the plan review prompt** (for `ready`, `not_installed`, and `not_authed` — skip only on `disabled`).
 Read the plan file being reviewed (the file the user pointed this review at, or the branch
@@ -713,7 +730,7 @@ Display:
 - **Eng Review (required by default):** The only review that gates shipping. Covers architecture, code quality, tests, performance. Can be disabled globally with \`gstack-config set skip_eng_review true\` (the "don't bother me" setting).
 - **CEO Review (optional):** Use your judgment. Recommend it for big product/business changes, new user-facing features, or scope decisions. Skip for bug fixes, refactors, infra, and cleanup.
 - **Design Review (optional):** Use your judgment. Recommend it for UI/UX changes. Skip for backend-only, infra, or prompt-only changes.
-- **Adversarial Review (automatic):** Always-on for every review. Every diff gets both Claude adversarial subagent and Codex adversarial challenge. Large diffs (200+ lines) additionally get Codex structured review with P1 gate. No configuration needed.
+- **Adversarial Review:** Every diff gets the in-session Claude adversarial pass. Codex cross-model passes are offered when configured and run only after explicit provider-and-payload export authorization; large authorized diffs (200+ lines) additionally get Codex structured review with a P1 gate.
 - **Outside Voice (optional):** Independent plan review from a different AI model. Offered after all review sections complete in /plan-ceo-review and /plan-eng-review. Falls back to Claude subagent if Codex is unavailable. Never gates shipping.
 
 **Verdict logic:**

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -1640,9 +1640,11 @@ If no documentation files exist, skip this step silently.
 
 ---
 
-## Step 5.7: Adversarial review (always-on)
+## Step 5.7: Adversarial review (in-session always-on; external pass consent-gated)
 
-Every diff gets adversarial review from both Claude and Codex. LOC is not a proxy for risk — a 5-line auth change can be critical.
+Every diff gets the in-session Claude adversarial review. The Codex cross-model pass
+is offered when configured and runs only after explicit authorization to export the
+named payload. LOC is not a proxy for risk — a 5-line auth change can be critical.
 
 **Detect diff size:**
 
@@ -1655,6 +1657,9 @@ echo "DIFF_SIZE: $DIFF_TOTAL"
 ```
 
 **Detect the Codex master switch + tool availability:**
+
+Run this local provider/configuration preflight first. It does not export
+repository content:
 
 ```bash
 # Codex preflight: one block (functions sourced here don't persist to later blocks).
@@ -1677,7 +1682,17 @@ Branch on the echoed `CODEX_MODE`:
 - **`disabled`** — the user turned Codex reviews off (`codex_reviews=disabled`). Skip the Codex passes only; the Claude adversarial subagent below STILL runs (it is free and fast). Print: "Codex passes skipped (codex_reviews disabled) — running Claude adversarial only."
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
-- **`ready`** — run the Codex pass below.
+- **`ready`** — do not read or assemble the provider payload yet. First confirm
+  that the current user explicitly authorized sending the specific payload to the
+  **OpenAI Codex model service** for this invocation. Name the actual payload:
+  complete diff and necessary source, a plan, documentation plus its comparison
+  diff, or other repository context. Authentication, command execution approval,
+  `codex_reviews=enabled`, and a generic request for an "independent review" are
+  not source-export consent. If the request does not name OpenAI Codex and the data
+  scope, use AskUserQuestion and wait. Never infer consent from another provider,
+  PR, repository, or earlier session. If declined, treat Codex as unavailable and
+  continue only with the caller's in-session fallback. Only after authorization is
+  confirmed may the Codex pass below read, assemble, or dispatch the payload.
 
 For this diff-review path, `CODEX_MODE: disabled` means skip the Codex passes ONLY — the
 Claude adversarial subagent below still runs (it's free and fast). `ready` runs the Codex

--- a/review/greptile-triage.md
+++ b/review/greptile-triage.md
@@ -6,14 +6,33 @@ Shared reference for fetching, filtering, and classifying Greptile review commen
 
 ## Fetch
 
-Run these commands to detect the PR and fetch comments. Both API calls run in parallel.
+First establish GitHub authentication using a tri-state check:
+
+```bash
+GH_AUTH_OUTPUT=$(gh auth status 2>&1)
+GH_AUTH_EXIT=$?
+printf '%s\n' "$GH_AUTH_OUTPUT"
+```
+
+- A successful status is **authenticated**.
+- An explicit host-context "not logged in" result is **unauthenticated**; note that
+  Greptile triage was skipped and include `gh auth login` guidance.
+- A credential-store, network, sandbox, or command-access failure is **unverified**.
+  Repeat only `gh auth status` with host credential-store/network access before
+  deciding. If that recheck cannot run, surface "GitHub authentication unverified"
+  and continue without Greptile; never describe this as no PR or no comments.
+
+After authentication is confirmed, run these commands to detect the PR and fetch
+comments. Both API calls run in parallel.
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
 PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
 ```
 
-**If either fails or is empty:** Skip Greptile triage silently. This integration is additive — the workflow works without it.
+**If either fails because there is authoritatively no PR for the current branch:**
+Skip Greptile triage silently. For access, network, or credential errors, use the
+tri-state behavior above and surface an unverified result instead of claiming no PR.
 
 ```bash
 # Fetch line-level review comments AND top-level PR comments in parallel
@@ -24,7 +43,9 @@ gh api repos/$REPO/issues/$PR_NUMBER/comments \
 wait
 ```
 
-**If API errors or zero Greptile comments across both endpoints:** Skip silently.
+**If both successful API responses contain zero Greptile comments:** Skip silently.
+If either API request fails, report Greptile coverage as unverified and continue;
+do not turn an access failure into a clean zero-comment result.
 
 The `position != null` filter on line-level comments automatically skips outdated comments from force-pushed code.
 

--- a/scripts/resolvers/constants.ts
+++ b/scripts/resolvers/constants.ts
@@ -57,6 +57,17 @@ export function codexErrorHandling(feature: string): string {
 On any error: continue — ${feature} is informational, not a gate.`;
 }
 
+/** Compact consent gate for optional Codex voices that already have their own probe. */
+export function codexExportAuthorization(payload: string): string {
+  return `**External data authorization:** Before reading or assembling ${payload}, confirm
+the user authorized sending that payload to the **OpenAI Codex model service** for
+this invocation. Authentication, command approval, \`codex_reviews=enabled\`, or a
+generic request for independent review is not export consent. If OpenAI Codex and
+the payload were not both named, use AskUserQuestion and wait. Decline or inability
+to ask means skip Codex and continue locally. Never reuse consent across providers,
+repositories, pull requests, or sessions.`;
+}
+
 /**
  * Shared Codex preflight bash block — the single source of truth for deciding
  * whether a Codex review pass should run. Used by ADVERSARIAL_STEP,
@@ -91,7 +102,10 @@ export function codexPreflight(opts: { modeVar?: string; disabledBehavior: 'skip
   const disabledLine = opts.disabledBehavior === 'codex-only'
     ? 'Skip the Codex passes only; the Claude adversarial subagent below STILL runs (it is free and fast). Print: "Codex passes skipped (codex_reviews disabled) — running Claude adversarial only."'
     : 'Skip this section entirely; do NOT fall back to a Claude subagent — disabled means no extra review step. Print: "Codex review skipped (codex_reviews disabled). Re-enable: `gstack-config set codex_reviews enabled`."';
-  return `\`\`\`bash
+  return `Run this local provider/configuration preflight first. It does not export
+repository content:
+
+\`\`\`bash
 # Codex preflight: one block (functions sourced here don't persist to later blocks).
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo off)
 _CODEX_CFG=$(~/.claude/skills/gstack/bin/gstack-config get codex_reviews 2>/dev/null || echo enabled)
@@ -112,5 +126,15 @@ Branch on the echoed \`CODEX_MODE\`:
 - **\`disabled\`** — the user turned Codex reviews off (\`codex_reviews=disabled\`). ${disabledLine}
 - **\`not_installed\`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: \`npm install -g @openai/codex\`." Fall back to the Claude subagent path.
 - **\`not_authed\`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run \`codex login\` or set \`$CODEX_API_KEY\`." Fall back to the Claude subagent path.
-- **\`ready\`** — run the Codex pass below.`;
+- **\`ready\`** — do not read or assemble the provider payload yet. First confirm
+  that the current user explicitly authorized sending the specific payload to the
+  **OpenAI Codex model service** for this invocation. Name the actual payload:
+  complete diff and necessary source, a plan, documentation plus its comparison
+  diff, or other repository context. Authentication, command execution approval,
+  \`codex_reviews=enabled\`, and a generic request for an "independent review" are
+  not source-export consent. If the request does not name OpenAI Codex and the data
+  scope, use AskUserQuestion and wait. Never infer consent from another provider,
+  PR, repository, or earlier session. If declined, treat Codex as unavailable and
+  continue only with the caller's in-session fallback. Only after authorization is
+  confirmed may the Codex pass below read, assemble, or dispatch the payload.`;
 }

--- a/scripts/resolvers/design.ts
+++ b/scripts/resolvers/design.ts
@@ -1,5 +1,10 @@
 import type { TemplateContext } from './types';
-import { AI_SLOP_BLACKLIST, OPENAI_HARD_REJECTIONS, OPENAI_LITMUS_CHECKS } from './constants';
+import {
+  AI_SLOP_BLACKLIST,
+  OPENAI_HARD_REJECTIONS,
+  OPENAI_LITMUS_CHECKS,
+  codexExportAuthorization,
+} from './constants';
 
 export function generateDesignReviewLite(ctx: TemplateContext): string {
   const litmusList = OPENAI_LITMUS_CHECKS.map((item, i) => `${i + 1}. ${item}`).join(' ');
@@ -7,13 +12,17 @@ export function generateDesignReviewLite(ctx: TemplateContext): string {
   // Codex block only for Claude host
   const codexBlock = ctx.host === 'codex' ? '' : `
 
-7. **Codex design voice** (optional, automatic if available):
+7. **Codex design voice** (optional, consent-gated when configured):
 
 \`\`\`bash
 command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 \`\`\`
 
-If Codex is available, run a lightweight design check on the diff:
+If Codex is available, apply this gate before reading the diff:
+
+${codexExportAuthorization('the design diff and necessary source context')}
+
+If authorized, run a lightweight design check on the diff:
 
 \`\`\`bash
 TMPERR_DRL=$(mktemp /tmp/codex-drl-XXXXXXXX)
@@ -634,7 +643,9 @@ Be bold. Be specific. No hedging.`;
 
   // Build the opt-in section
   const optInSection = isAutomatic ? `
-**Automatic:** Outside voices run automatically when Codex is available. No opt-in needed.` : `
+**Configured automatically:** The in-session design voice runs as part of this review.
+The Codex voice still requires explicit OpenAI-and-payload export authorization for
+this invocation.` : `
 Use AskUserQuestion:
 > "Want outside design voices${isPlanDesignReview ? ' before the detailed review' : ''}? Codex evaluates against OpenAI's design hard rules + litmus checks; Claude subagent does an independent ${isDesignConsultation ? 'design direction proposal' : 'completeness review'}."
 >
@@ -686,12 +697,20 @@ Merge findings into the triage with \`[codex]\` / \`[subagent]\` / \`[cross-mode
   return `## Design Outside Voices (parallel)
 ${optInSection}
 
-**Check Codex availability:**
+**Check Codex availability, then authorize export:**
+
 \`\`\`bash
 command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 \`\`\`
 
-**If Codex is available**, launch both voices simultaneously:
+If Codex is available, apply this gate before reading or assembling its payload:
+
+${codexExportAuthorization(
+  'the design plan, design artifacts, and necessary source context',
+)}
+
+Launch the Claude design subagent. If Codex is also authorized, launch its voice
+simultaneously:
 
 1. **Codex design voice** (via Bash):
 \`\`\`bash
@@ -1154,4 +1173,3 @@ Flat design can strip away useful visual information that signals interactivity.
 Prioritize ruthlessly: things needed in a hurry go close at hand, everything
 else a few taps away with an obvious path to get there.`;
 }
-

--- a/scripts/resolvers/review.ts
+++ b/scripts/resolvers/review.ts
@@ -1,13 +1,16 @@
 /**
  * Cross-model review resolver
  *
- * Data sent to external review services (via Codex CLI):
- *   - Plan markdown content, repository name, branch name, review type
- * Data NOT sent:
- *   - Source code files, credentials, environment variables, git history
+ * Data sent to external review services (via Codex CLI), only
+ * after provider-and-payload authorization:
+ *   - Diff/source context, plan markdown, documentation, repository/branch
+ *     identifiers, and review type as required by the selected review pass
+ * Data NOT sent intentionally:
+ *   - Credentials and environment-variable values
  *
- * Users invoke this explicitly via /plan-eng-review, /plan-ceo-review,
- * or /plan-design-review. No data is sent without user invocation.
+ * These paths are reached through user-invoked review skills. Invoking a skill
+ * does not itself authorize provider export; each external dispatch requires
+ * the provider-and-payload authorization described below.
  *
  * Review logs are stored locally at ~/.gstack/reviews/review-log.jsonl.
  * Codex CLI prompts are written to temp files to prevent shell injection.
@@ -55,7 +58,7 @@ Display:
 - **Eng Review (required by default):** The only review that gates shipping. Covers architecture, code quality, tests, performance. Can be disabled globally with \\\`gstack-config set skip_eng_review true\\\` (the "don't bother me" setting).
 - **CEO Review (optional):** Use your judgment. Recommend it for big product/business changes, new user-facing features, or scope decisions. Skip for bug fixes, refactors, infra, and cleanup.
 - **Design Review (optional):** Use your judgment. Recommend it for UI/UX changes. Skip for backend-only, infra, or prompt-only changes.
-- **Adversarial Review (automatic):** Always-on for every review. Every diff gets both Claude adversarial subagent and Codex adversarial challenge. Large diffs (200+ lines) additionally get Codex structured review with P1 gate. No configuration needed.
+- **Adversarial Review:** Every diff gets the in-session Claude adversarial pass. Codex cross-model passes are offered when configured and run only after explicit provider-and-payload export authorization; large authorized diffs (200+ lines) additionally get Codex structured review with a P1 gate.
 - **Outside Voice (optional):** Independent plan review from a different AI model. Offered after all review sections complete in /plan-ceo-review and /plan-eng-review. Falls back to Claude subagent if Codex is unavailable. Never gates shipping.
 
 **Verdict logic:**
@@ -476,9 +479,11 @@ export function generateAdversarialStep(ctx: TemplateContext): string {
   const isShip = ctx.skillName === 'ship';
   const stepNum = isShip ? '11' : '5.7';
 
-  return `## Step ${stepNum}: Adversarial review (always-on)
+  return `## Step ${stepNum}: Adversarial review (in-session always-on; external pass consent-gated)
 
-Every diff gets adversarial review from both Claude and Codex. LOC is not a proxy for risk — a 5-line auth change can be critical.
+Every diff gets the in-session Claude adversarial review. The Codex cross-model pass
+is offered when configured and runs only after explicit authorization to export the
+named payload. LOC is not a proxy for risk — a 5-line auth change can be critical.
 
 **Detect diff size:**
 
@@ -614,20 +619,24 @@ export function generateCodexPlanReview(ctx: TemplateContext): string {
   // Codex host: strip entirely — Codex should never invoke itself
   if (ctx.host === 'codex') return '';
 
-  return `## Outside Voice — Independent Plan Challenge (default-on)
+  return `## Outside Voice — Independent Plan Challenge (configured by default; export consent required)
 
-After all review sections are complete, run an independent second opinion from a
-different AI system automatically — it is a standard part of plan review, not an
-opt-in. Two models agreeing on a plan is stronger signal than one model's thorough
-review. The user turns this off only by asking explicitly
+After all review sections are complete, offer an independent second opinion from a
+different AI system. It is configured as a standard plan-review option, but it is
+never permission to export the plan: each invocation requires explicit provider-and-
+payload authorization. Two models agreeing on a plan is stronger signal than one
+model's thorough review. The user can disable the option with
 (\`gstack-config set codex_reviews disabled\`).
 
 **Preflight — decide whether and how the outside voice runs:**
 
 ${codexPreflight({ disabledBehavior: 'skip-all' })}
 
-When the mode is \`ready\`, \`not_installed\`, or \`not_authed\`, print one line so the off-switch
-stays discoverable: "Running the outside voice automatically (standard step). Disable: \`gstack-config set codex_reviews disabled\`."
+When the mode is \`ready\` and authorization was granted, print one line so the
+off-switch stays discoverable: "Outside voice authorized for this payload. Disable
+future offers: \`gstack-config set codex_reviews disabled\`." For \`not_installed\`
+or \`not_authed\`, use the in-session fallback without describing OpenAI export as
+authorized.
 
 **Construct the plan review prompt** (for \`ready\`, \`not_installed\`, and \`not_authed\` — skip only on \`disabled\`).
 Read the plan file being reviewed (the file the user pointed this review at, or the branch
@@ -744,19 +753,24 @@ export function generateCodexDocReview(ctx: TemplateContext): string {
   // Codex host: strip entirely — Codex should never invoke itself
   if (ctx.host === 'codex') return '';
 
-  return `## Codex Documentation Review (default-on)
+  return `## Codex Documentation Review (configured by default; export consent required)
 
 After the documentation updates above are written, run an independent cross-model pass that
-checks the docs against what actually shipped. This is a standard part of /document-release,
-not an opt-in. The user turns it off only by asking explicitly
+checks the docs against what actually shipped. This is a configured standard option in
+/document-release, but it never authorizes exporting documentation or a comparison diff.
+Each invocation requires explicit provider-and-payload authorization. The user can disable
+the option with
 (\`gstack-config set codex_reviews disabled\`).
 
 **Preflight — decide whether and how the doc review runs:**
 
 ${codexPreflight({ disabledBehavior: 'skip-all' })}
 
-When the mode is \`ready\`, \`not_installed\`, or \`not_authed\`, print one line so the off-switch
-stays discoverable: "Running the Codex doc review automatically (standard step). Disable: \`gstack-config set codex_reviews disabled\`."
+When the mode is \`ready\` and authorization was granted, print one line so the
+off-switch stays discoverable: "Codex documentation review authorized for this
+payload. Disable future offers: \`gstack-config set codex_reviews disabled\`." For
+\`not_installed\` or \`not_authed\`, use the in-session fallback without describing
+OpenAI export as authorized.
 
 **Determine the release diff range (D3 — reuse the method, do not invent one).**
 Recompute the SAME range document-release used in its pre-flight / diff analysis, with the

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -944,7 +944,7 @@ Display:
 - **Eng Review (required by default):** The only review that gates shipping. Covers architecture, code quality, tests, performance. Can be disabled globally with \`gstack-config set skip_eng_review true\` (the "don't bother me" setting).
 - **CEO Review (optional):** Use your judgment. Recommend it for big product/business changes, new user-facing features, or scope decisions. Skip for bug fixes, refactors, infra, and cleanup.
 - **Design Review (optional):** Use your judgment. Recommend it for UI/UX changes. Skip for backend-only, infra, or prompt-only changes.
-- **Adversarial Review (automatic):** Always-on for every review. Every diff gets both Claude adversarial subagent and Codex adversarial challenge. Large diffs (200+ lines) additionally get Codex structured review with P1 gate. No configuration needed.
+- **Adversarial Review:** Every diff gets the in-session Claude adversarial pass. Codex cross-model passes are offered when configured and run only after explicit provider-and-payload export authorization; large authorized diffs (200+ lines) additionally get Codex structured review with a P1 gate.
 - **Outside Voice (optional):** Independent plan review from a different AI model. Offered after all review sections complete in /plan-ceo-review and /plan-eng-review. Falls back to Claude subagent if Codex is unavailable. Never gates shipping.
 
 **Verdict logic:**

--- a/ship/sections/adversarial.md
+++ b/ship/sections/adversarial.md
@@ -1,8 +1,10 @@
 <!-- AUTO-GENERATED from adversarial.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->
-## Step 11: Adversarial review (always-on)
+## Step 11: Adversarial review (in-session always-on; external pass consent-gated)
 
-Every diff gets adversarial review from both Claude and Codex. LOC is not a proxy for risk — a 5-line auth change can be critical.
+Every diff gets the in-session Claude adversarial review. The Codex cross-model pass
+is offered when configured and runs only after explicit authorization to export the
+named payload. LOC is not a proxy for risk — a 5-line auth change can be critical.
 
 **Detect diff size:**
 
@@ -15,6 +17,9 @@ echo "DIFF_SIZE: $DIFF_TOTAL"
 ```
 
 **Detect the Codex master switch + tool availability:**
+
+Run this local provider/configuration preflight first. It does not export
+repository content:
 
 ```bash
 # Codex preflight: one block (functions sourced here don't persist to later blocks).
@@ -37,7 +42,17 @@ Branch on the echoed `CODEX_MODE`:
 - **`disabled`** — the user turned Codex reviews off (`codex_reviews=disabled`). Skip the Codex passes only; the Claude adversarial subagent below STILL runs (it is free and fast). Print: "Codex passes skipped (codex_reviews disabled) — running Claude adversarial only."
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
-- **`ready`** — run the Codex pass below.
+- **`ready`** — do not read or assemble the provider payload yet. First confirm
+  that the current user explicitly authorized sending the specific payload to the
+  **OpenAI Codex model service** for this invocation. Name the actual payload:
+  complete diff and necessary source, a plan, documentation plus its comparison
+  diff, or other repository context. Authentication, command execution approval,
+  `codex_reviews=enabled`, and a generic request for an "independent review" are
+  not source-export consent. If the request does not name OpenAI Codex and the data
+  scope, use AskUserQuestion and wait. Never infer consent from another provider,
+  PR, repository, or earlier session. If declined, treat Codex as unavailable and
+  continue only with the caller's in-session fallback. Only after authorization is
+  confirmed may the Codex pass below read, assemble, or dispatch the payload.
 
 For this diff-review path, `CODEX_MODE: disabled` means skip the Codex passes ONLY — the
 Claude adversarial subagent below still runs (it's free and fast). `ready` runs the Codex

--- a/ship/sections/review-army.md
+++ b/ship/sections/review-army.md
@@ -107,13 +107,23 @@ source <(~/.claude/skills/gstack/bin/gstack-diff-scope <base> 2>/dev/null)
 
 Substitute: TIMESTAMP = ISO 8601 datetime, STATUS = "clean" if 0 findings or "issues_found", N = total findings, M = auto-fixed count, COMMIT = output of `git rev-parse --short HEAD`.
 
-7. **Codex design voice** (optional, automatic if available):
+7. **Codex design voice** (optional, consent-gated when configured):
 
 ```bash
 command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
-If Codex is available, run a lightweight design check on the diff:
+If Codex is available, apply this gate before reading the diff:
+
+**External data authorization:** Before reading or assembling the design diff and necessary source context, confirm
+the user authorized sending that payload to the **OpenAI Codex model service** for
+this invocation. Authentication, command approval, `codex_reviews=enabled`, or a
+generic request for independent review is not export consent. If OpenAI Codex and
+the payload were not both named, use AskUserQuestion and wait. Decline or inability
+to ask means skip Codex and continue locally. Never reuse consent across providers,
+repositories, pull requests, or sessions.
+
+If authorized, run a lightweight design check on the diff:
 
 ```bash
 TMPERR_DRL=$(mktemp /tmp/codex-drl-XXXXXXXX)

--- a/test/external-review-preflight.test.ts
+++ b/test/external-review-preflight.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+describe('external review preflight', () => {
+  test('Claude auth treats inaccessible credentials as unknown, not logged out', () => {
+    const template = read('claude/SKILL.md.tmpl');
+
+    expect(template).toContain('echo "AUTH_UNKNOWN: cli_exit=$_CLAUDE_AUTH_EXIT"');
+    expect(template).toContain('do not report that authentication is missing');
+    expect(template).toContain('request narrowly scoped host credential/network access');
+    expect(template).toContain('Never turn an access failure into a logout');
+  });
+
+  test('standalone Claude and Codex wrappers require provider-specific export consent', () => {
+    const claude = read('claude/SKILL.md.tmpl');
+    const codex = read('codex/SKILL.md.tmpl');
+
+    expect(claude).toContain('External Data Authorization Boundary');
+    expect(claude).toContain('Anthropic Claude');
+    expect(claude).toContain('generic request for an "independent review"');
+
+    expect(codex).toContain('External data authorization');
+    expect(codex).toContain('OpenAI Codex model');
+    expect(codex).toContain('generic request for an "independent review"');
+  });
+
+  test('automatic Codex review callers share the same export-consent gate', () => {
+    const constants = read('scripts/resolvers/constants.ts');
+
+    expect(constants).toContain('local provider/configuration preflight first');
+    expect(constants).toContain('codex_reviews=enabled');
+    expect(constants).toContain('do not read or assemble the provider payload yet');
+    expect(constants).toContain('Never infer consent from another provider');
+    expect(constants).toContain('Only after authorization is');
+  });
+
+  test('design Codex callers also use the shared export-consent gate', () => {
+    const design = read('scripts/resolvers/design.ts');
+
+    expect(design).toContain("codexExportAuthorization('the design diff and necessary source context')");
+    expect(design).toContain("'the design plan, design artifacts, and necessary source context'");
+    expect(design).not.toContain('Outside voices run automatically when Codex is available. No opt-in needed.');
+  });
+
+  test('GitHub and Greptile access failures remain unverified rather than clean', () => {
+    const triage = read('review/greptile-triage.md');
+
+    expect(triage).toContain('GitHub authentication unverified');
+    expect(triage).toContain('Repeat only `gh auth status` with host');
+    expect(triage).toContain('do not turn an access failure into a clean zero-comment result');
+  });
+
+  test('Codex review assets resolve from GSTACK_ROOT and include triage data', () => {
+    const host = read('hosts/codex.ts');
+
+    expect(host).toContain("{ from: '.claude/skills/review', to: '$GSTACK_ROOT/review' }");
+    expect(host).toContain("'design-checklist.md'");
+    expect(host).toContain("'greptile-triage.md'");
+    expect(host).toContain("'TODOS-format.md'");
+  });
+});

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -944,7 +944,7 @@ Display:
 - **Eng Review (required by default):** The only review that gates shipping. Covers architecture, code quality, tests, performance. Can be disabled globally with \`gstack-config set skip_eng_review true\` (the "don't bother me" setting).
 - **CEO Review (optional):** Use your judgment. Recommend it for big product/business changes, new user-facing features, or scope decisions. Skip for bug fixes, refactors, infra, and cleanup.
 - **Design Review (optional):** Use your judgment. Recommend it for UI/UX changes. Skip for backend-only, infra, or prompt-only changes.
-- **Adversarial Review (automatic):** Always-on for every review. Every diff gets both Claude adversarial subagent and Codex adversarial challenge. Large diffs (200+ lines) additionally get Codex structured review with P1 gate. No configuration needed.
+- **Adversarial Review:** Every diff gets the in-session Claude adversarial pass. Codex cross-model passes are offered when configured and run only after explicit provider-and-payload export authorization; large authorized diffs (200+ lines) additionally get Codex structured review with a P1 gate.
 - **Outside Voice (optional):** Independent plan review from a different AI model. Offered after all review sections complete in /plan-ceo-review and /plan-eng-review. Falls back to Claude subagent if Codex is unavailable. Never gates shipping.
 
 **Verdict logic:**

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -916,7 +916,7 @@ Display:
 - **Eng Review (required by default):** The only review that gates shipping. Covers architecture, code quality, tests, performance. Can be disabled globally with \`gstack-config set skip_eng_review true\` (the "don't bother me" setting).
 - **CEO Review (optional):** Use your judgment. Recommend it for big product/business changes, new user-facing features, or scope decisions. Skip for bug fixes, refactors, infra, and cleanup.
 - **Design Review (optional):** Use your judgment. Recommend it for UI/UX changes. Skip for backend-only, infra, or prompt-only changes.
-- **Adversarial Review (automatic):** Always-on for every review. Every diff gets both Claude adversarial subagent and Codex adversarial challenge. Large diffs (200+ lines) additionally get Codex structured review with P1 gate. No configuration needed.
+- **Adversarial Review:** Every diff gets the in-session Claude adversarial pass. Codex cross-model passes are offered when configured and run only after explicit provider-and-payload export authorization; large authorized diffs (200+ lines) additionally get Codex structured review with a P1 gate.
 - **Outside Voice (optional):** Independent plan review from a different AI model. Offered after all review sections complete in /plan-ceo-review and /plan-eng-review. Falls back to Claude subagent if Codex is unavailable. Never gates shipping.
 
 **Verdict logic:**
@@ -1231,7 +1231,7 @@ Use AskUserQuestion:
 - Continue with the workflow.
 
 **If "Add as P0 TODO":**
-- If `TODOS.md` exists, add the entry following the format in `review/TODOS-format.md` (or `.agents/skills/gstack/review/TODOS-format.md`).
+- If `TODOS.md` exists, add the entry following the format in `review/TODOS-format.md` (or `$GSTACK_ROOT/review/TODOS-format.md`).
 - If `TODOS.md` does not exist, create it with the standard header and add the entry.
 - Entry should include: title, the error output, which branch it was noticed on, and priority P0.
 - Continue with the workflow — treat the pre-existing failure as non-blocking.
@@ -1907,7 +1907,7 @@ Before reviewing code quality, check: **did they build what was requested — no
 
 Review the diff for structural issues that tests don't catch.
 
-1. Read `.agents/skills/gstack/review/checklist.md`. If the file cannot be read, **STOP** and report the error.
+1. Read `$GSTACK_ROOT/review/checklist.md`. If the file cannot be read, **STOP** and report the error.
 
 2. Run `git diff origin/<base>` to get the full diff (scoped to feature changes against the freshly-fetched base branch).
 
@@ -1991,7 +1991,7 @@ source <($GSTACK_BIN/gstack-diff-scope <base> 2>/dev/null)
 
 1. **Check for DESIGN.md.** If `DESIGN.md` or `design-system.md` exists in the repo root, read it. All design findings are calibrated against it — patterns blessed in DESIGN.md are not flagged. If not found, use universal design principles.
 
-2. **Read `.agents/skills/gstack/review/design-checklist.md`.** If the file cannot be read, skip design review with a note: "Design checklist not found — skipping design review."
+2. **Read `$GSTACK_ROOT/review/design-checklist.md`.** If the file cannot be read, skip design review with a note: "Design checklist not found — skipping design review."
 
 3. **Read each changed frontend file** (full file, not just diff hunks). Frontend files are identified by the patterns listed in the checklist.
 
@@ -2088,7 +2088,7 @@ Save the review output — it goes into the PR body in Step 19.
 
 **Subagent prompt:**
 
-> You are classifying Greptile review comments for a /ship workflow. Read `.agents/skills/gstack/review/greptile-triage.md` and follow the fetch, filter, classify, and **escalation detection** steps. Do NOT fix code, do NOT reply to comments, do NOT commit — report only.
+> You are classifying Greptile review comments for a /ship workflow. Read `$GSTACK_ROOT/review/greptile-triage.md` and follow the fetch, filter, classify, and **escalation detection** steps. Do NOT fix code, do NOT reply to comments, do NOT commit — report only.
 >
 > For each comment, assign: `classification` (`valid_actionable`, `already_fixed`, `false_positive`, `suppressed`), `escalation_tier` (1 or 2), the file:line or [top-level] tag, body summary, and permalink URL.
 >
@@ -2263,7 +2263,7 @@ stay agent judgment; the slot pick stays `gstack-next-version`.
 
 Cross-reference the project's TODOS.md against the changes being shipped. Mark completed items automatically; prompt only if the file is missing or disorganized.
 
-Read `.agents/skills/gstack/review/TODOS-format.md` for the canonical format reference.
+Read `$GSTACK_ROOT/review/TODOS-format.md` for the canonical format reference.
 
 **1. Check if TODOS.md exists** in the repository root.
 

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -918,7 +918,7 @@ Display:
 - **Eng Review (required by default):** The only review that gates shipping. Covers architecture, code quality, tests, performance. Can be disabled globally with \`gstack-config set skip_eng_review true\` (the "don't bother me" setting).
 - **CEO Review (optional):** Use your judgment. Recommend it for big product/business changes, new user-facing features, or scope decisions. Skip for bug fixes, refactors, infra, and cleanup.
 - **Design Review (optional):** Use your judgment. Recommend it for UI/UX changes. Skip for backend-only, infra, or prompt-only changes.
-- **Adversarial Review (automatic):** Always-on for every review. Every diff gets both Claude adversarial subagent and Codex adversarial challenge. Large diffs (200+ lines) additionally get Codex structured review with P1 gate. No configuration needed.
+- **Adversarial Review:** Every diff gets the in-session Claude adversarial pass. Codex cross-model passes are offered when configured and run only after explicit provider-and-payload export authorization; large authorized diffs (200+ lines) additionally get Codex structured review with a P1 gate.
 - **Outside Voice (optional):** Independent plan review from a different AI model. Offered after all review sections complete in /plan-ceo-review and /plan-eng-review. Falls back to Claude subagent if Codex is unavailable. Never gates shipping.
 
 **Verdict logic:**
@@ -2039,13 +2039,23 @@ $GSTACK_BIN/gstack-review-log '{"skill":"design-review-lite","timestamp":"TIMEST
 
 Substitute: TIMESTAMP = ISO 8601 datetime, STATUS = "clean" if 0 findings or "issues_found", N = total findings, M = auto-fixed count, COMMIT = output of `git rev-parse --short HEAD`.
 
-7. **Codex design voice** (optional, automatic if available):
+7. **Codex design voice** (optional, consent-gated when configured):
 
 ```bash
 command -v codex >/dev/null 2>&1 && echo "CODEX_AVAILABLE" || echo "CODEX_NOT_AVAILABLE"
 ```
 
-If Codex is available, run a lightweight design check on the diff:
+If Codex is available, apply this gate before reading the diff:
+
+**External data authorization:** Before reading or assembling the design diff and necessary source context, confirm
+the user authorized sending that payload to the **OpenAI Codex model service** for
+this invocation. Authentication, command approval, `codex_reviews=enabled`, or a
+generic request for independent review is not export consent. If OpenAI Codex and
+the payload were not both named, use AskUserQuestion and wait. Decline or inability
+to ask means skip Codex and continue locally. Never reuse consent across providers,
+repositories, pull requests, or sessions.
+
+If authorized, run a lightweight design check on the diff:
 
 ```bash
 TMPERR_DRL=$(mktemp /tmp/codex-drl-XXXXXXXX)
@@ -2386,9 +2396,11 @@ For each comment in `comments`:
 
 ---
 
-## Step 11: Adversarial review (always-on)
+## Step 11: Adversarial review (in-session always-on; external pass consent-gated)
 
-Every diff gets adversarial review from both Claude and Codex. LOC is not a proxy for risk — a 5-line auth change can be critical.
+Every diff gets the in-session Claude adversarial review. The Codex cross-model pass
+is offered when configured and runs only after explicit authorization to export the
+named payload. LOC is not a proxy for risk — a 5-line auth change can be critical.
 
 **Detect diff size:**
 
@@ -2401,6 +2413,9 @@ echo "DIFF_SIZE: $DIFF_TOTAL"
 ```
 
 **Detect the Codex master switch + tool availability:**
+
+Run this local provider/configuration preflight first. It does not export
+repository content:
 
 ```bash
 # Codex preflight: one block (functions sourced here don't persist to later blocks).
@@ -2423,7 +2438,17 @@ Branch on the echoed `CODEX_MODE`:
 - **`disabled`** — the user turned Codex reviews off (`codex_reviews=disabled`). Skip the Codex passes only; the Claude adversarial subagent below STILL runs (it is free and fast). Print: "Codex passes skipped (codex_reviews disabled) — running Claude adversarial only."
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
-- **`ready`** — run the Codex pass below.
+- **`ready`** — do not read or assemble the provider payload yet. First confirm
+  that the current user explicitly authorized sending the specific payload to the
+  **OpenAI Codex model service** for this invocation. Name the actual payload:
+  complete diff and necessary source, a plan, documentation plus its comparison
+  diff, or other repository context. Authentication, command execution approval,
+  `codex_reviews=enabled`, and a generic request for an "independent review" are
+  not source-export consent. If the request does not name OpenAI Codex and the data
+  scope, use AskUserQuestion and wait. Never infer consent from another provider,
+  PR, repository, or earlier session. If declined, treat Codex as unavailable and
+  continue only with the caller's in-session fallback. Only after authorization is
+  confirmed may the Codex pass below read, assemble, or dispatch the payload.
 
 For this diff-review path, `CODEX_MODE: disabled` means skip the Codex passes ONLY — the
 Claude adversarial subagent below still runs (it's free and fast). `ready` runs the Codex

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1558,6 +1558,7 @@ describe('DESIGN_OUTSIDE_VOICES resolver', () => {
     const content = readSkillUnion('plan-design-review');
     expect(content).toContain('Design Outside Voices');
     expect(content).toContain('CODEX_AVAILABLE');
+    expect(content).toContain('External data authorization');
     expect(content).toContain('LITMUS SCORECARD');
   });
 
@@ -1776,9 +1777,8 @@ describe('Codex generation (--host codex)', () => {
   test('Codex output includes Claude outside-voice skill with read-only boundary', () => {
     const content = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-claude', 'SKILL.md'), 'utf-8');
     expect(content).toContain('claude -p');
-    expect(content).toContain('mktemp /tmp/gstack-claude-prompt-');
-    expect(content).toContain('mktemp /tmp/gstack-claude-diff-');
-    expect(content).not.toContain('/tmp/gstack-claude-diff-$$');
+    expect(content).toContain('mktemp -d /tmp/gstack-claude-');
+    expect(content).toContain('DIFF_FILE="$CLAUDE_TMP_DIR/diff.patch"');
     expect(content).toContain('cat "$PROMPT_FILE" | claude -p');
     expect(content).toContain('--disable-slash-commands');
     expect(content).toContain('--tools ""');
@@ -1874,22 +1874,21 @@ describe('Codex generation (--host codex)', () => {
 
   // ─── Path rewriting regression tests ─────────────────────────
 
-  test('sidecar paths point to .agents/skills/gstack/review/ (not gstack-review/)', () => {
-    // Regression: gen-skill-docs rewrote .claude/skills/review → .agents/skills/gstack-review
-    // but setup puts sidecars under .agents/skills/gstack/review/. Must match setup layout.
+  test('review assets resolve through the computed Codex runtime root', () => {
+    // Regression: a literal project-relative sidecar path fails when a project
+    // uses the global Codex install. GSTACK_ROOT selects the project sidecar when
+    // present and otherwise falls back to ~/.codex/skills/gstack.
     const content = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-review', 'SKILL.md'), 'utf-8');
-    // Correct: references to sidecar files use gstack/review/ path
-    expect(content).toContain('.agents/skills/gstack/review/checklist.md');
-    // design-checklist.md is now referenced via Review Army specialist (Claude only, stripped for Codex)
-    // Wrong: must NOT reference gstack-review/checklist.md (file doesn't exist there)
+    expect(content).toContain('$GSTACK_ROOT/review/checklist.md');
+    expect(content).not.toContain('.agents/skills/gstack/review/checklist.md');
     expect(content).not.toContain('.agents/skills/gstack-review/checklist.md');
   });
 
   test('sidecar paths in ship skill point to gstack/review/ for pre-landing review', () => {
     const content = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-ship', 'SKILL.md'), 'utf-8');
-    // Ship references the review checklist in its pre-landing review step
     if (content.includes('checklist.md')) {
-      expect(content).toContain('.agents/skills/gstack/review/');
+      expect(content).toContain('$GSTACK_ROOT/review/');
+      expect(content).not.toContain('.agents/skills/gstack/review/');
       expect(content).not.toContain('.agents/skills/gstack-review/checklist');
     }
   });
@@ -1897,7 +1896,8 @@ describe('Codex generation (--host codex)', () => {
   test('greptile-triage sidecar path is correct', () => {
     const content = fs.readFileSync(path.join(AGENTS_DIR, 'gstack-review', 'SKILL.md'), 'utf-8');
     if (content.includes('greptile-triage')) {
-      expect(content).toContain('.agents/skills/gstack/review/greptile-triage.md');
+      expect(content).toContain('$GSTACK_ROOT/review/greptile-triage.md');
+      expect(content).not.toContain('.agents/skills/gstack/review/greptile-triage.md');
       expect(content).not.toContain('.agents/skills/gstack-review/greptile-triage');
     }
   });
@@ -1913,8 +1913,9 @@ describe('Codex generation (--host codex)', () => {
     // Rule 2: .claude/skills/gstack → .agents/skills/gstack
     expect(content).not.toContain('.claude/skills/gstack');
 
-    // Rule 3: .claude/skills/review → .agents/skills/gstack/review
+    // Rule 3: .claude/skills/review → $GSTACK_ROOT/review
     expect(content).not.toContain('.claude/skills/review');
+    expect(content).toContain('$GSTACK_ROOT/review');
 
     // Rule 4: .claude/skills → .agents/skills (catch-all)
     expect(content).not.toContain('.claude/skills');

--- a/test/helpers/providers/claude.ts
+++ b/test/helpers/providers/claude.ts
@@ -25,12 +25,24 @@ export class ClaudeAdapter implements ProviderAdapter {
     if (!resolved) {
       return { ok: false, reason: 'claude CLI not found on PATH. Install from https://claude.ai/download or npm i -g @anthropic-ai/claude-code (or set GSTACK_CLAUDE_BIN)' };
     }
-    // Auth sniff: ~/.claude/.credentials.json OR ANTHROPIC_API_KEY
+    // Prefer the CLI's own auth check because current macOS builds store OAuth
+    // credentials in Keychain rather than ~/.claude/.credentials.json.
     const credsPath = path.join(os.homedir(), '.claude', '.credentials.json');
     const hasCreds = fs.existsSync(credsPath);
     const hasKey = !!process.env.ANTHROPIC_API_KEY;
-    if (!hasCreds && !hasKey) {
-      return { ok: false, reason: 'No Claude auth found. Log in via `claude` interactive session, or export ANTHROPIC_API_KEY.' };
+    let hasCliAuth = false;
+    try {
+      execFileSync(
+        resolved.command,
+        [...resolved.argsPrefix, 'auth', 'status', '--json'],
+        { stdio: 'ignore', timeout: 5_000 },
+      );
+      hasCliAuth = true;
+    } catch {
+      // Older CLI builds may not support `auth status`; retain legacy fallbacks.
+    }
+    if (!hasCreds && !hasKey && !hasCliAuth) {
+      return { ok: false, reason: 'No Claude auth found. Run `claude auth login` (or `claude` interactively), or export ANTHROPIC_API_KEY.' };
     }
     return { ok: true };
   }

--- a/test/skill-validation.test.ts
+++ b/test/skill-validation.test.ts
@@ -1384,12 +1384,12 @@ describe('Codex skill', () => {
     }
   });
 
-  test('adversarial review in /review always runs both passes', () => {
+  test('adversarial review in /review always runs in-session and consent-gates Codex', () => {
     const content = fs.readFileSync(path.join(ROOT, 'review', 'SKILL.md'), 'utf-8');
-    expect(content).toContain('Adversarial review (always-on)');
-    // Always-on: both Claude and Codex adversarial
+    expect(content).toContain('Adversarial review (in-session always-on; external pass consent-gated)');
     expect(content).toContain('Claude adversarial subagent (always runs)');
     expect(content).toContain('Codex adversarial challenge (runs whenever');
+    expect(content).toContain('do not read or assemble the provider payload yet');
     // Claude adversarial subagent dispatch
     expect(content).toContain('Agent tool');
     expect(content).toContain('FIXABLE');
@@ -1408,9 +1408,9 @@ describe('Codex skill', () => {
     expect(content).toContain('200');
   });
 
-  test('adversarial review in /ship always runs both passes', () => {
+  test('adversarial review in /ship always runs in-session and consent-gates Codex', () => {
     const content = readShipUnion();
-    expect(content).toContain('Adversarial review (always-on)');
+    expect(content).toContain('Adversarial review (in-session always-on; external pass consent-gated)');
     expect(content).toContain('adversarial-review');
     expect(content).toContain('reasoning_effort="high"');
     expect(content).toContain('Investigate and fix');
@@ -1453,28 +1453,29 @@ describe('Codex skill', () => {
     expect(content).toContain('codex exec');
   });
 
-  // D5 regression guard: the Codex outside voice is default-on, not opt-in. A future
-  // gen-skill-docs change must not silently reintroduce the "Want an outside voice?"
-  // AskUserQuestion. The CODEX_PLAN_REVIEW content renders into each skill's
+  // D5 regression guard: the Codex outside voice remains configured by default,
+  // but provider-and-payload authorization is mandatory before export. The
+  // CODEX_PLAN_REVIEW content renders into each skill's
   // sections/review-sections.md (the skeleton points at it). plan-design-review uses
   // DESIGN_OUTSIDE_VOICES, not CODEX_PLAN_REVIEW, so it is excluded here.
-  test('plan reviews run the Codex outside voice default-on (no opt-in question)', () => {
+  test('plan reviews offer the default Codex outside voice behind export consent', () => {
     for (const skill of ['plan-eng-review', 'plan-ceo-review', 'plan-devex-review']) {
       const content = fs.readFileSync(
         path.join(ROOT, skill, 'sections', 'review-sections.md'), 'utf-8');
-      expect(content).not.toContain('Want an outside voice');
-      expect(content).toContain('Outside Voice — Independent Plan Challenge (default-on)');
+      expect(content).toContain('Outside Voice — Independent Plan Challenge (configured by default; export consent required)');
+      expect(content).toContain('do not read or assemble the provider payload yet');
       expect(content).toContain('CODEX_MODE');
       expect(content).toContain('command -v codex'); // preflight install check (e2e relies on it)
     }
   });
 
-  test('/document-release includes the default-on Codex documentation review', () => {
+  test('/document-release includes the consent-gated Codex documentation review', () => {
     // The doc-review renders into the carved release-body section (kept out of the
     // always-loaded skeleton to respect the skeleton-byte budget).
     const content = fs.readFileSync(
       path.join(ROOT, 'document-release', 'sections', 'release-body.md'), 'utf-8');
-    expect(content).toContain('Codex Documentation Review (default-on)');
+    expect(content).toContain('Codex Documentation Review (configured by default; export consent required)');
+    expect(content).toContain('do not read or assemble the provider payload yet');
     expect(content).toContain('CODEX_MODE');
     expect(content).toContain('codex-doc-review');
   });


### PR DESCRIPTION
## Summary

- resolve Codex review checklist and triage assets through the computed gstack runtime root
- treat Claude and GitHub authentication as tri-state so sandbox, Keychain, and network failures remain unverified instead of becoming false logout or clean-result reports
- require fresh provider-and-payload authorization before sending repository content to Anthropic Claude or OpenAI Codex
- retain the preceding portable Claude temp-file and macOS Keychain detection fixes in this branch

## Verification

- `bun run test` (repository wrapper passed)
- focused generation, validation, audit, parity, and preflight suites: 750 passed, 0 failed
- all-host generation and freshness checks passed
- `bun run build` passed
- `git diff --check` passed
- installed Codex runtime verified locally, including checklist resolution and consent/auth instructions

## Notes

The raw Bun runner still prints pre-existing gbrain/path harness failures that reproduce unchanged on the parent commit; the repository test wrapper completes successfully. No repository content was sent to an external model while preparing this change.