### PR TITLE
feat(hosts): add support for pi coding agent host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bin/gstack-global-discover*
 .cursor/
 .openclaw/
 .hermes/
+.pi/
 .gbrain/
 .gbrain-source
 .context/

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These are conversational skills. Your OpenClaw agent runs them directly via chat
 
 ### Other AI Agents
 
-gstack works on 10 AI coding agents, not just Claude. Setup auto-detects which
+gstack works on 11 AI coding agents, not just Claude. Setup auto-detects which
 agents you have installed:
 
 ```bash
@@ -120,6 +120,7 @@ Or target a specific agent with `./setup --host <name>`:
 | Slate | `--host slate` | `~/.slate/skills/gstack-*/` |
 | Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |
 | Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |
+| Pi | `--host pi` | `~/.pi/agent/skills/gstack-*/` |
 | GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |
 
 **Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).

--- a/docs/ADDING_A_HOST.md
+++ b/docs/ADDING_A_HOST.md
@@ -1,7 +1,7 @@
 # Adding a New Host to gstack
 
 gstack uses a declarative host config system. Each supported AI coding agent
-(Claude, Codex, Factory, Kiro, OpenCode, Slate, Cursor, OpenClaw) is defined
+(Claude, Codex, Factory, Kiro, OpenCode, Slate, Cursor, OpenClaw, Pi) is defined
 as a typed TypeScript config object. Adding a new host means creating one file
 and re-exporting it. Zero code changes to the generator, setup, or tooling.
 
@@ -17,6 +17,7 @@ hosts/
 ├── slate.ts         # Slate (Random Labs)
 ├── cursor.ts        # Cursor
 ├── openclaw.ts      # OpenClaw (hybrid: config + adapter)
+├── pi.ts            # Pi CLI
 └── index.ts         # Registry: imports all, derives Host type
 ```
 

--- a/docs/PI.md
+++ b/docs/PI.md
@@ -1,0 +1,89 @@
+# Pi integration
+
+[gstack](../README.md) supports [Pi](https://pi.dev) as a native host. Pi keeps
+its core CLI intentionally small and does not include sub-agents, so the Pi
+integration uses the [`pi-subagents`](https://pi.dev/packages/pi-subagents)
+package for delegation.
+
+## Install
+
+Run the normal setup command with the Pi host selected:
+
+```bash
+./setup --host pi
+```
+
+If Pi is installed and you use automatic host detection, this also works:
+
+```bash
+./setup --host auto
+```
+
+Setup installs the package at user scope when it is missing:
+
+```bash
+pi install npm:pi-subagents
+```
+
+The package provides the `subagent` and `subagent_wait` tools, the builtin
+`reviewer`, `worker`, `scout`, `researcher`, `delegate`, and `oracle` agents,
+and the `workflowScript` API for sequential and parallel workflows. Review the
+package source before installing it because Pi packages run with full system
+access.
+
+## What setup installs
+
+- Generated Pi skills under `~/.pi/agent/skills/gstack-*`.
+- A small runtime root at `~/.pi/agent/skills/gstack` containing gstack's
+  binaries and runtime assets.
+- The `pi-subagents` package in Pi's global package settings.
+
+Pi skill files are generated from the same `.tmpl` sources as the other hosts,
+but their frontmatter and paths are rewritten for Pi. Delegation sections stay
+enabled and refer to `pi-subagents` workflows instead of Claude Code's Agent
+tool.
+
+## Updating
+
+Run setup again after pulling a gstack update:
+
+```bash
+cd /path/to/gstack
+./setup --host pi
+```
+
+Update the Pi package separately when desired:
+
+```bash
+pi update npm:pi-subagents
+```
+
+Use `pi list` to confirm that the package is installed. If it is missing, run
+`pi install npm:pi-subagents` and restart Pi (or use `/reload`).
+
+## Troubleshooting
+
+### `subagent` is unavailable
+
+Install the package at user scope and restart Pi:
+
+```bash
+pi install npm:pi-subagents
+pi list
+```
+
+If the package appears in `pi list` but the tool is still unavailable, run
+`/subagents-doctor` inside Pi and then `/reload`.
+
+### Skills are stale
+
+Regenerate the Pi output from the gstack checkout and rerun setup:
+
+```bash
+bun run gen:skill-docs --host pi
+./setup --host pi
+```
+
+Pi skills are generated into `.pi/skills/` in the checkout and copied or linked
+to the user skill directory by setup. The generated `.pi/` directory is
+runtime output and is intentionally gitignored.

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,10 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import pi, { PI_SUBAGENTS_PACKAGE, PI_SUBAGENT_ROLES } from './pi';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, pi];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +66,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, pi, PI_SUBAGENTS_PACKAGE, PI_SUBAGENT_ROLES };

