### PR TITLE
fix(memory-ingest): refuse to advance state when gbrain imports fewer pages than staged

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -1782,6 +1782,49 @@ async function ingestPass(args: CliArgs): Promise<BulkResult> {
     );
     failed += failedSources.size;
 
+    // Reconcile gbrain's own accounting against what we staged. Without this,
+    // a batch that gbrain never SAW is indistinguishable from a batch that
+    // succeeded: readNewFailures() only reports PER-FILE failures, so when
+    // `gbrain import` collects zero files it writes nothing to
+    // sync-failures.jsonl, failedSources is empty, and every prepared file
+    // gets state-recorded as ingested. The pass then reports "N written"
+    // while the brain gained nothing — and because state now says "done",
+    // no future run retries. Silent, permanent data loss.
+    //
+    // Observed cause: `gbrain import` honours .gitignore, and
+    // `gstack-artifacts-init` writes `.gitignore = "*"` into $GSTACK_HOME.
+    // makeStagingDir() stages under $GSTACK_HOME, so on any machine that has
+    // run artifacts-init, collect_files returns 0 for every batch.
+    //
+    // `skipped` counts content_hash no-ops, which ARE successful landings.
+    const expectedLandings = prep.prepared.length - failedSources.size;
+    const accountedLandings =
+      (importJson.imported ?? 0) + (importJson.skipped ?? 0);
+    if (accountedLandings < expectedLandings) {
+      const collected =
+        importJson.total_files !== undefined
+          ? ` gbrain collected ${importJson.total_files} file(s) from the staging dir.`
+          : "";
+      const msg =
+        `gbrain import accounted for ${accountedLandings} of ${expectedLandings} staged page(s) ` +
+        `(imported=${importJson.imported ?? 0}, unchanged=${importJson.skipped ?? 0}).${collected} ` +
+        `Refusing to advance state — the unaccounted pages would be marked ingested without ` +
+        `landing in the brain. If the count is 0, check whether ${stagingDir} is inside a git ` +
+        `repo that ignores it (gbrain import honours .gitignore).`;
+      console.error(`[memory-ingest] ERR: ${msg}`);
+      failed += prep.prepared.length;
+      return {
+        written: 0,
+        skipped_secret: prep.skippedSecret,
+        skipped_dedup: prep.skippedDedup,
+        skipped_unattributed: prep.skippedUnattributed,
+        failed,
+        duration_ms: Date.now() - t0,
+        partial_pages: prep.partialPages,
+        system_error: msg,
+      };
+    }
+
     // Phase 3: state recording. Only files that landed in gbrain get
     // their mtime+sha256 stamped. Failed source paths are deliberately
     // left un-state'd so the next run re-prepares them and gbrain's

