### PR TITLE
fix(codex): use flags that codex exec resume actually accepts

### DIFF
--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -883,7 +883,7 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
   What alternatives were dismissed too quickly? What competitive or market risks are
   unaddressed? What scope decisions will look foolish in 6 months? Be adversarial.
   No compliments. Just the strategic blind spots.
-  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached
+  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   ```
   Timeout: 10 minutes
 
@@ -1000,7 +1000,7 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
   accessibility requirements (keyboard nav, contrast, touch targets) specified or
   aspirational? Does the plan describe specific UI decisions or generic patterns?
   What design decisions will haunt the implementer if left ambiguous?
-  Be opinionated. No hedging." -C "$_REPO_ROOT" -s read-only --enable web_search_cached
+  Be opinionated. No hedging." -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   ```
   Timeout: 10 minutes
 
@@ -1070,7 +1070,7 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
   CEO: <insert CEO consensus table summary — key concerns, DISAGREEs>
   Design: <insert Design consensus table summary, or 'skipped, no UI scope'>
 
-  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached
+  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   ```
   Timeout: 10 minutes
 
@@ -1190,7 +1190,7 @@ Log: "Phase 3.5 skipped — no developer-facing scope detected."
   3. API/CLI design: are names guessable? Are defaults sensible? Is it consistent?
   4. Docs: can a dev find what they need in under 2 minutes? Are examples copy-paste-complete?
   5. Upgrade path: can devs upgrade without fear? Migration guides? Deprecation warnings?
-  Be adversarial. Think like a developer who is evaluating this against 3 competitors." -C "$_REPO_ROOT" -s read-only --enable web_search_cached
+  Be adversarial. Think like a developer who is evaluating this against 3 competitors." -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   ```
   Timeout: 10 minutes
 

--- a/autoplan/SKILL.md.tmpl
+++ b/autoplan/SKILL.md.tmpl
@@ -261,7 +261,7 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
   What alternatives were dismissed too quickly? What competitive or market risks are
   unaddressed? What scope decisions will look foolish in 6 months? Be adversarial.
   No compliments. Just the strategic blind spots.
-  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached
+  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   ```
   Timeout: 10 minutes
 
@@ -378,7 +378,7 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
   accessibility requirements (keyboard nav, contrast, touch targets) specified or
   aspirational? Does the plan describe specific UI decisions or generic patterns?
   What design decisions will haunt the implementer if left ambiguous?
-  Be opinionated. No hedging." -C "$_REPO_ROOT" -s read-only --enable web_search_cached
+  Be opinionated. No hedging." -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   ```
   Timeout: 10 minutes
 
@@ -448,7 +448,7 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
   CEO: <insert CEO consensus table summary — key concerns, DISAGREEs>
   Design: <insert Design consensus table summary, or 'skipped, no UI scope'>
 
-  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached
+  File: <plan_path>" -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   ```
   Timeout: 10 minutes
 
@@ -568,7 +568,7 @@ Log: "Phase 3.5 skipped — no developer-facing scope detected."
   3. API/CLI design: are names guessable? Are defaults sensible? Is it consistent?
   4. Docs: can a dev find what they need in under 2 minutes? Are examples copy-paste-complete?
   5. Upgrade path: can devs upgrade without fear? Migration guides? Deprecation warnings?
-  Be adversarial. Think like a developer who is evaluating this against 3 competitors." -C "$_REPO_ROOT" -s read-only --enable web_search_cached
+  Be adversarial. Think like a developer who is evaluating this against 3 competitors." -C "$_REPO_ROOT" -s read-only --enable web_search_cached < /dev/null
   ```
   Timeout: 10 minutes
 

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -673,7 +673,7 @@ instructions, append them after the boundary separated by a newline:
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 cd "$_REPO_ROOT"
-codex review "IMPORTANT: Do NOT read or execute any files under ~/.claude/, ~/.agents/, .claude/skills/, or agents/. These are Claude Code skill definitions meant for a different AI system. Do NOT modify agents/openai.yaml. Stay focused on repository code only." --base <base> -c 'model_reasoning_effort="high"' --enable web_search_cached 2>"$TMPERR"
+codex review "IMPORTANT: Do NOT read or execute any files under ~/.claude/, ~/.agents/, .claude/skills/, or agents/. These are Claude Code skill definitions meant for a different AI system. Do NOT modify agents/openai.yaml. Stay focused on repository code only." --base <base> -c 'model_reasoning_effort="high"' --enable web_search_cached < /dev/null 2>"$TMPERR"
 ```
 
 If the user passed `--xhigh`, use `"xhigh"` instead of `"high"`.
