### PR TITLE
fix(setup-gbrain): support current gbrain installs

### DIFF
--- a/bin/gstack-artifacts-init
+++ b/bin/gstack-artifacts-init
@@ -185,16 +185,22 @@ PUSH_URL=$("$URL_BIN" --to ssh "$CANONICAL_HTTPS" 2>/dev/null || echo "$CANONICA
 
 # ---- verify push URL is reachable ----
 echo "Verifying remote connectivity: $PUSH_URL"
-if ! git ls-remote "$PUSH_URL" >/dev/null 2>&1; then
-  cat >&2 <<EOF
-Remote not reachable via SSH: $PUSH_URL
+if ! GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND="ssh -o BatchMode=yes" git ls-remote "$PUSH_URL" >/dev/null 2>&1; then
+  echo "SSH remote unavailable; trying canonical HTTPS with the configured git credential helper." >&2
+  if GIT_TERMINAL_PROMPT=0 git ls-remote "$CANONICAL_HTTPS" >/dev/null 2>&1; then
+    PUSH_URL="$CANONICAL_HTTPS"
+    echo "HTTPS remote is reachable; using $PUSH_URL"
+  else
+    cat >&2 <<EOF
+Remote not reachable via SSH or HTTPS: $CANONICAL_HTTPS
 This could mean:
   - Wrong URL
-  - SSH key not added to your git host (GitHub: gh ssh-key list; GitLab: glab ssh-key list)
+  - SSH key and HTTPS credential helper are both unavailable
   - Network issue
-Fix and re-run gstack-artifacts-init.
+Fix credentials and re-run gstack-artifacts-init.
 EOF
-  exit 1
+    exit 1
+  fi
 fi
 
 # ---- git init ----

--- a/bin/gstack-gbrain-install
+++ b/bin/gstack-gbrain-install
@@ -56,6 +56,28 @@ die() { echo "gstack-gbrain-install: $*" >&2; exit 2; }
 fail() { echo "gstack-gbrain-install: $*" >&2; exit 3; }
 log()  { echo "gstack-gbrain-install: $*"; }
 
+# Read a top-level string or bin.gbrain from package.json without assuming jq
+# is installed. Bun is already a checked prerequisite for every install path.
+package_field() {
+  local file="$1"
+  local field="$2"
+  PACKAGE_FILE="$file" PACKAGE_FIELD="$field" bun -e '
+    try {
+      const data = await Bun.file(process.env.PACKAGE_FILE).json();
+      const field = process.env.PACKAGE_FIELD;
+      const value = field === "bin.gbrain" ? data?.bin?.gbrain : data?.[field];
+      if (typeof value === "string") process.stdout.write(value);
+    } catch {}
+  ' 2>/dev/null || true
+}
+
+resolve_path() {
+  RESOLVE_PATH="$1" bun -e '
+    import { realpathSync } from "node:fs";
+    try { process.stdout.write(realpathSync(process.env.RESOLVE_PATH)); } catch {}
+  ' 2>/dev/null || true
+}
+
 # --- parse args ---
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -98,10 +120,10 @@ is_valid_clone() {
   [ -d "$dir" ] || return 1
   [ -f "$dir/package.json" ] || return 1
   local name
-  name=$(jq -r '.name // empty' "$dir/package.json" 2>/dev/null || true)
+  name=$(package_field "$dir/package.json" name)
   [ "$name" = "gbrain" ] || return 1
   local bin
-  bin=$(jq -r '.bin.gbrain // empty' "$dir/package.json" 2>/dev/null || true)
+  bin=$(package_field "$dir/package.json" bin.gbrain)
   [ -n "$bin" ] || return 1
   return 0
 }
@@ -172,10 +194,7 @@ fi
 # Read the version from the install-dir's package.json; compare to
 # `gbrain --version`. If they disagree, PATH is returning a DIFFERENT
 # gbrain than the one we just linked. Fail hard with remediation.
-expected_version=$(jq -r '.version // empty' "$INSTALL_DIR/package.json" 2>/dev/null || true)
-if [ -z "$expected_version" ]; then
-  fail "cannot read version from $INSTALL_DIR/package.json (install may be broken)"
-fi
+expected_version=$(package_field "$INSTALL_DIR/package.json" version)
 
 if ! command -v gbrain >/dev/null 2>&1; then
   fail "bun link completed but 'gbrain' is not on PATH. Ensure ~/.bun/bin is in your PATH."
@@ -184,6 +203,28 @@ fi
 actual_version=$(gbrain --version 2>/dev/null | head -1 | awk '{print $NF}' | tr -d '[:space:]' || true)
 if [ -z "$actual_version" ]; then
   fail "gbrain is on PATH but 'gbrain --version' produced no output — the binary may be broken."
+fi
+
+# Current gbrain HEAD intentionally has no package.json version. In that case,
+# prove D19 by comparing the resolved PATH binary with package.json's bin target
+# instead of weakening or skipping the shadow check.
+if [ -z "$expected_version" ]; then
+  package_bin=$(package_field "$INSTALL_DIR/package.json" bin.gbrain)
+  [ -n "$package_bin" ] || fail "cannot read bin.gbrain from $INSTALL_DIR/package.json (install may be broken)"
+  expected_bin=$(resolve_path "$INSTALL_DIR/${package_bin#./}")
+  actual_bin=$(resolve_path "$(command -v gbrain)")
+  if [ -z "$expected_bin" ] || [ "$actual_bin" != "$expected_bin" ]; then
+    echo "" >&2
+    echo "gstack-gbrain-install: PATH SHADOWING DETECTED" >&2
+    echo "" >&2
+    echo "  $INSTALL_DIR/package.json has no version, so path identity is required." >&2
+    echo "  Expected: ${expected_bin:-unresolvable}" >&2
+    echo "  PATH gives: ${actual_bin:-unresolvable}" >&2
+    echo "" >&2
+    echo "  Ensure ~/.bun/bin precedes other user bin directories, then re-run /setup-gbrain." >&2
+    exit 3
+  fi
+  expected_version="$actual_version"
 fi
 
 # Tolerate a leading "v" (gbrain may print either "0.18.2" or "v0.18.2").
@@ -216,11 +257,31 @@ log "installed gbrain $actual_version from $INSTALL_DIR"
 # as the PATH-shadow / version-mismatch failures above. A warning here is exactly
 # how the data-loss class slipped through, so this gate fails closed.
 version_lt() {
-  # 0 (true) when $1 < $2 by version sort; equal versions are NOT less-than.
-  [ "$1" = "$2" ] && return 1
-  [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ]
+  # 0 (true) when $1 < $2. Avoid GNU-only `sort -V`: this installer targets
+  # macOS too. Validate and compare the first three numeric SemVer components.
+  local a_major a_minor a_patch a_rest b_major b_minor b_patch b_rest
+  case "$1" in *[!0-9.]*|'') return 2 ;; esac
+  case "$2" in *[!0-9.]*|'') return 2 ;; esac
+  IFS=. read -r a_major a_minor a_patch a_rest <<EOF
+$1
+EOF
+  IFS=. read -r b_major b_minor b_patch b_rest <<EOF
+$2
+EOF
+  for component in "$a_major" "$a_minor" "$a_patch" "$b_major" "$b_minor" "$b_patch"; do
+    case "$component" in ''|*[!0-9]*) return 2 ;; esac
+  done
+  [ "$a_major" -lt "$b_major" ] && return 0
+  [ "$a_major" -gt "$b_major" ] && return 1
+  [ "$a_minor" -lt "$b_minor" ] && return 0
+  [ "$a_minor" -gt "$b_minor" ] && return 1
+  [ "$a_patch" -lt "$b_patch" ]
 }
