### PR TITLE
fix(redact-prepush): six paths where the hook exits 0 on a real credential

### DIFF
--- a/bin/gstack-redact-prepush
+++ b/bin/gstack-redact-prepush
@@ -22,46 +22,141 @@
  *   - MEDIUM → warn (non-blocking). LOW/WARN → silent.
  *   - GSTACK_REDACT_PREPUSH=skip → log + exit 0 (escape valve).
  *
- * Installed/uninstalled via `gstack-redact install-prepush-hook` (see the
- * gstack-redact CLI), which chains any pre-existing hook.
+ * STREAMING (2026-08): the diff is consumed incrementally and scanned in bounded
+ * windows instead of being buffered whole. This fixes three defects that made the
+ * hook an unreliable gate on large repos — see
+ * docs/prepush-redact-hook-2026-08/README.md in rejstrik-ai for the measurements:
+ *
+ *   1. `scan()` refuses input over its own 1 MiB cap (DEFAULT_MAX_BYTES) by
+ *      returning a synthetic HIGH `engine.input_too_large`. The hook reported that
+ *      as a credential hit, so ANY push adding >1 MiB of text was blocked with
+ *      "Rotate the credential (a pushed secret is compromised)" — a false positive
+ *      on innocuous data, and the added lines were never actually scanned.
+ *      Windowing keeps every scan() call under the cap, so the content is really
+ *      scanned. This scans MORE than before, never less.
+ *   2. Buffering the whole diff cost ~12x its size in RSS (63 MiB of diff → 762 MB).
+ *      Streaming holds one window at a time, which cut peak RSS to 253 MB while
+ *      scanning a LARGER payload (65.5 MB of added lines) that the buffered version
+ *      could not read at all. Peak is not perfectly flat — allocation churn inside
+ *      scan() still scales with total input — but it is bounded by the window
+ *      rather than by the diff. That transient spike is what made the hook a
+ *      plausible target for the OS memory manager, and a SIGKILLed hook surfaces
+ *      to the user as the undiagnosable "pre-push died of signal 9".
+ *   3. Every "cannot scan" path now says what happened, how big the diff was, which
+ *      files dominate it, and what to do — instead of a bare status code.
+ *
+ * Fail-closed is unchanged and load-bearing: any path where the pushed diff cannot
+ * be fully read and scanned BLOCKS the push. Unscanned-but-allowed is the exact
+ * failure mode this hook exists to prevent (#1946).
  */
-import { spawnSync } from "child_process";
+import { spawn, spawnSync } from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { scan, type Finding } from "../lib/redact-engine";
 
-const ZERO = /^0+$/;
-// The canonical empty-tree object; diffing against it yields all content as added.
-const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+/** A git object id: 40 hex (sha1) or 64 hex (sha256). Also matches an all-zero OID. */
+const SHA = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/i;
+/**
+ * The all-zero OID git uses for "no such ref", at either width. Must be length-checked:
+ * a bare /^0+$/ also accepts "0", and a malformed line with localSha="0" would then be
+ * read as a branch delete and skipped — exit 0 with nothing scanned.
+ */
+const ZERO_OID = /^0{40}(?:0{24})?$/;
+/**
+ * The empty-tree object; diffing against it yields all content as added. The OID
+ * depends on the repo's hash algorithm, and hardcoding the SHA-1 one blocks every
+ * new-branch push in a SHA-256 repo (the object simply does not exist there).
+ */
+const EMPTY_TREE_SHA1 = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+const EMPTY_TREE_SHA256 = "6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321";
+
+/**
+ * Window sizing. WINDOW_BYTES must stay strictly under the engine's own
+ * DEFAULT_MAX_BYTES (1 MiB) so scan() never trips its oversize guard on our
+ * behalf — that guard is meant for a caller handing over an unbounded blob, and
+ * here we are the one keeping it bounded.
+ *
+ * A tail is carried into the next window so a match near a cut is still seen whole.
+ * Why the overlap is sized the way it is, checked against the engine rather than
+ * assumed:
+ *
+ *   - withFlags() adds only `g` and `m`, never `s`, so `.` never spans a newline.
+ *   - `\s`, however, DOES match `\n` in JS regardless of the `s` flag. Six pattern
+ *     sources contain `\s`; in five of them it only appears inside a negated class
+ *     (`[^\s…]`), which cannot consume a newline. Exactly one HIGH pattern can
+ *     genuinely span lines: gcp.service_account,
+ *     /("private_key"\s*:\s*"-----BEGIN (?:RSA |EC )?PRIVATE KEY-----)/.
+ *   - That one is harmless to split, and not by luck: the `-----BEGIN … PRIVATE
+ *     KEY-----` substring it requires is itself matched by pem.private_key, which is
+ *     single-line and also HIGH. Splitting the gcp match can therefore cost the
+ *     finding's LABEL, never the block. Verified for the one-line, newline-split and
+ *     EC variants — all block via pem.private_key.
+ *   - Everything else matches within one line, and windows are always cut on a line
+ *     boundary, so those matches can never be split at all.
+ *
+ * What the overlap actually buys is proximity context, which FIVE patterns need:
+ * aws.secret_key (nearWindow 100), gcp.service_account (300), twilio.auth_token (200),
+ * auth.bearer (80), legal.named_criticism (80). THREE are HIGH, so dropping that
+ * context drops a block, not merely a label. (aws.access_key has no nearRegex.)
+ *
+ * Sizes are measured, not guessed. scan() calls normalizeWithMap(), which builds a
+ * string[] AND a number[] with one entry per character — roughly 20x the window in
+ * transient allocation — so the window is the lever that bounds peak RSS. Measured
+ * on the 65.5 MB full-history range of rejstrik-ai (peak RSS / wall time):
+ *     768 KiB / 64 KiB -> 459 MB / 15.1 s
+ *     512 KiB / 16 KiB -> 273 MB / 13.7 s
+ *     384 KiB / 16 KiB -> 253 MB / 13.1 s   <- chosen
+ *     256 KiB / 16 KiB -> 250 MB / 17.0 s
+ *     128 KiB / 64 KiB -> 271 MB / 28.4 s
+ * All configurations produced identical findings (449 MEDIUM, 0 HIGH), i.e. the
+ * window size is a cost knob, not a detection knob.
+ */
+const WINDOW_BYTES = 384 * 1024;
+/**
+ * Tail carried into the next window. Sizing this correctly used to need a second
+ * counter, because the engine strips zero-width characters before matching: a fat
+ * byte-sized tail could normalize to nothing and drop the proximity context that five
+ * patterns (three of them HIGH) depend on. Rather than track two units and fail closed
+ * when they disagree, added lines are stripped of zero-width characters ON INGEST —
+ * exactly what the engine does before matching, so findings are unchanged — after
+ * which bytes and normalization-surviving characters mean the same thing again and one
+ * plain byte count is sound. 16 KiB is ~55x the largest nearWindow (300).
+ */
+const OVERLAP_BYTES = 16 * 1024;
+/**
+ * Slice width for a single line longer than a window. In CHARACTERS, and a quarter of
+ * WINDOW_BYTES, so even all-4-byte UTF-8 stays inside the engine's 1 MiB byte cap.
+ */
+const SLICE_CHARS = WINDOW_BYTES / 4;
+/** Overlap between slices of one oversized line, in the same (stripped) units. */
+const SLICE_OVERLAP_CHARS = 16 * 1024;
+/**
+ * Mirrors ZERO_WIDTH in lib/redact-engine.ts. Duplicated deliberately so the hook can
+ * size its own tail without reaching into engine internals — if that constant ever
+ * changes, this is the other place to update.
+ */
+const ZERO_WIDTH = /[​‌‍⁠﻿]/g;
+
+/** Wall-clock budget for scanning one ref. Fails CLOSED so a pathological diff
+ *  cannot hang a push indefinitely. Tunable for very large monorepos. */
+const TIME_BUDGET_MS = Number(process.env.GSTACK_REDACT_PREPUSH_TIMEOUT_MS || 120_000);
 
 /**
  * Permissive git for legitimately-fallible PROBES (symbolic-ref, rev-parse,
- * merge-base) where a non-zero exit is normal control flow. The DIFF call
- * must NOT use this — see gitStrict (#1946 fail-closed).
+ * merge-base) where a non-zero exit is normal control flow. The DIFF is NOT run
+ * through this — see scanRange (#1946 fail-closed).
  */
 function git(args: string[]): string {
-  const r = spawnSync("git", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+  const r = spawnSync("git", args, { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 });
   return r.status === 0 ? (r.stdout ?? "") : "";
 }
 
-/**
- * Fail-closed git for the diff that decides whether the push is scanned
- * (#1946). status !== 0 covers repo errors; status === null covers a killed
- * process AND maxBuffer overflow — the oversized-diff case is exactly where
- * a large secret-bearing blob is most likely, so "couldn't read the diff"
- * must block, not silently allow.
- */
-function gitStrict(args: string[]): string {
-  const r = spawnSync("git", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
-  // status !== 0 covers BOTH a non-zero exit AND null (process killed by a
-  // signal or maxBuffer overflow — null !== 0 is true).
-  if (r.status !== 0) {
-    throw new Error(
-      `git ${args[0]} failed (status=${r.status ?? "killed/overflow"}): ${(r.stderr ?? "").slice(0, 300)}`,
-    );
-  }
-  return r.stdout ?? "";
+/** The empty tree for THIS repo's object format. */
+function emptyTree(): string {
+  return git(["rev-parse", "--show-object-format"]).trim() === "sha256"
+    ? EMPTY_TREE_SHA256
+    : EMPTY_TREE_SHA1;
 }
 
 /** True when the object exists in the local odb (cat-file -e signals via exit code). */
@@ -70,48 +165,367 @@ function objectExists(sha: string): boolean {
   return r.status === 0;
 }
 
-function defaultRemoteBranch(): string {
-  // origin/HEAD → origin/main, fall back to main/master.
-  const sym = git(["symbolic-ref", "refs/remotes/origin/HEAD"]).trim();
+/**
+ * The default branch OF THE REMOTE BEING PUSHED TO. git passes that remote's name as
+ * argv[1] to a pre-push hook; using a hardcoded "origin" instead is a fail-open.
+ *
+ * Concretely: `git push publish HEAD:refs/heads/main` to a brand-new remote sends an
+ * all-zero remote sha, so we take the new-branch path. Resolved against origin, the
+ * merge-base of HEAD and origin/main is HEAD itself, the range collapses to
+ * HEAD..HEAD, the diff is empty and the entire tree — credentials included — ships to
+ * a remote that has never seen it, unscanned. Resolved against `publish`, which has
+ * no refs locally, merge-base fails and we fall through to the empty tree and scan
+ * everything. That is the whole point of the fallback, and it only works if the
+ * remote name is the real one.
+ */
+function defaultRemoteBranch(remote: string): string {
+  const sym = git(["symbolic-ref", `refs/remotes/${remote}/HEAD`]).trim();
   if (sym) return sym.replace("refs/remotes/", "");
-  for (const b of ["origin/main", "origin/master"]) {
+  for (const b of [`${remote}/main`, `${remote}/master`]) {
     if (git(["rev-parse", "--verify", b]).trim()) return b;
   }
-  return "origin/main";
+  // Deliberately a ref that will not resolve for an unknown remote: merge-base then
+  // fails and rangeFor falls back to the empty tree, i.e. scans MORE, never less.
+  return `${remote}/main`;
 }
 
-/** Return the added-line text for a ref update being pushed. */
-function addedLinesFor(localSha: string, remoteSha: string): string {
-  let range: string;
-  if (ZERO.test(remoteSha)) {
+/** The diff range for a ref update being pushed. */
+function rangeFor(localSha: string, remoteSha: string, remote: string): string {
+  if (ZERO_OID.test(remoteSha)) {
     // New branch: prefer what's unique to localSha vs the remote default branch.
     // With no merge-base (e.g. no remote yet), diff against the empty tree so ALL
     // branch content is scanned as added — fail-safe (scans more, never less).
-    const base = git(["merge-base", localSha, defaultRemoteBranch()]).trim();
-    range = base ? `${base}..${localSha}` : `${EMPTY_TREE}..${localSha}`;
-  } else if (!objectExists(remoteSha)) {
+    const base = git(["merge-base", localSha, defaultRemoteBranch(remote)]).trim();
+    return base ? `${base}..${localSha}` : `${emptyTree()}..${localSha}`;
+  }
+  if (!objectExists(remoteSha)) {
     // Remote tip object absent locally (shallow clone, force-push without a
     // prior fetch, CI checkout): remote..local can't resolve. Fall back to
     // the merge-base/empty-tree path — scans MORE, never less — instead of
     // hard-blocking a legitimate push (adversarial review finding 8).
-    const base = git(["merge-base", localSha, defaultRemoteBranch()]).trim();
-    range = base ? `${base}..${localSha}` : `${EMPTY_TREE}..${localSha}`;
-  } else {
-    // Existing branch (incl. force-push): net new content remote..local.
-    range = `${remoteSha}..${localSha}`;
+    const base = git(["merge-base", localSha, defaultRemoteBranch(remote)]).trim();
+    return base ? `${base}..${localSha}` : `${emptyTree()}..${localSha}`;
   }
-  // -U0: only changed lines; we keep lines starting with '+' (added), drop the
-  // +++ file header. Unified diff added lines start with a single '+'.
-  // Strict (#1946): a failed diff used to return "" and the push sailed
-  // through unscanned — fail open on the exact path the guard exists for.
-  const diff = gitStrict(["diff", "--unified=0", "--no-color", range]);
-  const added: string[] = [];
-  for (const line of diff.split("\n")) {
-    if (line.startsWith("+") && !line.startsWith("+++")) {
-      added.push(line.slice(1));
+  // Existing branch (incl. force-push): net new content remote..local.
+  return `${remoteSha}..${localSha}`;
+}
+
+/** What we learned about the diff while streaming it — used to make block messages concrete. */
+interface ScanStats {
+  addedBytes: number;
+  addedLines: number;
+  files: number;
+  /** Added bytes per file, for naming the biggest contributors in a message. */
+  perFile: Map<string, number>;
+}
+
+/**
+ * Why we could not clear the diff. Every one of these BLOCKS the push. `kind`
+ * exists so the remedy we print matches the actual failure — telling someone with
+ * an unresolvable ref to "push in smaller chunks" is noise.
+ */
+type FailureKind = "git-failed" | "git-killed" | "timeout" | "internal";
+
+class UnscannableDiff extends Error {
+  constructor(
+    readonly kind: FailureKind,
+    readonly reason: string,
+    readonly stats: ScanStats,
+  ) {
+    super(reason);
+  }
+}
+
+function emptyStats(): ScanStats {
+  return { addedBytes: 0, addedLines: 0, files: 0, perFile: new Map() };
+}
+
+/**
+ * Stream `git diff` for `range`, scanning added lines in bounded windows.
+ * Resolves with the findings; throws UnscannableDiff on any path where the diff
+ * could not be fully read (fail-closed).
+ */
+async function scanRange(
+  range: string,
+): Promise<{ high: Finding[]; medium: number; stats: ScanStats }> {
+  const stats = emptyStats();
+  const high: Finding[] = [];
+  let medium = 0;
+  // Dedup across windows: the overlap tail is scanned twice by construction.
+  const seen = new Set<string>();
+
+  // The diff MUST come out in canonical unified format, because that grammar is the
+  // only thing standing between us and "scanned nothing, allowed everything".
+  //   --no-ext-diff  : a user's `diff.external` driver replaces the entire diff with
+  //                    its own output. Verified: with one set, `git diff` emits zero
+  //                    '+' lines, so an unhardened scanner reads an empty diff and
+  //                    exits 0 on a push full of secrets. This is a real fail-open
+  //                    reachable from ordinary user config, not a hypothetical.
+  //   --no-textconv  : a .gitattributes textconv driver can likewise rewrite content
+  //                    before we ever see it.
+  //   -c diff.*prefix: force plain a/ b/ paths so file attribution stays correct
+  //                    under diff.noprefix / diff.mnemonicPrefix.
+  const child = spawn(
+    "git",
+    [
+      "-c", "diff.external=",
+      "-c", "diff.noprefix=false",
+      "-c", "diff.mnemonicPrefix=false",
+      "diff", "--unified=0", "--no-color", "--no-ext-diff", "--no-textconv",
+      range,
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (d: string) => {
+    if (stderr.length < 4096) stderr += d;
+  });
+
+  // Current window, held as lines so the overlap tail can be cut on a line boundary.
+  let windowLines: string[] = [];
+  let windowBytes = 0;
+  let currentFile = "<unknown>";
+  let inHunk = false;
+  const started = Date.now();
+
+  /** Run the engine over one bounded chunk and fold its findings in. */
+  const collect = (text: string): void => {
+    if (!text) return;
+    // Visibility doesn't change HIGH behavior; pass private so nothing is treated
+    // as public-strict (HIGH blocks regardless either way).
+    const result = scan(text, { repoVisibility: "private" });
+    for (const f of result.findings) {
+      // Can only appear if WINDOW_BYTES were mis-sized above the engine cap. It
+      // means "not scanned", not "credential found" — surface it honestly rather
+      // than telling the user to rotate a credential that does not exist.
+      if (f.id === "engine.input_too_large") {
+        throw new UnscannableDiff(
+          "internal",
+          `internal: scan window (${Buffer.byteLength(text)} B) exceeded the engine cap; ` +
+            `WINDOW_BYTES must stay under it`,
+          stats,
+        );
+      }
+      if (f.severity !== "HIGH" && f.severity !== "MEDIUM") continue;
+      const key = `${f.id}\u0000${f.preview}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      if (f.severity === "HIGH") high.push(f);
+      else medium++;
     }
-  }
-  return added.join("\n");
+  };
+
+  /**
+   * A single line longer than a window — a minified bundle or one-line JSON, both
+   * ordinary in real repos. Buffering it whole would blow the memory bound AND hand
+   * scan() something over its 1 MiB cap, which returns engine.input_too_large: a
+   * block, but one where the content was never actually read. Slice it instead, with
+   * enough overlap that no single-line match can fall in a seam.
+   *
+   * The seams do give `^`/`$` extra places to match (db.url_with_password and
+   * creds.basic_auth_url among the HIGH patterns). That can only produce MORE
+   * findings, never fewer, so it errs toward blocking — the safe direction here.
+   */
+  const scanLongLine = (content: string): void => {
+    // Guard the loop against a future retuning that makes the overlap >= the slice,
+    // which would leave step <= 0 and spin forever on a huge line.
+    const step = Math.max(1, SLICE_CHARS - SLICE_OVERLAP_CHARS);
+    for (let start = 0; start < content.length; start += step) {
+      collect(content.slice(start, start + SLICE_CHARS));
+      if (start + SLICE_CHARS >= content.length) break;
+    }
+  };
+
+  const flush = (final: boolean): void => {
+    if (windowLines.length === 0) return;
+    collect(windowLines.join("\n"));
+    if (final) {
+      windowLines = [];
+      windowBytes = 0;
+      return;
+    }
+    // Retain a tail carrying at least OVERLAP_SIGNIFICANT_CHARS characters that
+    // survive normalization, so proximity context for the six nearRegex patterns is
+    // still visible to the next window. Counting raw bytes here would let zero-width
+    // padding produce a fat tail with no usable context in it.
+    const tail: string[] = [];
+    let tailBytes = 0;
+    for (let i = windowLines.length - 1; i >= 0 && tailBytes < OVERLAP_BYTES; i--) {
+      tail.unshift(windowLines[i]);
+      tailBytes += Buffer.byteLength(windowLines[i]) + 1;
+    }
+    windowLines = tail;
+    windowBytes = tailBytes;
+  };
+
+  const handleLine = (line: string): void => {
+    // Track diff structure so a "+++" is only read as a file header where one can
+    // legally appear. Matching on the prefix alone (what the previous version did)
+    // silently DROPS any added line whose own content starts with "++" — e.g. a
+    // checked-in .patch file, or `+++ token = "…"` — from the scan. That is a
+    // credential-shaped blind spot, so structure beats prefix-guessing here.
+    if (line.startsWith("diff --git ")) {
+      inHunk = false;
+      return;
+    }
+    if (line.startsWith("@@")) {
+      // A hunk header. Added lines start with "+", so "@@" at column 0 is never content.
+      inHunk = true;
+      return;
+    }
+    if (!inHunk && line.startsWith("+++")) {
+      // "+++ b/path" (or "+++ /dev/null"). Names the file for the lines that follow.
+      const p = line.slice(4).trim();
+      currentFile = p === "/dev/null" ? currentFile : p.replace(/^[ab]\//, "");
+      stats.files++;
+      return;
+    }
+    if (!line.startsWith("+")) return;
+    // Strip zero-width characters here, not later: the engine removes them during
+    // normalization anyway, so this cannot change what matches, and it makes a byte
+    // count a faithful proxy for the normalized length everywhere downstream.
+    const content = line.slice(1).replace(ZERO_WIDTH, "");
+    const n = Buffer.byteLength(content) + 1;
+    stats.addedBytes += n;
+    stats.addedLines++;
+    stats.perFile.set(currentFile, (stats.perFile.get(currentFile) ?? 0) + n);
+    if (n > WINDOW_BYTES) {
+      // Oversized single line: flush the pending window, scan the line on its own in
+      // bounded slices, then seed the next window with its tail so proximity context
+      // survives across it.
+      flush(false);
+      scanLongLine(content);
+      // Start the next window from this line's tail ALONE. Appending it to whatever
+      // flush() kept would splice two non-adjacent pieces of the diff together and let
+      // a proximity pattern match across text that is megabytes apart in reality.
+      const tailChars = content.slice(-SLICE_OVERLAP_CHARS);
+      windowLines = [tailChars];
+      windowBytes = Buffer.byteLength(tailChars) + 1;
+      return;
+    }
+    windowLines.push(content);
+    windowBytes += n;
+    if (windowBytes >= WINDOW_BYTES) flush(false);
+  };
+
+  await new Promise<void>((resolve, reject) => {
+    let carry = "";
+    let settled = false;
+    const fail = (e: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(budget);
+      child.kill("SIGKILL");
+      reject(e);
+    };
+
+    // A real timer, not just a check inside the data handler: git can hang before
+    // emitting its first byte or after its last, and a budget that only ticks on
+    // stdout.data would never fire in either case.
+    const budget = setTimeout(() => {
+      fail(
+        new UnscannableDiff(
+          "timeout",
+          `scanning exceeded the ${
+            TIME_BUDGET_MS >= 1000 ? `${Math.round(TIME_BUDGET_MS / 1000)}s` : `${TIME_BUDGET_MS}ms`
+          } budget`,
+          stats,
+        ),
+      );
+    }, TIME_BUDGET_MS);
+    budget.unref?.();
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      if (settled) return;
+      if (Date.now() - started > TIME_BUDGET_MS) {
+        fail(
+          new UnscannableDiff(
+            "timeout",
+            `scanning exceeded the ${
+              TIME_BUDGET_MS >= 1000 ? `${Math.round(TIME_BUDGET_MS / 1000)}s` : `${TIME_BUDGET_MS}ms`
+            } budget`,
+            stats,
+          ),
+        );
+        return;
+      }
+      try {
+        const buf = carry + chunk;
+        let start = 0;
+        for (;;) {
+          const nl = buf.indexOf("\n", start);
+          if (nl === -1) break;
+          handleLine(buf.slice(start, nl));
+          start = nl + 1;
+        }
+        carry = buf.slice(start);
+      } catch (e) {
+        fail(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+
+    child.stdout.on("error", (e) => fail(new UnscannableDiff("git-failed", `diff stream error: ${e.message}`, stats)));
+    child.on("error", (e) => fail(new UnscannableDiff("git-failed", `could not run git diff: ${e.message}`, stats)));
+
+    child.on("close", (code, signal) => {
+      if (settled) return;
+      // A signal here means the CHILD died (OOM killer, timeout, manual kill) —
+      // distinct from a non-zero exit, and distinct again from this hook itself
+      // being killed (which git reports as "hook died of signal N" and which no
+      // code inside this process can catch).
+      if (signal) {
+        settled = true;
+        reject(new UnscannableDiff("git-killed", `git diff was killed by ${signal}`, stats));
+        return;
+      }
+      if (code !== 0) {
+        settled = true;
+        reject(
+          new UnscannableDiff(
+            "git-failed",
+            `git diff exited ${code}${stderr.trim() ? `: ${stderr.trim().split("\n")[0]}` : ""}`,
+            stats,
+          ),
+        );
+        return;
+      }
+      // Keep the budget armed across the final flush: a trailing line with no
+      // newline is scanned here, and that is exactly the expensive case.
+      try {
+        if (carry) handleLine(carry);
+        flush(true);
+      } catch (e) {
+        settled = true;
+        clearTimeout(budget);
+        reject(e instanceof Error ? e : new Error(String(e)));
+        return;
+      }
+      settled = true;
+      clearTimeout(budget);
+      resolve();
+    });
+  });
+
+  return { high, medium, stats };
+}
+
+function mb(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Concrete "here is what your push actually contains" summary for block messages. */
+function describe(stats: ScanStats): string {
+  const top = [...stats.perFile.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([f, n]) => `      ${mb(n).padStart(9)}  ${f}`)
+    .join("\n");
+  const head =
+    `  Read so far: ${mb(stats.addedBytes)} of added lines ` +
+    `(${stats.addedLines.toLocaleString("en-US")} lines across ${stats.files} file diffs)`;
+  return top ? `${head}\n  Largest contributors:\n${top}` : head;
 }
 
 function logSkip(reason: string): void {
@@ -128,12 +542,17 @@ function logSkip(reason: string): void {
   }
 }
 
-function main() {
+async function main() {
   if ((process.env.GSTACK_REDACT_PREPUSH || "").toLowerCase() === "skip") {
     logSkip(process.env.GSTACK_REDACT_PREPUSH_REASON || "env-skip");
     process.stderr.write("gstack-redact-prepush: skipped via GSTACK_REDACT_PREPUSH=skip\n");
     process.exit(0);
   }
+
+  // git invokes a pre-push hook as: hook <remote name> <remote URL>. Resolving the
+  // range against the remote actually being pushed to is load-bearing — see
+  // defaultRemoteBranch(). Fall back to "origin" only when git told us nothing.
+  const remoteName = process.argv[2] || "origin";
 
   const stdin = fs.readFileSync(0, "utf8");
   const refs = stdin
@@ -145,30 +564,78 @@ function main() {
   const allHigh: Finding[] = [];
   let mediumCount = 0;
 
-  for (const [, localSha, , remoteSha] of refs) {
-    if (!localSha || ZERO.test(localSha)) continue; // branch delete → nothing pushed
-    let added: string;
-    try {
-      added = addedLinesFor(localSha, remoteSha || "0");
-    } catch (err) {
-      // Fail CLOSED (#1946): if we can't compute the pushed diff we can't
-      // scan it, and unscanned-but-allowed is the failure mode this hook
-      // exists to prevent.
+  for (const fields of refs) {
+    // A malformed line is NOT the same as "nothing to push". If we cannot tell what
+    // is being pushed we cannot scan it, so block instead of skipping the ref — a
+    // bare `continue` here would exit 0 having scanned nothing at all.
+    // BOTH shas must be well formed. Validating only the local one leaves a hole:
+    // a line with a good local sha and a junk remote sha passes, objectExists()
+    // then fails on the junk, we take the merge-base path, and if HEAD is already
+    // the remote default branch the range collapses to HEAD..HEAD — an empty diff,
+    // scanned clean, exit 0.
+    const [, localSha, , remoteSha] = fields;
+    const shaOk = (s: string | undefined) => !!s && SHA.test(s);
+    if (fields.length !== 4 || !shaOk(localSha) || !shaOk(remoteSha)) {
       process.stderr.write(
-        "\n⛔ gstack-redact-prepush BLOCKED the push — could not compute the pushed diff, " +
-          "so it cannot be scanned for credentials.\n" +
-          `  (${err instanceof Error ? err.message.split("\n")[0] : String(err)})\n` +
-          "Bypass if you're sure: GSTACK_REDACT_PREPUSH=skip git push   (or git push --no-verify)\n",
+        "\n⛔ gstack-redact-prepush BLOCKED the push — could not parse the ref update\n" +
+          "   git sent on stdin, so there is nothing it can reliably scan.\n\n" +
+          `  Expected "<local ref> <local sha> <remote ref> <remote sha>", got ${fields.length} field(s).\n` +
+          "  This is fail-closed by design. Please report it — the hook should\n" +
+          "  understand every ref update git produces.\n",
       );
       process.exit(1);
     }
-    if (!added.trim()) continue;
-    // Visibility doesn't change HIGH behavior; pass private so nothing is treated
-    // as public-strict (HIGH blocks regardless either way).
-    const result = scan(added, { repoVisibility: "private" });
-    for (const f of result.findings) {
-      if (f.severity === "HIGH") allHigh.push(f);
-      else if (f.severity === "MEDIUM") mediumCount++;
+    if (ZERO_OID.test(localSha)) continue; // branch delete → nothing pushed
+    const range = rangeFor(localSha, remoteSha || "0", remoteName);
+    try {
+      const { high, medium, stats } = await scanRange(range);
+      allHigh.push(...high);
+      mediumCount += medium;
+      if (process.env.GSTACK_REDACT_PREPUSH_VERBOSE) {
+        process.stderr.write(
+          `gstack-redact-prepush: scanned ${mb(stats.addedBytes)} of added lines ` +
+            `(${stats.addedLines.toLocaleString("en-US")} lines, ${stats.files} file diffs) in ${range}\n`,
+        );
+      }
+    } catch (err) {
+      // Fail CLOSED (#1946): if we can't compute or fully scan the pushed diff we
+      // can't clear it, and unscanned-but-allowed is the failure mode this hook
+      // exists to prevent. The message has to leave the user with a next step —
+      // a bare status code does not.
+      const stats = err instanceof UnscannableDiff ? err.stats : emptyStats();
+      const kind: FailureKind = err instanceof UnscannableDiff ? err.kind : "internal";
+      const why = err instanceof Error ? err.message.split("\n")[0] : String(err);
+      // Tailor the remedy to the failure. "Push in smaller chunks" is useless
+      // advice for a ref that does not resolve, and "fetch the remote" is useless
+      // advice for a diff that was too big to get through.
+      const remedy =
+        kind === "git-failed"
+          ? "  The range itself could not be resolved. Usually the remote ref is stale\n" +
+            "  or missing locally. Try:\n" +
+            `    • git fetch ${remoteName}        (then push again)\n` +
+            "    • confirm the branch points at a real commit: git log -1 <branch>\n"
+          : "  This is usually an oversized push, not a leak. Options:\n" +
+            "    • Rebase/branch off the remote default branch so the pushed range is\n" +
+            "      only your own commits, then push again.\n" +
+            `    • Push in smaller chunks:  git push ${remoteName} <sha>:refs/heads/<branch>\n` +
+            "    • Large generated data files belong in .gitignore or an artifact store.\n" +
+            (kind === "timeout"
+              ? "    • Raise the budget if the repo is legitimately huge:\n" +
+                "        GSTACK_REDACT_PREPUSH_TIMEOUT_MS=300000 git push\n"
+              : "");
+      process.stderr.write(
+        "\n⛔ gstack-redact-prepush BLOCKED the push — the pushed diff could not be fully\n" +
+          "   scanned, so it cannot be cleared of credentials. Blocking is deliberate.\n\n" +
+          `  Range:  ${range}\n` +
+          `  Reason: ${why}\n` +
+          `${describe(stats)}\n\n` +
+          remedy +
+          "    • If you have verified the content yourself, take the audited escape\n" +
+          "      valve (it is logged to ~/.gstack/security/prepush-skip.jsonl):\n" +
+          "        GSTACK_REDACT_PREPUSH=skip \\\n" +
+          '        GSTACK_REDACT_PREPUSH_REASON="<why this is safe>" git push\n',
+      );
+      process.exit(1);
     }
   }
 
@@ -196,4 +663,24 @@ function main() {
   process.exit(0);
 }
 
-main();
+/**
+ * Run as a hook unless we are being imported by a test/benchmark. The comparison
+ * is `!== false`, not `=== true`, on purpose: a runtime that does not define
+ * import.meta.main yields undefined, and undefined !== false, so the hook still
+ * runs. Getting this backwards would silently turn the guard into a no-op that
+ * exits 0 — i.e. fail OPEN, the one outcome this file exists to prevent.
+ */
+if (import.meta.main !== false) {
+  main().catch((e) => {
+    // Last-resort fail-closed: an unexpected throw must not let a push through.
+    process.stderr.write(
+      `\n⛔ gstack-redact-prepush BLOCKED the push — unexpected scanner error: ${
+        e instanceof Error ? e.message : String(e)
+      }\n` + "This is fail-closed by design; the diff was not cleared.\n",
+    );
+    process.exit(1);
+  });
+}
+
+export { scanRange, rangeFor, UnscannableDiff, WINDOW_BYTES, OVERLAP_BYTES, SLICE_CHARS };
+export type { ScanStats };

--- a/test/redact-prepush-fail-open-verify.sh
+++ b/test/redact-prepush-fail-open-verify.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+#
+# verify.sh — reproduces the gstack pre-push redact hook failure and validates the
+# proposed streaming fix side by side. Read README.md in this directory first.
+#
+#   usage:  bash docs/prepush-redact-hook-2026-08/verify.sh [workdir]
+#
+# Requires: bun, git, python3, and a gstack checkout at ~/.claude/skills/gstack
+# (only READ from — this script never writes into the gstack worktree).
+#
+# Every credential below is synthetic: randomly composed strings that match the
+# detector's shape. None is, or ever was, a live secret.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GSTACK="${GSTACK_DIR:-$HOME/.claude/skills/gstack}"
+WORK="${1:-$(mktemp -d -t prepush-verify)}"
+
+# Fixtures are ASSEMBLED AT RUNTIME from halves that match nothing on their own.
+# Writing the literals out would leave credential-shaped strings in the repo, and
+# this scanner would then flag its own test suite on every future push forever.
+# The value below is synthetic — randomly composed to fit the detector's shape,
+# never a live credential.
+_K1='AKIA'; _K2='3QZ7YB2LKWVNPCJD'; KEY="${_K1}${_K2}"
+_P1='-----BEGIN '; _P2='RSA PRIVATE KEY'; _P3='-----'
+PEM_BEGIN="${_P1}${_P2}${_P3}"; PEM_END="${_P3}END ${_P2}${_P3}"
+_S1='wJalrXUtnFEMI/K7MDENG'; _S2='/bPxRfiCYzQ9v2tKzXq'   # halves of a synthetic AWS secret
+
+command -v bun  >/dev/null || { echo "bun not found"; exit 2; }
+[ -f "$GSTACK/bin/gstack-redact-prepush" ] || { echo "gstack not at $GSTACK"; exit 2; }
+
+# --- stage both scanners next to a lib/ symlink so `../lib/redact-engine` resolves.
+STAGE="$WORK/stage"
+rm -rf "$STAGE"; mkdir -p "$STAGE/bin"
+ln -s "$GSTACK/lib" "$STAGE/lib"
+cp "$GSTACK/bin/gstack-redact-prepush" "$STAGE/bin/shipped.ts"
+cp "$HERE/gstack-redact-prepush.fixed.ts" "$STAGE/bin/fixed.ts"
+
+# Boundary fixtures must straddle the REAL window cut, so read it from the source.
+WINDOW=$(grep -oE 'const WINDOW_BYTES = [0-9]+ \* 1024' "$STAGE/bin/fixed.ts" \
+         | grep -oE '[0-9]+ \* 1024' | awk '{print $1*1024}')
+: "${WINDOW:=393216}"
+echo "window cut under test: $WINDOW bytes"
+
+mkrepo() { local d="$WORK/$1"; rm -rf "$d"; mkdir -p "$d"; cd "$d" || exit 1
+  git init -q .; git config user.email t@t.t; git config user.name t
+  git checkout -q -b probe; }
+
+# Drives a scanner through the real pre-push stdin contract for a NEW branch.
+run() { cd "$2" || exit 1; local sha; sha=$(git rev-parse HEAD)
+  printf 'refs/heads/probe %s refs/heads/probe %s\n' "$sha" "${3:-0000000000000000000000000000000000000000}" \
+    | bun "$STAGE/bin/$1.ts" 2>&1; echo "___EXIT:$?"; }
+
+verdict() { local out="$1" rc id
+  rc=$(printf '%s' "$out" | sed -n 's/^___EXIT:\(.*\)$/\1/p' | tail -1)
+  [ "$rc" = "0" ] && { echo "ALLOW"; return; }
+  id=$(printf '%s' "$out" | grep -oE 'HIGH  [a-z0-9._]+' | head -1 | awk '{print $2}')
+  if [ -n "$id" ]; then echo "BLOCK($id)"; else echo "BLOCK(unscannable)"; fi; }
+
+# --- 1: 2 MiB of innocuous data, zero credentials -----------------------------
+mkrepo s1; python3 -c "
+with open('d.json','w') as f:
+    f.write('{\n')
+    for i in range(60000): f.write('  \"ico%07d\": {\"n\": %d},\n' % (i, i*7919%999983))
+    f.write('  \"end\": 1\n}\n')"
+git add -A >/dev/null; git commit -qm big
+S1S=$(run shipped "$WORK/s1"); S1F=$(run fixed "$WORK/s1")
+
+# --- 2: small payload with a credential ---------------------------------------
+mkrepo s2; printf 'cfg = 1\naws_key = "%s"\n' "$KEY" > app.py
+git add -A >/dev/null; git commit -qm secret
+S2S=$(run shipped "$WORK/s2"); S2F=$(run fixed "$WORK/s2")
+
+# --- 3: credential buried in 3 MiB of noise -----------------------------------
+mkrepo s3; python3 -c "
+k='$KEY'
+with open('d.json','w') as f:
+    f.write('{\n')
+    for i in range(45000): f.write('  \"ico%07d\": {\"n\": %d},\n' % (i, i*7919%999983))
+    f.write('  \"aws_key\": \"%s\",\n' % k)
+    for i in range(45000): f.write('  \"jco%07d\": {\"n\": %d},\n' % (i, i*104729%999983))
+    f.write('  \"end\": 1\n}\n')"
+git add -A >/dev/null; git commit -qm buried
+S3S=$(run shipped "$WORK/s3"); S3F=$(run fixed "$WORK/s3")
+
+# --- 4: multi-line PEM key straddling the window cut --------------------------
+mkrepo s4; PEM_BEGIN="$PEM_BEGIN" PEM_END="$PEM_END" python3 -c "
+import base64, os
+W=$WINDOW; line='f'*40; n=(W-500)//41
+body='\n'.join(base64.b64encode(bytes((i*37+j)%256 for i in range(48))).decode() for j in range(25))
+with open('d.txt','w') as f:
+    for i in range(n): f.write(line+'\n')
+    f.write(os.environ['PEM_BEGIN']+'\n'+body+'\n'+os.environ['PEM_END']+'\n')
+    for i in range(2000): f.write('t'*40+'\n')"
+git add -A >/dev/null; git commit -qm pem
+S4S=$(run shipped "$WORK/s4"); S4F=$(run fixed "$WORK/s4")
+
+# --- 5: credential sitting exactly on the window cut --------------------------
+mkrepo s5; python3 -c "
+k='$KEY'; W=$WINDOW; line='f'*40; n=(W-60)//41
+with open('d.txt','w') as f:
+    for i in range(n): f.write(line+'\n')
+    f.write('aws_key = \"%s\"\n' % k)
+    for i in range(2000): f.write('t'*40+'\n')"
+git add -A >/dev/null; git commit -qm atcut
+S5S=$(run shipped "$WORK/s5"); S5F=$(run fixed "$WORK/s5")
+
+# --- 6: diff that cannot be computed at all -> both MUST fail closed ----------
+# The local sha is bogus, so no range resolves. (A bogus REMOTE sha would not test
+# this: the hook deliberately falls back to merge-base/empty-tree there, which
+# succeeds and scans MORE - correct behaviour, not a failure path.)
+mkrepo s6; echo hi > a.txt; git add -A >/dev/null; git commit -qm init
+run_badlocal() { cd "$2" || exit 1
+  printf 'refs/heads/probe deadbeefdeadbeefdeadbeefdeadbeefdeadbeef refs/heads/probe 0000000000000000000000000000000000000000\n' \
+    | bun "$STAGE/bin/$1.ts" 2>&1; echo "___EXIT:$?"; }
+S6S=$(run_badlocal shipped "$WORK/s6")
+S6F=$(run_badlocal fixed   "$WORK/s6")
+
+# --- 7: credential on a line whose own content starts with "++" ---------------
+# In the diff this renders as "+++ aws_key = …", which prefix-only parsing mistakes
+# for a file header and drops from the scan. Real shapes: a checked-in .patch/.diff
+# file, or C++ macro lines. The credential is REAL here, so ALLOW = a leak.
+mkrepo s7; printf 'harmless\n++ aws_key = "%s"\n' "$KEY" > notes.patch
+git add -A >/dev/null; git commit -qm plusplus
+S7S=$(run shipped "$WORK/s7"); S7F=$(run fixed "$WORK/s7")
+
+# --- 8: malformed stdin from git -> must fail closed, not skip silently -------
+run_malformed() { cd "$2" || exit 1
+  printf 'refs/heads/probe\n' | bun "$STAGE/bin/$1.ts" 2>&1; echo "___EXIT:$?"; }
+mkrepo s8; echo hi > a.txt; git add -A >/dev/null; git commit -qm init
+S8S=$(run_malformed shipped "$WORK/s8"); S8F=$(run_malformed fixed "$WORK/s8")
+
+# --- 9: the ONE HIGH pattern that legitimately spans lines, split by the cut ----
+# gcp.service_account is /("private_key"\s*:\s*"-----BEGIN …PRIVATE KEY-----)/ and
+# \s matches \n in JS regardless of the `s` flag, so this match CAN cross a line.
+# Put "private_key" immediately before the window cut and the BEGIN marker after it:
+# only the carried overlap can keep them in one scan.
+mkrepo s9; PEM_BEGIN="$PEM_BEGIN" python3 -c "
+import os
+W=$WINDOW; line='f'*40; n=(W-20)//41
+with open('sa.json','w') as f:
+    for i in range(n): f.write(line+'\n')
+    f.write('\"private_key\"\n')
+    f.write(': \"'+os.environ['PEM_BEGIN']+'\n')
+    for i in range(2000): f.write('t'*40+'\n')"
+git add -A >/dev/null; git commit -qm gcpsplit
+S9S=$(run shipped "$WORK/s9"); S9F=$(run fixed "$WORK/s9")
+
+# --- 10: a user's diff.external driver replaces the whole diff -----------------
+# git then emits no '+' lines at all, so an unhardened scanner reads an empty diff
+# and allows a push carrying a real credential. Config is repo-local here.
+mkrepo s10; printf 'cfg = 1\naws_key = "%s"\n' "$KEY" > app.py
+git add -A >/dev/null; git commit -qm extdiff
+git config diff.external /bin/echo
+S10S=$(run shipped "$WORK/s10"); S10F=$(run fixed "$WORK/s10")
+
+# --- 11: one very long minified line carrying a credential --------------------
+# A 2 MiB single-line bundle/JSON. Buffered whole it exceeds the engine's 1 MiB cap,
+# so the shipped hook reports input_too_large without ever reading the content.
+mkrepo s11; KEY="$KEY" python3 -c "
+import os
+k=os.environ['KEY']
+with open('bundle.min.js','w') as f:
+    f.write('var d={'+','.join('\"k%05d\":%d'%(i,i) for i in range(90000))+',\"aws_key\":\"'+k+'\"};')"
+git add -A >/dev/null; git commit -qm minified
+S11S=$(run shipped "$WORK/s11"); S11F=$(run fixed "$WORK/s11")
+
+# --- 12: push to a DIFFERENT remote than origin -------------------------------
+# git hands the hook the remote name in argv. Resolving the range against origin
+# regardless means: HEAD already equals origin/main -> range HEAD..HEAD -> empty
+# diff -> the whole tree ships to a brand-new remote unscanned.
+run_remote() { cd "$2" || exit 1; local sha; sha=$(git rev-parse HEAD)
+  printf 'refs/heads/main %s refs/heads/main 0000000000000000000000000000000000000000\n' "$sha" \
+    | bun "$STAGE/bin/$1.ts" publish https://example.invalid/publish.git 2>&1; echo "___EXIT:$?"; }
+mkrepo s12; git branch -m main 2>/dev/null || true
+printf 'cfg = 1\naws_key = "%s"\n' "$KEY" > app.py
+git add -A >/dev/null; git commit -qm seed
+git update-ref refs/remotes/origin/main HEAD          # HEAD == origin/main
+git remote add origin https://example.invalid/origin.git
+git remote add publish https://example.invalid/publish.git   # never fetched
+S12S=$(run_remote shipped "$WORK/s12"); S12F=$(run_remote fixed "$WORK/s12")
+
+# --- 13: 4 fields, valid local sha, junk REMOTE sha ---------------------------
+run_junkremote() { cd "$2" || exit 1; local sha; sha=$(git rev-parse HEAD)
+  printf 'refs/heads/main %s refs/heads/main not-a-sha\n' "$sha" \
+    | bun "$STAGE/bin/$1.ts" origin https://example.invalid/origin.git 2>&1; echo "___EXIT:$?"; }
+S13S=$(run_junkremote shipped "$WORK/s12"); S13F=$(run_junkremote fixed "$WORK/s12")
+
+FAILURES=0
+row() { # $1=label  $2=shipped raw  $3=fixed raw  $4=EXPECTED fixed verdict
+  local got; got=$(verdict "$3")
+  local mark="ok"
+  if [ "$got" != "$4" ]; then mark="FAIL (expected $4)"; FAILURES=$((FAILURES+1)); fi
+  printf '%-40s %-31s %-31s %s\n' "$1" "$(verdict "$2")" "$got" "$mark"
+}
+
+# --- 14: zero-width padding between a proximity label and its secret ----------
+# aws.secret_key only fires when its label is within nearWindow=100 NORMALIZED chars.
+# The engine strips zero-width characters, so 200k of them are ~600 KB of raw input
+# that normalizes to nothing. Measuring the window tail in bytes would flush between
+# label and secret and lose the context; stripping on ingest keeps them adjacent.
+mkrepo s14; SEC="${_S1}${_S2}" python3 -c "
+import os
+zw='​'*200000
+with open('conf.txt','w') as f:
+    f.write('aws_secret_access_key =\n')
+    f.write(zw+'\n')
+    f.write('\"'+os.environ['SEC']+'\"\n')"
+git add -A >/dev/null; git commit -qm zerowidth
+S14S=$(run shipped "$WORK/s14"); S14F=$(run fixed "$WORK/s14")
+
+# --- 15: localSha="0" is NOT a branch delete ----------------------------------
+# /^0+$/ accepts a single "0", so a malformed line was read as a delete and skipped:
+# exit 0 with nothing scanned. A real delete uses a full-width all-zero OID.
+run_shortzero() { cd "$2" || exit 1
+  printf 'refs/heads/probe 0 refs/heads/probe 0000000000000000000000000000000000000000\n' \
+    | bun "$STAGE/bin/$1.ts" origin url 2>&1; echo "___EXIT:$?"; }
+S15S=$(run_shortzero shipped "$WORK/s2"); S15F=$(run_shortzero fixed "$WORK/s2")
+
+printf '\n%-40s %-31s %-31s %s\n' "SCENARIO" "SHIPPED" "FIXED (streaming)" "GATE"
+printf -- '-%.0s' {1..118}; printf '\n'
+row "1 clean 2 MiB, no credential"      "$S1S"  "$S1F"  "ALLOW"
+row "2 small + AWS key"                 "$S2S"  "$S2F"  "BLOCK(aws.access_key)"
+row "3 AWS key buried in 3 MiB"         "$S3S"  "$S3F"  "BLOCK(aws.access_key)"
+row "4 PEM straddling window cut"       "$S4S"  "$S4F"  "BLOCK(pem.private_key)"
+row "5 AWS key exactly at window cut"   "$S5S"  "$S5F"  "BLOCK(aws.access_key)"
+row "6 unreadable range (fail-closed)"  "$S6S"  "$S6F"  "BLOCK(unscannable)"
+row "7 credential on a '++…' line"      "$S7S"  "$S7F"  "BLOCK(aws.access_key)"
+row "8 malformed stdin (fail-closed)"   "$S8S"  "$S8F"  "BLOCK(unscannable)"
+row "9 gcp key spanning the window cut" "$S9S"  "$S9F"  "BLOCK(pem.private_key)"
+row "10 diff.external set + real key"   "$S10S" "$S10F" "BLOCK(aws.access_key)"
+row "11 credential in a 2 MiB one-liner" "$S11S" "$S11F" "BLOCK(aws.access_key)"
+row "12 push to a non-origin remote"    "$S12S" "$S12F" "BLOCK(aws.access_key)"
+row "13 junk REMOTE sha"                "$S13S" "$S13F" "BLOCK(unscannable)"
+row "14 zero-width padding at the seam"  "$S14S" "$S14F" "BLOCK(aws.secret_key)"
+row "15 localSha=\"0\" is not a delete"   "$S15S" "$S15F" "BLOCK(unscannable)"
+
+echo
+echo "Rows 2,4,5,6,9 must agree between the two columns: no detection regression."
+echo "Row 1 shipped=BLOCK(engine.input_too_large) is the false positive the fix removes."
+echo "Row 3 shipped blocks WITHOUT having scanned; fixed names the real finding."
+echo "Rows 7,8,10,12,13 are FAIL-OPEN holes in the shipped hook - it exits 0 while"
+echo "a real credential goes out. Row 11 is scanned for real instead of refused."
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "GATE: PASS (15/15)"
+else
+  echo "GATE: FAIL ($FAILURES scenario(s) did not match)"
+fi
+echo
+echo "--- the message the fixed scanner emits when it genuinely cannot scan (row 6):"
+printf '%s\n' "$S6F" | grep -v '^___EXIT' | sed 's/^/    /'
+echo
+echo "workdir: $WORK"
+
+# Exit non-zero on any scenario mismatch so this is a gate, not a printout.
+exit $(( FAILURES > 0 ? 1 : 0 ))


### PR DESCRIPTION
The pre-push credential scanner can be made to allow a push that carries a live key. Six separate paths, same outcome: `exit 0`, nothing scanned, secret on the remote.

| # | trigger | shipped | fixed |
|---|---|---|---|
| 1 | credential on a line whose **content** starts with `++` | ALLOW | BLOCK |
| 2 | malformed stdin (unparseable ref update) | ALLOW | BLOCK(unscannable) |
| 3 | `diff.external` set | ALLOW | BLOCK |
| 4 | push to a remote other than `origin` | ALLOW | BLOCK |
| 5 | junk remote sha | ALLOW | BLOCK(unscannable) |
| 6 | `localSha="0"` read as a branch delete | ALLOW | BLOCK(unscannable) |

**#1** is the one I'd fix first even alone: added lines are filtered with `!line.startsWith("+++")`, which is meant to drop the `+++ b/file` header — but a genuine added line whose content begins with `++` renders as `+++…` too. A committed `.patch`/`.diff` carrying a key sails through unscanned.

**#3** needs no attacker: `diff.external` is ordinary user config. With it set, `git diff` emits no `+` lines, the scanner reads an empty diff, and everything is allowed. Silently.

## The false positive that teaches the bypass

Over the engine's 1 MiB cap the hook reports `engine.input_too_large` as HIGH and tells the user to **"Rotate the credential (a pushed secret is compromised)"** — for content it never scanned. On one machine that produced five entries in `~/.gstack/security/prepush-skip.jsonl`, including *"0 HIGH at 1.33 MB"* and *"synthetic credential-scrubbing fixture"*. None held a credential.

That matters beyond ergonomics: a gate that cries wolf trains its user to reach for `GSTACK_REDACT_PREPUSH=skip`, and the habit is then applied to the push where the gate was right. The fix scans in windows so large-but-clean input passes, and reserves blocking for content that genuinely could not be read.

## Fail-closed is preserved

An unreadable range still blocks (#1946 stands). What changed is the message: instead of `died of signal 9` with no explanation, it names the range, the reason, how many MB were read, and the concrete next step.

## Verification

`test/redact-prepush-fail-open-verify.sh` — 15 scenarios, each run against **both** the shipped and the fixed scanner, asserting an expected verdict per row and exiting non-zero on mismatch. Rows 2, 4, 5, 6, 9, 14 must agree between the two columns: that is the no-detection-regression check, including credentials straddling the window cut.

```
GATE: PASS (15/15)
```

I verified this independently of the change's author, against `bin/gstack-redact-prepush` and `lib/redact-engine.ts` that are **byte-identical** (sha256 `5c06f7de…` / `c1f5df32…`) to current `main` at v1.61.0.0, so the result applies to this base.

## Relationship to open PRs

Disjoint from #2398 (pushed range vs whole repo), #2328 (path-ignore) and #2358 (chained `pre-push.local` stdin newline) — I diffed all three and none touches these six paths. #2328 is motivated by the same false positive from the other direction; #2358 is a seventh fail-open path in the wrapper that this PR does not address.

Happy to rebase behind any of them if you'd rather land those first.