--- a/test/gstack-memory-ingest.test.ts
+++ b/test/gstack-memory-ingest.test.ts
@@ -330,7 +330,7 @@ describe("gstack-memory-ingest --limit", () => {
  */
 function installFakeGbrain(
   home: string,
-  opts: { failingPaths?: string[] } = {},
+  opts: { failingPaths?: string[]; collectNothing?: boolean } = {},
 ): { binDir: string; logFile: string; argsFile: string; stagingListFile: string } {
   const binDir = join(home, "fake-bin");
   mkdirSync(binDir, { recursive: true });
@@ -390,6 +390,13 @@ EOF
     if [ -d "\$DIR" ]; then
       TOTAL=\$(find "\$DIR" -name "*.md" -type f | wc -l | tr -d ' ')
     else
+      TOTAL=0
+    fi
+    # collectNothing: simulate gbrain walking the staging dir and finding
+    # nothing — the real-world shape when .gitignore hides every staged file
+    # from collect_files. Crucially this writes NO sync-failures.jsonl entry,
+    # because there is no per-file failure: gbrain never saw the files.
+    if [ "${opts.collectNothing ? "1" : "0"}" = "1" ]; then
       TOTAL=0
     fi
     ERRORS=0
@@ -468,6 +475,51 @@ describe("gstack-memory-ingest writer (gbrain v0.20+ batch `import` interface)",
     // dir root. If writeStaged ever regresses to flat layout, this fails.
     const stagedList = readFileSync(stagingListFile, "utf-8");
     expect(stagedList).toMatch(/^\.\/transcripts\/claude-code\/.+\.md$/m);
+  });
+
+  // Silent-data-loss regression: gbrain accepts the import call, exits 0, and
+  // reports imported=0 because collect_files found nothing in the staging dir
+  // (real-world cause: gstack-artifacts-init writes `.gitignore = "*"` into
+  // $GSTACK_HOME, and `gbrain import` honours .gitignore, so every file staged
+  // under $GSTACK_HOME is invisible to it).
+  //
+  // No per-file failure is written to sync-failures.jsonl — gbrain never SAW
+  // the files — so readNewFailures returns empty. Before the reconciliation
+  // check, that made a total loss indistinguishable from success: every
+  // prepared file got state-recorded as ingested and the pass reported
+  // "N written". State then said "done", so no later run ever retried.
+  it("refuses to advance state when gbrain imports fewer pages than were staged", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    mkdirSync(gstackHome, { recursive: true });
+    const { binDir, logFile } = installFakeGbrain(home, { collectNothing: true });
+
+    const session =
+      `{"type":"user","message":{"role":"user","content":"hi"},"timestamp":"2026-05-01T00:00:00Z","cwd":"/tmp/foo"}\n` +
+      `{"type":"assistant","message":{"role":"assistant","content":"hello"},"timestamp":"2026-05-01T00:00:01Z"}\n`;
+    writeClaudeCodeSession(home, "tmp-foo", "abc123", session);
+
+    const r = runScript(["--bulk", "--include-unattributed", "--quiet"], {
+      HOME: home,
+      GSTACK_HOME: gstackHome,
+      PATH: `${binDir}:${process.env.PATH || ""}`,
+    });
+
+    // gbrain WAS called — this is not a "gbrain missing" path.
+    expect(existsSync(logFile)).toBe(true);
+
+    // The pass must not claim success.
+    expect(r.stderr).toMatch(/\[memory-ingest\] ERR:.*accounted for 0 of 1 staged page/);
+    expect(r.stderr).toMatch(/Refusing to advance state/);
+    expect(r.stdout).not.toMatch(/written:\s+1/);
+
+    // The critical assertion: state must NOT mark the session ingested, or the
+    // next run skips it forever and the transcript is lost silently.
+    const statePath = join(gstackHome, ".transcript-ingest-state.json");
+    if (existsSync(statePath)) {
+      const state = JSON.parse(readFileSync(statePath, "utf-8"));
+      expect(Object.keys(state.sessions || {}).length).toBe(0);
+    }
   });
 
   // Originally landed in v1.32.0.0 (PR #1411) on the per-file `gbrain put`


### PR DESCRIPTION
## Summary

`gstack-memory-ingest` can report `N written` while writing nothing to the brain, and mark every one of those sessions as ingested in state — so no later run ever retries them. On the install where I found this, state claimed **1013 sessions ingested** while the brain held **391 pages**. Transcripts from ~2 days were gone with no error anywhere.

This PR makes that failure loud instead of silent. It does not change the happy path.

## The bug

`written` is counted from the **staged** set, never reconciled against gbrain's own totals:

```js
for (const p of prep.prepared) {
  if (failedSources.has(p.source_path)) continue;
  state.sessions[p.source_path] = {...};   // marked ingested
  written++;                                // counted as written
}
```

`failedSources` comes from `readNewFailures()`, which reads **per-file** failures out of `sync-failures.jsonl`. When `gbrain import` collects *zero* files, there are no per-file failures to report — gbrain never saw them — so that set is empty, every prepared file is state-recorded, and the pass reports success.

`importJson.imported` holds the truth. It's used in exactly one place: the `console.error` summary a few lines below. It is never compared to anything.

## Why it triggers in practice

`gbrain import` honours `.gitignore`. `bin/gstack-artifacts-init` writes `.gitignore = "*"` into `$GSTACK_HOME`:

```
bin/gstack-artifacts-init:21   #   2. Write .gitignore = "*"  (ignore everything; allowlist is explicit)
bin/gstack-artifacts-init:213  cat > "$GSTACK_HOME/.gitignore" <<'EOF'
```

`makeStagingDir()` stages into `$GSTACK_HOME/.staging-ingest-<pid>-<ts>/`. So on any machine that has run `artifacts-init`, **every** staged file is invisible to `collect_files`, forever.

Only affects the local-gbrain path. In remote-http MCP mode the code takes `makePersistentTranscriptDir()` and never calls `gbrain import`, so those users don't hit it.

## Clean-room reproduction

No reference to my setup — reproducible on a fresh checkout in about two minutes:

```bash
export H=$(mktemp -d)
bin/gstack-artifacts-init --remote "file://$(mktemp -d)/remote.git"   # GSTACK_HOME=$H
cat "$H/.gitignore"        # => *

D="$H/.staging-ingest-1-1"; mkdir -p "$D/transcripts/x"
printf -- '---\ntitle: probe\n---\nbody\n' > "$D/transcripts/x/probe.md"

gbrain import "$D" --no-embed        # Found 0 markdown files   <-- silent loss
cp -R "$D" /tmp/control
gbrain import /tmp/control --no-embed # Found 1 markdown files  <-- control
```

Same bytes, same filenames, same directory shape. The only variable is whether the path sits inside an `artifacts-init` home.

## The fix

Reconcile `imported + skipped` against `prepared - failed` (`skipped` is a content-hash no-op, which *is* a successful landing). On a shortfall: error, return `written: 0`, and **leave state untouched** so the next run re-prepares and gbrain's `content_hash` dedup short-circuits the re-import.

This mirrors the existing `"exited 0 but emitted no parseable --json payload. Refusing to advance state."` branch directly above — same intent, one failure mode further along.

The error names the likely cause and the staging path, so the next person sees it in one line rather than bisecting a 70KB file.

## Test

`test/gstack-memory-ingest.test.ts` gains a `collectNothing` option on the existing `installFakeGbrain` shim: gbrain exits 0, reports `imported=0`/`total_files=0`, and writes **no** `sync-failures.jsonl` entry — the exact silent-loss shape.

The test asserts the state file stays empty. **It fails without the source change** (verified by reverting the fix and re-running).

```
bun test test/gstack-memory-ingest.test.ts   # 24 pass, 0 fail
bun test                                      # full free suite, exit 0
```

## Notes for the maintainer

- **No VERSION bump or CHANGELOG entry included** — those collide with whatever lands first, and your CLAUDE.md scopes them to `/ship`. Happy to add both at whatever version you want this to land at, just say the word.
- **The deeper fix is arguably to stop staging inside `$GSTACK_HOME`** — ephemeral scratch in a directory that syncs to a GitHub artifacts repo is uncomfortable regardless, since transcripts can carry PII. I left that alone: `checkOwnedStagingDir()` hard-requires "direct child of `$GSTACK_HOME`", so moving it means changing that contract and its tests. Reconciling the counts makes the failure visible either way, and seemed like the right smallest first step. Glad to follow up if you'd prefer the relocation.
- No test asserted that staged pages actually land after import, which is how this shipped. The new one closes that gap narrowly.
- This comes from a fork, so the eval/E2E CI jobs won't receive base-repo secrets and will fail on empty-env auth. The free suite (`bun test`) is unaffected and passes. Push the branch to the base repo if you want a full green run.
