### PR TITLE
fix: stop eating the URL scheme when parsing Deploy Configuration

### DIFF
--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -1004,8 +1004,11 @@ echo "$DEPLOY_CONFIG"
 
 # If config exists, parse it
 if [ "$DEPLOY_CONFIG" != "NO_CONFIG" ]; then
-  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/.*: *//')
-  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/.*: *//')
+  # Cut at the FIRST ": ", not the last. A greedy 's/.*: *//' ate the scheme of
+  # any URL: "Production URL: https://x.com" became "//x.com", because the last
+  # ":" belongs to "https:".
+  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/^[^:]*: *//')
+  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/^[^:]*: *//')
   echo "PERSISTED_PLATFORM:$PLATFORM"
   echo "PERSISTED_URL:$PROD_URL"
 fi
@@ -1590,8 +1593,11 @@ echo "$DEPLOY_CONFIG"
 
 # If config exists, parse it
 if [ "$DEPLOY_CONFIG" != "NO_CONFIG" ]; then
-  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/.*: *//')
-  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/.*: *//')
+  # Cut at the FIRST ": ", not the last. A greedy 's/.*: *//' ate the scheme of
+  # any URL: "Production URL: https://x.com" became "//x.com", because the last
+  # ":" belongs to "https:".
+  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/^[^:]*: *//')
+  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/^[^:]*: *//')
   echo "PERSISTED_PLATFORM:$PLATFORM"
   echo "PERSISTED_URL:$PROD_URL"
 fi

--- a/scripts/resolvers/utility.ts
+++ b/scripts/resolvers/utility.ts
@@ -57,8 +57,11 @@ echo "$DEPLOY_CONFIG"
 
 # If config exists, parse it
 if [ "$DEPLOY_CONFIG" != "NO_CONFIG" ]; then
-  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/.*: *//')
-  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/.*: *//')
+  # Cut at the FIRST ": ", not the last. A greedy 's/.*: *//' ate the scheme of
+  # any URL: "Production URL: https://x.com" became "//x.com", because the last
+  # ":" belongs to "https:".
+  PROD_URL=$(echo "$DEPLOY_CONFIG" | grep -i "production.*url" | head -1 | sed 's/^[^:]*: *//')
+  PLATFORM=$(echo "$DEPLOY_CONFIG" | grep -i "platform" | head -1 | sed 's/^[^:]*: *//')
   echo "PERSISTED_PLATFORM:$PLATFORM"
   echo "PERSISTED_URL:$PROD_URL"
 fi


### PR DESCRIPTION
## The bug

The deploy bootstrap parses the `## Deploy Configuration` block in `CLAUDE.md` with a greedy `sed 's/.*: *//'`. That cuts at the **last** colon on the line, so any URL with a scheme loses it:

```bash
$ echo "- Production URL: https://example.com" | sed 's/.*: *//'
//example.com
```

The last `:` belongs to `https:`, not to the key/value separator.

## Why it matters

That value becomes `PERSISTED_URL`, which `/land-and-deploy` and `/setup-deploy` use for the post-deploy health check. The check then hits a malformed URL and fails in a way that looks unrelated to the config, so the natural next move is to go debug the deploy instead of the parser.

It bit every project whose `Production URL` is written with a scheme, which is the normal way to write it. In my case `https://ismaelbriasco.com` silently became `//ismaelbriasco.com`.

## The fix

Anchor the pattern so it cuts at the **first** `": "`:

```bash
$ echo "- Production URL: https://example.com" | sed 's/^[^:]*: *//'
https://example.com
```

`PLATFORM` gets the same treatment. Its value has no colon today, so that line is a no-op, but it guards the same class of bug if a platform identifier ever grows one.

## Scope

Fixed in `scripts/resolvers/utility.ts` (the generator source) and regenerated with `bun run gen:skill-docs`, which is why `land-and-deploy/SKILL.md` moves in the same commit. No other generated host changed.

Verified against the real line that triggered it, before and after.
