### PR TITLE
fix(gitattributes): pin *.txt to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 *.yaml       text eol=lf
 *.json       text eol=lf
 *.toml       text eol=lf
+*.txt        text eol=lf
 
 # Bash scripts must always use LF — CRLF in bash scripts produces bizarre
 # "Bad interpreter" / "command not found" errors on Linux runners.


### PR DESCRIPTION
One line added to `.gitattributes`:

```
*.txt        text eol=lf
```

## Why

`.gitattributes` already pins LF for every other text format in the repo — `*.md`, `*.tmpl`, `*.yml`, `*.yaml`, `*.json`, `*.toml`, `*.sh`, `*.bash`, `setup`, `bin/*`, `**/scripts/*`, `*.ts/tsx/js/mjs/cjs`, and the hash-pinned `lib/diagram-render/dist/*`. `*.txt` is the one text format left out.

On Windows with `core.autocrlf=true`, the two tracked `.txt` files get rewritten to CRLF at checkout, so `git status` is never clean in a fresh clone.

## Repro

Fresh clone of `main`, `core.autocrlf=true`, comparing blob bytes to worktree bytes:

```
gstack/llms.txt                                    blob=12443  worktree=12617  +174
make-pdf/test/fixtures/combined-gate.expected.txt  blob=987    worktree=1007   +20
README.md                                          blob=45456  worktree=45456    0   <- pinned, unaffected
```

Exactly one byte per line, and `README.md` is the control: it is pinned by `*.md text eol=lf` and comes out clean. With this patch both `.txt` files also come out at delta 0.

## User-visible symptom

`git status` reports `gstack/llms.txt` as modified forever. Because `/gstack-upgrade` runs `git stash` before `git reset --hard`, every upgrade saves a phantom stash — one whose diff against its own parent is empty. The user is then told to `git stash pop` to recover changes that never existed.

## Scope

Only the two files above are affected today. I checked `make-pdf/test/fixtures/combined-gate.expected.txt` since it is an expected-output fixture, but `copyPasteGate` runs the text through `normalize()` and `collapseWhitespace()`, so I could not produce a test failure from the CRLF — this is a cleanliness fix, not a test fix.

## Note for existing checkouts

The attribute only affects future checkouts. Anyone with a dirty tree today needs a one-time renormalize:

```bash
git add --renormalize .
# or, per file:
rm gstack/llms.txt && git checkout -- gstack/llms.txt
```

Verified on Windows (Git for Windows, `core.autocrlf=true`) against `main` @ v1.61.0.0.