### PR TITLE
fix(test): restore env per-test, not once at the end

### DIFF
--- a/test/gstack-memory-helpers.test.ts
+++ b/test/gstack-memory-helpers.test.ts
@@ -11,7 +11,7 @@
  * Free-tier (~50ms total). Runs in `bun test`.
  */
 
-import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, mkdirSync, chmodSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -338,7 +338,10 @@ describe("withErrorContext", () => {
     process.env.GSTACK_HOME = testHome;
   });
 
-  afterAll(() => {
+  // afterEach, not afterAll: the save above runs per-test, so a once-at-the-end
+  // restore writes back whatever the LAST beforeEach captured — which is the
+  // previous test's temp dir, not the original value.
+  afterEach(() => {
     if (savedHome === undefined) delete process.env.GSTACK_HOME;
     else process.env.GSTACK_HOME = savedHome;
   });
@@ -414,7 +417,13 @@ describe("detectEngineTier", () => {
     process.env.HOME = testHome;
   });
 
-  afterAll(() => {
+  // afterEach, not afterAll. beforeEach re-captures these on every test, so by
+  // the last one `savedRealHome` holds the PREVIOUS test's temp dir. Restoring
+  // that at the end left HOME pointing at a fixture containing a
+  // .gbrain/config.json with engine=postgres, which the next FILE then read —
+  // see test/gbrain-detect-install.test.ts, which expects pglite and passes in
+  // isolation.
+  afterEach(() => {
     if (savedHome === undefined) delete process.env.GSTACK_HOME;
     else process.env.GSTACK_HOME = savedHome;
     if (savedGbrainHome === undefined) delete process.env.GBRAIN_HOME;


### PR DESCRIPTION
## The bug

Two `describe` blocks in `test/gstack-memory-helpers.test.ts` save env in **`beforeEach`** and restore it in **`afterAll`**:

```ts
beforeEach(() => {
  savedRealHome = process.env.HOME;   // re-captured every test
  process.env.HOME = testHome;
});

afterAll(() => {
  else process.env.HOME = savedRealHome;   // runs once, at the end
});
```

`beforeEach` re-captures on every test, so after the first one `savedRealHome` no longer holds the real `HOME` — it holds the *previous test's* temp dir. The `afterAll` then "restores" `HOME` to that stale fixture.

That fixture contains a `.gbrain/config.json` with `engine=postgres`, so the **next file in the run** reads it as if it were the user's real config:

```
test/gbrain-detect-install.test.ts:107
  expect(j.gbrain_engine).toBe('pglite')
  Expected: "pglite"   Received: "postgres"
```

That file passes in isolation (16/16) and fails in the suite — which is what makes this read as flakiness rather than a leak. It also takes out `gbrain-sync`'s two split-engine cases for the same reason.

## The fix

Pair the hooks. `beforeEach` saves, `afterEach` restores, so every capture is of a genuinely un-mutated value. No change to what the tests assert.

## Verified

```
polluter alone       29 pass  0 fail   (unchanged)
polluter + victim    45 pass  0 fail   (was 42 pass, 3 fail)
full suite           17 fails -> 12    (3 gbrain-detect + 2 gbrain-sync gone)
```

Environment: bun 1.3.14, Ubuntu 24.04.4 LTS, `main` @ `960c3a8d` (v1.60.2.0).

## Related

Independent of #2480, which hardens `gstack-config.test.ts` against a *different* leak (module-scope `GSTACK_HOME` assignments in five suites). That one makes a victim immune; this one removes a polluter. Both are needed — they're separate bugs with the same symptom class, and the suite has enough cross-file env mutation that it's worth a broader audit than either PR does.

Worth noting the two are hard to spot because `bun` shares one process across files and the suite's exit code is unreliable (#2435), so a leak like this shows up as "those tests are flaky" rather than as a failure anyone chases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3KRWmyJnSvzzxeooDxuU3