### PR TITLE
fix(redact): scan large diffs in slices; stop digit-only UUIDs matching as cards/phones

### DIFF
--- a/bin/gstack-redact-prepush
+++ b/bin/gstack-redact-prepush
@@ -114,6 +114,64 @@ function addedLinesFor(localSha: string, remoteSha: string): string {
   return added.join("\n");
 }
 
+/**
+ * Byte budget per scan() call. Kept comfortably under redact-engine's
+ * DEFAULT_MAX_BYTES (1 MiB) so a slice never trips its oversize guard.
+ */
+const SCAN_CHUNK_BYTES = 768 * 1024;
+
+/**
+ * Scan added lines in line-aligned slices, unioning the findings.
+ *
+ * Why: the engine refuses input over its byte cap and fails closed, which is
+ * right for one scan() call but wrong as a push policy — a feature branch
+ * catching up to a busy main legitimately produces more added lines than the
+ * cap (1,146,782 bytes against the 1 MiB default in the push that prompted
+ * this, and only ~7% of that was the lockfile). The push then blocked on
+ * `engine.input_too_large` — a size error naming no credential — which trains
+ * people to reach for --no-verify, defeating the guardrail far more thoroughly
+ * than a large diff does.
+ *
+ * Slicing loses NO detection coverage, because every pattern is single-line:
+ * none in redact-patterns.ts carries the `m` or `s` flag, the
+ * BEGIN-PRIVATE-KEY patterns capture only the header line rather than the key
+ * body, and the engine itself iterates line by line. A line boundary therefore
+ * cannot bisect a detectable secret, so no inter-slice overlap is needed.
+ *
+ * Fail-closed is preserved: a SINGLE line over the budget is still passed to
+ * the engine intact, so a genuinely unscannable blob (minified bundle,
+ * embedded base64) trips input_too_large and blocks exactly as before.
+ *
+ * Findings' line/col are slice-relative, which is fine here — this hook only
+ * reads severity, id and preview. Do not lift this into the engine, where
+ * callers rely on absolute line numbers.
+ */
+function scanAddedLines(added: string, opts: Parameters<typeof scan>[1]): Finding[] {
+  const findings: Finding[] = [];
+  let slice: string[] = [];
+  let sliceBytes = 0;
+
+  const flush = () => {
+    if (slice.length === 0) return;
+    findings.push(...scan(slice.join("\n"), opts).findings);
+    slice = [];
+    sliceBytes = 0;
+  };
+
+  for (const line of added.split("\n")) {
+    // +1 for the newline that rejoins it.
+    const lineBytes = Buffer.byteLength(line, "utf8") + 1;
+    // Close the current slice BEFORE overflowing it. A single oversized line
+    // lands in a slice of its own and is handed to the engine as-is.
+    if (sliceBytes > 0 && sliceBytes + lineBytes > SCAN_CHUNK_BYTES) flush();
+    slice.push(line);
+    sliceBytes += lineBytes;
+  }
+  flush();
+
+  return findings;
+}
+
 function logSkip(reason: string): void {
   try {
     const home = process.env.GSTACK_HOME || path.join(os.homedir(), ".gstack");
@@ -165,8 +223,9 @@ function main() {
     if (!added.trim()) continue;
     // Visibility doesn't change HIGH behavior; pass private so nothing is treated
     // as public-strict (HIGH blocks regardless either way).
-    const result = scan(added, { repoVisibility: "private" });
-    for (const f of result.findings) {
+    // Sliced (see scanAddedLines) so a large-but-legitimate diff is actually
+    // scanned rather than blocked unscanned on the engine's size cap.
+    for (const f of scanAddedLines(added, { repoVisibility: "private" })) {
       if (f.severity === "HIGH") allHigh.push(f);
       else if (f.severity === "MEDIUM") mediumCount++;
     }

--- a/lib/redact-patterns.ts
+++ b/lib/redact-patterns.ts
@@ -174,6 +174,53 @@ export function isPlaceholderSpan(span: string): boolean {
   return false;
 }
 
+/** Canonical 8-4-4-4-12 hex UUID. Global: a line may hold several. */
+const UUID_RE = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g;
+
+/** How far either side of a span to look for an enclosing UUID. A UUID is 36
+ * chars, so 40 covers one that starts immediately before the span. Bounded so
+ * this stays cheap on a multi-megabyte buffer. */
+const UUID_CONTEXT_CHARS = 40;
+
+/**
+ * True when the matched span sits ENTIRELY inside a UUID.
+ *
+ * Digit-only UUIDs — `00000000-0000-0000-0000-000000000000`,
+ * `11111111-1111-…` — are the standard fixture shape in test suites, and their
+ * digit runs collide with both the credit-card and phone patterns: a 16-digit
+ * slice of one is Luhn-valid often enough to matter, and the hyphen groups read
+ * as national phone formatting. Observed live: 14 of 21 MEDIUM findings on one
+ * ordinary branch were this, all from test files. That volume is what stops
+ * people reading MEDIUM output at all, so it costs real detection elsewhere.
+ *
+ * Containment must be TOTAL, deliberately. A span merely adjacent to or
+ * overlapping a UUID still reports — suppression is the exception, so it may
+ * only fire when the whole match is demonstrably UUID interior.
+ *
+ * Takes the match (not just the span) because the decision needs surrounding
+ * context; span offset is derived exactly as redact-engine.ts derives it, so
+ * the two cannot disagree about where the span begins.
+ */
+export function insideUuid(match: RegExpExecArray): boolean {
+  const input = match.input ?? "";
+  // Mirror the engine: capture group 1 when present, else the whole match.
+  const spanStartInMatch = match[1] !== undefined ? match[0].indexOf(match[1]) : 0;
+  const spanStart = match.index + Math.max(0, spanStartInMatch);
+  const spanEnd = spanStart + (match[1] ?? match[0]).length;
+
+  const from = Math.max(0, spanStart - UUID_CONTEXT_CHARS);
+  const window = input.slice(from, spanEnd + UUID_CONTEXT_CHARS);
+
+  UUID_RE.lastIndex = 0;
+  let u: RegExpExecArray | null;
+  while ((u = UUID_RE.exec(window)) !== null) {
+    const uuidStart = from + u.index;
+    const uuidEnd = uuidStart + u[0].length;
+    if (spanStart >= uuidStart && spanEnd <= uuidEnd) return true;
+  }
+  return false;
+}
+
 // ── The taxonomy ─────────────────────────────────────────────────────────────
 
 export const PATTERNS: RedactPattern[] = [
@@ -431,7 +478,8 @@ export const PATTERNS: RedactPattern[] = [
     regex: /(?<![\w.])(\+?[1-9]\d{0,2}[ \-.]?\(?\d{2,4}\)?[ \-.]?\d{3,4}[ \-.]?\d{3,4})(?![\w.])/,
     autoRedactable: true,
     redactToken: "<REDACTED-PHONE>",
-    validate: (span) => span.replace(/\D/g, "").length >= 10,
+    // A digit-only UUID's hyphen groups read as national phone formatting.
+    validate: (span, match) => !insideUuid(match) && span.replace(/\D/g, "").length >= 10,
   },
   {
     id: "pii.ssn",
@@ -455,7 +503,9 @@ export const PATTERNS: RedactPattern[] = [
     regex: /\b((?:\d[ \-]?){13,19})\b/,
     autoRedactable: true,
     redactToken: "<REDACTED-CC>",
-    validate: (span) => luhnValid(span),
+    // A 13-19 digit slice of a digit-only UUID passes Luhn often enough to
+    // matter; the enclosing-UUID check runs first so it never reaches Luhn.
+    validate: (span, match) => !insideUuid(match) && luhnValid(span),
   },
   {
     id: "pii.ip_public",

--- a/test/redact-engine.test.ts
+++ b/test/redact-engine.test.ts
@@ -201,6 +201,34 @@ describe("PII patterns", () => {
     expect(ids("local 192.168.1.5")).not.toContain("pii.ip_public");
     expect(ids("local 10.0.0.1")).not.toContain("pii.ip_public");
   });
+
+  // Digit-only UUIDs are the standard test-fixture shape, and their digit runs
+  // collide with both the card pattern (a 13-19 digit slice passes Luhn often
+  // enough to matter) and the phone pattern (hyphen groups read as national
+  // formatting). Observed live: 14 of 21 MEDIUM findings on one ordinary branch
+  // were exactly this, all from test files — the volume that makes people stop
+  // reading MEDIUM output at all.
+  test("digit-only UUID fixtures are not cards or phones", () => {
+    expect(ids("owner_user_id: '00000000-0000-0000-0000-000000000000'")).not.toContain("pii.cc");
+    expect(ids("const OWNER = '11111111-1111-1111-1111-111111111111'")).not.toContain(
+      "pii.phone.e164",
+    );
+    expect(ids("const TEAM = '22222222-2222-2222-2222-222222222222'")).not.toContain(
+      "pii.phone.e164",
+    );
+    // Hex UUIDs never matched these digit patterns; pinned so the suppression
+    // is not silently widened to something that swallows real numbers.
+    expect(ids("id 'a1b2c3d4-1111-2222-3333-444455556666'")).not.toContain("pii.cc");
+  });
+
+  test("UUID suppression requires TOTAL containment", () => {
+    // Real card sitting next to a UUID still reports — suppression is the
+    // exception and may only fire when the whole match is UUID interior.
+    expect(ids("00000000-0000-0000-0000-000000000000 4111111111111111")).toContain("pii.cc");
+    // And the plain cases are untouched.
+    expect(ids("card 4111-1111-1111-1111")).toContain("pii.cc");
+    expect(ids("reach me on +1 415 555 2671")).toContain("pii.phone.e164");
+  });
 });
 
 describe("internal + legal patterns", () => {


### PR DESCRIPTION
Two fixes to the redact guardrail, both found while using gstack on a real
monorepo — the workflow CONTRIBUTING.md recommends.

They're independent; happy to split into two PRs if you'd prefer.

## 1. `engine.input_too_large` blocks ordinary pushes

`gstack-redact-prepush` calls `scan()` once on the whole pushed diff, so any
diff over `DEFAULT_MAX_BYTES` (1 MiB) comes back as a single
`engine.input_too_large` HIGH finding and blocks the push.

That threshold is reached by ordinary work. A feature branch catching up to a
busy `main` produced **1,146,782 bytes** of added lines — only 9% over, and
only ~7% of it was the lockfile; the rest was genuine source.

The failure mode is worse than a noisy block:

- The message names no file, no line and no credential, so it reads as a bug.
- The documented remedy — "Rotate the credential" — doesn't apply.
- The documented escape hatch is `--no-verify`, which disables scanning
  **entirely**.

So a size cap that fires on normal branches actively trains people to bypass
the guard. It also silently discarded real findings: once actually scanned,
that same diff reported **21 MEDIUM** (PII/internal) that had never been
surfaced while the scan was aborting on size.

**Fix:** scan added lines in 768 KiB line-aligned slices and union the
findings.

No detection coverage is lost, because every pattern is single-line: none in
`redact-patterns.ts` carries the `m` or `s` flag, the `BEGIN PRIVATE KEY`
patterns capture only the header line rather than the key body, and the engine
already iterates line by line. A line boundary therefore cannot bisect a
detectable secret, so no inter-slice overlap is needed.

**Fail-closed is preserved.** A *single line* larger than the budget is still
handed to the engine intact, so a genuinely unscannable blob (minified bundle,
embedded base64) trips `input_too_large` and blocks exactly as before.

Kept in the hook rather than the engine on purpose: slice-relative `line`/`col`
are fine there (only `severity`, `id` and `preview` are read), but would break
engine callers that rely on absolute line numbers.

Verified by invoking the hook with real pre-push stdin:

| Case | Result |
|---|---|
| 1.79 MiB benign diff | exit 0, scanned — previously blocked |
| secret in the **last** slice of 1.8 MiB | exit 1, `HIGH pem.private_key` |
| single 1.5 MiB line | exit 1, `input_too_large` (fail-closed intact) |
| the real diff that needed `--no-verify` | exit 0 |

## 2. Digit-only UUIDs match as credit cards and phone numbers

Placeholder UUIDs — `00000000-0000-0000-0000-000000000000`,
`11111111-1111-…`, `22222222-2222-…` — are the standard fixture shape in test
suites, and their digit runs collide with two MEDIUM patterns. A 13–19 digit
slice of one passes Luhn often enough to matter, so `pii.cc` fires; the hyphen
groups read as national phone formatting, so `pii.phone.e164` fires.

Of the 21 MEDIUM findings above, **14 were exactly this** — every one from a
test file, reported as "Credit-card number (Luhn-valid)" and "Phone number".
That volume is what stops people reading MEDIUM output at all.

**Fix:** add `insideUuid(match)` and gate both patterns on it. The same branch
now reports 7 findings, all genuine (a published contact address, a documented
support link, upstream lockfile maintainer emails, one migration filename), and
the three test files responsible for all 14 drop to zero.

**Containment must be TOTAL, deliberately.** A span merely adjacent to or
overlapping a UUID still reports, so suppression can only fire when the whole
match is demonstrably UUID interior. A real card sitting next to a fixture UUID
is still caught — pinned by a test, since that's how this change could quietly
become a hole.

It takes the match rather than the span because the decision needs surrounding
context; the span offset is derived exactly as `redact-engine.ts` derives it
(group 1 when present, else `match[0]`), so the two can't disagree about where a
span starts. The UUID scan is windowed to 40 chars either side to stay cheap on
a multi-megabyte buffer.

Scoped to cards and phones only. `pii.ssn` can't collide (its 3-2-4 grouping
never aligns with 8-4-4-4-12) and `pii.ip_public` needs dots, so widening the
gate there would add risk for no benefit.

## Verification

- `test/redact-engine.test.ts` — **78 pass** (2 new tests added)
- engine + pattern-lint + autoredact + CLI suites — **138 pass, 0 fail**
- `bun run build` — clean
- The new UUID test **fails against the pre-change patterns file** and passes
  after, so it's a real regression guard rather than a tautology.
- `redact-pattern-lint.test.ts` passes, so the added regex is linear-time.

One caveat on my environment, in the interest of not overclaiming: I'm on
Windows, and a full `bun test` here has failures I did **not** introduce —
`browse/test/batch.test.ts` (a `beforeEach`/`afterEach` hook timeout), an
`appendSemanticReview` POSIX file-mode `0600` assertion, and three
`gstack-config-redact-keys` round-trips. I confirmed each is identical against a
pristine checkout of the files I touched. Worth a CI run on Linux to be sure.

Separately, and not fixed here: `test/redact-prepush-hook.test.ts` builds `PATH`
with `:` as the separator, so on Windows its `git` stub never applies and the
"diff killed by a signal BLOCKS" case fails (14 pass / 1 fail, before and after
this PR). Happy to fix that in a follow-up if useful — it seemed out of scope
for these two.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Disclosing the tooling in case it affects how you'd like to review. The
verification in each section above was actually executed rather than asserted:
the hook was invoked with real pre-push stdin for all four cases, and the new
UUID test was confirmed to fail against the pre-change patterns file before it
was kept.
