### PR TITLE
Fix: decision cards never appear in the Claude desktop app (AskUserQuestion parked by permissionDecision 'defer')

### DIFF
--- a/hosts/claude/hooks/question-preference-hook.ts
+++ b/hosts/claude/hooks/question-preference-hook.ts
@@ -93,9 +93,24 @@ function readStdin(): Promise<string> {
 }
 
 function defer(additionalContext?: string): void {
+  // Deliberately does NOT emit permissionDecision:'defer'.
+  //
+  // In Claude Code, 'defer' does not mean "no opinion" — it means "park this
+  // tool call so a later resume can pick it up". It is ignored in interactive
+  // sessions, but HONORED whenever the session is flagged non-interactive,
+  // which includes the Claude desktop app even with a human present. A parked
+  // AskUserQuestion never runs and never returns a result, so the model sees
+  // "[Tool result missing due to internal error]" and the decision card never
+  // reaches the user.
+  //
+  // This function's contract is "no enforcement — proceed normally, let the
+  // user be asked" (see the never-ask + one-way safety override above, which
+  // requires the question to still reach the human). The correct encoding of
+  // that in Claude Code is to omit permissionDecision entirely; it is
+  // .optional() in the PreToolUse hookSpecificOutput schema. additionalContext
+  // is still delivered, so plan-tune memory injection is unaffected.
   const out: Record<string, unknown> = {
     hookEventName: 'PreToolUse',
-    permissionDecision: 'defer',
   };
   if (additionalContext) out.additionalContext = additionalContext;
   process.stdout.write(JSON.stringify({ hookSpecificOutput: out }));

--- a/test/memory-cache-injection.test.ts
+++ b/test/memory-cache-injection.test.ts
@@ -91,7 +91,7 @@ describe('memory injection', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toContain('verbose explanations');
   });
 
@@ -115,7 +115,7 @@ describe('memory injection', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toBeUndefined();
   });
 
@@ -219,7 +219,7 @@ describe('per-session memory cache', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(r.parsed?.hookSpecificOutput?.additionalContext).toBeUndefined();
   });
 });

