### PR TITLE
Route normal GBrain queries through MCP

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -340,6 +340,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -356,10 +377,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -369,19 +396,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -475,6 +475,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -491,10 +512,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -504,19 +531,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -344,6 +344,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -360,10 +381,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -373,19 +400,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -344,6 +344,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -360,10 +381,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -373,19 +400,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -342,6 +342,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -358,10 +379,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -371,19 +398,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -467,6 +467,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -483,10 +504,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -496,19 +523,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -470,6 +470,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -486,10 +507,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -499,19 +526,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -471,6 +471,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -487,10 +508,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -500,19 +527,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -470,6 +470,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -486,10 +507,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -499,19 +526,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -473,6 +473,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -489,10 +510,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -502,19 +529,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -493,6 +493,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -509,10 +530,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -522,19 +549,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -474,6 +474,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -490,10 +511,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -503,19 +530,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -471,6 +471,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -487,10 +508,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -500,19 +527,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -488,6 +488,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -504,10 +525,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -517,19 +544,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -473,6 +473,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -489,10 +510,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -502,19 +529,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/diagram/SKILL.md
+++ b/diagram/SKILL.md
@@ -468,6 +468,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -484,10 +505,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -497,19 +524,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/document-generate/SKILL.md
+++ b/document-generate/SKILL.md
@@ -473,6 +473,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -489,10 +510,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -502,19 +529,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -471,6 +471,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -487,10 +508,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -500,19 +527,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -469,6 +469,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -485,10 +506,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -498,19 +525,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -508,6 +508,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -524,10 +545,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -537,19 +564,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/ios-clean/SKILL.md
+++ b/ios-clean/SKILL.md
@@ -471,6 +471,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -487,10 +508,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -500,19 +527,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/ios-design-review/SKILL.md
+++ b/ios-design-review/SKILL.md
@@ -473,6 +473,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -489,10 +510,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -502,19 +529,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/ios-fix/SKILL.md
+++ b/ios-fix/SKILL.md
@@ -474,6 +474,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -490,10 +511,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -503,19 +530,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/ios-qa/SKILL.md
+++ b/ios-qa/SKILL.md
@@ -477,6 +477,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -493,10 +514,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -506,19 +533,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/ios-sync/SKILL.md
+++ b/ios-sync/SKILL.md
@@ -471,6 +471,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -487,10 +508,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -500,19 +527,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -466,6 +466,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -482,10 +503,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -495,19 +522,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -467,6 +467,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -483,10 +504,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -496,19 +523,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -469,6 +469,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -485,10 +506,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -498,19 +525,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -379,6 +379,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -395,10 +416,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -408,19 +435,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -504,6 +504,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -520,10 +541,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -533,19 +560,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -466,6 +466,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -482,10 +503,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -495,19 +522,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -468,6 +468,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -484,10 +505,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -497,19 +524,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -498,6 +498,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -514,10 +535,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -527,19 +554,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -470,6 +470,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -486,10 +507,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -499,19 +526,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -476,6 +476,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -492,10 +513,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -505,19 +532,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -474,6 +474,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -490,10 +511,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -503,19 +530,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -479,6 +479,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -495,10 +516,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -508,19 +535,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -469,6 +469,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -485,10 +506,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -498,19 +525,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -475,6 +475,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -491,10 +512,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -504,19 +531,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -486,6 +486,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -502,10 +523,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -515,19 +542,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -471,6 +471,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -487,10 +508,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -500,19 +527,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/scrape/SKILL.md
+++ b/scrape/SKILL.md
@@ -467,6 +467,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -483,10 +504,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -496,19 +523,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/scripts/resolvers/preamble/generate-brain-sync-block.ts
+++ b/scripts/resolvers/preamble/generate-brain-sync-block.ts
@@ -45,6 +45,27 @@ fi
 _BRAIN_SYNC_BIN="${ctx.paths.binDir}/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="${ctx.paths.binDir}/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^\[mcp_servers\.gbrain\]$/ { in_gbrain = 1; next }
