### PR TITLE
fix(browse): pass windowsHide so the daemon stops popping console windows on Windows

### DIFF
--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -75,6 +75,9 @@ globalThis.Bun = {
       timeout: options.timeout,
       env: options.env,
       cwd: options.cwd,
+      // Bun never shows a console window; node's spawn defaults windowsHide to
+      // false, so without this every console child pops a window on Windows.
+      windowsHide: true,
     });
 
     return {
@@ -91,6 +94,10 @@ globalThis.Bun = {
       stdio,
       env: options.env,
       cwd: options.cwd,
+      // See spawnSync. This is the one users notice: spawnTerminalAgent() launches
+      // `bun run terminal-agent.ts` through here and the daemon respawns it on a
+      // watchdog, so an empty console window reappears every few minutes.
+      windowsHide: true,
     });
 
     return {

--- a/browse/test/bun-polyfill.test.ts
+++ b/browse/test/bun-polyfill.test.ts
@@ -10,7 +10,7 @@ describe('bun-polyfill', () => {
 
   test('Bun.sleep resolves after delay', async () => {
     const result = Bun.spawnSync(['node', '-e', `
-      require('${polyfillPath}');
+      require(${JSON.stringify(polyfillPath)});
       (async () => {
         const start = Date.now();
         await Bun.sleep(50);
@@ -24,7 +24,7 @@ describe('bun-polyfill', () => {
 
   test('Bun.spawnSync runs a command and returns stdout', () => {
     const result = Bun.spawnSync(['node', '-e', `
-      require('${polyfillPath}');
+      require(${JSON.stringify(polyfillPath)});
       const r = Bun.spawnSync(['echo', 'hello'], { stdout: 'pipe' });
       console.log(r.stdout.toString().trim());
       console.log('exit:' + r.exitCode);
@@ -36,7 +36,7 @@ describe('bun-polyfill', () => {
 
   test('Bun.spawn launches a process with pid', async () => {
     const result = Bun.spawnSync(['node', '-e', `
-      require('${polyfillPath}');
+      require(${JSON.stringify(polyfillPath)});
       const p = Bun.spawn(['echo', 'test'], { stdio: ['pipe', 'pipe', 'pipe'] });
       console.log(typeof p.pid === 'number' ? 'HAS_PID' : 'NO_PID');
       console.log(typeof p.kill === 'function' ? 'HAS_KILL' : 'NO_KILL');
@@ -50,7 +50,7 @@ describe('bun-polyfill', () => {
 
   test('Bun.serve creates an HTTP server that responds', async () => {
     const result = Bun.spawnSync(['node', '-e', `
-      require('${polyfillPath}');
+      require(${JSON.stringify(polyfillPath)});
       const server = Bun.serve({
         port: 0,  // Note: polyfill uses port directly, so we pick one
         hostname: '127.0.0.1',
@@ -68,5 +68,26 @@ describe('bun-polyfill', () => {
     const lines = result.stdout.toString().trim().split('\n');
     expect(lines[0]).toBe('HAS_STOP');
     expect(lines[1]).toBe('HAS_PORT');
+  });
+
+  // Regression: node defaults windowsHide to false, so a console child spawned
+  // through this shim pops a visible window on Windows — bun never does. Asserted
+  // by stubbing child_process before the polyfill destructures it, so the check is
+  // deterministic and runs on every platform.
+  test('spawn and spawnSync pass windowsHide so Windows shows no console window', () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      const cp = require('child_process');
+      const seen = [];
+      cp.spawn = (c, a, o) => { seen.push(o); return { pid: 1, stdout: null, stderr: null, stdin: null, unref() {}, kill() {} }; };
+      cp.spawnSync = (c, a, o) => { seen.push(o); return { status: 0, stdout: Buffer.from(''), stderr: Buffer.from('') }; };
+      require(${JSON.stringify(polyfillPath)});
+      Bun.spawn(['echo', 'x'], { stdio: ['pipe', 'pipe', 'pipe'] });
+      Bun.spawnSync(['echo', 'x'], { stdout: 'pipe' });
+      console.log(seen.length === 2 ? 'BOTH' : 'GOT_' + seen.length);
+      console.log(seen.every((o) => o && o.windowsHide === true) ? 'HIDDEN' : 'VISIBLE');
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    const lines = result.stdout.toString().trim().split('\n');
+    expect(lines[0]).toBe('BOTH');
+    expect(lines[1]).toBe('HIDDEN');
   });
 });


### PR DESCRIPTION
On Windows, `browse` leaves empty black console windows sitting on top of whatever you're doing. They arrive every few minutes for as long as any browser skill is alive, and they outlive the process that created them — so closing one isn't enough. I hit this mid-screen-share, which is how it earned a diagnosis.

## Cause

`browse/src/bun-polyfill.cjs` maps `Bun.spawn`/`Bun.spawnSync` onto node's `child_process`, and **node defaults `windowsHide` to `false`**. Bun never creates these windows, so nothing in the daemon's own code reads as wrong — the behaviour only exists on the node fallback path.

The one users actually notice is `spawnTerminalAgent()`, which launches `bun run terminal-agent.ts` through the shim. The daemon **respawns it on a watchdog**, so the window keeps coming back. Ten `bun.exe` processes were live on the machine I diagnosed this on, across two daemons.

Why the frames linger after the child exits: with *Default terminal application* set to "Let Windows decide", the console is brokered through Windows Terminal via `svchost`, and WT leaves the empty frame behind when its only child exits. The frame has **no child process at all** — which is why it looks like a dead terminal and is always safe to close.

## Fix

`windowsHide: true` on both wrappers. That covers every console child routed through the shim — the bun agent, plus the `tasklist` / `git` / `powershell` calls elsewhere in the daemon. No-op on macOS and Linux.

## Second commit: the tests couldn't run on Windows

While adding a regression test I found `bun test browse/test/bun-polyfill.test.ts` was **0 pass / 4 fail on Windows** — every test in the file, on the platform the polyfill exists for.

Each test interpolates the polyfill's absolute path into a *single-quoted* JS string for `node -e`. On Windows the backslashes are eaten as escapes:

```
'C:\Users\jwilk\dev\gstack-fork\browse\src\bun-polyfill.cjs'
  ->  C:Usersjwilkdevgstack-forkrowsesrcun-polyfill.cjs
```

`\b` is a real escape, so it deletes a character too. `require()` throws, the subprocess dies, stdout is empty, and every assertion compares against `""`. It passes on macOS/Linux only because those paths have no backslashes.

Fixed with `JSON.stringify(polyfillPath)`. Kept as a separate commit so you can take either half independently.

## Verification (Windows 11, bun 1.3.14, gstack 1.61.0.0)

| | pass | fail |
|---|---|---|
| pristine upstream | 0 | 4 |
| with both commits | **5** | **0** |
| with commit 2 only (fix reverted) | 4 | 1 — the new test, `VISIBLE` instead of `HIDDEN` |

The regression test stubs `child_process.spawn`/`spawnSync` *before* the polyfill destructures them and asserts the captured options, so it's deterministic, needs no window, and still verifies the contract on macOS/Linux where the option is a no-op.

End to end: restarted the daemon after patching and confirmed no bun window appeared, with the agent and Chromium still running normally.

## Not covered

`chromium.launch()` (`browse/src/…`, via playwright) goes through playwright's own process launcher, not this shim, so it still creates **one** window per daemon start rather than one every few minutes. Setting *Default terminal application* to "Windows Console Host" makes that one close with its process instead of being abandoned, but a `windowsHide` on the playwright launch would be the real answer. Happy to follow up if you'd like it in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
