### PR TITLE
fix(land-and-deploy): specify auto-merge method

### DIFF
--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -1472,10 +1472,11 @@ If the user chooses A or C: Tell the user "Merging now." Continue to Step 4.
 Record the start timestamp for timing data. Also record which merge path is taken
 (auto-merge vs direct) for the deploy report.
 
-Try auto-merge first (respects repo merge settings and merge queues):
+Try auto-merge first (respects repo merge settings and merge queues). Specify the
+merge method explicitly because `gh` requires one in non-interactive sessions:
 
 ```bash
-gh pr merge --auto --delete-branch
+gh pr merge --squash --auto --delete-branch
 ```
 
 If `--auto` succeeds: record `MERGE_PATH=auto`. This means the repo has auto-merge enabled

--- a/land-and-deploy/SKILL.md.tmpl
+++ b/land-and-deploy/SKILL.md.tmpl
@@ -595,10 +595,11 @@ If the user chooses A or C: Tell the user "Merging now." Continue to Step 4.
 Record the start timestamp for timing data. Also record which merge path is taken
 (auto-merge vs direct) for the deploy report.
 
-Try auto-merge first (respects repo merge settings and merge queues):
+Try auto-merge first (respects repo merge settings and merge queues). Specify the
+merge method explicitly because `gh` requires one in non-interactive sessions:
 
 ```bash
-gh pr merge --auto --delete-branch
+gh pr merge --squash --auto --delete-branch
 ```
 
 If `--auto` succeeds: record `MERGE_PATH=auto`. This means the repo has auto-merge enabled

--- a/test/land-and-deploy-postfail.test.ts
+++ b/test/land-and-deploy-postfail.test.ts
@@ -36,6 +36,13 @@ function readMd(): string {
 }
 
 describe("PR #1620 §4a-postfail in land-and-deploy template", () => {
+  test("auto-merge specifies a method in template and generated skill", () => {
+    for (const body of [readTmpl(), readMd()]) {
+      expect(body).toContain("gh pr merge --squash --auto --delete-branch");
+      expect(body).not.toContain("gh pr merge --auto --delete-branch");
+    }
+  });
+
   test("§4a-postfail header present in template", () => {
     expect(readTmpl()).toMatch(/### 4a-postfail: Post-failure PR-state check/);
   });


### PR DESCRIPTION
## Summary

- add an explicit squash method to the non-interactive auto-merge command
- pin the template and generated skill against regression

## Verification

- `bun test test/land-and-deploy-postfail.test.ts` (13 passed)