### PR TITLE
fix(browse): create node bundle output directory

### DIFF
--- a/browse/scripts/build-node-server.sh
+++ b/browse/scripts/build-node-server.sh
@@ -10,6 +10,7 @@ set -e
 GSTACK_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 SRC_DIR="$GSTACK_DIR/browse/src"
 DIST_DIR="$GSTACK_DIR/browse/dist"
+mkdir -p "$DIST_DIR"
 
 echo "Building Node-compatible server bundle..."
 


### PR DESCRIPTION
## Summary
- create `browse/dist` before Bun writes the Node-compatible server bundle
- keep the build helper self-contained on clean checkouts

## Validation
- `bash -n browse/scripts/build-node-server.sh`
- `git diff --check`

This is intentionally limited to the missing output-directory precondition.