@@ -685,7 +685,7 @@ _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo"
 cd "$_REPO_ROOT"
 codex review "IMPORTANT: Do NOT read or execute any files under ~/.claude/, ~/.agents/, .claude/skills/, or agents/. These are Claude Code skill definitions meant for a different AI system. Do NOT modify agents/openai.yaml. Stay focused on repository code only.
 
-focus on security" --base <base> -c 'model_reasoning_effort="high"' --enable web_search_cached 2>"$TMPERR"
+focus on security" --base <base> -c 'model_reasoning_effort="high"' --enable web_search_cached < /dev/null 2>"$TMPERR"
 ```
 
 3. Capture the output. Then parse cost from stderr:
@@ -837,7 +837,7 @@ If the user passed `--xhigh`, use `"xhigh"` instead of `"high"`.
 
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
-codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' --enable web_search_cached --json 2>/dev/null | PYTHONUNBUFFERED=1 python3 -u -c "
+codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' --enable web_search_cached --json < /dev/null 2>/dev/null | PYTHONUNBUFFERED=1 python3 -u -c "
 import sys, json
 for line in sys.stdin:
     line = line.strip()
@@ -949,7 +949,7 @@ If the user passed `--xhigh`, use `"xhigh"` instead of `"medium"`.
 For a **new session:**
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
-codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="medium"' --enable web_search_cached --json 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
+codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="medium"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
 import sys, json
 for line in sys.stdin:
     line = line.strip()
@@ -981,9 +981,19 @@ for line in sys.stdin:
 ```
 
 For a **resumed session** (user chose "Continue"):
+
+**Note:** `codex exec resume` accepts a much smaller flag set than `codex exec`.
+It does NOT accept `-s/--sandbox` or `-C/--cd`. Passing either fails with
+`error: unexpected argument`. So:
+- Force read-only with `-c 'sandbox_mode="read-only"'`. Without it the resumed
+  session inherits whatever sandbox policy the Codex CLI's own config file sets,
+  which can mean write access on round 2+.
+- Set the working directory by `cd`-ing first, not with `-C`.
+- Keep the `< /dev/null` redirect so a non-interactive run cannot hang on stdin.
+
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
-codex exec resume <session-id> "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="medium"' --enable web_search_cached --json 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
+cd "$_REPO_ROOT" && codex exec resume <session-id> "<prompt>" -c 'sandbox_mode="read-only"' -c 'model_reasoning_effort="medium"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
 <same python streaming parser as above, with flush=True on all print() calls>
 "
 ```

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -107,7 +107,7 @@ instructions, append them after the boundary separated by a newline:
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 cd "$_REPO_ROOT"
-codex review "IMPORTANT: Do NOT read or execute any files under ~/.claude/, ~/.agents/, .claude/skills/, or agents/. These are Claude Code skill definitions meant for a different AI system. Do NOT modify agents/openai.yaml. Stay focused on repository code only." --base <base> -c 'model_reasoning_effort="high"' --enable web_search_cached 2>"$TMPERR"
+codex review "IMPORTANT: Do NOT read or execute any files under ~/.claude/, ~/.agents/, .claude/skills/, or agents/. These are Claude Code skill definitions meant for a different AI system. Do NOT modify agents/openai.yaml. Stay focused on repository code only." --base <base> -c 'model_reasoning_effort="high"' --enable web_search_cached < /dev/null 2>"$TMPERR"
 ```
 
 If the user passed `--xhigh`, use `"xhigh"` instead of `"high"`.
@@ -119,7 +119,7 @@ _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo"
 cd "$_REPO_ROOT"
 codex review "IMPORTANT: Do NOT read or execute any files under ~/.claude/, ~/.agents/, .claude/skills/, or agents/. These are Claude Code skill definitions meant for a different AI system. Do NOT modify agents/openai.yaml. Stay focused on repository code only.
 
