### PR TITLE
fix(make-pdf): reject a directory when resolving the browse binary

### DIFF
--- a/make-pdf/src/browseClient.ts
+++ b/make-pdf/src/browseClient.ts
@@ -158,6 +158,11 @@ export function resolveBrowseBin(env: NodeJS.ProcessEnv = process.env): string {
 
 function isExecutable(p: string): boolean {
   try {
+    // Must be a regular FILE. access(X_OK) alone is true for directories — they carry the
+    // execute/traverse bit on POSIX and pass the Windows check too — so discovery happily
+    // "found" ~/.claude/skills/browse, which is the skill's docs folder containing nothing
+    // but SKILL.md, and returned a directory as the browse binary.
+    if (!fs.statSync(p).isFile()) return false;
     fs.accessSync(p, fs.constants.X_OK);
     return true;
   } catch {

--- a/make-pdf/test/browseClient.test.ts
+++ b/make-pdf/test/browseClient.test.ts
@@ -59,6 +59,41 @@ describe("findExecutable", () => {
     const found = findExecutable("/nonexistent/path/to/nothing");
     expect(found).toBeNull();
   });
+
+  // access(X_OK) is TRUE for directories — they carry the execute/traverse bit — so a
+  // bare X_OK test returned ~/.claude/skills/browse, the skill's docs folder, as "the
+  // browse binary". Every browse call then failed with an empty error, which surfaced
+  // as make-pdf reporting "Chromium failed to launch".
+  test("rejects a DIRECTORY even though it passes access(X_OK)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mkpdf-dir-"));
+    try {
+      // Prove the precondition: the directory really does pass the old test.
+      let passesXok = true;
+      try {
+        fs.accessSync(dir, fs.constants.X_OK);
+      } catch {
+        passesXok = false;
+      }
+      expect(passesXok).toBe(true);
+
+      expect(findExecutable(dir)).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a directory that shadows a real binary name", () => {
+    // The exact shape of the bug: a directory named like the thing being looked for.
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "mkpdf-shadow-"));
+    const shadow = path.join(base, "browse");
+    fs.mkdirSync(shadow);
+    fs.writeFileSync(path.join(shadow, "SKILL.md"), "# not a binary\n");
+    try {
+      expect(findExecutable(shadow)).toBeNull();
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("resolveBrowseBin", () => {


### PR DESCRIPTION
## The bug

`isExecutable()` tests `access(X_OK)` alone. That is **true for directories** — they carry the execute/traverse bit on POSIX and pass the check on Windows too — so binary discovery accepts a directory as the browse binary.

It bites on a stock global install. `~/.claude/skills/browse` is the skill's own docs folder, containing nothing but `SKILL.md`, but it sits on a probed path, passes `X_OK`, and wins.

## What the user sees

```
[1/5] Checking browse binary... OK (C:\Users\...\.claude\skills\browse)
[2/5] Launching Chromium... FAIL
Chromium failed to launch: browse newtab exited 1:
```

Two things make this hard to diagnose: the first line reports the **wrong path as OK**, and the error string is empty because what actually happened is that a directory was executed as a program. Setting `GSTACK_BROWSE_BIN` works around it, which makes it look like a discovery-*order* problem rather than a type-check problem.

## The fix

One `statSync(p).isFile()` before the access check.

## Tests

2 added to `make-pdf/test/browseClient.test.ts`, both failing before this change and passing after:

- **`rejects a DIRECTORY even though it passes access(X_OK)`** — asserts the precondition explicitly first, that the directory really does pass `access(X_OK)`, so the test documents *why* the bare check was wrong rather than only pinning the new behaviour.
- **`rejects a directory that shadows a real binary name`** — reproduces the exact shape: a directory named `browse` containing a `SKILL.md`.

```
WITH fix:     11 pass, 0 fail
WITHOUT fix:   9 pass, 2 fail   ← the two new ones
```

No pre-existing failures in this suite on Windows.

## Relationship to #2537

Found while fixing #2537 (`about:blank` blocked, which stops the daemon initialising). They're independent bugs in different packages — either can be merged alone — but on a Windows machine you need both before `make-pdf` works, so it's worth knowing they travel together.