-if version_lt "$actual_norm" "$MIN_GBRAIN_VERSION"; then
+version_cmp_rc=0
+version_lt "$actual_norm" "$MIN_GBRAIN_VERSION" || version_cmp_rc=$?
+if [ "$version_cmp_rc" -eq 2 ]; then
+  fail "cannot compare gbrain version '$actual_version' against minimum '$MIN_GBRAIN_VERSION'"
+elif [ "$version_cmp_rc" -eq 0 ]; then
   echo "" >&2
   echo "gstack-gbrain-install: gbrain $actual_version is below the minimum gstack-tested version ($MIN_GBRAIN_VERSION)." >&2
   echo "  gstack's sync integration needs the v0.20+ source/list surface." >&2

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -1445,7 +1445,7 @@ curated `~/.gstack/` artifacts into gbrain so the retrieval surface
 
 Run the probe to size the operation:
 ```bash
-~/.claude/skills/gstack/bin/gstack-memory-ingest --probe
+bun run ~/.claude/skills/gstack/bin/gstack-memory-ingest.ts --probe
 ```
 
 Read the output. If `Total files in window: 0`, skip — there's nothing
@@ -1453,7 +1453,7 @@ to ingest. Set `gstack-config set transcript_ingest_mode incremental`
 silently and continue to Step 8.
 
 If `New (never ingested)` is < 200 AND total bytes are < 100MB: silent
-bulk via `gstack-memory-ingest --bulk --quiet`. Set
+bulk via `bun run ~/.claude/skills/gstack/bin/gstack-memory-ingest.ts --bulk --quiet`. Set
 `transcript_ingest_mode=incremental` and continue.
 
 Otherwise (the "many transcripts on disk" path): AskUserQuestion with

