### PR TITLE
fix(browse): forward windowsHide through the Bun polyfill spawn shims

### DIFF
--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -75,6 +75,10 @@ globalThis.Bun = {
       timeout: options.timeout,
       env: options.env,
       cwd: options.cwd,
+      // Node defaults windowsHide to false; Bun.spawn hides the console
+      // window. Without this the shim silently inverts the behavior on the
+      // one platform it exists to serve. See the spawn() note below.
+      windowsHide: options.windowsHide !== false,
     });
 
     return {
@@ -91,6 +95,11 @@ globalThis.Bun = {
       stdio,
       env: options.env,
       cwd: options.cwd,
+      // stdio:'ignore' silences a child's output but does not suppress its
+      // console window on Windows. The terminal-agent respawn (server.ts
+      // watchdog, 60s ticker) therefore popped a visible bun.exe window on
+      // every respawn until this was forwarded.
+      windowsHide: options.windowsHide !== false,
     });
 
     return {

--- a/browse/src/terminal-agent-control.ts
+++ b/browse/src/terminal-agent-control.ts
@@ -77,6 +77,10 @@ export function spawnTerminalAgent(opts: {
       ...(opts.extraEnv || {}),
     },
     stdio: ['ignore', 'ignore', 'ignore'],
+    // Explicit for the Node fallback path (dist/bun-polyfill.cjs), where the
+    // host default is the opposite of Bun's. A visible console window on every
+    // watchdog respawn is the symptom when this is missing.
+    windowsHide: true,
   });
   proc.unref?.();
   return proc.pid ?? null;

--- a/browse/test/bun-polyfill.test.ts
+++ b/browse/test/bun-polyfill.test.ts
@@ -3,6 +3,9 @@ import * as path from 'path';
 
 // Load the polyfill into a fresh object (don't clobber globalThis.Bun)
 const polyfillPath = path.resolve(import.meta.dir, '../src/bun-polyfill.cjs');