--- a/hosts/pi.ts
+++ b/hosts/pi.ts
@@ -1,0 +1,142 @@
+import type { HostConfig } from '../scripts/host-config';
+
+/** Pi package installed by setup to provide the `subagent` tool and builtin agents. */
+export const PI_SUBAGENTS_PACKAGE = 'npm:pi-subagents';
+
+/** Role mapping used by generated Pi delegation instructions. */
+export const PI_SUBAGENT_ROLES = {
+  review: 'reviewer',
+  implementation: 'worker',
+  reconnaissance: 'scout',
+  secondOpinion: 'oracle',
+  general: 'delegate',
+} as const;
+
+function piSingleWorkflow(agent: string, key = 'main'): string {
+  return `Call the \`subagent\` tool with this input: {"workflowScript":"return runs.run('${key}', { agent: '${agent}', context: 'fresh', task: '<task>' })","async":false}.`;
+}
+
+function piParallelWorkflow(agent: string): string {
+  return `Call the \`subagent\` tool with this input: {"workflowScript":"const [first, second] = await runs.all([{ key: 'first', agent: '${agent}', task: '<first task>' }, { key: 'second', agent: '${agent}', task: '<second task>' }]); return [first.output, second.output]","async":false}. Add one runs.all item for each selected task and return the collected outputs.`;
+}
+
+const pi: HostConfig = {
+  name: 'pi',
+  displayName: 'Pi',
+  cliCommand: 'pi',
+  cliAliases: [],
+
+  globalRoot: '.pi/agent/skills/gstack',
+  localSkillRoot: '.pi/skills/gstack',
+  hostSubdir: '.pi',
+  usesEnvVars: true,
+
+  frontmatter: {
+    mode: 'allowlist',
+    keepFields: ['name', 'description'],
+    descriptionLimit: 1024,
+  },
+
+  generation: {
+    generateMetadata: false,
+    skipSkills: ['codex'],
+  },
+
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.pi/agent/skills/gstack' },
+    { from: '~/.claude/skills', to: '~/.pi/agent/skills' },
+    { from: '$HOME/.claude/skills/gstack', to: '$HOME/.pi/agent/skills/gstack' },
+    { from: '$HOME/.claude/skills', to: '$HOME/.pi/agent/skills' },
+    { from: '.claude/skills/gstack', to: '.pi/skills/gstack' },
+    { from: '.claude/skills', to: '.pi/skills' },
+    // Pi uses AGENTS.md for project instructions.
+    { from: 'CLAUDE.md', to: 'AGENTS.md' },
+    // Identity rewrites keep generated instructions host-neutral.
+    { from: 'Claude Code', to: 'Pi' },
+    { from: 'claude code', to: 'Pi' },
+    { from: 'this Pi window', to: 'this Pi session' },
+  ],
+
+  toolRewrites: {
+    'AskUserQuestion': 'ask the user in chat',
+    'WebSearch': 'web search (if available)',
+    'use the Bash tool': 'use the bash tool',
+    'use the Write tool': 'use the write tool',
+    'use the Read tool': 'use the read tool',
+    'use the Edit tool': 'use the edit tool',
+    'use the Grep tool': 'use the grep tool',
+    'use the Glob tool': 'use the find tool',
+    'the Bash tool': 'the bash tool',
+    'the Read tool': 'the read tool',
+    'the Write tool': 'the write tool',
+    'the Edit tool': 'the edit tool',
+    'the Grep tool': 'the grep tool',
+    'the Glob tool': 'the find tool',
+
+    // pi-subagents exposes a workflowScript API rather than Claude's Agent
+    // tool. Handle the complete high-value instructions before the generic
+    // replacements below so the generated prose retains its intent.
+    '**Launch N Agent subagents in a single message** (parallel execution). Use the Agent\ntool with `subagent_type: "general-purpose"` for each variant. Each agent is independent\nand handles its own generation, quality check, verification, and retry.': `**Launch N child agents in one workflowScript** (parallel execution). ${piParallelWorkflow(PI_SUBAGENT_ROLES.general)} Each child is independent and handles its own generation, quality check, verification, and retry.`,
+    '**Dispatch this step as a subagent** using the Agent tool with `subagent_type: "general-purpose"`.': `**Dispatch this step with the subagent tool.** ${piSingleWorkflow(PI_SUBAGENT_ROLES.review)}`,
+    '**Dispatch the fetch + classification as a subagent** using the Agent tool with `subagent_type: "general-purpose"`.': `**Dispatch the fetch + classification with the subagent tool.** ${piSingleWorkflow(PI_SUBAGENT_ROLES.reconnaissance)}`,
+    '**Dispatch /document-release as a subagent** using the Agent tool with `subagent_type: "general-purpose"`.': `**Dispatch /document-release with the subagent tool.** ${piSingleWorkflow(PI_SUBAGENT_ROLES.implementation)}`,
+    'For each selected specialist, launch an independent subagent via the Agent tool.\n**Launch ALL selected specialists in a single message** (multiple Agent tool calls)\nso they run in parallel. Each subagent has fresh context — no prior review bias.': `For each selected specialist, add a fresh reviewer child to one workflowScript. ${piParallelWorkflow(PI_SUBAGENT_ROLES.review)} Each child has fresh context — no prior review bias.`,
+    'If activated, dispatch one more subagent via the Agent tool (foreground, not background).': `If activated, run one more reviewer child in a foreground workflow. ${piSingleWorkflow(PI_SUBAGENT_ROLES.review, 'red-team')}`,
+    'For each candidate finding, launch an independent verification sub-task using the Agent tool. The verifier has fresh context and cannot see the initial scan\'s reasoning — only the finding itself and the FP filtering rules.': `For each candidate finding, add an independent reviewer child to a workflowScript. ${piParallelWorkflow(PI_SUBAGENT_ROLES.review)} Each verifier has fresh context and cannot see the initial scan's reasoning — only the finding itself and the FP filtering rules.`,
+    'Launch all verifiers in parallel.': `Use a workflowScript with runs.all([...]) to launch all verifiers in parallel. ${piParallelWorkflow(PI_SUBAGENT_ROLES.review)}`,
+    'Use the Agent tool to dispatch an independent reviewer. The reviewer has fresh context': `Use the subagent tool with a workflowScript. ${piSingleWorkflow(PI_SUBAGENT_ROLES.review)} The reviewer child has fresh context`,
+    '**If CODEX_NOT_AVAILABLE (or Codex errored):**\n\nDispatch via the Agent tool. The subagent has fresh context — genuine independence.': `**If CODEX_NOT_AVAILABLE (or Codex errored):**\n\nUse the \`subagent\` tool with a workflowScript. ${piSingleWorkflow(PI_SUBAGENT_ROLES.secondOpinion)} The oracle child has fresh context — genuine independence.`,
+    'Dispatch via the Agent tool. The subagent has fresh context': `Use the \`subagent\` tool with a workflowScript. ${piSingleWorkflow(PI_SUBAGENT_ROLES.review)} The reviewer child has fresh context`,
+    'Dispatch via the Agent tool with the same prompt.': `Use the \`subagent\` tool with a workflowScript. ${piSingleWorkflow(PI_SUBAGENT_ROLES.review)} Pass it the same prompt and bound it at a 5-minute timeout.`,
+    'Dispatch via the Agent tool.': `Use the \`subagent\` tool with a workflowScript. ${piSingleWorkflow(PI_SUBAGENT_ROLES.review)} `,
+
+    // The autoplan and design templates describe the Agent tool in several
+    // shorter forms. Keep those instructions, but point them at Pi's API.
+    'via Agent tool': `via the \`subagent\` tool. ${piSingleWorkflow(PI_SUBAGENT_ROLES.review)}`,
+    'foreground Agent tool': 'foreground `subagent` workflow (`async: false`)',
+    'Agent tool,': '`subagent` tool with a `workflowScript`,',
+    'Agent tool)': '`subagent` tool with a `workflowScript`)',
+    'Claude subagent': 'Pi reviewer subagent',
+    'Claude adversarial subagent': 'Pi adversarial reviewer subagent',
+    'Claude design subagent': 'Pi design reviewer subagent',
+    'Claude CEO subagent': 'Pi CEO reviewer subagent',
+    'Claude eng subagent': 'Pi eng reviewer subagent',
+    'Claude DX subagent': 'Pi DX reviewer subagent',
+    'Claude-only': 'Pi-only',
+    'Claude ': 'Pi ',
+    'CLAUDE SUBAGENT': 'PI REVIEWER SUBAGENT',
+    'Subagent prompt': 'Child-agent prompt',
+    'subagent prompt': 'child-agent prompt',
+    'subagent_type: "general-purpose"': 'agent: "delegate"',
+    'do NOT use run_in_background': 'set `async: false` for this foreground run',
+    'run_in_background': '`async: true`',
+    'Claude Code\'s Agent tool': 'Pi\'s `subagent` tool',
+    'agents do NOT inherit': 'child agents do NOT inherit',
+    'Agent subagents': 'subagent children',
+    'Agent tool': '`subagent` tool',
+  },
+
+  // Unlike Pi's bare CLI, pi-subagents provides the child sessions needed by
+  // these workflows. Keep the delegation and outside-voice resolvers enabled;
+  // setup installs the package before Pi skills are generated.
+  suppressedResolvers: [],
+
+  runtimeRoot: {
+    globalSymlinks: [
+      'bin', 'browse/dist', 'browse/bin', 'design/dist', 'make-pdf/dist',
+      'extension', 'lib/diagram-render', 'gstack-upgrade', 'ETHOS.md',
+    ],
+    globalFiles: {
+      'review': ['checklist.md', 'TODOS-format.md'],
+    },
+  },
+
+  install: {
+    prefixable: false,
+    linkingStrategy: 'symlink-generated',
+  },
+
+  learningsMode: 'basic',
+};
+
+export default pi;

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -780,6 +780,13 @@ function processExternalHost(
   // Transform frontmatter (host-aware)
   let result = transformFrontmatter(content, host);
 
+  // Pi requires the frontmatter name to match the parent directory.
+  // Templates use short names (e.g., "ship") but Pi emits into
+  // gstack-prefixed directories (e.g., gstack-ship/).
+  if (host === 'pi') {
+    result = result.replace(/^(name:\s*).+$/m, `$1${name}`);
+  }
+
   // Insert safety advisory at the top of the body (after frontmatter)
   if (safetyProse) {
     const bodyStart = result.indexOf('\n---') + 4;

--- a/setup
+++ b/setup
@@ -24,6 +24,9 @@ FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
 OPENCODE_SKILLS="$HOME/.config/opencode/skills"
 OPENCODE_GSTACK="$OPENCODE_SKILLS/gstack"
+PI_SKILLS="$HOME/.pi/agent/skills"
+PI_GSTACK="$PI_SKILLS/gstack"
+PI_SUBAGENTS_PACKAGE="npm:pi-subagents"
 
 IS_WINDOWS=0
 case "$(uname -s)" in
@@ -85,7 +88,7 @@ NO_TEAM_MODE=0
 PLAN_TUNE_HOOKS_MODE=""   # "" = resolve from env/config/prompt; "yes"/"no" = explicit
 while [ $# -gt 0 ]; do
   case "$1" in
-    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, pi, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
     --host=*) HOST="${1#--host=}"; shift ;;
     --local) LOCAL_INSTALL=1; shift ;;
     --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
@@ -101,7 +104,7 @@ while [ $# -gt 0 ]; do
 done
 
 case "$HOST" in
-  claude|codex|kiro|factory|opencode|auto) ;;
+  claude|codex|kiro|factory|opencode|pi|auto) ;;
   openclaw)
     echo ""
     echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