--- a/setup-gbrain/SKILL.md.tmpl
+++ b/setup-gbrain/SKILL.md.tmpl
@@ -691,7 +691,7 @@ curated `~/.gstack/` artifacts into gbrain so the retrieval surface
 
 Run the probe to size the operation:
 ```bash
-~/.claude/skills/gstack/bin/gstack-memory-ingest --probe
+bun run ~/.claude/skills/gstack/bin/gstack-memory-ingest.ts --probe
 ```
 
 Read the output. If `Total files in window: 0`, skip — there's nothing
@@ -699,7 +699,7 @@ to ingest. Set `gstack-config set transcript_ingest_mode incremental`
 silently and continue to Step 8.
 
 If `New (never ingested)` is < 200 AND total bytes are < 100MB: silent
-bulk via `gstack-memory-ingest --bulk --quiet`. Set
+bulk via `bun run ~/.claude/skills/gstack/bin/gstack-memory-ingest.ts --bulk --quiet`. Set
 `transcript_ingest_mode=incremental` and continue.
 
 Otherwise (the "many transcripts on disk" path): AskUserQuestion with

--- a/test/gbrain-detect-install.test.ts
+++ b/test/gbrain-detect-install.test.ts
@@ -248,6 +248,22 @@ describe('gstack-gbrain-install D19 PATH-shadow validation', () => {
     }
   });
 
