### PR TITLE
fix(diff-scope): detect Drizzle migrations, root-level migrations/, and singular migration/

### DIFF
--- a/bin/gstack-diff-scope
+++ b/bin/gstack-diff-scope
@@ -63,8 +63,16 @@ while IFS= read -r f; do
     .github/*) CONFIG=true ;;
     requirements.txt|pyproject.toml|go.mod|Cargo.toml|composer.json) CONFIG=true ;;
 
-    # Migrations: database migration files
-    db/migrate/*|*/migrations/*|alembic/*|prisma/migrations/*) MIGRATIONS=true ;;
+    # Migrations: database migration files.
+    # Match BROADLY on purpose: a false positive costs one extra specialist pass, a false
+    # negative silently skips the data-migration reviewer on the diff that needed it most.
+    # (Observed: a Drizzle repo dropping a column DEFAULT scored SCOPE_MIGRATIONS=false.)
+    db/migrate/*|db/migration/*) MIGRATIONS=true ;;
+    migrations/*|migration/*|*/migrations/*|*/migration/*) MIGRATIONS=true ;;
+    alembic/*|prisma/migrations/*) MIGRATIONS=true ;;
+    # Drizzle: default `out` is ./drizzle — bare .sql files plus a meta/ journal+snapshots.
+    # Nested form covers a monorepo package or a custom `out` one level down.
+    drizzle/*.sql|drizzle/meta/*|*/drizzle/*.sql|*/drizzle/meta/*) MIGRATIONS=true ;;
 
     # API: routes, controllers, endpoints, GraphQL/OpenAPI schemas
     *controller*|*route*|*endpoint*|*/api/*) API=true ;;

--- a/test/diff-scope.test.ts
+++ b/test/diff-scope.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, test, expect, afterAll } from 'bun:test';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
 
@@ -34,7 +34,10 @@ function createRepo(files: string[]): string {
   run('git', ['checkout', '-b', 'feature/test']);
   for (const f of files) {
     const fullPath = join(dir, f);
-    const dirPath = fullPath.substring(0, fullPath.lastIndexOf('/'));
+    // dirname(), not lastIndexOf('/'): join() emits BACKSLASHES on Windows, so the
+    // hand-rolled scan returned -1, substring(0, -1) gave '', and mkdirSync('') threw
+    // ENOENT -- every test in this file failed on Windows, including the no-subdir ones.
+    const dirPath = dirname(fullPath);
     if (dirPath !== dir) mkdirSync(dirPath, { recursive: true });
     writeFileSync(fullPath, '# test content\n');
   }
@@ -111,6 +114,52 @@ describe('gstack-diff-scope', () => {
     const dir = createRepo(['prisma/migrations/20260330/migration.sql']);
     const scope = runScope(dir);
     expect(scope.SCOPE_MIGRATIONS).toBe('true');
+  });
+
+  // Drizzle writes bare .sql files plus a meta/ journal into its `out` dir (default
+  // ./drizzle), which matched NO migration pattern -- so a Drizzle PR dropping a column
+  // DEFAULT scored SCOPE_MIGRATIONS=false and silently skipped the data-migration
+  // reviewer, the one pass most relevant to that diff.
+  test('detects migrations via drizzle output dir', () => {
+    for (const f of [
+      'drizzle/20260805040502_lazy_champions.sql',
+      'drizzle/meta/_journal.json',
+      'drizzle/meta/0001_snapshot.json',
+    ]) {
+      const scope = runScope(createRepo([f]));
+      expect(scope.SCOPE_MIGRATIONS).toBe('true');
+    }
+  });
+
+  test('detects migrations via drizzle in a monorepo package', () => {
+    const dir = createRepo(['packages/db/drizzle/0001_init.sql']);
+    const scope = runScope(dir);
+    expect(scope.SCOPE_MIGRATIONS).toBe('true');
+  });
+
+  // `*/migrations/*` requires a parent segment, so a ROOT-level migrations/ dir --
+  // Knex, Sequelize, golang-migrate, Atlas -- fell through.
+  test('detects migrations via root-level migrations/', () => {
+    const dir = createRepo(['migrations/001_init.sql']);
+    const scope = runScope(dir);
+    expect(scope.SCOPE_MIGRATIONS).toBe('true');
+  });
+
+  // Flyway and some Ecto/Java layouts use the SINGULAR `migration/`.
+  test('detects migrations via singular migration/ (Flyway)', () => {
+    for (const f of ['db/migration/V1__init.sql', 'src/main/resources/db/migration/V2__x.sql']) {
+      const scope = runScope(createRepo([f]));
+      expect(scope.SCOPE_MIGRATIONS).toBe('true');
+    }
+  });
+
+  // The widened patterns must not fire on ORM CONFIG or on prose that merely contains
+  // the word -- only on an actual path segment.
+  test('does NOT flag drizzle config or migration prose as a migration', () => {
+    for (const f of ['drizzle.config.ts', 'docs/migration-guide.md', 'src/db/schema.ts']) {
+      const scope = runScope(createRepo([f]));
+      expect(scope.SCOPE_MIGRATIONS).toBe('false');
+    }
   });
 
   test('detects API via controller files', () => {


### PR DESCRIPTION
## What

`SCOPE_MIGRATIONS` returned `false` on a PR whose diff contained a migration, so
`/ship` never dispatched the **data-migration specialist** — on a diff that dropped a
column `DEFAULT`. Found while shipping a Drizzle + Postgres app; I force-included the
specialist manually, and it turned out to be the pass that mattered most on that diff.

The pattern list matched `db/migrate/`, `*/migrations/`, `alembic/` and `prisma/migrations/`.
Three gaps:

1. **Drizzle** writes bare `.sql` files plus a `meta/` journal into its `out` dir (default
   `./drizzle`), matching none of them. This is the case that surfaced it.
2. **`*/migrations/*` requires a parent segment**, so a **root-level** `migrations/` dir —
   Knex, Sequelize, golang-migrate, Atlas — fell through.
3. **Flyway** and some Java/Ecto layouts use the singular `migration/`.

Matching is deliberately broad, on the asymmetry that a false positive costs one extra
specialist pass while a false negative silently skips the reviewer on the diff that most
needed one.

## Also: the test file could not run on Windows at all

Every one of `test/diff-scope.test.ts`'s 16 tests failed before this change — not from a
regression, it had simply never worked there. `createRepo` derived the parent directory with:

```js
const dirPath = fullPath.substring(0, fullPath.lastIndexOf('/'));
```

`join()` emits **backslashes** on Windows, so `lastIndexOf('/')` returned `-1`,
`substring(0, -1)` gave `''`, and `mkdirSync('')` threw `ENOENT`. Now uses `dirname()`.

I verified this is pre-existing rather than mine by stashing both files and re-running:
**0 pass / 16 fail** on a clean checkout.

## Verification

`bun test test/diff-scope.test.ts` on Windows:

| | before | after |
|---|---|---|
| pass | 0 | **21** |
| fail | 16 | **0** |

Six new cases cover Drizzle output (bare `.sql`, `meta/` journal, monorepo package),
root-level `migrations/`, singular `migration/`, and a **negative** case asserting the
widened patterns do *not* fire on `drizzle.config.ts` or on prose like
`docs/migration-guide.md` — only on a real path segment.

## Note

Branched from `v1.60.1.0`, which is what my install was pinned at. `bin/gstack-diff-scope`
and `test/diff-scope.test.ts` are both untouched upstream since then, so it should apply
cleanly — happy to rebase if you'd prefer.