### PR TITLE
Fix browse daemon crash-loop diagnostics + a shell-injection bug found along the way

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -91,7 +91,32 @@ export function shouldEnableChromiumSandbox(): boolean {
  * restarts on backoff.
  */
 export async function resolveDisconnectCause(browser: Browser | null): Promise<'clean' | 'crash'> {
-  const proc = browser?.process();
+  // browser.process() has thrown "browser?.process is not a function" in
+  // the wild (confirmed live: killing the headless-shell child process
+  // triggered it) -- some browser instances/connection modes apparently
+  // don't carry a real .process() the way a plain chromium.launch() result
+  // does. That's a synchronous throw inside this async function, which
+  // rejects the promise; the caller (handleChromiumDisconnect) awaits it
+  // without its own try/catch and is itself invoked via `void` (fire-and-
+  // forget) from the 'disconnected' event handler, so the rejection had
+  // nowhere to go but server.ts's top-level unhandledRejection handler --
+  // which exits the WHOLE daemon. The function whose entire job is
+  // classifying a disconnect was, on this path, causing a second, harder
+  // to diagnose crash of its own. Default to 'crash' (the conservative,
+  // pre-existing behavior for anything abnormal) when we can't even
+  // determine why the browser disconnected, instead of taking the daemon
+  // down over a diagnostic step.
+  let proc: ReturnType<NonNullable<Browser['process']>> | null = null;
+  try {
+    proc = browser?.process() ?? null;
+  } catch (err) {
+    // Log rather than swallow silently -- the entire point of this diff is
+    // making crash causes diagnosable (see cli.ts's daemon log redirect).
+    // A future error here that ISN'T today's known "not a function" case
+    // would otherwise vanish the same way the original bug did.
+    console.error('[browse] resolveDisconnectCause: browser.process() threw:', (err as Error)?.message || err);
+    proc = null;
+  }
   if (proc && proc.exitCode === null && proc.signalCode === null) {
     await new Promise<void>((resolve) => {
       const timer = setTimeout(resolve, 1000);

--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -11,7 +11,46 @@
 'use strict';
 
 const http = require('http');
-const { spawnSync, spawn } = require('child_process');
+const { spawnSync: nodeSpawnSync, spawn: nodeSpawn } = require('child_process');
+// Node's spawn on Windows without shell:true only matches an EXACT
+// executable name -- no PATHEXT resolution the way a real shell (or
+// Bun.spawn, which this file exists to polyfill) does. A bare command
+// name like 'bun' (no .exe/.cmd) then fails ENOENT even though `bun`
+// works fine typed at a prompt (confirmed live: this is what produced
+// "[browse] FATAL uncaught exception: spawn bun ENOENT" from
+// terminal-agent-control.ts's respawn path, once daemon output was
+// actually being captured to a file instead of silently discarded).
+//
+// Two things this is NOT fixed with, both tried and rejected here:
+//
+// 1. shell:true + array args. This file is also reached (via server.ts ->
+//    write-commands.ts/meta-commands.ts -> cookie-import-browser.ts/
+//    browser-skill-commands.ts) by calls that pass genuinely variable
+//    content -- browser-skill-commands.ts:266 spreads `...opts.skillArgs`,
+//    sourced from `$B skill run <name> --arg k=v`'s passthrough CLI args,
+//    into the spawned argv. shell:true on Windows routes through cmd.exe,
+//    and Node's own array-arg handling for that combination does NOT
+//    neutralize cmd.exe metacharacters (& | ^ % < >) -- confirmed by
+//    directly spawning a resolved .cmd path with an arg containing
+//    `& echo INJECTED > proof.txt`: the file was created. Hand-rolled
+//    double-quote-only escaping (an earlier version of this fix) doesn't
+//    close that either -- it only handles embedded quotes.
+//
+// 2. Resolve the .exe/.cmd path ourselves and spawn it with NO shell.
+//    Works for .exe targets, but Node flat-out refuses (EINVAL) to spawn
+//    a .cmd/.bat file without shell:true -- deliberately, as part of
+//    Node's own CVE-2024-27980 fix for implicit unsafe .cmd execution.
+//    bun's own Windows install (npm global) is exactly a .cmd shim, so
+//    this path is not optional to support.
+//
+// cross-spawn (already resolved in node_modules -- a transitive dep of
+// @modelcontextprotocol/sdk, added here as a direct dependency) is the
+// established, battle-tested library for precisely this problem: it does
+// PATHEXT resolution AND correct Windows/cmd.exe argument escaping
+// together. Verified against the same injection payload above: the
+// malicious arg reached the child as a single literal argument, no file
+// was created, and normal resolution (`bun --version`) still worked.
+const crossSpawn = require('cross-spawn');
 
 globalThis.Bun = {
   serve(options) {
@@ -66,7 +105,8 @@ globalThis.Bun = {
 
   spawnSync(cmd, options = {}) {
     const [command, ...args] = cmd;
-    const result = spawnSync(command, args, {
+    const spawnFn = process.platform === 'win32' ? crossSpawn.sync : nodeSpawnSync;
+    const result = spawnFn(command, args, {
       stdio: [
         options.stdin || 'pipe',
         options.stdout === 'pipe' ? 'pipe' : 'ignore',
@@ -86,8 +126,9 @@ globalThis.Bun = {
 
   spawn(cmd, options = {}) {
     const [command, ...args] = cmd;
+    const spawnFn = process.platform === 'win32' ? crossSpawn : nodeSpawn;
     const stdio = options.stdio || ['pipe', 'pipe', 'pipe'];
-    const proc = spawn(command, args, {
+    const proc = spawnFn(command, args, {
       stdio,
       env: options.env,
       cwd: options.cwd,

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -292,6 +292,27 @@ function raiseHeadedWindowMacOS(): void {
 }
 
 // ─── Server Lifecycle ──────────────────────────────────────────
+// Detached daemon's own stdout/stderr used to be wired to 'ignore' on every
+// platform, so console.error('[browse] FATAL: ...') from a Chromium crash,
+// an uncaughtException, or an unhandledRejection (see server.ts's handlers
+// and browser-manager.ts's handleChromiumDisconnect) went nowhere -- not to
+// a file, not to the terminal, just discarded at the OS level. That made a
+// crash-and-respawn indistinguishable from any other cause of a dropped
+// session: nothing on disk ever recorded WHY. Redirect both streams to
+// <stateDir>/browse-daemon.log instead (opened here, in the CLI's own
+// process, and passed down as a real fd/stream so it survives past this
+// process exiting) -- append mode, so it accumulates across the server's
+// full lifetime and every respawn stays visible in one place.
+function openDaemonLogSink(): number | 'ignore' {
+  try {
+    return fs.openSync(path.join(config.stateDir, 'browse-daemon.log'), 'a');
+  } catch {
+    // stateDir not writable (permissions, disk full) -- fall back to the
+    // previous behavior rather than fail the whole launch over logging.
+    return 'ignore';
+  }
+}
+
 async function startServer(extraEnv?: Record<string, string>): Promise<ServerState> {
   ensureStateDir(config);
 
@@ -320,10 +341,18 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     // with { detached: true } instead, which is the gold standard for Windows
     // process independence. Credit: PR #191 by @fqueiro.
     const extraEnvStr = JSON.stringify({ BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: parentPid, ...(extraEnv || {}) });
+    // The daemon's real process lives inside THIS launcher's own `node -e`
+    // invocation, not in cli.ts's process -- so the log file has to be
+    // opened from inside the launcher string too; a fd opened here in
+    // cli.ts wouldn't cross the spawn boundary. Falls back to 'ignore' the
+    // same way openDaemonLogSink() does if the state dir isn't writable.
+    const daemonLogPathStr = JSON.stringify(path.join(config.stateDir, 'browse-daemon.log'));
     const launcherCode =
       `const{spawn}=require('child_process');` +
+      `const fs=require('fs');` +
+      `let logFd;try{logFd=fs.openSync(${daemonLogPathStr},'a');}catch(e){logFd='ignore';}` +
       `spawn(process.execPath,[${JSON.stringify(NODE_SERVER_SCRIPT)}],` +
-      `{detached:true,stdio:['ignore','ignore','ignore'],env:Object.assign({},process.env,` +
+      `{detached:true,stdio:['ignore',logFd,logFd],env:Object.assign({},process.env,` +
       `${extraEnvStr})}).unref()`;
     Bun.spawnSync(['node', '-e', launcherCode], { stdio: ['ignore', 'ignore', 'ignore'] });
   } else {
@@ -338,9 +367,10 @@ async function startServer(extraEnv?: Record<string, string>): Promise<ServerSta
     // which calls setsid() so the server becomes its own session leader
     // (PPID=1, STAT=Ss) and survives the spawning shell's exit. Mirrors
     // the Windows path's rationale — same root cause, different OS API.
+    const daemonLogFd = openDaemonLogSink();
     nodeSpawn('bun', ['run', SERVER_SCRIPT], {
       detached: true,
-      stdio: ['ignore', 'ignore', 'ignore'],
+      stdio: ['ignore', daemonLogFd, daemonLogFd],
       env: { ...process.env, BROWSE_STATE_FILE: config.stateFile, BROWSE_PARENT_PID: parentPid, ...extraEnv },
     }).unref();
   }

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@huggingface/transformers": "^4.1.0",
         "@ngrok/ngrok": "^1.7.0",
+        "cross-spawn": "^7.0.6",
         "diff": "^7.0.0",
         "html-to-docx": "1.8.0",
         "marked": "^18.0.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@huggingface/transformers": "^4.1.0",
     "@ngrok/ngrok": "^1.7.0",
+    "cross-spawn": "^7.0.6",
     "diff": "^7.0.0",
     "html-to-docx": "1.8.0",
     "marked": "^18.0.2",


### PR DESCRIPTION
## Summary
- The detached browse daemon's stdout/stderr were wired to `'ignore'` on every platform, so every `console.error('[browse] FATAL: ...')` from a crash (Chromium disconnect, uncaughtException, unhandledRejection) went nowhere — a restart was indistinguishable from any other cause of a dropped session, with nothing on disk recording why.
- `cli.ts`: both the Windows and macOS/Linux spawn paths now redirect stdout/stderr to `<stateDir>/browse-daemon.log` (append mode, accumulates across the daemon's full lifetime and every respawn).
- That immediately surfaced two real, previously invisible bugs, both fixed here:
  1. **`spawn bun ENOENT`** — `bun-polyfill.cjs`'s `Bun.spawn`/`spawnSync` polyfill called Node's `child_process.spawn` with a bare command name (`'bun'`), which Windows can't resolve without PATHEXT lookup.
  2. **`browser?.process is not a function`** — `resolveDisconnectCause()` (the crash classifier itself) threw on some browser/connection-mode shapes, and being an unhandled fire-and-forget rejection, took the whole daemon down a second, harder-to-diagnose way.

## A note on how the fix for #1 evolved
My first attempt used `shell:true` with hand-rolled double-quote escaping to fix the PATHEXT resolution. I verified empirically (not just reasoned about it) that this does **not** neutralize cmd.exe metacharacters (`&|^%<>`), and is reachable via `browser-skill-commands.ts`'s `...opts.skillArgs` passthrough from `$B skill run <name> --arg k=v`. Spawning a resolved `.cmd` path with an arg containing `& echo INJECTED > proof.txt` actually created the file.

Replaced it with [`cross-spawn`](https://github.com/moxystudio/node-cross-spawn) — already resolved in `node_modules` transitively via `@modelcontextprotocol/sdk`, now added as a direct dependency — the established library for correct Windows PATHEXT resolution + argument escaping together. Re-verified the same injection payload no longer executes, and normal resolution (`bun --version`) still works.

## Test plan
- [x] Killed the live Chromium child under a running daemon — log now shows a single clean `FATAL: Chromium process crashed or was killed`, terminal-agent respawns successfully, daemon auto-recovers to a healthy new PID
- [x] Re-ran the same test after reverting each fix individually to confirm each is load-bearing (not just cosmetically present)
- [x] Confirmed the shell-injection payload (`& echo INJECTED > proof.txt`) no longer executes after the `cross-spawn` fix
- [x] Confirmed normal resolution (`bun --version` via both `spawn` and `spawnSync`) still works, including paths/args containing spaces
- [x] 24/24 pre-existing `browser-manager-unit` tests pass
- [x] `bun build --compile` succeeds for both `cli.ts` and the Node server bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)