+  test('checks the version floor without GNU sort -V (macOS portability)', () => {
+    const installDir = seedInstallDir('0.41.29');
+    const fakeBin = seedFakeGbrainBinary('0.41.29');
+    fs.writeFileSync(path.join(fakeBin, 'sort'), '#!/bin/bash\nexit 99\n', { mode: 0o755 });
+    try {
+      const r = run(INSTALL, ['--validate-only', '--install-dir', installDir], {
+        env: { PATH: `${fakeBin}:${SAFE_PATH}` },
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain('installed gbrain 0.41.29');
+    } finally {
+      fs.rmSync(installDir, { recursive: true, force: true });
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
   test('fails hard with exit 3 and PATH-shadow message on version mismatch', () => {
     const installDir = seedInstallDir('0.18.2');
     const fakeBin = seedFakeGbrainBinary('0.18.1');
@@ -283,18 +299,47 @@ describe('gstack-gbrain-install D19 PATH-shadow validation', () => {
     }
   });
 
-  test('fails hard when install-dir package.json lacks version', () => {
+  test('passes without package.json version when PATH resolves to install-dir bin', () => {
     const d = fs.mkdtempSync(path.join(os.tmpdir(), 'gbrain-install-'));
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fake-bin-'));
     fs.writeFileSync(
       path.join(d, 'package.json'),
       JSON.stringify({ name: 'gbrain', bin: { gbrain: './src/cli.ts' } })
     );
+    fs.mkdirSync(path.join(d, 'src'));
+    fs.writeFileSync(path.join(d, 'src', 'cli.ts'), '#!/bin/bash\necho "gbrain 0.45.1.0"\n', { mode: 0o755 });
+    fs.symlinkSync(path.join(d, 'src', 'cli.ts'), path.join(binDir, 'gbrain'));
     try {
-      const r = run(INSTALL, ['--validate-only', '--install-dir', d]);
-      expect(r.status).toBe(3);
-      expect(r.stderr).toContain('cannot read version');
+      const r = run(INSTALL, ['--validate-only', '--install-dir', d], {
+        env: { PATH: `${binDir}:${SAFE_PATH}` },
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain('installed gbrain 0.45.1.0');
     } finally {
       fs.rmSync(d, { recursive: true, force: true });
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  test('fails hard without package.json version when PATH resolves elsewhere', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'gbrain-install-'));
+    const fakeBin = seedFakeGbrainBinary('0.45.1.0');
+    fs.writeFileSync(
+      path.join(d, 'package.json'),
+      JSON.stringify({ name: 'gbrain', bin: { gbrain: './src/cli.ts' } })
+    );
+    fs.mkdirSync(path.join(d, 'src'));
+    fs.writeFileSync(path.join(d, 'src', 'cli.ts'), '#!/bin/bash\necho "gbrain 0.45.1.0"\n', { mode: 0o755 });
+    try {
+      const r = run(INSTALL, ['--validate-only', '--install-dir', d], {
+        env: { PATH: `${fakeBin}:${SAFE_PATH}` },
+      });
+      expect(r.status).toBe(3);
+      expect(r.stderr).toContain('PATH SHADOWING DETECTED');
+      expect(r.stderr).toContain('package.json has no version');
+    } finally {
+      fs.rmSync(d, { recursive: true, force: true });
+      fs.rmSync(fakeBin, { recursive: true, force: true });
     }
   });
 });

--- a/test/gstack-artifacts-init.test.ts
+++ b/test/gstack-artifacts-init.test.ts
@@ -113,7 +113,13 @@ while [ $i -lt \${#args[@]} ]; do
 done
 sub="\${args[$i]:-}"
 case "$sub" in
-  ls-remote|fetch|push|pull) exit 0 ;;
+  ls-remote)
+    if [[ "$*" == *"git@"* ]] && [[ "\${GIT_SSH_COMMAND:-}" != *"BatchMode=yes"* ]]; then exit 9; fi
+    if [ "\${GIT_FAKE_FAIL_ALL_REMOTES:-}" = "1" ]; then exit 1; fi
+    if [ "\${GIT_FAKE_FAIL_SSH:-}" = "1" ] && [[ "$*" == *"git@"* ]]; then exit 1; fi
+    exit 0
+    ;;
+  fetch|push|pull) exit 0 ;;
   *) exec "${realGit}" "$@" ;;
 esac
 `;
@@ -257,6 +263,24 @@ describe('gstack-artifacts-init canonical URL storage (codex Finding #10)', () =
     expect(r.status).toBe(0);
     const remote = spawnSync('git', ['-C', tmpHome, 'remote', 'get-url', 'origin'], { encoding: 'utf-8' });
     expect(remote.stdout.trim()).toBe('git@github.com:testuser/gstack-artifacts-testuser.git');
+  });
+
+  test('falls back to HTTPS when SSH is unavailable', () => {
+    makeFakeGh({ webUrl: 'https://github.com/testuser/gstack-artifacts-testuser' });
+    const r = run(['--host', 'github'], { env: { GIT_FAKE_FAIL_SSH: '1' } });
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain('SSH remote unavailable');
+    const remote = spawnSync('git', ['-C', tmpHome, 'remote', 'get-url', 'origin'], { encoding: 'utf-8' });
+    expect(remote.stdout.trim()).toBe('https://github.com/testuser/gstack-artifacts-testuser');
+  });
+
+  test('fails closed without initializing git when SSH and HTTPS are unavailable', () => {
+    makeFakeGh({ webUrl: 'https://github.com/testuser/gstack-artifacts-testuser' });
+    const r = run(['--host', 'github'], { env: { GIT_FAKE_FAIL_ALL_REMOTES: '1' } });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('Remote not reachable via SSH or HTTPS');
+    expect(fs.existsSync(path.join(tmpHome, '.git'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpHome, '.gstack-artifacts-remote.txt'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Fix `/setup-gbrain` against the current gbrain HEAD and unattended Linux/macOS environments.

- accept gbrain packages that intentionally omit top-level `version`, while preserving fail-closed PATH-shadow validation through resolved binary identity
- resolve package metadata and paths with Bun instead of requiring `jq` or GNU-specific tooling
- compare the minimum version floor without GNU `sort -V`, including gbrain's four-component version output
- fall back from unreachable SSH artifact remotes to canonical HTTPS without interactive credential prompts
- use SSH `BatchMode=yes` and fail before initializing local artifact state when neither transport is reachable
- invoke the actual TypeScript memory-ingest entrypoint through Bun in generated setup docs

## Why

A real `/setup-gbrain` run with gbrain `0.45.1.0` failed because current gbrain omits `package.json.version`. After restoring the CLI, artifact initialization also failed on a server where GitHub HTTPS auth worked but SSH did not. The setup docs referenced a shell wrapper that does not exist.

## Verification

- `bun test` — full Tier-1 suite passed
- `bun test test/gbrain-detect-install.test.ts test/gstack-artifacts-init.test.ts test/setup-gbrain-path4-structure.test.ts` — 53 passed
- `bash -n bin/gstack-gbrain-install bin/gstack-artifacts-init` — passed
- `bun run scripts/gen-skill-docs.ts --dry-run` — fresh
- live `gstack-gbrain-install` against gbrain `0.45.1.0` — passed
- live artifacts initialization against a private GitHub repository with SSH unavailable and HTTPS available — passed
- independent exact-candidate review at staged diff SHA-256 `3102158a012480b6ee6ce28397fe84287cf2e148c094bafba46deb18a58c80aa` — passed, no blocking findings

## Security / lifecycle

- credentials remain in Git credential helpers; no token is added to argv, logs, or committed configuration
- SSH and HTTPS connectivity probes are non-interactive
- artifact initialization remains fail-closed and does not write local repository state if both transports fail