+    /^\[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style \`.gbrain-source\` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -61,10 +82,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See \"## GBrain Search Guidance\" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \\\`gbrain search\\\`/\\\`gbrain query\\\` over Grep for"
       echo "semantic questions; use \\\`gbrain code-def\\\`/\\\`code-refs\\\`/\\\`code-callers\\\` for"
       echo "symbol-aware code lookup. See \\"## GBrain Search Guidance\\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \\\`/sync-gbrain --full\\\`"
       echo "before relying on \\\`gbrain search\\\` for code questions in this worktree."
@@ -74,19 +101,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -338,6 +338,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -354,10 +375,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -367,19 +394,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -470,6 +470,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -486,10 +507,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -499,19 +526,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -469,6 +469,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -485,10 +506,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -498,19 +525,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')
@@ -1557,25 +1571,29 @@ last-sync time. Machine state stays in the Configuration block above.
 ## GBrain Search Guidance (configured by /sync-gbrain)
 <!-- gstack-gbrain-search-guidance:start -->
 
-GBrain is set up and synced on this machine. The agent should prefer gbrain
-over Grep when the question is semantic or when you don't know the exact
-identifier yet. Two indexed corpora available via the `gbrain` CLI:
+GBrain is set up and synced on this machine. Prefer the registered
+`mcp__gbrain__*` tools over Grep when the question is semantic or when you
+don't know the exact identifier yet. The MCP service may be the sole owner of
+the local PGLite database, so do not run the corresponding `gbrain` CLI query
+while that service is live. Two indexed corpora are available through MCP:
 - This repo's code (registered as `gstack-code-<repo>` source).
 - `~/.gstack/` curated memory (registered as `gstack-brain-<user>` source via
   the existing federation pipeline).
 
-Prefer gbrain when:
+Prefer GBrain MCP when:
 - "Where is X handled?" / semantic intent, no exact string yet:
-    `gbrain search "<terms>"` or `gbrain query "<question>"`
+    `mcp__gbrain__search` or `mcp__gbrain__query`
 - "Where is symbol Y defined?" / symbol-based code questions:
-    `gbrain code-def <symbol>` or `gbrain code-refs <symbol>`
+    `mcp__gbrain__code_def` or `mcp__gbrain__code_refs`
 - "What calls Y?" / "What does Y depend on?":
-    `gbrain code-callers <symbol>` / `gbrain code-callees <symbol>`
+    `mcp__gbrain__code_callers` / `mcp__gbrain__code_callees`
 - "What did we decide last time?" / past plans, retros, learnings:
-    `gbrain search "<terms>" --source gstack-brain-<user>`
+    `mcp__gbrain__search` with `source_id: gstack-brain-<user>`
 
 Grep is still right for known exact strings, regex, multiline patterns, and
-file globs. The brain auto-syncs incrementally on every gstack skill start.
+file globs. Use the local CLI only as a fallback when MCP is not registered
+and no live GBrain server owns PGLite. The brain auto-syncs incrementally on
+every gstack skill start.
 Run `/sync-gbrain` to force-refresh, `/sync-gbrain --full` for full reindex.
 
 <!-- gstack-gbrain-search-guidance:end -->

--- a/setup-gbrain/SKILL.md.tmpl
+++ b/setup-gbrain/SKILL.md.tmpl
@@ -803,25 +803,29 @@ last-sync time. Machine state stays in the Configuration block above.
 ## GBrain Search Guidance (configured by /sync-gbrain)
 <!-- gstack-gbrain-search-guidance:start -->
 
-GBrain is set up and synced on this machine. The agent should prefer gbrain
-over Grep when the question is semantic or when you don't know the exact
-identifier yet. Two indexed corpora available via the `gbrain` CLI:
+GBrain is set up and synced on this machine. Prefer the registered
+`mcp__gbrain__*` tools over Grep when the question is semantic or when you
+don't know the exact identifier yet. The MCP service may be the sole owner of
+the local PGLite database, so do not run the corresponding `gbrain` CLI query
+while that service is live. Two indexed corpora are available through MCP:
 - This repo's code (registered as `gstack-code-<repo>` source).
 - `~/.gstack/` curated memory (registered as `gstack-brain-<user>` source via
   the existing federation pipeline).
 
-Prefer gbrain when:
+Prefer GBrain MCP when:
 - "Where is X handled?" / semantic intent, no exact string yet:
-    `gbrain search "<terms>"` or `gbrain query "<question>"`
+    `mcp__gbrain__search` or `mcp__gbrain__query`
 - "Where is symbol Y defined?" / symbol-based code questions:
-    `gbrain code-def <symbol>` or `gbrain code-refs <symbol>`
+    `mcp__gbrain__code_def` or `mcp__gbrain__code_refs`
 - "What calls Y?" / "What does Y depend on?":
-    `gbrain code-callers <symbol>` / `gbrain code-callees <symbol>`
+    `mcp__gbrain__code_callers` / `mcp__gbrain__code_callees`
 - "What did we decide last time?" / past plans, retros, learnings:
-    `gbrain search "<terms>" --source gstack-brain-<user>`
+    `mcp__gbrain__search` with `source_id: gstack-brain-<user>`
 
 Grep is still right for known exact strings, regex, multiline patterns, and
-file globs. The brain auto-syncs incrementally on every gstack skill start.
+file globs. Use the local CLI only as a fallback when MCP is not registered
+and no live GBrain server owns PGLite. The brain auto-syncs incrementally on
+every gstack skill start.
 Run `/sync-gbrain` to force-refresh, `/sync-gbrain --full` for full reindex.
 
 <!-- gstack-gbrain-search-guidance:end -->

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -471,6 +471,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -487,10 +508,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -500,19 +527,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/skillify/SKILL.md
+++ b/skillify/SKILL.md
@@ -467,6 +467,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -483,10 +504,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -496,19 +523,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -468,6 +468,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -484,10 +505,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -497,19 +524,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')
@@ -1538,6 +1552,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -1554,10 +1589,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -1567,19 +1608,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -469,6 +469,27 @@ fi
 _BRAIN_SYNC_BIN="~/.claude/skills/gstack/bin/gstack-brain-sync"
 _BRAIN_CONFIG_BIN="~/.claude/skills/gstack/bin/gstack-config"
 
+# Detect an MCP registration before printing query guidance. A local HTTP MCP
+# server may be the sole owner of PGLite, so normal agent queries must not
+# start a competing gbrain CLI process.
+_GBRAIN_MCP_MODE="none"
+if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
+  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
+  case "$_GBRAIN_MCP_TYPE" in
+    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
+    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
+  esac
+fi
+if [ "$_GBRAIN_MCP_MODE" = "none" ] && [ -f "$HOME/.codex/config.toml" ]; then
+  _GBRAIN_MCP_MODE=$(awk '
+    /^[mcp_servers.gbrain]$/ { in_gbrain = 1; next }
+    /^[/ { in_gbrain = 0 }
+    in_gbrain && /^[[:space:]]*url[[:space:]]*=/ { print "remote-http"; exit }
+    in_gbrain && /^[[:space:]]*command[[:space:]]*=/ { print "local-stdio"; exit }
+  ' "$HOME/.codex/config.toml" 2>/dev/null)
+  [ -n "$_GBRAIN_MCP_MODE" ] || _GBRAIN_MCP_MODE="none"
+fi
+
 # /sync-gbrain context-load: teach the agent to use gbrain when it's available.
 # Per-worktree pin: post-spike redesign uses kubectl-style `.gbrain-source` in the
 # git toplevel to scope queries. Look for the pin in the worktree (not a global
@@ -485,10 +506,16 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
       _GBRAIN_PIN_PATH="$_REPO_TOP/.gbrain-source"
     fi
     if [ -n "$_GBRAIN_PIN_PATH" ]; then
+      if [ "$_GBRAIN_MCP_MODE" != "none" ]; then
+        echo "GBrain MCP is configured. Use mcp__gbrain__search/query and mcp__gbrain__code_*"
+        echo "for normal queries. Do not run the local gbrain CLI while the MCP server owns PGLite."
+        echo "See "## GBrain Search Guidance" in CLAUDE.md. Run /sync-gbrain to refresh."
+      else
       echo "GBrain configured. Prefer \`gbrain search\`/\`gbrain query\` over Grep for"
       echo "semantic questions; use \`gbrain code-def\`/\`code-refs\`/\`code-callers\` for"
       echo "symbol-aware code lookup. See \"## GBrain Search Guidance\" in CLAUDE.md."
       echo "Run /sync-gbrain to refresh."
+      fi
     else
       echo "GBrain configured but this worktree isn't pinned yet. Run \`/sync-gbrain --full\`"
       echo "before relying on \`gbrain search\` for code questions in this worktree."
@@ -498,19 +525,6 @@ if [ -f "$_GBRAIN_CONFIG" ] && command -v gbrain >/dev/null 2>&1; then
 fi
 
 _BRAIN_SYNC_MODE=$("$_BRAIN_CONFIG_BIN" get artifacts_sync_mode 2>/dev/null || echo off)
-
-# Detect remote-MCP mode (Path 4 of /setup-gbrain). Local artifacts sync is
-# a no-op in remote mode; the brain server pulls from GitHub/GitLab on its
-# own cadence. Read claude.json directly to keep this preamble fast (no
-# subprocess to claude CLI on every skill start).
-_GBRAIN_MCP_MODE="none"
-if command -v jq >/dev/null 2>&1 && [ -f "$HOME/.claude.json" ]; then
-  _GBRAIN_MCP_TYPE=$(jq -r '.mcpServers.gbrain.type // .mcpServers.gbrain.transport // empty' "$HOME/.claude.json" 2>/dev/null)
-  case "$_GBRAIN_MCP_TYPE" in
-    url|http|sse) _GBRAIN_MCP_MODE="remote-http" ;;
-    stdio) _GBRAIN_MCP_MODE="local-stdio" ;;
-  esac
-fi
 
 if [ -f "$_BRAIN_REMOTE_FILE" ] && [ ! -d "$_GSTACK_HOME/.git" ] && [ "$_BRAIN_SYNC_MODE" = "off" ]; then
   _BRAIN_NEW_URL=$(head -1 "$_BRAIN_REMOTE_FILE" 2>/dev/null | tr -d '[:space:]')
@@ -1106,14 +1120,16 @@ Verbatim block content (copy exactly):
 ## GBrain Search Guidance (configured by /sync-gbrain)
 <!-- gstack-gbrain-search-guidance:start -->
 
-GBrain is set up and synced on this machine. The agent should prefer gbrain
-over Grep when the question is semantic or when you don't know the exact
-identifier yet.
+GBrain is set up and synced on this machine. Prefer the registered
+`mcp__gbrain__*` tools over Grep when the question is semantic or when you
+don't know the exact identifier yet. The MCP service may be the sole owner of
+the local PGLite database, so do not run the corresponding `gbrain` CLI query
+while that service is live.
 
 **This worktree is pinned to a worktree-scoped code source** via the
 `.gbrain-source` file in the repo root (kubectl-style context).
-`gbrain code-def`, `code-refs`, `code-callers`, `code-callees`, `search`, and
-`query` from anywhere under this worktree route to that source by default —
+`mcp__gbrain__code_def`, `code_refs`, `code_callers`, `code_callees`, `search`,
+and `query` from anywhere under this worktree route to that source by default —
 no `--source` flag needed (gbrain >= 0.41.38.0; on older gbrain the call-graph
 commands need `--source "$(cat .gbrain-source)"`). Conductor sibling worktrees
 of the same repo each have their own pin and their own indexed pages, so
@@ -1125,25 +1141,27 @@ built first — run `/sync-gbrain --dream` (or `--full`) if they return
 symbols; on a non-code-aware pack `--dream` completes but the graph stays empty
 and reports a WARN. `code-def`/`code-refs` need the same extraction.
 
-Two indexed corpora available via the `gbrain` CLI:
+Two indexed corpora available through the GBrain MCP service:
 - This worktree's code (auto-pinned via `.gbrain-source`).
 - `~/.gstack/` curated memory (registered as `gstack-brain-<user>` source via
   the existing federation pipeline).
 
-Prefer gbrain when:
+Prefer GBrain MCP when:
 - "Where is X handled?" / semantic intent, no exact string yet:
-    `gbrain search "<terms>"` or `gbrain query "<question>"`
+    `mcp__gbrain__search` or `mcp__gbrain__query`
 - "Where is symbol Y defined?" / symbol-based code questions:
-    `gbrain code-def <symbol>` or `gbrain code-refs <symbol>`
+    `mcp__gbrain__code_def` or `mcp__gbrain__code_refs`
 - "What calls Y?" / "What does Y depend on?":
-    `gbrain code-callers <symbol>` / `gbrain code-callees <symbol>`
+    `mcp__gbrain__code_callers` / `mcp__gbrain__code_callees`
 - "What did we decide last time?" / past plans, retros, learnings:
-    `gbrain search "<terms>" --source gstack-brain-<user>`
+    `mcp__gbrain__search` with `source_id: gstack-brain-<user>`
 
 Grep is still right for known exact strings, regex, multiline patterns, and
-file globs. Run `/sync-gbrain` after meaningful code changes; for ongoing
-auto-sync across all worktrees, run `gbrain autopilot --install` once per
-machine — gbrain's daemon handles incremental refresh on a schedule.
+file globs. Use the local CLI only as a fallback when MCP is not registered
+and no live GBrain server owns PGLite. Run `/sync-gbrain` after meaningful
+code changes; for ongoing
+auto-sync across all worktrees, run `gbrain autopilot --install` only on a
+machine where MCP is not registered. Do not run two database-owning services.
 
 Safety: don't run `/sync-gbrain` while `gbrain autopilot` is active — the
 orchestrator refuses destructive source ops when it detects a running autopilot

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -352,14 +352,16 @@ Verbatim block content (copy exactly):
 ## GBrain Search Guidance (configured by /sync-gbrain)
 <!-- gstack-gbrain-search-guidance:start -->
 
-GBrain is set up and synced on this machine. The agent should prefer gbrain
-over Grep when the question is semantic or when you don't know the exact
-identifier yet.
+GBrain is set up and synced on this machine. Prefer the registered
+`mcp__gbrain__*` tools over Grep when the question is semantic or when you
+don't know the exact identifier yet. The MCP service may be the sole owner of
+the local PGLite database, so do not run the corresponding `gbrain` CLI query
+while that service is live.
 
 **This worktree is pinned to a worktree-scoped code source** via the
 `.gbrain-source` file in the repo root (kubectl-style context).
-`gbrain code-def`, `code-refs`, `code-callers`, `code-callees`, `search`, and
-`query` from anywhere under this worktree route to that source by default —
+`mcp__gbrain__code_def`, `code_refs`, `code_callers`, `code_callees`, `search`,
+and `query` from anywhere under this worktree route to that source by default —
 no `--source` flag needed (gbrain >= 0.41.38.0; on older gbrain the call-graph
 commands need `--source "$(cat .gbrain-source)"`). Conductor sibling worktrees
 of the same repo each have their own pin and their own indexed pages, so
@@ -371,25 +373,27 @@ built first — run `/sync-gbrain --dream` (or `--full`) if they return
 symbols; on a non-code-aware pack `--dream` completes but the graph stays empty
 and reports a WARN. `code-def`/`code-refs` need the same extraction.
 
-Two indexed corpora available via the `gbrain` CLI:
+Two indexed corpora available through the GBrain MCP service:
 - This worktree's code (auto-pinned via `.gbrain-source`).
 - `~/.gstack/` curated memory (registered as `gstack-brain-<user>` source via
   the existing federation pipeline).
 
-Prefer gbrain when:
+Prefer GBrain MCP when:
 - "Where is X handled?" / semantic intent, no exact string yet:
-    `gbrain search "<terms>"` or `gbrain query "<question>"`
+    `mcp__gbrain__search` or `mcp__gbrain__query`
 - "Where is symbol Y defined?" / symbol-based code questions:
-    `gbrain code-def <symbol>` or `gbrain code-refs <symbol>`
+    `mcp__gbrain__code_def` or `mcp__gbrain__code_refs`
 - "What calls Y?" / "What does Y depend on?":
-    `gbrain code-callers <symbol>` / `gbrain code-callees <symbol>`
+    `mcp__gbrain__code_callers` / `mcp__gbrain__code_callees`
 - "What did we decide last time?" / past plans, retros, learnings:
-    `gbrain search "<terms>" --source gstack-brain-<user>`
+    `mcp__gbrain__search` with `source_id: gstack-brain-<user>`
 
 Grep is still right for known exact strings, regex, multiline patterns, and
-file globs. Run `/sync-gbrain` after meaningful code changes; for ongoing
-auto-sync across all worktrees, run `gbrain autopilot --install` once per
-machine — gbrain's daemon handles incremental refresh on a schedule.
+file globs. Use the local CLI only as a fallback when MCP is not registered
+and no live GBrain server owns PGLite. Run `/sync-gbrain` after meaningful
+code changes; for ongoing
+auto-sync across all worktrees, run `gbrain autopilot --install` only on a
+machine where MCP is not registered. Do not run two database-owning services.
 
 Safety: don't run `/sync-gbrain` while `gbrain autopilot` is active — the
 orchestrator refuses destructive source ops when it detects a running autopilot

--- a/test/gbrain-mcp-routing-guidance.test.ts
+++ b/test/gbrain-mcp-routing-guidance.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { generateBrainSyncBlock } from '../scripts/resolvers/preamble/generate-brain-sync-block';
+import { HOST_PATHS } from '../scripts/resolvers/types';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+
+describe('GBrain MCP routing guidance', () => {
+  test('skill preamble detects MCP before telling the agent how to query', () => {
+    const block = generateBrainSyncBlock({
+      skillName: 'sync-gbrain',
+      tmplPath: 'sync-gbrain/SKILL.md.tmpl',
+      host: 'codex',
+      paths: HOST_PATHS.codex,
+    });
+
+    expect(block).toContain('mcp__gbrain__search/query');
+    expect(block).toContain('Do not run the local gbrain CLI while the MCP server owns PGLite.');
+    expect(block).toContain('$HOME/.codex/config.toml');
+    expect(block.indexOf('_GBRAIN_MCP_MODE="none"')).toBeLessThan(
+      block.indexOf('GBrain MCP is configured.'),
+    );
+  });
+
+  test('setup and sync templates make MCP primary and CLI a lock-safe fallback', () => {
+    for (const template of ['setup-gbrain/SKILL.md.tmpl', 'sync-gbrain/SKILL.md.tmpl']) {
+      const content = fs.readFileSync(path.join(ROOT, template), 'utf8');
+      expect(content).toContain('`mcp__gbrain__*` tools');
+      expect(content).toContain('do not run the corresponding `gbrain` CLI query');
+      expect(content).toContain('no live GBrain server owns PGLite');
+    }
+  });
+});


### PR DESCRIPTION
## What changed

- detect Claude and Codex GBrain MCP registrations before printing query guidance
- direct normal semantic and code-graph reads through `mcp__gbrain__*`
- reserve the local CLI for installations without a live PGLite-owning MCP service
- add regression coverage for the generated preamble and setup/sync guidance

## Why

A local HTTP MCP service can be the sole owner of a PGLite database. The generated guidance still told agents to start local `gbrain` CLI queries, which creates avoidable lock contention.

## Verification

- `bun run gen:skill-docs`
- `bun run gen:skill-docs --host codex`
- `bun test test/gbrain-mcp-routing-guidance.test.ts test/gen-skill-docs.test.ts` (404 pass)