### PR TITLE
fix(make-pdf): three bugs that break browse resolution and temp-file writes

### DIFF
--- a/make-pdf/src/browseClient.ts
+++ b/make-pdf/src/browseClient.ts
@@ -158,6 +158,12 @@ export function resolveBrowseBin(env: NodeJS.ProcessEnv = process.env): string {
 
 function isExecutable(p: string): boolean {
   try {
+    // Directories carry the execute (traverse) bit, so an X_OK check alone
+    // matches them. ./setup creates a skill directory at ~/.claude/skills/browse
+    // (holding a SKILL.md symlink), which the `../browse` sibling candidate
+    // resolves to — so without an isFile() guard we "find" a directory and
+    // every subsequent browse call fails with EACCES.
+    if (!fs.statSync(p).isFile()) return false;
     fs.accessSync(p, fs.constants.X_OK);
     return true;
   } catch {

--- a/make-pdf/src/browseClient.ts
+++ b/make-pdf/src/browseClient.ts
@@ -196,16 +196,18 @@ function runBrowse(args: string[]): string {
 }
 
 /**
- * Write a payload to a tmp file and return the path. Used for any payload
- * >4KB to avoid Windows argv limits (Codex round 2 #3).
+ * Temp dir for any file handed to browse (payloads, rendered HTML, PDF output).
  *
  * Path must be under the browse safe-dirs allowlist (/tmp or cwd on
  * non-Windows; os.tmpdir on Windows).  v1.6.0.0 tightened --from-file
  * validation to close a CLI/API parity gap (PR #1103), so os.tmpdir()
  * on macOS (/var/folders/...) now fails validateReadPath.  Use the same
  * TEMP_DIR convention as browse/src/platform.ts.
+ *
+ * Exported because orchestrator.ts and setup.ts write files that browse must
+ * read back; os.tmpdir() there trips the same validateReadPath rejection.
  */
-const PAYLOAD_TMP_DIR = process.platform === "win32" ? os.tmpdir() : "/tmp";
+export const PAYLOAD_TMP_DIR = process.platform === "win32" ? os.tmpdir() : "/tmp";
 
 function writePayloadFile(payload: Record<string, unknown>): string {
   const hash = crypto.createHash("sha256")

--- a/make-pdf/src/orchestrator.ts
+++ b/make-pdf/src/orchestrator.ts
@@ -15,7 +15,6 @@
  */
 
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
 import { spawn } from "node:child_process";
@@ -86,7 +85,7 @@ export async function generate(opts: GenerateOptions): Promise<string> {
 
   const to = opts.to ?? "pdf";
   const outputPath = path.resolve(
-    opts.output ?? path.join(os.tmpdir(), `${deriveSlug(input)}.${to}`),
+    opts.output ?? path.join(browseClient.PAYLOAD_TMP_DIR, `${deriveSlug(input)}.${to}`),
   );
 
   // Stage 1: read markdown
@@ -358,7 +357,7 @@ export async function preview(opts: PreviewOptions): Promise<string> {
   progress.end("Rendering HTML", `${rendered.meta.wordCount} words`);
 
   // Write to a stable path under /tmp so the user can reload in the same tab.
-  const previewPath = path.join(os.tmpdir(), `make-pdf-preview-${deriveSlug(input)}.html`);
+  const previewPath = path.join(browseClient.PAYLOAD_TMP_DIR, `make-pdf-preview-${deriveSlug(input)}.html`);
   fs.writeFileSync(previewPath, rendered.html, "utf8");
 
   progress.begin("Opening preview");
@@ -378,7 +377,7 @@ function deriveSlug(p: string): string {
 
 function tmpFile(ext: string): string {
   const hash = crypto.randomBytes(6).toString("hex");
-  return path.join(os.tmpdir(), `make-pdf-${process.pid}-${hash}.${ext}`);
+  return path.join(browseClient.PAYLOAD_TMP_DIR, `make-pdf-${process.pid}-${hash}.${ext}`);
 }
 
 function tryOpen(pathOrUrl: string): void {

--- a/make-pdf/src/setup.ts
+++ b/make-pdf/src/setup.ts
@@ -10,7 +10,6 @@
  *   6. Print a 3-command cheatsheet
  */
 
-import * as os from "node:os";
 import * as path from "node:path";
 import * as fs from "node:fs";
 
@@ -77,8 +76,8 @@ export async function runSetup(): Promise<void> {
     "The second paragraph contains curly quotes (\"hello\"), an em dash -- like this, and an ellipsis... all of which should render correctly.",
     "",
   ].join("\n");
-  const fixturePath = path.join(os.tmpdir(), `make-pdf-smoke-${process.pid}.md`);
-  const outPath = path.join(os.tmpdir(), `make-pdf-smoke-${process.pid}.pdf`);
+  const fixturePath = path.join(browseClient.PAYLOAD_TMP_DIR, `make-pdf-smoke-${process.pid}.md`);
+  const outPath = path.join(browseClient.PAYLOAD_TMP_DIR, `make-pdf-smoke-${process.pid}.pdf`);
   fs.writeFileSync(fixturePath, fixture, "utf8");
 
   try {

--- a/make-pdf/src/setup.ts
+++ b/make-pdf/src/setup.ts
@@ -3,7 +3,7 @@
  *
  * Flow (per the CEO plan CLI UX spec):
  *   1. Verify browse binary exists and responds
- *   2. Verify Chromium launches via $B goto about:blank
+ *   2. Verify Chromium launches by opening a blank file: page
  *   3. Verify pdftotext is installed (warn, don't fail)
  *   4. Generate a smoke-test PDF from an inline 2-paragraph fixture
  *   5. Open it
@@ -31,11 +31,16 @@ export async function runSetup(): Promise<void> {
     process.exit(4);
   }
 
-  // 2. Chromium smoke (navigate a dedicated tab to about:blank)
+  // 2. Chromium smoke (navigate a dedicated tab to a throwaway blank page)
   process.stderr.write("  [2/5] Launching Chromium...");
   let chromiumTab: number | null = null;
+  // browse only permits http:, https: and file: URLs, and confines file: paths
+  // to the safe-dirs allowlist, so "about:blank" is rejected on both counts.
+  // A blank file: page under PAYLOAD_TMP_DIR is the network-free equivalent.
+  const smokePage = path.join(browseClient.PAYLOAD_TMP_DIR, `make-pdf-smoke-${process.pid}.html`);
   try {
-    chromiumTab = browseClient.newtab("about:blank");
+    fs.writeFileSync(smokePage, "<!doctype html><title>make-pdf smoke</title>");
+    chromiumTab = browseClient.newtab(`file://${smokePage}`);
     process.stderr.write(` OK (tab ${chromiumTab})\n`);
   } catch (err: any) {
     process.stderr.write(" FAIL\n");
@@ -47,6 +52,7 @@ export async function runSetup(): Promise<void> {
     if (chromiumTab !== null) {
       try { browseClient.closetab(chromiumTab); } catch { /* ignore */ }
     }
+    try { fs.unlinkSync(smokePage); } catch { /* best-effort cleanup */ }
   }
 
   // 3. pdftotext (optional — CI gate only)


### PR DESCRIPTION
## Summary

`make-pdf` is unusable on a stock global install: `$P setup` fails at step 1 or 2 and `$P generate` fails at the write stage. Three independent bugs, each with a one-line-ish fix. All three still reproduce on `main` at v1.61.0.0.

Found while using make-pdf for real work (a multi-page letter), per the CONTRIBUTING "fix gstack while doing your real work" flow.

## The bugs

**1. `isExecutable()` resolves a directory as the browse binary**

`resolveBrowseBin()` tries `path.resolve(selfDir, "../browse")` as a sibling candidate. `./setup` creates a skill *directory* at `~/.claude/skills/browse` (holding a `SKILL.md` symlink). `isExecutable()` only called `fs.accessSync(p, X_OK)`, which succeeds on directories because they carry the traverse bit:

```
path:                /Users/me/.claude/skills/browse
exists:              true
accessSync(X_OK)  -> true    <- old isExecutable() said this IS the binary
statSync().isFile -> false   <- new guard correctly rejects it
```

So make-pdf "found" a directory and every later browse call died:

```
[1/5] Checking browse binary... OK (/Users/me/.claude/skills/browse)
[2/5] Launching Chromium... FAIL
```

Fix: guard with `statSync(p).isFile()`.

**2. Temp files land outside browse's safe-dirs allowlist**

`browseClient.ts` already documents this exactly, and already introduced `PAYLOAD_TMP_DIR` to solve it:

> v1.6.0.0 tightened `--from-file` validation to close a CLI/API parity gap (PR #1103), so `os.tmpdir()` on macOS (`/var/folders/...`) now fails `validateReadPath`.

But only `writePayloadFile()` ever used the constant. `orchestrator.ts` (default output, preview HTML, `tmpFile()`) and `setup.ts` (smoke fixture + output) still used `os.tmpdir()`, so browse rejects them:

```
[4/5] Generating smoke-test PDF...
      FAILED: browse pdf exited 1: Path must be within: /private/tmp, ...
```

Fix: export `PAYLOAD_TMP_DIR`, use it at those five sites. Side benefit: the default output path now matches what `SKILL.md` already documents (`$P generate letter.md` → `/tmp/letter.pdf`).

**3. Chromium smoke test uses a blocked URL scheme**

browse permits only `http:`, `https:`, `file:`. `setup.ts` opened `about:blank`:

```
[2/5] Launching Chromium... FAIL
Chromium failed to launch: browse newtab exited 1:
  Blocked: scheme "about:" is not allowed.
```

Fix: write a one-line blank HTML file under `PAYLOAD_TMP_DIR` and open that. Network-free, cleaned up in the existing `finally`.

## Verification

`bun test make-pdf/test/` → **185 pass, 0 fail**.

Built the branch and ran the flow that was broken:

```
[1/5] Checking browse binary... OK (.../gstack/browse/dist/browse)
[2/5] Launching Chromium... OK (tab 2)
[3/5] Checking pdftotext (optional)... OK
[4/5] Generating smoke-test PDF...
      PASSED.
[5/5] All checks passed.
```

Also rendered a real 2,212-word / 8-page document end to end.

## Notes

- Three commits, one per bug, so they can be taken or dropped independently.
- No VERSION bump or CHANGELOG entry: those are branch-scoped to your ship flow and would conflict across PRs. Happy to add one if you'd rather.
- Not fixed here, flagged only: `diagram-prepass.ts:294` now declares its own duplicate `PAYLOAD_TMP_DIR`. Worth collapsing onto the exported one, but that felt like separate scope.
- Found on macOS 27.0 (arm64), Bun 1.3.14. Bugs 1 and 3 are platform-independent; bug 2 is macOS-specific, since `os.tmpdir()` only diverges from `/tmp` there.
