### PR TITLE
fix(design): create OpenAI key file owner-only to close write-then-chmod race

### DIFF
--- a/design/src/auth.ts
+++ b/design/src/auth.ts
@@ -111,7 +111,10 @@ export function describeApiKeySource(resolution: ApiKeyResolution): string {
 export function saveApiKey(key: string): void {
   const dir = path.dirname(configPath());
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(configPath(), JSON.stringify({ api_key: key }, null, 2));
+  // Create the file owner-only up front so the API key is never briefly
+  // world/group-readable in the window between write and chmod. The trailing
+  // chmodSync is kept as a backstop to tighten a pre-existing loose file.
+  fs.writeFileSync(configPath(), JSON.stringify({ api_key: key }, null, 2), { mode: 0o600 });
   fs.chmodSync(configPath(), 0o600);
 }
 

--- a/design/test/auth.test.ts
+++ b/design/test/auth.test.ts
@@ -111,6 +111,27 @@ describe("resolveApiKeyInfo", () => {
   });
 });
 
+describe("saveApiKey", () => {
+  test("stores the key file owner-only, even under a permissive umask", () => {
+    // The OpenAI key file must never be group/other-readable. saveApiKey now
+    // creates it with mode 0600 up front (matching session.ts / #859) instead
+    // of writing at the default umask and tightening afterwards, so the key is
+    // not briefly world-readable in the write-then-chmod window (CWE-377/367).
+    const prevUmask = process.umask(0o000);
+    try {
+      saveApiKey("sk-secret-value");
+    } finally {
+      process.umask(prevUmask);
+    }
+
+    const keyPath = path.join(tmpHome, ".gstack", "openai.json");
+    const mode = fs.statSync(keyPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+    // No group/other read/write/exec bits.
+    expect(mode & 0o077).toBe(0);
+  });
+});
+
 describe("requireApiKey", () => {
   test("prints source disclosure without leaking the key", () => {
     process.env.OPENAI_API_KEY = "sk-secret-value";


### PR DESCRIPTION
## What

`saveApiKey()` in `design/src/auth.ts` persists the OpenAI API key to `~/.gstack/openai.json` by writing at the process default umask and only tightening permissions afterwards:

```ts
fs.writeFileSync(configPath(), JSON.stringify({ api_key: key }, null, 2));
fs.chmodSync(configPath(), 0o600);
```

On a typical umask (022) the file is created `0644` (group/world-readable). Between the `writeFileSync` and the `chmodSync` there is a window where the file containing the OpenAI API key is readable by any other local user. This is CWE-377 (insecure file creation) / CWE-367 (TOCTOU) — low severity, only exploitable by a co-located local user on a shared/multi-user host, but it's a real key-disclosure window and a cheap thing to close.

## Fix

Create the file owner-only up front by passing `{ mode: 0o600 }` to `writeFileSync`, so it is never briefly world-readable. The trailing `chmodSync` is kept as a backstop that still tightens a pre-existing loose file.

```ts
fs.writeFileSync(configPath(), JSON.stringify({ api_key: key }, null, 2), { mode: 0o600 });
fs.chmodSync(configPath(), 0o600);
```

This matches the convention already used for session files in `design/src/session.ts` (`{ mode: 0o600 }` on create, landed in #859). #859 hardened the session files but the actual API key file kept the write-then-chmod pattern — this brings it in line.

## Test

Adds a `saveApiKey` regression test that writes the key under a deliberately permissive umask (`0o000`) and asserts the resulting file is exactly `0600` with no group/other bits.

```
$ bun test design/test/auth.test.ts
 7 pass
 0 fail
```

## Scope

Two files, `design/src/auth.ts` (+3/-1) and `design/test/auth.test.ts` (+21). No behavior change beyond the file-creation mode.