@@ -136,7 +139,7 @@ case "$HOST" in
     echo "GBrain setup and brain skills ship from the GBrain repo."
     echo ""
     exit 0 ;;
-  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, pi, gbrain, or auto)" >&2; exit 1 ;;
 esac
 
 # ─── Resolve skill prefix preference ─────────────────────────
@@ -200,14 +203,16 @@ INSTALL_CODEX=0
 INSTALL_KIRO=0
 INSTALL_FACTORY=0
 INSTALL_OPENCODE=0
+INSTALL_PI=0
 if [ "$HOST" = "auto" ]; then
   command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
   command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
   command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
   command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
   command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
+  command -v pi >/dev/null 2>&1 && INSTALL_PI=1
   # If none found, default to claude
-  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ]; then
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ] && [ "$INSTALL_PI" -eq 0 ]; then
     INSTALL_CLAUDE=1
   fi
 elif [ "$HOST" = "claude" ]; then
@@ -220,6 +225,34 @@ elif [ "$HOST" = "factory" ]; then
   INSTALL_FACTORY=1
 elif [ "$HOST" = "opencode" ]; then
   INSTALL_OPENCODE=1
+elif [ "$HOST" = "pi" ]; then
+  INSTALL_PI=1
+fi
+
+# Pi's core CLI intentionally has no sub-agents. gstack's Pi skills use the
+# `subagent` tool and builtin agents from pi-subagents, so make the dependency
+# explicit and install it at user scope before generating any Pi skills.
+ensure_pi_subagents() {
+  if ! command -v pi >/dev/null 2>&1; then
+    echo "gstack setup failed: pi is required for --host pi." >&2
+    echo "  Install Pi first: https://pi.dev" >&2
+    return 1
+  fi
+
+  if pi list 2>/dev/null | grep -qE "^[[:space:]]+${PI_SUBAGENTS_PACKAGE//:/\\:}([[:space:]]|$)"; then
+    return 0
+  fi
+
+  log "Installing Pi delegation package ($PI_SUBAGENTS_PACKAGE)..."
+  if ! pi install "$PI_SUBAGENTS_PACKAGE"; then
+    echo "gstack setup failed: could not install $PI_SUBAGENTS_PACKAGE." >&2
+    echo "  Install it manually with: pi install $PI_SUBAGENTS_PACKAGE" >&2
+    return 1
+  fi
+}
+
+if [ "$INSTALL_PI" -eq 1 ]; then
+  ensure_pi_subagents
 fi
 
 migrate_direct_codex_install() {
@@ -444,6 +477,7 @@ fi
 # Always regenerate: generation is fast (<2s) and mtime-based staleness checks are fragile
 # (miss stale files when timestamps match after clone/checkout/upgrade).
 AGENTS_DIR="$SOURCE_GSTACK_DIR/.agents/skills"
+PI_GEN_DIR="$SOURCE_GSTACK_DIR/.pi/skills"
 NEEDS_AGENTS_GEN=1
 
 if [ "$NEEDS_AGENTS_GEN" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
@@ -472,6 +506,17 @@ if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
     cd "$SOURCE_GSTACK_DIR"
     bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
     bun_cmd run gen:skill-docs --host opencode
+  )
+fi
+
+# 1e. Generate .pi/ Pi skill docs when installing for Pi. The package check
+# above runs first so generated skills can safely retain delegation workflows.
+if [ "$INSTALL_PI" -eq 1 ] && [ "$NEEDS_BUILD" -eq 0 ]; then
+  log "Generating .pi/ skill docs..."
+  (
+    cd "$SOURCE_GSTACK_DIR"
+    bun_cmd install --frozen-lockfile 2>/dev/null || bun_cmd install
+    bun_cmd run gen:skill-docs --host pi
   )
 fi
 
@@ -972,6 +1017,93 @@ link_opencode_skill_dirs() {
   fi
 }
 
+# ─── Pi runtime root and generated skill installation ────────────────
+# Pi discovers ~/.pi/agent/skills recursively. Keep the gstack runtime assets
+# under ~/.pi/agent/skills/gstack and expose generated Pi skills alongside it.
+create_pi_runtime_root() {
+  local gstack_dir="$1"
+  local pi_gstack="$2"
+  local pi_dir="$gstack_dir/.pi/skills"
+
+  if [ -L "$pi_gstack" ]; then
+    rm -f "$pi_gstack"
+  elif [ -d "$pi_gstack" ] && [ "$pi_gstack" != "$gstack_dir" ]; then
+    rm -rf "$pi_gstack"
+  fi
+
+  mkdir -p "$pi_gstack" "$pi_gstack/browse" "$pi_gstack/design" "$pi_gstack/make-pdf" \
+    "$pi_gstack/extension" "$pi_gstack/lib/diagram-render" "$pi_gstack/gstack-upgrade" \
+    "$pi_gstack/review" "$pi_gstack/qa" "$pi_gstack/plan-devex-review"
+
+  if [ -f "$pi_dir/gstack/SKILL.md" ]; then
+    _link_or_copy "$pi_dir/gstack/SKILL.md" "$pi_gstack/SKILL.md"
+  fi
+  if [ -f "$pi_dir/gstack-upgrade/SKILL.md" ]; then
+    _link_or_copy "$pi_dir/gstack-upgrade/SKILL.md" "$pi_gstack/gstack-upgrade/SKILL.md"
+  fi
+
+  for asset in bin browse/dist browse/bin design/dist make-pdf/dist extension lib/diagram-render; do
+    local src="$gstack_dir/$asset"
+    local dst="$pi_gstack/$asset"
+    if [ -e "$src" ]; then
+      mkdir -p "$(dirname "$dst")"
+      _link_or_copy "$src" "$dst"
+    fi
+  done
+  if [ -f "$gstack_dir/ETHOS.md" ]; then
+    _link_or_copy "$gstack_dir/ETHOS.md" "$pi_gstack/ETHOS.md"
+  fi
+
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$gstack_dir/review/$f" ]; then
+      _link_or_copy "$gstack_dir/review/$f" "$pi_gstack/review/$f"
+    fi
+  done
+  for asset in review/specialists qa/templates qa/references plan-devex-review/dx-hall-of-fame.md; do
+    local src="$gstack_dir/$asset"
+    local dst="$pi_gstack/$asset"
+    if [ -e "$src" ]; then
+      mkdir -p "$(dirname "$dst")"
+      _link_or_copy "$src" "$dst"
+    fi
+  done
+}
+
+link_pi_skill_dirs() {
+  local gstack_dir="$1"
+  local skills_dir="$2"
+  local pi_dir="$gstack_dir/.pi/skills"
+  local linked=()
+
+  if [ ! -d "$pi_dir" ]; then
+    echo "  Generating .pi/ skill docs..."
+    ( cd "$gstack_dir" && bun_cmd run gen:skill-docs --host pi )
+  fi
+
+  if [ ! -d "$pi_dir" ]; then
+    echo "  warning: .pi/skills/ generation failed — run 'bun run gen:skill-docs --host pi' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$pi_dir"/gstack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      # The root skill is installed into the runtime root by create_pi_runtime_root.
+      [ "$skill_name" = "gstack" ] && continue
+      target="$skills_dir/$skill_name"
+      # Windows installs are regular directory copies, so refresh them on every
+      # setup run; otherwise a git pull leaves stale Pi SKILL.md files behind.
+      if [ "$IS_WINDOWS" -eq 1 ] || [ -L "$target" ] || [ ! -e "$target" ]; then
+        _link_or_copy "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked Pi skills: ${linked[*]}"
+  fi
+}
+
 # 4. Install for Claude (default)
 SKILLS_BASENAME="$(basename "$INSTALL_SKILLS_DIR")"
 SKILLS_PARENT_BASENAME="$(basename "$(dirname "$INSTALL_SKILLS_DIR")")"
@@ -1193,14 +1325,24 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   echo "  opencode skills: $OPENCODE_SKILLS"
 fi
 
-# 7. Create .agents/ sidecar symlinks for the real Codex skill target.
+# 7. Install for Pi
+if [ "$INSTALL_PI" -eq 1 ]; then
+  mkdir -p "$PI_SKILLS"
+  create_pi_runtime_root "$SOURCE_GSTACK_DIR" "$PI_GSTACK"
+  link_pi_skill_dirs "$SOURCE_GSTACK_DIR" "$PI_SKILLS"
+  log "gstack ready (pi)."
+  log "  browse: $BROWSE_BIN"
+  log "  pi skills: $PI_SKILLS"
+fi
+
+# 8. Create .agents/ sidecar symlinks for the real Codex skill target.
 # The root Codex skill ends up pointing at $SOURCE_GSTACK_DIR/.agents/skills/gstack,
 # so the runtime assets must live there for both global and repo-local installs.
 if [ "$INSTALL_CODEX" -eq 1 ]; then
   create_agents_sidecar "$SOURCE_GSTACK_DIR"
 fi
 
-# 8. Run pending version migrations
+# 9. Run pending version migrations
 # Migrations handle state fixes that ./setup alone can't cover (stale config,
 # orphaned files, directory structure changes). Each migration is idempotent.
 MIGRATIONS_DIR="$SOURCE_GSTACK_DIR/gstack-upgrade/migrations"
@@ -1227,7 +1369,7 @@ if [ "$CURRENT_VERSION" != "unknown" ]; then
   echo "$CURRENT_VERSION" > "$HOME/.gstack/.last-setup-version"
 fi
 
-# 9. First-time welcome + legacy cleanup
+# 10. First-time welcome + legacy cleanup
 if [ ! -f "$HOME/.gstack/.welcome-seen" ]; then
   log ""
   log "  gstack is ready. First move:"
@@ -1243,7 +1385,7 @@ if [ ! -f "$HOME/.gstack/.welcome-seen" ]; then
 fi
 rm -f /tmp/gstack-latest-version
 
-# 10. Team mode: register/unregister SessionStart hook
+# 11. Team mode: register/unregister SessionStart hook
 SETTINGS_HOOK="$SOURCE_GSTACK_DIR/bin/gstack-settings-hook"
 HOOK_CMD="$SOURCE_GSTACK_DIR/bin/gstack-session-update"
 

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -2124,6 +2124,49 @@ describe('Factory generation (--host factory)', () => {
   });
 });
 
