### PR TITLE
test(host-config): skip the claude-detect case when claude is not on PATH

### DIFF
--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -401,10 +401,17 @@ describe('host-config-export.ts CLI', () => {
     expect(exitCode).toBe(1);
   });
 
-  test('detect finds claude (since we are running in claude)', () => {
+  // `detect` reports the hosts whose binaries are on PATH, so asserting it
+  // finds claude is really an assertion about the machine. That holds in CI and
+  // in a developer's own session; it does not hold when the suite runs as a
+  // service account, or anywhere claude is installed for a different user.
+  // Skipping there keeps the suite runnable off a dev box without weakening the
+  // check where it is meaningful — it still runs wherever claude is present.
+  const claudeOnPath = Bun.which('claude') !== null;
+
+  test.skipIf(!claudeOnPath)('detect finds claude (when claude is on PATH)', () => {
     const { stdout, exitCode } = run('detect');
     expect(exitCode).toBe(0);
-    // claude binary should be on PATH in this environment
     expect(stdout).toContain('claude');
   });
 


### PR DESCRIPTION
```
test('detect finds claude (since we are running in claude)', () => {
  // claude binary should be on PATH in this environment
  expect(stdout).toContain('claude');
});
```

`detect` reports the hosts whose binaries are on PATH, so this asserts something about the **machine**, not about the code. It holds in CI and in a developer's own session. It does not hold when the suite runs as a service account, or anywhere claude is installed under a different user — `/root/.local/bin/claude` is not on a non-root PATH.

`test.skipIf` keeps the check where it's meaningful and skips it where it can only report the environment. The idiom is already used in `diagram-render-drift`, `setup-windows-fallback` and `gbrain-sync-voyage-code-3-integration`.

**Coverage in CI is unchanged** — claude is on PATH there, so the case still runs. It only skips where it would have been testing the host rather than the product.

Also dropped "since we are running in claude" from the name, since that's the assumption that turned out not to be universal.

## Verified

```
claude absent (this box)   76 pass, 1 skip, 0 fail
fake claude on PATH        the case runs and passes
```

I tested the positive branch with a stub on PATH rather than only confirming the skip — a guard that always skips would look identical from the passing side.

## Context

Last of the failures I hit running the suite on a headless Ubuntu VPS as a service account. The others are #2480, #2481, #2482 and #2483.

For the record, the two remaining failures on that box are also environmental and **not** worth a code change: `browse/test/cdp-e2e.test.ts` needs `GSTACK_CHROMIUM_NO_SANDBOX=1` on Ubuntu 23.10+ (already documented in `browser-manager.ts`, #1562), and `browse/test/handoff.test.ts` needs a headed browser, so an X server or `xvfb-run`. Both are correctly the operator's problem, not the suite's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3KRWmyJnSvzzxeooDxuU3