### PR TITLE
fix(browse): allow about:blank so a restarted daemon can initialise

### DIFF
--- a/browse/src/url-validation.ts
+++ b/browse/src/url-validation.ts
@@ -269,9 +269,24 @@ export async function validateNavigationUrl(url: string): Promise<string> {
     return pathToFileURL(fsPath).href + parsed.search + parsed.hash;
   }
 
+  // about:blank ONLY — the canonical empty page, and the one the daemon opens its own
+  // first tab on. Blocking it meant `browse newtab about:blank` failed, which is what
+  // `make-pdf setup` runs as its Chromium smoke test: make-pdf reported "Chromium failed
+  // to launch" against a perfectly healthy Chromium, and any browse session whose daemon
+  // restarted could never recreate the blank tab it starts from.
+  //
+  // Deliberately not the whole `about:` scheme. about:blank has no origin, loads nothing
+  // and runs nothing; about:config, about:net-internals and friends are real surfaces.
+  // Exact href match, not a prefix test, so `about:blankfoo` stays blocked.
+  // Compared lower-cased: the URL parser normalises the PROTOCOL but not the opaque part,
+  // so `ABOUT:BLANK` parses to href `about:BLANK` and an exact === would reject it.
+  if (parsed.protocol === 'about:' && parsed.href.toLowerCase() === 'about:blank') {
+    return 'about:blank';
+  }
+
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new Error(
-      `Blocked: scheme "${parsed.protocol}" is not allowed. Only http:, https:, and file: URLs are permitted.`
+      `Blocked: scheme "${parsed.protocol}" is not allowed. Only http:, https:, file:, and about:blank URLs are permitted.`
     );
   }
 

--- a/browse/test/url-validation.test.ts
+++ b/browse/test/url-validation.test.ts
@@ -47,6 +47,28 @@ describe('validateNavigationUrl', () => {
     await expect(validateNavigationUrl('file://host.example.com/foo.html')).rejects.toThrow(/Unsupported file URL host/i);
   });
 
+  // The daemon opens its own first tab on about:blank, so blocking it meant a restarted
+  // daemon could never initialise — and `make-pdf setup`, whose Chromium smoke test is
+  // `browse newtab about:blank`, reported "Chromium failed to launch" on a healthy browser.
+  it('allows about:blank — the daemon opens its own first tab there', async () => {
+    await expect(validateNavigationUrl('about:blank')).resolves.toBe('about:blank');
+  });
+
+  it('allows about:blank regardless of case, since URL parsing normalises it', async () => {
+    await expect(validateNavigationUrl('ABOUT:BLANK')).resolves.toBe('about:blank');
+  });
+
+  // The allowance is about:blank EXACTLY, not the about: scheme. about:blank has no
+  // origin and loads nothing; the rest of the scheme is a real surface.
+  it('still blocks other about: URLs', async () => {
+    await expect(validateNavigationUrl('about:config')).rejects.toThrow(/scheme.*not allowed/i);
+    await expect(validateNavigationUrl('about:net-internals')).rejects.toThrow(/scheme.*not allowed/i);
+  });
+
+  it('blocks about:blankfoo — exact match, never a prefix test', async () => {
+    await expect(validateNavigationUrl('about:blankfoo')).rejects.toThrow(/scheme.*not allowed/i);
+  });
+
   it('blocks javascript: scheme', async () => {
     await expect(validateNavigationUrl('javascript:alert(1)')).rejects.toThrow(/scheme.*not allowed/i);
   });


### PR DESCRIPTION
## The bug

`validateNavigationUrl` rejects every scheme except http(s) and file — including `about:blank`. But the daemon opens its own first tab on about:blank, so once it restarts it can never come back:

```
$ browse newtab about:blank
Blocked: scheme "about:" is not allowed. Only http:, https:, and file: URLs are permitted.
```

## Why it shows up as a make-pdf failure

make-pdf's Chromium smoke test is exactly that command, so `make-pdf setup` reports:

```
[2/5] Launching Chromium... FAIL
Chromium failed to launch: browse newtab exited 1
```

against a completely healthy Chromium — and `generate` fails downstream with `page.pdf: Protocol error (IO.read): Read failed`, which is what talking to a half-started daemon looks like. Both symptoms point away from the cause, which is why this was slow to find.

**It only reproduces once the daemon restarts.** A daemon still holding its original tab keeps working, so the bug stays hidden until something recycles the process — and then make-pdf is dead until the tab gets recreated some other way.

## Scope

As narrow as it can be: `about:blank` **exactly**, matched on `href`, not the `about:` scheme.

| URL | Before | After |
|---|---|---|
| `about:blank` | blocked | **allowed** |
| `ABOUT:BLANK` | blocked | **allowed** |
| `about:config` | blocked | blocked |
| `about:net-internals` | blocked | blocked |
| `about:blankfoo` | blocked | blocked |
| `javascript:` / `data:` / `chrome://` | blocked | blocked |

about:blank has no origin, loads nothing and runs nothing. The rest of the scheme is a real surface and stays out.

Compared lower-cased because the URL parser normalises the protocol but not the opaque part, so `ABOUT:BLANK` parses to href `about:BLANK`. My first version used `===` and the test caught it.

## Tests

4 added to `browse/test/url-validation.test.ts` — about:blank resolves (and case-insensitively), about:config and about:net-internals still rejected, about:blankfoo still rejected.

Verified end to end on Windows: with the daemon killed, `make-pdf generate` on a 9-page document now goes cold start → PDF in 4.8s. Before, it failed every time.

## One note for reviewers on Windows

`browse/test/url-validation.test.ts` has **5 pre-existing failures** on this platform, all in the `file://` suites, which assume POSIX paths (`/tmp`, `/etc/passwd`). Unrelated to this change and unchanged by it — same 5 before and after. Happy to send a separate PR for those if useful.
