### PR TITLE
fix(gbrain-install): --dry-run no longer requires the network (fixes flaky bun test)

### DIFF
--- a/bin/gstack-gbrain-install
+++ b/bin/gstack-gbrain-install
@@ -84,7 +84,14 @@ if ! $VALIDATE_ONLY; then
   # GitHub reachability — fail fast if offline rather than hanging `git clone`.
   # --max-time 10, --head (no body), quiet. Status code 200-4xx means we reached
   # the server (even 404 is reachability proof).
-  if ! curl -s --head --max-time 10 https://github.com >/dev/null 2>&1; then
+  #
+  # Skipped under --dry-run: a dry run prints a plan and exits without ever
+  # cloning, so requiring the network buys nothing and costs a real failure mode.
+  # It made `--dry-run` fail (exit 3, "cannot reach https://github.com") whenever
+  # the curl lost a race for sockets/DNS — reproducible at ~15% by running 60
+  # dry-runs concurrently, and the cause of intermittent red in the D5 tests,
+  # which call this exact path.
+  if ! $DRY_RUN && ! curl -s --head --max-time 10 https://github.com >/dev/null 2>&1; then
     fail "cannot reach https://github.com. Check your network and try again."
   fi
 fi


### PR DESCRIPTION
Fixes the `bun test` non-determinism in #2536. One-line guard, plus a comment explaining why it's there.

## The bug

`gstack-gbrain-install --dry-run` prints a plan and exits without cloning anything — but it makes a live request to github.com first:

```sh
if ! $VALIDATE_ONLY; then
  check_prereq bun ...
  check_prereq git ...
  if ! curl -s --head --max-time 10 https://github.com >/dev/null 2>&1; then
    fail "cannot reach https://github.com. Check your network and try again."
  fi
fi
```

The check is gated on `VALIDATE_ONLY`. `--dry-run` sets `DRY_RUN`. So the dry-run path hits the network for a result nothing downstream uses — both dry-run branches `exit 0` before any clone.

When that curl loses a race for sockets or DNS, `fail()` exits **3** and a dry run reports "cannot reach https://github.com" on a machine that is online.

## Direct proof, no test runner involved

60 concurrent `--dry-run` invocations against temp `HOME`/`GSTACK_HOME`:

| | Failures |
|---|---|
| before | **9 / 60** (~15%), all `cannot reach https://github.com` |
| after | **0 / 60** |

## Why this made the suite flaky

The three `gstack-gbrain-install D5 detect-first` tests each call `run(INSTALL, ['--dry-run'])` and assert `expect(r.status).toBe(0)`. A full `bun test` spawns many concurrent processes, the curl occasionally loses, and whichever D5 test was running goes red.

Every symptom lines up: green in isolation (16/16, repeatedly), a *different* one of the three failing each run, sub-second failures rather than timeouts, and the observed exit code of exactly 3.

## Validation

The documented Tier 1 gate, on a clean clone:

| | Runs | Failed |
|---|---|---|
| before (#2536) | 7 | **3 (43%)** |
| after | 10 | **0** |

Ten consecutive clean runs against a 43% per-run failure rate is roughly a 0.4% coincidence.

## Scope

Real installs are unchanged — they still get the fail-fast offline check rather than a hanging `git clone`. Only the path that never clones skips it.

I first blamed a `PATH` leak and proposed defaulting `SAFE_PATH` in the test helper. That was wrong, and I've retracted it in #2536 — it would also have broken these tests on any machine where bun lives at `~/.bun/bin`, which `SAFE_PATH` excludes.

## Not addressed here

`telemetry > connects to Supabase when config exists` appeared once in my first sample and looks like the same shape — a real network call inside the free suite. I haven't investigated it and make no claim about it; noting it in case it's worth a look.

Environment: macOS (Darwin 25.5.0), bun 1.3.13, clean clone at `94993f7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
