### PR TITLE
fix(setup): use Playwright 1.62.1 on Ubuntu 26.04

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "diff": "^7.0.0",
         "html-to-docx": "1.8.0",
         "marked": "^18.0.2",
-        "playwright": "^1.58.2",
+        "playwright": "1.62.1",
         "puppeteer-core": "^24.40.0",
         "socks": "^2.8.8",
       },
@@ -504,9 +504,9 @@
 
     "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
-    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
 
-    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "diff": "^7.0.0",
     "html-to-docx": "1.8.0",
     "marked": "^18.0.2",
-    "playwright": "^1.58.2",
+    "playwright": "1.62.1",
     "puppeteer-core": "^24.40.0",
     "socks": "^2.8.8"
   },

--- a/setup
+++ b/setup
@@ -250,17 +250,19 @@ if [ "$INSTALL_CODEX" -eq 1 ]; then
 fi
 
 ensure_playwright_browser() {
+  # Verify the full Chromium executable used by headed mode as well as a
+  # headless launch. A cached headless shell alone is not a complete install.
   if [ "$IS_WINDOWS" -eq 1 ]; then
     # On Windows, Bun can't launch Chromium due to broken pipe handling
     # (oven-sh/bun#4253). Use Node.js to verify Chromium works instead.
     (
       cd "$SOURCE_GSTACK_DIR"
-      node -e "const { chromium } = require('playwright'); (async () => { const b = await chromium.launch(); await b.close(); })()" 2>/dev/null
+      node -e "const { chromium } = require('playwright'); const fs = require('fs'); (async () => { if (!fs.existsSync(chromium.executablePath())) process.exit(1); const b = await chromium.launch(); await b.close(); })()" 2>/dev/null
     )
   else
     (
       cd "$SOURCE_GSTACK_DIR"
-      bun --eval 'import { chromium } from "playwright"; const browser = await chromium.launch(); await browser.close();'
+      bun --eval 'import { chromium } from "playwright"; import { existsSync } from "fs"; if (!existsSync(chromium.executablePath())) process.exit(1); const browser = await chromium.launch(); await browser.close();'
     ) >/dev/null 2>&1
   fi
 }
@@ -480,7 +482,11 @@ if ! ensure_playwright_browser; then
   echo "Installing Playwright Chromium..."
   (
     cd "$SOURCE_GSTACK_DIR"
-    bunx playwright install chromium
+    # Match the browser revision to the exact Playwright package used to build
+    # and run browse. An unversioned bunx may resolve a different release.
+    pw_version="$(bun --eval 'console.log(require("playwright/package.json").version)')"
+    [ -n "$pw_version" ] || { echo "gstack setup failed: could not resolve the installed Playwright version" >&2; exit 1; }
+    bunx "playwright@$pw_version" install chromium
   )
 
   if [ "$IS_WINDOWS" -eq 1 ]; then

--- a/test/setup-playwright-version.test.ts
+++ b/test/setup-playwright-version.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const root = path.resolve(import.meta.dir, '..');
+const setup = fs.readFileSync(path.join(root, 'setup'), 'utf8');
+const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+const lock = fs.readFileSync(path.join(root, 'bun.lock'), 'utf8');
+
+describe('Playwright setup version consistency', () => {
+  test('package and lock select the same exact release', () => {
+    const version = packageJson.dependencies.playwright;
+    expect(version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(lock).toContain(`"playwright": "${version}"`);
+    expect(lock).toContain(`"playwright": ["playwright@${version}"`);
+    expect(lock).toContain(`"playwright-core": ["playwright-core@${version}"`);
+  });
+
+  test('browser download uses the installed package version', () => {
+    expect(setup).toContain('require("playwright/package.json").version');
+    expect(setup).toContain('bunx "playwright@$pw_version" install chromium');
+    expect(setup).not.toMatch(/^\s*bunx playwright install chromium\s*$/m);
+  });
+
+  test('verification requires the full executable before launch', () => {
+    expect(setup).toContain('fs.existsSync(chromium.executablePath())');
+    expect(setup).toContain('existsSync(chromium.executablePath())');
+  });
+});


### PR DESCRIPTION
## Summary

- pin Playwright and playwright-core to 1.62.1 through package.json and bun.lock
- install Chromium with the exact Playwright version used by gstack instead of an unversioned bunx resolution
- require the full Chromium executable and a successful launch before setup continues
- guard package, lockfile, installer, and verification consistency with focused tests

## Verification

- `bun install --frozen-lockfile`
- `bash -n setup`
- `bun test test/setup-playwright-version.test.ts`
- `bun test`
- Playwright 1.62.1 downloaded and launched Chromium 151.0.7922.34 on Ubuntu 26.04 and macOS arm64