### PR TITLE
fix(test): prepush hook test builds PATH with a POSIX-only separator

### DIFF
--- a/test/redact-prepush-hook.test.ts
+++ b/test/redact-prepush-hook.test.ts
@@ -44,6 +44,24 @@ function runHook(
   return { code: r.status ?? 0, stderr: r.stderr ?? "" };
 }
 
+/**
+ * Env override that puts `binDir` first on the search path, for tests that
+ * shadow a real binary with a stub.
+ *
+ * Two portability details, both of which a hardcoded `PATH: "dir:" + ...`
+ * gets wrong (mirrors `prependPath` in test/gstack-brain-context-load.test.ts):
+ *   - The separator is `;` on Windows, not `:`. Using the literal produces one
+ *     unparseable entry, so the stub is never found and the REAL binary runs —
+ *     a test that silently passes through rather than failing loudly.
+ *   - Windows env keys are case-insensitive and commonly spelled `Path`. Adding
+ *     a second `PATH` key alongside an inherited `Path` leaves which one wins up
+ *     to the spawn implementation, so reuse whichever key already exists.
+ */
+function prependPath(binDir: string): Record<string, string> {
+  const pathKey = Object.keys(process.env).find((k) => k.toLowerCase() === "path") || "PATH";
+  return { [pathKey]: `${binDir}${path.delimiter}${process.env[pathKey] || ""}` };
+}
+
 const ZERO = "0000000000000000000000000000000000000000";
 
 beforeEach(() => {
@@ -141,30 +159,44 @@ describe("fail closed on unscannable diffs (#1946)", () => {
     expect(stderr).not.toContain("could not compute the pushed diff");
   });
 
-  test("a diff killed by a signal (null status — the maxBuffer/kill class) BLOCKS", () => {
-    // Stub git: probes delegate to the real git; the diff invocation kills
-    // itself, producing spawnSync status === null. This is the exact branch
-    // gitStrict's docstring names (oversized-diff overflow is delivered the
-    // same way) — pre-landing review flagged it as untested.
-    const realGit = Bun.which("git") || "/usr/bin/git";
-    const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "prepush-stubgit-"));
-    try {
-      const stub = `#!/bin/sh\nif [ "$1" = "diff" ]; then kill -KILL $$; fi\nexec "${realGit}" "$@"\n`;
-      fs.writeFileSync(path.join(stubDir, "git"), stub);
-      fs.chmodSync(path.join(stubDir, "git"), 0o755);
+  // POSIX-only, for two independent reasons. `spawnSync` reports
+  // `status === null` only when a child dies from a signal, and Windows has no
+  // equivalent — a force-killed process surfaces a non-zero exit code there — so
+  // the branch this test names is unreachable. The stub below is also a
+  // `#!/bin/sh` file named `git`, which Windows will not execute at all, since
+  // process creation resolves commands through PATHEXT (.exe/.cmd/.bat) and
+  // ignores the shebang. A Windows variant would have to assert the non-zero
+  // exit path instead, i.e. a different branch than the name claims, so it is
+  // skipped rather than rewritten. Gate style follows
+  // test/session-runner-timeout.test.ts and test/setup-emoji-font.test.ts.
+  test.skipIf(process.platform === "win32")(
+    "a diff killed by a signal (null status — the maxBuffer/kill class) BLOCKS",
+    () => {
+      // Stub git: probes delegate to the real git; the diff invocation kills
+      // itself, producing spawnSync status === null. This is the exact branch
+      // gitStrict's docstring names (oversized-diff overflow is delivered the
+      // same way) — pre-landing review flagged it as untested.
+      const realGit = Bun.which("git") || "/usr/bin/git";
+      const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "prepush-stubgit-"));
+      try {
+        const stub = `#!/bin/sh\nif [ "$1" = "diff" ]; then kill -KILL $$; fi\nexec "${realGit}" "$@"\n`;
+        fs.writeFileSync(path.join(stubDir, "git"), stub);
+        fs.chmodSync(path.join(stubDir, "git"), 0o755);
 
-      const base = git(["rev-parse", "HEAD"]);
-      const head = commit("clean.txt", "clean content\n", "clean commit");
-      const { code, stderr } = runHook(`refs/heads/main ${head} refs/heads/main ${base}\n`, {
-        PATH: `${stubDir}:${process.env.PATH}`,
-      });
-      expect(code).toBe(1);
-      expect(stderr).toContain("could not compute the pushed diff");
-      expect(stderr).toContain("GSTACK_REDACT_PREPUSH=skip");
-    } finally {
-      fs.rmSync(stubDir, { recursive: true, force: true });
-    }
-  });
+        const base = git(["rev-parse", "HEAD"]);
+        const head = commit("clean.txt", "clean content\n", "clean commit");
+        const { code, stderr } = runHook(
+          `refs/heads/main ${head} refs/heads/main ${base}\n`,
+          prependPath(stubDir),
+        );
+        expect(code).toBe(1);
+        expect(stderr).toContain("could not compute the pushed diff");
+        expect(stderr).toContain("GSTACK_REDACT_PREPUSH=skip");
+      } finally {
+        fs.rmSync(stubDir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("install UX surfaces (#1946 / eng review D3+D10)", () => {


### PR DESCRIPTION
The follow-up I offered in #2543. Independent of that PR — touches one test file
and no shipping code, so it can land in either order.

## The bug

`test/redact-prepush-hook.test.ts` shadows `git` with a stub by prepending a temp
dir to PATH, built as:

```js
PATH: `${stubDir}:${process.env.PATH}`
```

On Windows the separator is `;`, so `:` produces a single unparseable entry, the
stub is never found, and the **real** git runs. The diff then succeeds,
`gitStrict` never throws, and the hook exits 0 where the test expects 1.

It surfaces as a wrong assertion (`Expected: 1, Received: 0`) rather than as a
portability problem, which is what made it hard to place — I initially assumed it
was a regression from my own changes in #2543 and only found the real cause after
reproducing it against a pristine checkout.

## The fix

A `prependPath` helper mirroring the one already in
`test/gstack-brain-context-load.test.ts`, which handles both platform details:

- `path.delimiter` rather than a hardcoded `:`
- a case-insensitive lookup of the existing env key — Windows commonly spells it
  `Path`, and adding a second `PATH` alongside an inherited `Path` leaves which
  one wins up to the spawn implementation

On POSIX the helper resolves to `{ PATH: binDir + ":" + process.env.PATH }` —
byte-identical to the expression it replaces, so **behaviour there is
unchanged**.

## Why the test is also gated to POSIX

Fixing the separator alone does not make it pass on Windows, and it can't:

- The premise is that a signal-killed child yields `spawnSync` `status === null`.
  Windows has no equivalent — a force-killed process reports a non-zero exit
  code — so the branch the test names is unreachable there.
- The stub is a `#!/bin/sh` file named `git`, which Windows will not execute at
  all: process creation resolves commands through PATHEXT (.exe/.cmd/.bat) and
  ignores the shebang.

A Windows variant would have to assert the non-zero-exit path instead — a
different branch than the test name claims — so it's gated with
`test.skipIf(process.platform === "win32")`, matching
`test/session-runner-timeout.test.ts` and `test/setup-emoji-font.test.ts`.

The separator fix is still worth landing on its own: it's a latent trap for the
next test that copies this idiom, and the current form fails *silently* by
running the real binary rather than loudly.

## Verification

Windows, `bun test test/redact-prepush-hook.test.ts`:

| | before | after |
|---|---|---|
| pass | 14 | 14 |
| skip | 0 | 1 |
| **fail** | **1** | **0** |

Three consecutive clean runs after the change.

Two caveats, since I can only verify one platform here:

- **POSIX is unverified by me.** The test should still run and pass there, by the
  byte-identical argument above, but it's worth a CI run.
- I saw the neighbouring `new branch (zero remote sha)` test fail once at
  ~6.8s under heavy parallel load, then pass 3/3 afterwards, and it also passes
  on a pristine checkout. I believe it's load-related flakiness unrelated to this
  change, but flagging it rather than leaving it unmentioned in case you've seen
  it in CI too.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Disclosing the tooling, as in #2543. The before/after numbers above were measured
by running the suite, not inferred, including against a pristine checkout to
confirm the failure pre-dated my changes.
