### PR TITLE
fix(codex-import): empty find must not fall through to cwd

### DIFF
--- a/bin/gstack-codex-session-import
+++ b/bin/gstack-codex-session-import
@@ -64,8 +64,15 @@ case "$MODE" in
       echo "NO_SESSIONS: $CODEX_SESSIONS_ROOT does not exist"
       exit 0
     fi
-    LATEST=$(find "$CODEX_SESSIONS_ROOT" -type f -name "rollout-*.jsonl" -print 2>/dev/null \
-      | xargs ls -t 2>/dev/null | head -1 || true)
+    # -exec ... + rather than | xargs: with no matches, xargs still runs
+    # `ls -t` with no operands, which lists the CURRENT DIRECTORY. LATEST then
+    # holds a random entry from wherever the caller happened to be, the
+    # emptiness check below passes, and we "import" that path — reporting
+    # "IMPORTED: 0 events from 1 session(s)" instead of NO_SESSIONS.
+    # `find -exec +` never runs the command when nothing matched, and stays
+    # portable (no GNU-only `xargs -r`).
+    LATEST=$(find "$CODEX_SESSIONS_ROOT" -type f -name "rollout-*.jsonl" \
+      -exec ls -t {} + 2>/dev/null | head -1 || true)
     if [ -z "$LATEST" ]; then
       echo "NO_SESSIONS: no rollout-*.jsonl files under $CODEX_SESSIONS_ROOT"
       exit 0


### PR DESCRIPTION
## The bug

`bin/gstack-codex-session-import:67`

```sh
LATEST=$(find "$CODEX_SESSIONS_ROOT" -type f -name "rollout-*.jsonl" -print 2>/dev/null \
  | xargs ls -t 2>/dev/null | head -1 || true)
```

When `find` matches nothing, `xargs` still runs `ls -t` — with **no operands** — and `ls -t` with no operands lists the **current directory**. So `LATEST` holds a random entry from wherever the caller happened to be, the `[ -z "$LATEST" ]` guard on the next line passes, and the script imports that path.

Run from the repo root on a machine with no Codex sessions:

```
IMPORTED: 0 events from 1 session(s)
```

instead of `NO_SESSIONS`. It reports a successful import of a directory it picked up off the floor. Reproduced directly:

```
$ find /tmp/empty -name 'rollout-*.jsonl' | xargs ls -t 2>/dev/null | head -1
test          # ← a directory in the gstack repo, because that was cwd
```

## The fix

`-exec ls -t {} +` never runs the command when nothing matched.

Chose that over `xargs -r` deliberately: `-r` is GNU-only, this repo targets macOS, and there is no existing `xargs -r` in `bin/` or `scripts/` to follow.

## Verified

```
empty dir       -> blank, guard fires, prints NO_SESSIONS
populated dir   -> newest rollout-*.jsonl (unchanged behavior)
bash -n         clean
the test        6 pass / 1 fail  ->  7 pass / 0 fail
```

## Three more sites, deliberately not touched here

The same pattern appears in three other places, and two are user-visible:

| | effect when the dir is empty or missing |
|---|---|
| `scripts/resolvers/review.ts:859` | `PLAN` becomes a random `.md` from cwd — `/review` reads the wrong file as the plan |
| `scripts/resolvers/preamble/generate-context-recovery.ts:15` | "RECENT ARTIFACTS" lists unrelated cwd files |
| `scripts/resolvers/preamble/generate-context-recovery.ts:24` | `LATEST_CHECKPOINT` points at a random file, which the skill is then told to read |

I fixed them locally and backed it out: those two files are **resolvers**, so changing them regenerates 44 `SKILL.md` files and the golden-file baselines. That is a call for you to make, not something to smuggle into a one-line bug fix. The same `-exec ... +` substitution applies verbatim to all three, followed by `bun run gen:skill-docs`.

Environment: bun 1.3.14, Ubuntu 24.04.4 LTS, `main` @ `960c3a8d` (v1.60.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3KRWmyJnSvzzxeooDxuU3