+// Forward slashes so the path survives interpolation into a JS string literal
+// on Windows, which is the platform this polyfill exists for.
+const requirePath = polyfillPath.replace(/\\/g, '/');
 
 describe('bun-polyfill', () => {
   // We test the polyfill by requiring it in a subprocess under Node.js
@@ -10,7 +13,7 @@ describe('bun-polyfill', () => {
 
   test('Bun.sleep resolves after delay', async () => {
     const result = Bun.spawnSync(['node', '-e', `
-      require('${polyfillPath}');
+      require('${requirePath}');
       (async () => {
         const start = Date.now();
         await Bun.sleep(50);
@@ -24,7 +27,7 @@ describe('bun-polyfill', () => {
 
   test('Bun.spawnSync runs a command and returns stdout', () => {
     const result = Bun.spawnSync(['node', '-e', `
-      require('${polyfillPath}');
+      require('${requirePath}');
       const r = Bun.spawnSync(['echo', 'hello'], { stdout: 'pipe' });
       console.log(r.stdout.toString().trim());
       console.log('exit:' + r.exitCode);
@@ -36,7 +39,7 @@ describe('bun-polyfill', () => {
 
   test('Bun.spawn launches a process with pid', async () => {
     const result = Bun.spawnSync(['node', '-e', `
-      require('${polyfillPath}');
+      require('${requirePath}');
       const p = Bun.spawn(['echo', 'test'], { stdio: ['pipe', 'pipe', 'pipe'] });
       console.log(typeof p.pid === 'number' ? 'HAS_PID' : 'NO_PID');
       console.log(typeof p.kill === 'function' ? 'HAS_KILL' : 'NO_KILL');
@@ -48,9 +51,52 @@ describe('bun-polyfill', () => {
     expect(lines[2]).toBe('HAS_UNREF');
   });
 
+  // windowsHide is the one option where Node's default is the opposite of
+  // Bun's: Node shows the child's console window, Bun hides it. Dropping it
+  // in translation makes every spawned child pop a window on Windows, which
+  // is the platform this whole file exists for. Both shims are covered.
+  test('Bun.spawn defaults windowsHide to true', () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      const cp = require('child_process');
+      const orig = cp.spawn;
+      let seen;
+      cp.spawn = (c, a, o) => { seen = o; return orig(c, a, o); };
+      require('${requirePath}');
+      Bun.spawn(['node', '-e', ''], { stdio: ['ignore', 'ignore', 'ignore'] });
+      console.log('windowsHide:' + seen.windowsHide);
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    expect(result.stdout.toString().trim()).toBe('windowsHide:true');
+  });
+
+  test('Bun.spawnSync defaults windowsHide to true', () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      const cp = require('child_process');
+      const orig = cp.spawnSync;
+      let seen;
+      cp.spawnSync = (c, a, o) => { seen = o; return orig(c, a, o); };
+      require('${requirePath}');
+      Bun.spawnSync(['node', '-e', '']);
+      console.log('windowsHide:' + seen.windowsHide);
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    expect(result.stdout.toString().trim()).toBe('windowsHide:true');
+  });
+
+  test('an explicit windowsHide:false is honored', () => {
+    const result = Bun.spawnSync(['node', '-e', `
+      const cp = require('child_process');
+      const orig = cp.spawn;
+      let seen;
+      cp.spawn = (c, a, o) => { seen = o; return orig(c, a, o); };
+      require('${requirePath}');
+      Bun.spawn(['node', '-e', ''], { stdio: ['ignore', 'ignore', 'ignore'], windowsHide: false });
+      console.log('windowsHide:' + seen.windowsHide);
+    `], { stdout: 'pipe', stderr: 'pipe' });
+    expect(result.stdout.toString().trim()).toBe('windowsHide:false');
+  });
+
   test('Bun.serve creates an HTTP server that responds', async () => {
     const result = Bun.spawnSync(['node', '-e', `
-      require('${polyfillPath}');
+      require('${requirePath}');
       const server = Bun.serve({
         port: 0,  // Note: polyfill uses port directly, so we pick one
         hostname: '127.0.0.1',


### PR DESCRIPTION
## The bug

On Windows, a `bun.exe` console window reopens by itself every so often, with no scheduled task, Run key, or startup shortcut behind it. I chased it down to the browse daemon and it turned out to be three things stacked, only the last of which is a defect:

1. A browse daemon left running from a headed session cannot self-terminate. The parent-process watchdog is disabled by design in headed mode (`browse/src/server.ts:686`), which is correct, but it means an orphaned daemon lives until killed.
2. That daemon runs a 60s ticker that respawns the terminal-agent whenever the recorded child PID is dead (`browse/src/server.ts:1493-1548`).
3. Each respawn opens a **visible console window**, because `browse/src/bun-polyfill.cjs` accepts a `Bun.spawn` options object and forwards only `stdio`, `env`, and `cwd` to `child_process.spawn`.

`windowsHide` is dropped in translation. Node defaults it to `false`; `Bun.spawn` hides the window. So the shim silently inverts the behavior on the one platform it exists to serve, per its own header comment ("Bun API polyfill for Node.js — Windows compatibility layer").

`stdio: 'ignore'` silences the child's output but does not suppress its console window, so the existing spawn options don't cover this.

## The fix

Both shims forward the option and default it to `true`, matching the Bun API being emulated. An explicit `windowsHide: false` still passes through, so nothing loses the escape hatch. `spawnTerminalAgent` also sets it explicitly at the call site, which is where the symptom surfaced.

## Tests

Three cases added to `browse/test/bun-polyfill.test.ts`, in the file's existing subprocess style: the default for `spawn`, the default for `spawnSync`, and that an explicit `false` is honored. They patch `child_process` before the polyfill is required, so they assert on what actually reaches Node rather than on the source text.

I verified each one goes red against the unpatched shim (3 fail) and green with it (7 pass), so they are known to detect the defect rather than merely passing.

## One drive-by, and why it was unavoidable

The suite could not run at all on Windows before this. The tests interpolate an absolute path into a JS string literal, so `C:\Users\...` had its backslashes consumed as escapes and every `require()` failed with MODULE_NOT_FOUND. All four tests failed for that reason alone, not on their assertions.

The path is now normalized to forward slashes, which Node accepts on Windows. This file goes from **0/4 to 7/7 on Windows**. I kept the change to the one line that builds the path plus the interpolations, so the existing tests are otherwise untouched.

## Verification

- `bun test browse/test/bun-polyfill.test.ts`: 7 pass, 0 fail (was 0 pass, 4 fail on Windows).
- `bun test browse/test/terminal-agent-pid-identity.test.ts browse/test/terminal-agent-integration.test.ts`: 9 pass, 6 fail, **identical to the clean baseline** on this machine. Those 6 are pre-existing Windows failures in that suite and are not touched by this change.
- I did not complete a full `bun test` run. It far exceeds the "<5s Tier 1" figure in CONTRIBUTING on Windows and timed out locally at 10 minutes. Happy to run anything specific you want covered.

Environment: Windows 10 Pro 19045, bun 1.3.14, branched from d078622 (v1.62.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