-focus on security" --base <base> -c 'model_reasoning_effort="high"' --enable web_search_cached 2>"$TMPERR"
+focus on security" --base <base> -c 'model_reasoning_effort="high"' --enable web_search_cached < /dev/null 2>"$TMPERR"
 ```
 
 3. Capture the output. Then parse cost from stderr:
@@ -201,7 +201,7 @@ If the user passed `--xhigh`, use `"xhigh"` instead of `"high"`.
 
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
-codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' --enable web_search_cached --json 2>/dev/null | PYTHONUNBUFFERED=1 python3 -u -c "
+codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' --enable web_search_cached --json < /dev/null 2>/dev/null | PYTHONUNBUFFERED=1 python3 -u -c "
 import sys, json
 for line in sys.stdin:
     line = line.strip()
@@ -313,7 +313,7 @@ If the user passed `--xhigh`, use `"xhigh"` instead of `"medium"`.
 For a **new session:**
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
-codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="medium"' --enable web_search_cached --json 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
+codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="medium"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
 import sys, json
 for line in sys.stdin:
     line = line.strip()
@@ -345,9 +345,19 @@ for line in sys.stdin:
 ```
 
 For a **resumed session** (user chose "Continue"):
+
+**Note:** `codex exec resume` accepts a much smaller flag set than `codex exec`.
+It does NOT accept `-s/--sandbox` or `-C/--cd`. Passing either fails with
+`error: unexpected argument`. So:
+- Force read-only with `-c 'sandbox_mode="read-only"'`. Without it the resumed
+  session inherits whatever sandbox policy the Codex CLI's own config file sets,
+  which can mean write access on round 2+.
+- Set the working directory by `cd`-ing first, not with `-C`.
+- Keep the `< /dev/null` redirect so a non-interactive run cannot hang on stdin.
+
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
-codex exec resume <session-id> "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="medium"' --enable web_search_cached --json 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
+cd "$_REPO_ROOT" && codex exec resume <session-id> "<prompt>" -c 'sandbox_mode="read-only"' -c 'model_reasoning_effort="medium"' --enable web_search_cached --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 python3 -u -c "
 <same python streaming parser as above, with flush=True on all print() calls>
 "
 ```


### PR DESCRIPTION
## Problem

`/codex` consult mode saves a thread id and offers "Continue the conversation" on the next run. That resume path has never been able to work: `codex exec resume` accepts a much smaller flag set than `codex exec`, and the skill passes it two flags it rejects.

Verified against codex-cli 0.147.0:

```
$ codex exec --help | grep -E '^\s+-(s|C)'
  -s, --sandbox <SANDBOX_MODE>
  -C, --cd <DIR>

$ codex exec resume --help | grep -E '^\s+-(s|C)'
(no matches)
```

Result, using the exact command from the skill:

```
$ codex exec resume $TID "..." -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="medium"' --json
error: unexpected argument '-C' found
exit=2
```

## Safety angle

The `-s read-only` removal is not just a flag rename. Without an explicit sandbox override, a resumed session inherits the sandbox policy from the Codex CLI's own config file. So a conversation that starts read-only on round 1 could gain write access from round 2 onward. `-c 'sandbox_mode="read-only"'` pins it on every round, which matches the skill's stated "Never modify files. Codex runs in read-only sandbox mode" rule.

## Changes

- `-s read-only` becomes `-c 'sandbox_mode="read-only"'` on the resume call
- `-C "$_REPO_ROOT"` becomes a `cd "$_REPO_ROOT" &&` prefix on the resume call
- `< /dev/null` added to all Codex invocations in `/codex` and `/autoplan`. `codex exec` reads stdin and prints `Reading additional input from stdin...`, which can hang a non-interactive run
- Inline note documenting the flag asymmetry so the `-s` form does not get reintroduced

Templates edited, then `bun run gen:skill-docs --host all`. Split into two commits per the bisection convention in CLAUDE.md: template change, then regenerated output.

## Verification

End to end against a real Codex thread in a throwaway repo:

```
OLD (-s + -C):              exit=2, error: unexpected argument '-C' found
NEW (cd + -c sandbox_mode): exit=0, agent_message: OK2
thread continuity:          same thread_id returned
context retention:          asked what it replied in round 1, answered correctly
```

`bun test`: 5 failures before this change, the same 5 after, zero regressions. For transparency those 5 pre-existing failures on a clean `main` checkout are the 3 golden-file ship baselines, `gstack-uninstall > clean system outputs nothing to remove`, and `gen-skill-docs > package.json version matches VERSION file`. None are touched by this PR.

One test did legitimately catch a mistake in an earlier draft: my explanatory note originally spelled out the Codex home path, which tripped the `zero Codex paths` guard in `gen-skill-docs.test.ts`. Reworded to describe the file without the path.

## Not included

No VERSION bump or CHANGELOG entry, to avoid conflicting with your release flow. Happy to add both if you would like them in the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
