### PR TITLE
fix(windows): grant icacls by SID, not unqualified username

### DIFF
--- a/browse/src/file-permissions.ts
+++ b/browse/src/file-permissions.ts
@@ -42,6 +42,52 @@ import * as os from 'os';
 
 let warnedOnce = false;
 
+let cachedSid: string | null | undefined;
+
+/**
+ * Resolve the current user's SID, cached for the process lifetime.
+ *
+ * Returns null if `whoami` is unavailable or its output cannot be parsed,
+ * in which case callers fall back to a domain-qualified account name.
+ */
+function currentUserSid(): string | null {
+  if (cachedSid !== undefined) return cachedSid;
+  try {
+    // Pin to the System32 binary. A bare `whoami` resolves to the MSYS/Git
+    // Bash build under a bash-flavoured PATH, which rejects `/user` — the
+    // lookup would then silently fail on one of the most common Windows
+    // setups for this tool.
+    const systemRoot = process.env.SystemRoot || process.env.windir || 'C:\\Windows';
+    const out = execFileSync(`${systemRoot}\\System32\\whoami.exe`, ['/user', '/fo', 'csv', '/nh'], {
+      encoding: 'utf8',
+    });
+    const match = out.match(/S-1-[\d-]+/);
+    cachedSid = match ? match[0] : null;
+  } catch {
+    cachedSid = null;
+  }
+  return cachedSid;
+}
+
+/**
+ * The principal to hand icacls for "the current user".
+ *
+ * An unqualified username is ambiguous: on a machine whose hostname equals
+ * the username, it fails to resolve to the user account and icacls silently
+ * writes an ACE for the machine SID instead. Combined with `/inheritance:r`
+ * that leaves a directory whose only ACE matches nobody — locking out the
+ * process that just created it.
+ *
+ * `*<SID>` is icacls' literal-SID form and is immune to that ambiguity.
+ * The domain-qualified name is the fallback.
+ */
+function currentUserPrincipal(): string {
+  const sid = currentUserSid();
+  if (sid) return `*${sid}`;
+  const domain = process.env.USERDOMAIN || os.hostname();
+  return `${domain}\\${os.userInfo().username}`;
+}
+
 function warnIcaclsFailure(fsPath: string, err: unknown): void {
   if (warnedOnce) return;
   warnedOnce = true;
@@ -67,7 +113,7 @@ function warnIcaclsFailure(fsPath: string, err: unknown): void {
 export function restrictFilePermissions(filePath: string): void {
   if (process.platform === 'win32') {
     try {
-      const user = os.userInfo().username;
+      const user = currentUserPrincipal();
       execFileSync(
         'icacls',
         [filePath, '/inheritance:r', '/grant:r', `${user}:(F)`],
@@ -97,7 +143,7 @@ export function restrictFilePermissions(filePath: string): void {
 export function restrictDirectoryPermissions(dirPath: string): void {
   if (process.platform === 'win32') {
     try {
-      const user = os.userInfo().username;
+      const user = currentUserPrincipal();
       execFileSync(
         'icacls',
         [dirPath, '/inheritance:r', '/grant:r', `${user}:(OI)(CI)(F)`],

--- a/browse/test/file-permissions.test.ts
+++ b/browse/test/file-permissions.test.ts
@@ -77,6 +77,26 @@ describe('restrictDirectoryPermissions', () => {
     fs.mkdirSync(d);
     expect(() => restrictDirectoryPermissions(d)).not.toThrow();
   });
+
+  test('on Windows, the directory stays usable by the calling process', () => {
+    if (process.platform !== 'win32') return;
+    const d = path.join(tmpDir, 'still-usable');
+    fs.mkdirSync(d);
+    fs.writeFileSync(path.join(d, 'before'), 'x');
+
+    restrictDirectoryPermissions(d);
+
+    // Regression: an unqualified username passed to icacls can resolve to
+    // the machine SID rather than the user account. Combined with
+    // /inheritance:r that leaves a directory whose only ACE matches nobody,
+    // so the process that just "secured" it can no longer enumerate or
+    // write to it. icacls still reports success, so a not-toThrow assertion
+    // sails straight past it — hence these access checks.
+    expect(() => fs.readdirSync(d)).not.toThrow();
+    expect(fs.readdirSync(d)).toContain('before');
+    expect(() => fs.writeFileSync(path.join(d, 'after'), 'y')).not.toThrow();
+    expect(fs.readFileSync(path.join(d, 'after'), 'utf8')).toBe('y');
+  });
 });
 
 describe('writeSecureFile', () => {
@@ -136,6 +156,16 @@ describe('mkdirSecure', () => {
     const d = path.join(tmpDir, 'dir');
     mkdirSecure(d);
     expect(() => mkdirSecure(d)).not.toThrow();
+  });
+
+  test('on Windows, the created directory stays usable by the caller', () => {
+    if (process.platform !== 'win32') return;
+    // The state-dir path that broke: mkdirSecure() creates .gstack/, hardens
+    // it, and the very next thing the daemon does is write a lockfile inside.
+    const d = path.join(tmpDir, 'state', '.gstack');
+    mkdirSecure(d);
+    expect(() => fs.writeFileSync(path.join(d, 'browse.json.lock'), '1')).not.toThrow();
+    expect(fs.readdirSync(d)).toContain('browse.json.lock');
   });
 
   test('recursive behavior: creates intermediate directories', () => {


### PR DESCRIPTION
Fixes #2478.

## The bug

`restrictFilePermissions()` / `restrictDirectoryPermissions()` pass an **unqualified** username to `icacls`:

```ts
const user = os.userInfo().username;
execFileSync('icacls', [dirPath, '/inheritance:r', '/grant:r', `${user}:(OI)(CI)(F)`], { stdio: 'ignore' });
```

On a machine whose **hostname equals the username**, the bare name does not resolve to the user account. `icacls` writes an ACE for the *machine* SID instead, and because the same call passes `/inheritance:r`, the directory is left with a single ACE that matches nobody. The process that just created the directory can no longer enumerate or write to it.

Observed on Windows 11, hostname `ESLAM`, user `ESLAM\eslam`:

| Form | Resolves to |
| --- | --- |
| `eslam` (current behaviour) | `NTAccount.Translate` throws "Some or all identity references could not be translated" |
| `ESLAM\eslam` | `S-1-5-21-<redacted>-1001` |
| `whoami /user` | `S-1-5-21-<redacted>-1001` |

Net effect: **browse can never start on an affected machine.** `mkdirSecure()` creates `.gstack/`, hardens it into inaccessibility, and the daemon's next act is writing a lockfile inside. `acquireServerLock()` returns `null` on the resulting `EACCES`, so the user sees:

```
[browse] Another instance is starting the server, waiting...
[browse] Timed out waiting for another instance to start the server
```

which points at a concurrency problem that does not exist. `icacls` reports success and `stdio: 'ignore'` discards its output, so nothing surfaces the real cause.

## The fix

Resolve the current user's SID and hand `icacls` the literal `*<SID>` form, which is immune to name-resolution ambiguity. Fall back to the domain-qualified name if the lookup fails.

One subtlety worth flagging for review: the SID lookup pins `%SystemRoot%\System32\whoami.exe` rather than calling a bare `whoami`. Under a bash-flavoured `PATH` (Git Bash / MSYS, extremely common for this tool on Windows) a bare `whoami` resolves to the MSYS build, which rejects `/user`. I hit exactly that on the first test run: the lookup silently failed and the code fell through to the qualified-name fallback. The fallback is correct, but without the pin the primary path would almost never fire.

## Tests

The existing Windows cases only assert `not.toThrow()`, which this bug sails straight past, since `icacls` genuinely succeeds while writing a useless ACE. The added cases assert the contract that actually broke: **the directory stays usable by the calling process after hardening.** No `icacls` output parsing, so no locale or version brittleness.

Verified both directions on an affected machine:

| Code path | Result |
| --- | --- |
| With this fix | **15 pass, 0 fail** |
| Pre-fix principal | **7 pass, 8 fail** |

Several of those 8 are *pre-existing* tests (`appendSecureFile`, `writeSecureFile`). The suite could always have caught this; it just never ran anywhere the hostname matched the username.

## Risk

Behaviour is unchanged on POSIX (the `chmod` paths are untouched) and unchanged on Windows machines where the bare username already resolved correctly, since `*<SID>` and the resolved name name the same principal. The fallback preserves today's behaviour if `whoami.exe` is unavailable.
