### PR TITLE
fix: scope headed-Chromium profile per project, not machine-wide

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -186,6 +186,15 @@ export class BrowserManager {
   // ─── Handoff State ─────────────────────────────────────────
   private isHeaded: boolean = false;
   private consecutiveFailures: number = 0;
+  // Set true only by handoff() (headless daemon transitioning to headed
+  // in-place via the CLI `handoff` command). Distinguishes that case from
+  // launchHeaded()/connect (daemon spawned headed from the start, e.g. by
+  // pair-agent with a real long-lived parent to track). The server's
+  // parent-process watchdog uses this to tell "the CLI process that
+  // happened to send this HTTP request is gone (expected — every CLI
+  // invocation is short-lived)" from "the process that's supposed to own
+  // this headed browser's lifecycle is gone (should shut down)".
+  private handoffTransition: boolean = false;
 
   // ─── Watch Mode ─────────────────────────────────────────
   private watching = false;
@@ -253,6 +262,16 @@ export class BrowserManager {
   public onDisconnect: ((exitCode?: number) => void | Promise<void>) | null = null;
 
   getConnectionMode(): 'launched' | 'headed' { return this.connectionMode; }
+  didHandoffTransition(): boolean { return this.handoffTransition; }
+
+  /** TEST-ONLY: simulate the state handoff() leaves behind, without
+   * launching a real browser — lets watchdog.test.ts exercise the
+   * "headed via handoff, parent gone" branch as a fast subprocess test.
+   * Never called by any real code path. */
+  __forceHandoffHeadedForTest(): void {
+    this.connectionMode = 'headed';
+    this.handoffTransition = true;
+  }
 
   // ─── Watch Mode Methods ─────────────────────────────────
   isWatching(): boolean { return this.watching; }
@@ -1608,6 +1627,7 @@ export class BrowserManager {
       this.pages.clear();
       this.tabSessions.clear();
       this.connectionMode = 'headed';
+      this.handoffTransition = true;
 
       // Same Layer C stealth as launch()/launchHeaded(). Must run BEFORE
       // restoreState() navigates so the init scripts apply to the restored

--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -1568,7 +1568,13 @@ export class BrowserManager {
         console.log('[browse] Handoff: extension not found — headed mode without side panel');
       }
 
-      const userDataDir = path.join(process.env.HOME || '/tmp', '.gstack', 'chromium-profile');
+      // Same resolver launchHeaded() uses — was hardcoded to a single
+      // machine-wide $HOME/.gstack/chromium-profile, which let concurrent
+      // headed sessions from OTHER projects steal/kill this one's profile
+      // lock (see resolveChromiumProfile's docstring). Clean stale locks
+      // first, matching launchHeaded()'s pre-launch safety.
+      const userDataDir = resolveChromiumProfile();
+      cleanSingletonLocks(userDataDir);
       fs.mkdirSync(userDataDir, { recursive: true });
 
       // T1: same automation-tell-stripping defaults as launchHeaded().

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import { spawn as nodeSpawn } from 'child_process';
 import { safeUnlink, safeUnlinkQuiet, safeKill, isProcessAlive } from './error-handling';
 import { writeSecureFile, mkdirSecure } from './file-permissions';
-import { resolveConfig, ensureStateDir, readVersionHash } from './config';
+import { resolveConfig, ensureStateDir, readVersionHash, resolveChromiumProfile } from './config';
 import { parseProxyConfig, computeConfigHash, ProxyConfigError } from './proxy-config';
 import { redactProxyUrl } from './proxy-redact';
 import { spawnTerminalAgent } from './terminal-agent-control';
@@ -212,9 +212,13 @@ function cleanupLegacyState(): void {
 }
 
 // ─── Chromium profile lock helpers (#1781) ─────────────────────
-/** Profile dir used by headed/connect Chromium sessions. */
+/** Profile dir used by headed/connect Chromium sessions. Delegates to the
+ * canonical resolver (config.ts) instead of re-deriving the path — was a
+ * second hardcoded copy of the same $HOME/.gstack/chromium-profile default
+ * that caused cross-project profile-lock collisions (see
+ * resolveChromiumProfile's docstring). */
 function chromiumProfileDir(): string {
-  return path.join(process.env.HOME || '/tmp', '.gstack', 'chromium-profile');
+  return resolveChromiumProfile();
 }
 
 /** Remove Chromium SingletonLock/Socket/Cookie so a relaunch can acquire the

--- a/browse/src/config.ts
+++ b/browse/src/config.ts
@@ -171,13 +171,29 @@ export function resolveGstackHome(): string {
  * Resolution order:
  *   1. `explicit` arg (passed via ServerConfig.chromiumProfile by embedders)
  *   2. CHROMIUM_PROFILE env (used by gbrowser's gbd per-workspace)
- *   3. <resolveGstackHome()>/chromium-profile (default)
+ *   3. <resolveConfig(env).stateDir>/chromium-profile (default — per-project)
+ *
+ * Per-project by default (not a single machine-wide path under
+ * resolveGstackHome()): the browse daemon is already isolated per git repo
+ * root via resolveConfig().stateDir, but headed/handoff Chromium used to
+ * share one `$HOME/.gstack/chromium-profile` across every project on the
+ * machine. Every daemon restart runs killOrphanChromium(), which reads the
+ * profile's SingletonLock and unconditionally kills whatever PID holds it —
+ * it can't tell "dead orphan" from "another project's live headed window".
+ * Two concurrent projects that both use headed mode (e.g. two sibling
+ * windows both driving a captcha-gated login) would intermittently kill
+ * each other's browser out from under the user. Scoping the profile per
+ * project removes the shared lock entirely.
  */
-export function resolveChromiumProfile(explicit?: string): string {
+export function resolveChromiumProfile(
+  explicit?: string,
+  env: Record<string, string | undefined> = process.env,
+): string {
   if (explicit && explicit.length > 0) return explicit;
-  const env = process.env.CHROMIUM_PROFILE;
-  if (env && env.length > 0) return env;
-  return path.join(resolveGstackHome(), 'chromium-profile');
+  const envOverride = env.CHROMIUM_PROFILE;
+  if (envOverride && envOverride.length > 0) return envOverride;
+  const { stateDir } = resolveConfig(env);
+  return path.join(stateDir, 'chromium-profile');
 }
 
 /**

--- a/browse/src/server.ts
+++ b/browse/src/server.ts
@@ -694,21 +694,33 @@ if (BROWSE_PARENT_PID > 0 && !IS_HEADED_WATCHDOG) {
       // 1. Active cookie picker (one-time code or session live)? Stay alive
       //    regardless of mode — tearing down the server mid-import leaves the
       //    picker UI with a stale "Failed to fetch" error.
-      // 2. Headed / tunnel mode? Shutdown. The idle timeout doesn't apply in
-      //    these modes (see idleCheckInterval above — both early-return), so
-      //    ignoring parent death here would leak orphan daemons after
-      //    /pair-agent or /open-gstack-browser sessions.
-      // 3. Normal (headless) mode? Stay alive. Claude Code's Bash tool kills
+      // 2. Headed via the CLI `handoff` command (headless daemon transitioned
+      //    in-place)? Stay alive. BROWSE_PARENT_PID here was set at the
+      //    daemon's ORIGINAL headless spawn — some earlier, already-exited
+      //    CLI invocation, not a process meant to own this headed browser's
+      //    lifecycle. Falling through to case 3's "shut down" would kill
+      //    every handoff within one watchdog tick (~15s) of the parent CLI
+      //    process exiting, which it always does almost immediately — this
+      //    was killing real handoff sessions out from under the user.
+      // 3. Headed via launchHeaded()/connect, or tunnel mode? Shutdown. The
+      //    idle timeout doesn't apply in these modes (see idleCheckInterval
+      //    above — both early-return), so ignoring parent death here would
+      //    leak orphan daemons after /pair-agent or /open-gstack-browser
+      //    sessions, where BROWSE_PARENT_PID is deliberately set to a real
+      //    long-lived owner process.
+      // 4. Normal (headless) mode? Stay alive. Claude Code's Bash tool kills
       //    the parent shell between invocations. The idle timeout (30 min)
       //    handles eventual cleanup.
       if (hasActivePicker()) return;
       const headed = activeBrowserManager.getConnectionMode() === 'headed';
-      if (headed || tunnelActive) {
+      const viaHandoff = activeBrowserManager.didHandoffTransition();
+      if ((headed && !viaHandoff) || tunnelActive) {
         console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited in ${headed ? 'headed' : 'tunnel'} mode, shutting down`);
         activeShutdown?.();
       } else if (!parentGone) {
         parentGone = true;
-        console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited (server stays alive, idle timeout will clean up)`);
+        const reason = headed ? 'headed via handoff' : 'headless';
+        console.log(`[browse] Parent process ${BROWSE_PARENT_PID} exited (${reason}, server stays alive, idle timeout will clean up)`);
       }
     }
   }, 15_000);
@@ -768,6 +780,12 @@ const browserManager = new BrowserManager();
 // whose connectionMode never leaves 'launched' — and headed mode never
 // short-circuits idle-shutdown.
 let activeBrowserManager: BrowserManager = browserManager;
+// TEST-ONLY: forces the "headed via handoff" state without a real browser
+// launch, so watchdog.test.ts can subprocess-test the branch added for the
+// handoff-vs-launchHeaded watchdog fix. Never set by any real caller.
+if (process.env.BROWSE_TEST_FORCE_HANDOFF_HEADED === '1') {
+  browserManager.__forceHandoffHeadedForTest();
+}
 // When the user closes the headed browser window, run full cleanup
 // (kill sidebar-agent, save session, remove profile locks, delete state file)
 // before exiting. Exit code 0 means user-initiated clean quit (Cmd+Q on

--- a/browse/test/config.test.ts
+++ b/browse/test/config.test.ts
@@ -361,17 +361,29 @@ describe('resolveChromiumProfile', () => {
     }
   });
 
-  test('falls back to resolveGstackHome()/chromium-profile when nothing set', () => {
+  test('falls back to <project stateDir>/chromium-profile when nothing set (per-project, not machine-wide)', () => {
     const origEnv = process.env.CHROMIUM_PROFILE;
-    const origHome = process.env.GSTACK_HOME;
     delete process.env.CHROMIUM_PROFILE;
-    process.env.GSTACK_HOME = '/tmp/fallback-gstack';
     try {
-      expect(resolveChromiumProfile()).toBe('/tmp/fallback-gstack/chromium-profile');
+      const gitRoot = getGitRoot();
+      expect(gitRoot).not.toBeNull();
+      expect(resolveChromiumProfile()).toBe(path.join(gitRoot!, '.gstack', 'chromium-profile'));
     } finally {
       if (origEnv !== undefined) process.env.CHROMIUM_PROFILE = origEnv;
-      if (origHome === undefined) delete process.env.GSTACK_HOME;
-      else process.env.GSTACK_HOME = origHome;
+    }
+  });
+
+  test('two different projects resolve to two different profile dirs (the cross-project collision this fixes)', () => {
+    const origEnv = process.env.CHROMIUM_PROFILE;
+    delete process.env.CHROMIUM_PROFILE;
+    try {
+      const projectA = resolveChromiumProfile(undefined, { BROWSE_STATE_FILE: '/tmp/project-a/.gstack/browse.json' });
+      const projectB = resolveChromiumProfile(undefined, { BROWSE_STATE_FILE: '/tmp/project-b/.gstack/browse.json' });
+      expect(projectA).toBe('/tmp/project-a/.gstack/chromium-profile');
+      expect(projectB).toBe('/tmp/project-b/.gstack/chromium-profile');
+      expect(projectA).not.toBe(projectB);
+    } finally {
+      if (origEnv !== undefined) process.env.CHROMIUM_PROFILE = origEnv;
     }
   });
 

--- a/browse/test/watchdog.test.ts
+++ b/browse/test/watchdog.test.ts
@@ -154,4 +154,35 @@ describe('parent-process watchdog (v0.18.1.0)', () => {
     await Bun.sleep(20_000);
     expect(isProcessAlive(serverPid)).toBe(true);
   }, 45_000);
+
+  test('headed via handoff: server STAYS ALIVE when parent dies (regression for the fix in this PR)', async () => {
+    // Reproduces the real bug: `handoff` (headless CLI → headed in-place)
+    // leaves BROWSE_PARENT_PID pointed at whatever short-lived CLI process
+    // happened to spawn the daemon — normally fine (case 3 above), but once
+    // connectionMode flips to 'headed' the OLD code took the "headed, parent
+    // gone → shutdown" branch and killed the freshly-handed-off browser
+    // within one watchdog tick, every time. BROWSE_TEST_FORCE_HANDOFF_HEADED
+    // simulates handoff()'s resulting state without launching a real
+    // browser (slow, sandbox-unfriendly) — see __forceHandoffHeadedForTest.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'watchdog-handoff-'));
+
+    parentProc = spawn(['sleep', '60'], { stdio: ['ignore', 'ignore', 'ignore'] });
+    const parentPid = parentProc.pid!;
+
+    serverProc = spawnServer(
+      { BROWSE_PARENT_PID: String(parentPid), BROWSE_TEST_FORCE_HANDOFF_HEADED: '1' },
+      34904,
+    );
+    const serverPid = serverProc.pid!;
+
+    await Bun.sleep(2000);
+    expect(isProcessAlive(serverPid)).toBe(true);
+
+    parentProc.kill('SIGKILL');
+
+    // Pre-fix: server would shut itself down on the first tick after the
+    // parent died (~15s). Post-fix: stays alive, same as plain headless.
+    await Bun.sleep(20_000);
+    expect(isProcessAlive(serverPid)).toBe(true);
+  }, 45_000);
 });


### PR DESCRIPTION
## Summary

Two separate bugs, both causing the same visible symptom (headed browser opens then vanishes within seconds — reported as a persistent crash by a user running two sibling project windows concurrently, both driving a captcha-gated login).

**1. Chromium profile shared machine-wide, not per-project**
- `resolveChromiumProfile()` defaulted to a single `$HOME/.gstack/chromium-profile`, even though each browse daemon is already isolated per git repo root (`resolveConfig().stateDir`).
- Every daemon restart runs `killOrphanChromium()` (cli.ts), which reads the profile's `SingletonLock` and kills whatever PID holds it — no way to distinguish a genuinely dead orphan from another project's live headed window.
- Fix: default now resolves to `<project stateDir>/chromium-profile`. Also fixed two call sites (`browser-manager.ts` `handoff()`, `cli.ts` `chromiumProfileDir()`) that had their own hardcoded copies of the old global path instead of going through the shared resolver.

**2. Parent-process watchdog was killing `handoff()` sessions within ~15s (found during verification of fix #1 — turned out to be the dominant cause, reproduces with zero concurrency)**
- `handoff()` transitions an already-running headless daemon to headed mode in-place. `BROWSE_PARENT_PID` on that daemon was set at its original headless spawn — some short-lived CLI process that's expected to exit almost immediately (headless mode's watchdog branch already tolerates this).
- Once `handoff()` flips `connectionMode` to `'headed'`, the watchdog's next 15s tick took the OTHER branch: "headed + parent gone → shutdown", intended for `/pair-agent`/`/open-gstack-browser` where `BROWSE_PARENT_PID` is deliberately a real long-lived owner. Applied to a handoff-transitioned daemon, the already-dead CLI parent triggered a shutdown almost immediately after every handoff succeeded.
- Fix: track whether headed mode was reached via `handoff()` specifically (`BrowserManager.handoffTransition` / `didHandoffTransition()`) and have the watchdog treat "headed via handoff, parent gone" the same as plain headless (stay alive).

## Test plan
- [x] `bun test browse/test/config.test.ts browse/test/handoff.test.ts browse/test/browser-manager-unit.test.ts browse/test/watchdog.test.ts browse/test/server-factory.test.ts` — all pass (config 42, handoff+browser-manager+config combined 81, watchdog 4 incl. new regression test, server-factory 33)
- [x] Verified via `git stash` that a full `bun test browse/test/` run truncates identically on unmodified `main` — pre-existing test-runner quirk, unrelated to this change
- [x] New subprocess-based regression test in `watchdog.test.ts` (`BROWSE_TEST_FORCE_HANDOFF_HEADED` env hook) proving the daemon stays alive when its parent dies while in handoff-headed state
- [x] Real-world verification against a live captcha-gated site: ran `handoff`, then waited 75s (5 watchdog ticks) checking `status` + actually driving the browser with `text` — same PID throughout, still headed, still responsive. (First verification pass only checked the immediate `handoff()` return value and missed bug #2 entirely — this is the corrected, patient verification.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)