--- a/test/question-preference-hook.test.ts
+++ b/test/question-preference-hook.test.ts
@@ -126,7 +126,7 @@ describe('defers (no enforcement)', () => {
       },
     });
     expect(r.status).toBe(0);
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('marker missing → defer (D18)', () => {
@@ -141,7 +141,7 @@ describe('defers (no enforcement)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('always-ask preference → defer', () => {
@@ -156,7 +156,7 @@ describe('defers (no enforcement)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('empty stdin → defer (crash safety)', () => {
@@ -168,13 +168,13 @@ describe('defers (no enforcement)', () => {
     const res = spawnSync(HOOK, [], { env, input: '', encoding: 'utf-8' });
     expect(res.status).toBe(0);
     const parsed = JSON.parse(res.stdout || '{}');
-    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('non-AUQ tool_name → defer (defensive)', () => {
     writeProjectPref('test-q', 'never-ask');
     const r = runHook({ session_id: 's4', tool_name: 'Bash', tool_use_id: 'tu-4', tool_input: {} });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 
@@ -219,7 +219,7 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('ambiguous recommendation (two labels) → defer (D2 refuse-on-ambiguous)', () => {
@@ -237,7 +237,7 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 
   test('no recommendation marker AND no prose match → defer', () => {
@@ -255,7 +255,7 @@ describe('enforces never-ask preferences', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 
@@ -317,7 +317,7 @@ describe('precedence: project wins over global (D8)', () => {
         ],
       },
     });
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 
@@ -443,7 +443,7 @@ describe('Conductor prose redirect', () => {
       undefined,
       CONDUCTOR,
     );
-    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).toBeUndefined();
   });
 });
 
@@ -491,5 +491,56 @@ describe('auto-decided event tagging', () => {
     });
     const markerPath = path.join(stateRoot, 'sessions', 's14', '.auto-decided-tu-14');
     expect(fs.existsSync(markerPath)).toBe(true);
+  });
+});
+
+describe('never emits permissionDecision:defer (AskUserQuestion regression)', () => {
+  // Regression guard. 'defer' is NOT "no opinion" in Claude Code — it means
+  // "park this tool call for a later resume". It is ignored in interactive
+  // sessions but HONORED whenever the session is flagged non-interactive,
+  // which includes the Claude desktop app even with a human present. A parked
+  // AskUserQuestion never runs and never returns, so the decision card never
+  // reaches the user and the model sees
+  // "[Tool result missing due to internal error]".
+  //
+  // The no-enforcement contract must therefore be encoded by OMITTING
+  // permissionDecision (it is .optional() in the PreToolUse schema), never by
+  // sending 'defer'. Only 'allow' | 'deny' | 'ask' are safe to emit.
+  const SAFE = new Set(['allow', 'deny', 'ask']);
+
+  const cases: Array<[string, unknown]> = [
+    ['no preference set', { session_id: 'r1', tool_name: 'AskUserQuestion', tool_use_id: 'tr-1',
+      tool_input: { questions: [{ question: 'Plain?', options: ['A) Yes', 'B) No'] }] } }],
+    ['marker present but no preference', { session_id: 'r2', tool_name: 'AskUserQuestion', tool_use_id: 'tr-2',
+      tool_input: { questions: [{ question: '<gstack-qid:test-q> Need approval?', options: ['A) Yes (recommended)', 'B) No'] }] } }],
+    ['empty stdin', {}],
+    ['non-AUQ tool', { session_id: 'r3', tool_name: 'Bash', tool_use_id: 'tr-3', tool_input: {} }],
+  ];
+
+  for (const [name, payload] of cases) {
+    test(`${name} → permissionDecision is never 'defer'`, () => {
+      const r = runHook(payload as never);
+      const decision = r.parsed?.hookSpecificOutput?.permissionDecision;
+      expect(decision).not.toBe('defer');
+      if (decision !== undefined) expect(SAFE.has(decision)).toBe(true);
+    });
+  }
+
+  test('one-way door with never-ask still reaches the user (no defer parking)', () => {
+    // The safety override: one-way doors must always ask. If this emitted
+    // 'defer', the question would be parked instead of asked — silently
+    // converting "always ask the human" into "never ask the human".
+    writeProjectPref('test-q-oneway', 'never-ask');
+    const r = runHook({
+      session_id: 'r5',
+      tool_name: 'AskUserQuestion',
+      tool_use_id: 'tr-5',
+      tool_input: {
+        questions: [
+          { question: '<gstack-qid:test-q-oneway> Destructive?', options: ['A) Do it (recommended)', 'B) Stop'] },
+        ],
+      },
+    });
+    expect(r.parsed?.hookSpecificOutput?.permissionDecision).not.toBe('defer');
   });
 });

--- a/test/skill-e2e-plan-tune-cathedral.test.ts
+++ b/test/skill-e2e-plan-tune-cathedral.test.ts
@@ -296,7 +296,7 @@ describeIfSelected('PlanTune cathedral E2E: annotation', ['plan-tune-annotation'
     });
     expect(res.status).toBe(0);
     const parsed = JSON.parse(res.stdout || '{}');
-    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('defer');
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBeUndefined();
     expect(parsed.hookSpecificOutput?.additionalContext).toContain('verbose explanations');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2466 — AskUserQuestion decision cards never appear when gstack runs in the **Claude desktop app**. The question is silently swallowed, the user sees nothing, and the agent gets back `[Tool result missing due to internal error]`.

`hosts/claude/hooks/question-preference-hook.ts` emitted `permissionDecision: 'defer'` on its no-enforcement path. In Claude Code, `defer` does **not** mean "no opinion" — it means *park this tool call so a later resume can pick it up*.

From the Claude Code 2.1.221 binary:

```js
case "defer": {
  if (!n.options.isNonInteractiveSession) {
    C(`Hook ${ce.hookName} returned permissionDecision=defer in interactive mode; ignoring (defer is print-mode only)`, {level:"warn"});
    break;                                   // ignored → card renders normally
  }
  ...
  return T.push({ message: al({ type: "hook_deferred_tool", ... }) })   // parked, never runs
}
```

`defer` is honored only when the session is flagged `isNonInteractiveSession` — and the Claude desktop app is flagged non-interactive even with a human present. So the AskUserQuestion call is parked, never executes, and never returns.

**This is why it went unreported:** in the terminal CLI `defer` is ignored and cards work fine, which is how most people run gstack. It reproduces only in the desktop app.

## The fix

Omit `permissionDecision` on the no-enforcement path. It is `.optional()` in the PreToolUse `hookSpecificOutput` schema:

```js
E.object({
  hookEventName: E.literal("PreToolUse"),
  permissionDecision: DM_().optional(),
  permissionDecisionReason: E.string().optional(),
  updatedInput: E.record(E.string(), E.unknown()).optional(),
  additionalContext: E.string().optional()
})
```

Omitting it is also what this path already *means*. The hook's own docstring states:

> `never-ask + one-way → defer (safety override; one-way always asks)`

If `defer` parked the tool, a one-way door would never reach the human — the exact inverse of the documented safety override. So the intent is "no enforcement, proceed normally, let the user be asked."

Only `allow` / `deny` / `ask` are safe to emit when the tool is expected to actually run.

## What is preserved

- `additionalContext` still flows → plan-tune memory-nugget injection unaffected
- `deny` paths untouched → never-ask auto-decide and the Conductor prose redirect both still work (`deny` is a valid, honored value)
- PostToolUse logging hooks unaffected

## Verification

Bisected on a real desktop-app session with all three AUQ hooks registered:

| Hooks live | Result |
|---|---|
| none | card renders ✅ |
| `question-preference-hook` only (emits `defer`) | `[Tool result missing due to internal error]` ❌ |
| all three, with this patch | card renders ✅ |

Across that machine's full transcript history before the fix: **3,700+ tool calls of every other kind resolved 100%; AskUserQuestion went 0-for-8.** After the fix, decision cards render and return normally, including multi-question and `multiSelect` cards.

## Tests

14 assertions across three suites encoded the old contract and are updated to `toBeUndefined()`. Added a regression guard (`never emits permissionDecision:defer`) covering the no-preference, no-marker, empty-stdin, and non-AUQ paths, plus the one-way-door safety override.

**93/93 passing** across the five hook suites against current `main` (v1.60.2.0):

```
bun test test/question-preference-hook.test.ts test/memory-cache-injection.test.ts \
         test/auq-error-fallback-hook.test.ts test/question-log-hook.test.ts \
         test/hook-scripts.test.ts
# 93 pass, 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
