### PR TITLE
fix(config): make key validation locale-independent

### DIFF
--- a/bin/gstack-config
+++ b/bin/gstack-config
@@ -264,7 +264,7 @@ case "${1:-}" in
     # endpoint-namespaced keys introduced by the brain-aware planning layer).
     # Endpoint ids are sha8/sha16 hex for remote MCP URLs, or the literal
     # "local" for stdio/PGLite engines (see endpoint_hash).
-    if ! printf '%s' "$KEY" | grep -qE '^[a-zA-Z0-9_]+(@[a-zA-Z0-9]+)?$'; then
+    if ! printf '%s' "$KEY" | LC_ALL=C grep -qE '^[a-zA-Z0-9_]+(@[a-zA-Z0-9]+)?$'; then
       echo "Error: key must contain only alphanumeric characters, underscores, and an optional @<endpoint-id> suffix" >&2
       exit 1
     fi
@@ -280,7 +280,7 @@ case "${1:-}" in
     VALUE="${3:?Usage: gstack-config set <key> <value>}"
     # Validate key (alphanumeric + underscore + optional @<endpoint-id> suffix).
     # Accepts hex hashes and the literal "local" from endpoint_hash.
-    if ! printf '%s' "$KEY" | grep -qE '^[a-zA-Z0-9_]+(@[a-zA-Z0-9]+)?$'; then
+    if ! printf '%s' "$KEY" | LC_ALL=C grep -qE '^[a-zA-Z0-9_]+(@[a-zA-Z0-9]+)?$'; then
       echo "Error: key must contain only alphanumeric characters, underscores, and an optional @<endpoint-id> suffix" >&2
       exit 1
     fi

--- a/test/gstack-config-key-locale.test.ts
+++ b/test/gstack-config-key-locale.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Locale-independent key validation tests for bin/gstack-config.
+ *
+ * POSIX bracket ranges such as a-z follow the active collation order. Under
+ * GNU grep with tr_TR.UTF-8, that excludes the ASCII letter i and silently
+ * breaks most stored preferences. macOS BSD grep does not reproduce the bug,
+ * so the source-level tripwire pins the C-locale boundary on every platform.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+const CONFIG = path.join(ROOT, "bin", "gstack-config");
+
+let stateRoot: string;
+
+function run(args: string[]) {
+  const result = spawnSync(CONFIG, args, {
+    encoding: "utf8",
+    env: { ...process.env, GSTACK_STATE_ROOT: stateRoot },
+  });
+
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+beforeEach(() => {
+  stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gstack-config-locale-"));
+});
+
+afterEach(() => {
+  fs.rmSync(stateRoot, { recursive: true, force: true });
+});
+
+describe("gstack-config key validation is locale-independent", () => {
+  test("both get and set validate ASCII ranges under the C locale", () => {
+    const source = fs.readFileSync(CONFIG, "utf8");
+    const guardedValidators = source.match(
+      /LC_ALL=C grep -qE '\^\[a-zA-Z0-9_\]\+\(@\[a-zA-Z0-9\]\+\)\?\$'/g,
+    );
+
+    expect(guardedValidators).toHaveLength(2);
+  });
+
+  test("round-trips existing keys that contain i", () => {
+    expect(run(["set", "skill_prefix", "true"]).status).toBe(0);
+
+    const get = run(["get", "skill_prefix"]);
+    expect(get.status).toBe(0);
+    expect(get.stdout).toBe("true");
+  });
+
+  test("accepts an existing endpoint-scoped ASCII key", () => {
+    expect(run(["set", "brain_trust_policy@local", "personal"]).status).toBe(0);
+
+    const get = run(["get", "brain_trust_policy@local"]);
+    expect(get.status).toBe(0);
+    expect(get.stdout).toBe("personal");
+  });
+
+  test("continues to reject non-ASCII keys", () => {
+    const set = run(["set", "skïll_prefix", "true"]);
+    expect(set.status).toBe(1);
+    expect(set.stderr).toContain("key must contain only alphanumeric characters");
+
+    const get = run(["get", "skïll_prefix"]);
+    expect(get.status).toBe(1);
+    expect(get.stderr).toContain("key must contain only alphanumeric characters");
+  });
+});


### PR DESCRIPTION
## Summary

- pin both gstack-config key validators to the C locale
- preserve the strict ASCII key contract instead of widening it with a locale-aware character class
- add a cross-platform regression tripwire plus get/set behavior coverage

Fixes #2494

## Why

POSIX bracket ranges follow locale collation. With GNU grep under tr_TR.UTF-8, the ASCII letter i can fall outside [a-z], so valid config keys are rejected and skill preambles silently fall back to their defaults.

## Tests

- fail-first: the new regression test failed on main because neither validator pinned LC_ALL
- `bun test test/gstack-config-key-locale.test.ts test/user-slug-fallback.test.ts test/docs-config-keys.test.ts test/explain-level-config.test.ts test/gstack-config-redact-keys.test.ts` — 35 pass, 0 fail
- `bash -n bin/gstack-config`
- `git diff --check`

## Full-suite note

I also attempted `bun test`, but it did not complete cleanly in my multi-repository macOS workspace: unrelated existing suites timed out or depended on unavailable local services and fixture assumptions (including global discovery, gbrain fixtures, and local server binding). The focused config suite above is green.