+// ─── Pi generation tests ─────────────────────────────────────
+
+describe('Pi generation (--host pi)', () => {
+  const PI_DIR = path.join(ROOT, '.pi', 'skills');
+
+  // Generate Pi output for tests. The directory is gitignored runtime output.
+  beforeAll(() => {
+    const result = Bun.spawnSync(['bun', 'run', 'scripts/gen-skill-docs.ts', '--host', 'pi'], {
+      cwd: ROOT, stdout: 'pipe', stderr: 'pipe',
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('retains delegation sections and targets pi-subagents', () => {
+    const autoplan = fs.readFileSync(path.join(PI_DIR, 'gstack-autoplan', 'SKILL.md'), 'utf-8');
+    const designShotgun = fs.readFileSync(path.join(PI_DIR, 'gstack-design-shotgun', 'SKILL.md'), 'utf-8');
+    const ship = fs.readFileSync(path.join(PI_DIR, 'gstack-ship', 'SKILL.md'), 'utf-8');
+
+    expect(autoplan).toContain('`subagent` tool');
+    expect(autoplan).toContain('workflowScript');
+    expect(autoplan).toContain('runs.run');
+    expect(autoplan).not.toContain('Agent tool');
+    expect(autoplan).not.toContain('delegation is unsupported');
+
+    expect(designShotgun).toContain('runs.all([');
+    expect(designShotgun).toContain("agent: 'delegate'");
+    expect(designShotgun).not.toContain('delegation is unsupported');
+
+    expect(ship).toContain('agent: "delegate"');
+    expect(ship).toContain("agent: 'worker'");
+    expect(ship).not.toContain('subagent_type: "general-purpose"');
+  });
+
+  test('Pi skill names match their generated directories', () => {
+    for (const entry of fs.readdirSync(PI_DIR)) {
+      const skillPath = path.join(PI_DIR, entry, 'SKILL.md');
+      if (!fs.existsSync(skillPath)) continue;
+      const content = fs.readFileSync(skillPath, 'utf-8');
+      expect(content).toContain(`name: ${entry}`);
+    }
+  });
+});
+
 // ─── Parameterized host smoke tests (config-driven) ─────────
 
 import { ALL_HOST_CONFIGS, getExternalHosts } from '../hosts/index';
@@ -2372,16 +2415,17 @@ describe('setup script validation', () => {
     expect(claudeSection).toContain('link_claude_root_skill_alias "$SOURCE_GSTACK_DIR" "$INSTALL_SKILLS_DIR"');
   });
 
-  test('setup supports --host auto|claude|codex|kiro|opencode', () => {
+  test('setup supports --host auto|claude|codex|kiro|opencode|pi', () => {
     expect(setupContent).toContain('--host');
-    expect(setupContent).toContain('claude|codex|kiro|factory|opencode|auto');
+    expect(setupContent).toContain('claude|codex|kiro|factory|opencode|pi|auto');
   });
 
-  test('auto mode detects claude, codex, kiro, and opencode binaries', () => {
+  test('auto mode detects claude, codex, kiro, opencode, and pi binaries', () => {
     expect(setupContent).toContain('command -v claude');
     expect(setupContent).toContain('command -v codex');
     expect(setupContent).toContain('command -v kiro-cli');
     expect(setupContent).toContain('command -v opencode');
+    expect(setupContent).toContain('command -v pi');
   });
 
   // T1: Sidecar skip guard — prevents .agents/skills/gstack from being linked as a skill
@@ -2421,6 +2465,24 @@ describe('setup script validation', () => {
     expect(setupContent).toContain('qa/templates');
     expect(setupContent).toContain('qa/references');
     expect(setupContent).toContain('dx-hall-of-fame.md');
+  });
+
+  test('setup installs Pi skills and the pi-subagents dependency', () => {
+    expect(setupContent).toContain('INSTALL_PI=');
+    expect(setupContent).toContain('PI_SKILLS="$HOME/.pi/agent/skills"');
+    expect(setupContent).toContain('PI_SUBAGENTS_PACKAGE="npm:pi-subagents"');
+    expect(setupContent).toContain('ensure_pi_subagents');
+    expect(setupContent).toContain('pi install "$PI_SUBAGENTS_PACKAGE"');
+    const packageCheck = setupContent.indexOf('  ensure_pi_subagents\n');
+    const piGeneration = setupContent.indexOf('bun_cmd run gen:skill-docs --host pi');
+    expect(packageCheck).toBeGreaterThan(0);
+    expect(packageCheck).toBeLessThan(piGeneration);
+    expect(setupContent).toContain('gen:skill-docs --host pi');
+    expect(setupContent).toContain('create_pi_runtime_root');
+    expect(setupContent).toContain('lib/diagram-render');
+    expect(setupContent).toContain('extension');
+    expect(setupContent).toContain('if [ "$IS_WINDOWS" -eq 1 ] || [ -L "$target" ]');
+    expect(setupContent).toContain('link_pi_skill_dirs');
   });
 
   test('create_agents_sidecar links runtime assets', () => {

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -22,6 +22,9 @@ import {
   slate,
   cursor,
   openclaw,
+  pi,
+  PI_SUBAGENTS_PACKAGE,
+  PI_SUBAGENT_ROLES,
 } from '../hosts/index';
 import { HOST_PATHS } from '../scripts/resolvers/types';
 import { RESOLVERS } from '../scripts/resolvers';
@@ -32,8 +35,8 @@ const RESOLVER_NAMES = new Set(Object.keys(RESOLVERS));
 // ─── hosts/index.ts ─────────────────────────────────────────
 
 describe('hosts/index.ts', () => {
-  test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+  test('ALL_HOST_CONFIGS has 11 hosts', () => {
+    expect(ALL_HOST_CONFIGS.length).toBe(11);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {
@@ -55,6 +58,7 @@ describe('hosts/index.ts', () => {
     expect(slate.name).toBe('slate');
     expect(cursor.name).toBe('cursor');
     expect(openclaw.name).toBe('openclaw');
+    expect(pi.name).toBe('pi');
   });
 
   test('getHostConfig returns correct config', () => {
@@ -527,6 +531,23 @@ describe('host config correctness', () => {
 
   test('openclaw has no staticFiles (SOUL.md removed)', () => {
     expect(openclaw.staticFiles).toBeUndefined();
+  });
+
+  test('Pi uses pi-subagents for delegation instead of suppressing workflows', () => {
+    expect(PI_SUBAGENTS_PACKAGE).toBe('npm:pi-subagents');
+    expect(PI_SUBAGENT_ROLES).toEqual({
+      review: 'reviewer',
+      implementation: 'worker',
+      reconnaissance: 'scout',
+      secondOpinion: 'oracle',
+      general: 'delegate',
+    });
+    expect(pi.suppressedResolvers).not.toContain('REVIEW_ARMY');
+    expect(pi.suppressedResolvers).not.toContain('ADVERSARIAL_STEP');
+    expect(pi.suppressedResolvers).not.toContain('SPEC_REVIEW_LOOP');
+    expect(pi.toolRewrites?.['Agent tool']).toContain('subagent');
+    expect(pi.toolRewrites?.['Agent tool,']).toContain('workflowScript');
+    expect(pi.toolRewrites?.['subagent_type: "general-purpose"']).toContain('delegate');
   });
 
   test('openclaw includeSkills is empty (native skills replaced generated ones)', () => {


### PR DESCRIPTION
For better functionality, requires pi-subagents package to be installed too for the pi setup so delegation works.

Supersedes #1918 in being a more complete implementation
