### PR TITLE
fix(deploy-config): stop greedy sed from mangling scheme-bearing URLs

### DIFF
--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -1004,8 +1004,10 @@ echo "$DEPLOY_CONFIG"
 
 # If config exists, parse it
 if [ "$DEPLOY_CONFIG" != "NO_CONFIG" ]; then
-  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/.*: *//')
-  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/.*: *//')
+  # Strip only the label before the FIRST colon. A greedy 's/.*: *//' cuts at the
+  # last colon instead, so "https://example.com" would come back as "//example.com".
+  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/^[^:]*: *//')
+  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/^[^:]*: *//')
   echo "PERSISTED_PLATFORM:$PLATFORM"
   echo "PERSISTED_URL:$PROD_URL"
 fi
@@ -1590,8 +1592,10 @@ echo "$DEPLOY_CONFIG"
 
 # If config exists, parse it
 if [ "$DEPLOY_CONFIG" != "NO_CONFIG" ]; then
-  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/.*: *//')
-  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/.*: *//')
+  # Strip only the label before the FIRST colon. A greedy 's/.*: *//' cuts at the
+  # last colon instead, so "https://example.com" would come back as "//example.com".
+  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/^[^:]*: *//')
+  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/^[^:]*: *//')
   echo "PERSISTED_PLATFORM:$PLATFORM"
   echo "PERSISTED_URL:$PROD_URL"
 fi

--- a/scripts/resolvers/utility.ts
+++ b/scripts/resolvers/utility.ts
@@ -57,8 +57,10 @@ echo "$DEPLOY_CONFIG"
 
 # If config exists, parse it
 if [ "$DEPLOY_CONFIG" != "NO_CONFIG" ]; then
-  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/.*: *//')
-  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/.*: *//')
+  # Strip only the label before the FIRST colon. A greedy 's/.*: *//' cuts at the
+  # last colon instead, so "https://example.com" would come back as "//example.com".
+  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/^[^:]*: *//')
+  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/^[^:]*: *//')
   echo "PERSISTED_PLATFORM:$PLATFORM"
   echo "PERSISTED_URL:$PROD_URL"
 fi


### PR DESCRIPTION
## The bug

`generateDeployBootstrap` (`scripts/resolvers/utility.ts`) parses the persisted deploy config with `sed 's/.*: *//'`. `.*:` is greedy, so it cuts at the **last** colon on the line instead of the label separator. Against the format `/setup-deploy` itself writes:

```
- Production URL: https://example.com   ->   //example.com
```

Every URL with a scheme is affected, which is every real production URL.

## Why it matters

`//example.com` does not resolve, so on any project that persists a Production URL:

- `/land-and-deploy`'s post-deploy canary curls an unresolvable address and reports the deploy as unverified.
- The Step 1.5b dry-run table prints the mangled URL, so a correctly configured project looks misconfigured. That is the failure mode I hit: the table said the prod URL was unreachable while the site was serving 200 the whole time.

`PLATFORM` uses the same pattern. It happens to survive today because platform values rarely contain a colon, but it has the same latent bug, so I fixed both.

## The fix

```diff
-  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/.*: *//')
-  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/.*: *//')
+  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/^[^:]*: *//')
+  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/^[^:]*: *//')
```

Anchor at the start, stop at the first colon. A comment above the lines explains the trap so it does not get "simplified" back.

## Verification

Against the real config format:

| input | output |
|---|---|
| `- Production URL: https://example.com` | `https://example.com` |
| `- Production URL: http://localhost:3000/health` | `http://localhost:3000/health` |
| `- Platform: Vercel (auto-deploy on push)` | `Vercel (auto-deploy on push)` |
| `- Production URL: example.com` | `example.com` |
| `- Production URL:https://no-space.com` | `https://no-space.com` |
| `- a line with no colon` | unchanged |

The last two confirm no behavior change where the old pattern was already correct.

End to end on a real project, the parsed URL went from `//<host>` to `https://<host>` and the health check returned 200.

## Notes for review

- The fix is in the generator source, not the generated `SKILL.md`, per CONTRIBUTING.
- `land-and-deploy/SKILL.md` is the regenerated output from `bun run gen:skill-docs --host all`, included so the `skill-docs.yml` freshness check passes. `gen:skill-docs --dry-run` exits 0 with zero STALE.
- `bun test` passes (exit 0, no failures).
- `bun run skill:check` exits 1 on `claude/SKILL.md — generated file missing!`. That reproduces identically on a clean tree with my changes stashed, so it is pre-existing and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)