### PR TITLE
test(browse): de-flake the lease expiry assertion in ring-buffer runtime

### DIFF
--- a/browse/test/terminal-agent-ring-buffer-runtime.test.ts
+++ b/browse/test/terminal-agent-ring-buffer-runtime.test.ts
@@ -148,7 +148,11 @@ describe('lease lifecycle interplay (via pty-session-lease)', () => {
     const vb = validateLease(b.sessionId);
     expect(va.ok && vb.ok).toBe(true);
     if (va.ok && vb.ok) {
-      expect(va.expiresAt).toBe(vb.expiresAt);
+      // Same TTL policy, not the same wall clock: the two mints can straddle
+      // a millisecond tick under load, so assert closeness rather than
+      // equality. The property under test is that both leases got the same
+      // TTL and neither is coupled to ring-buffer state.
+      expect(Math.abs(va.expiresAt - vb.expiresAt)).toBeLessThanOrEqual(5);
     }
   });
 });


### PR DESCRIPTION
## The flake

`browse/test/terminal-agent-ring-buffer-runtime.test.ts` — the test `lease registry is independent of ring buffer state` ends by asserting that two back-to-back `mintLease()` calls produce **identical** `expiresAt` values:

```js
const a = mintLease();
const b = mintLease();
...
expect(va.expiresAt).toBe(vb.expiresAt);
```

`mintLease()` computes `expiresAt` as `Date.now() + LEASE_TTL_MS`, so this only holds if both calls land inside the same millisecond. Under full-suite load they sometimes straddle a tick and the test fails on a 1 ms difference. It passes reliably when the file is run on its own, which is what makes it read as noise rather than a real regression.

Observed failing roughly 1 run in 3 of `bun test browse/test/`.

## The fix

Assert closeness rather than equality:

```js
expect(Math.abs(va.expiresAt - vb.expiresAt)).toBeLessThanOrEqual(5);
```

The property this test exists to check is that both leases got the same TTL policy and that neither is coupled to ring-buffer state. Wall-clock coincidence was never part of that, so nothing is lost — a real coupling regression (say, one lease inheriting a ring-buffer-derived expiry) would still blow well past a 5 ms window.

I considered injecting a fixed clock into `browse/src/pty-session-lease.ts` to make `mintLease` deterministic and keep exact equality. That works, but it adds a test seam to production code for an assertion that doesn't need one, so I went with the smaller change. Happy to switch if you'd prefer the deterministic-clock version.

I did **not** delete the assertion — the independence property is worth keeping.

## Scope check

I swept the rest of `browse/test/` for the same shape. No other assertion compares two separately-sampled timestamps for exact equality:

- `cdp-inspector-history-cap.test.ts` timestamp equalities use synthetic counter values (`0`, `49`, `50`), not sampled clocks
- `pty-session-lease.test.ts` and `sse-session-cookie.test.ts` already use `toBeGreaterThan`
- the elapsed-duration budgets in `sanitize.test.ts` and `security-audit-r2.test.ts` are a different pattern and have order-of-magnitude headroom

## Verification

7 consecutive full `bun test browse/test/` runs (121 files, ~140 s each). The lease assertion did not fail in any of them.

One run showed 2 unrelated load flakes that passed in the others and are untouched by this change: `browser-skills-e2e.test.ts:89` (its nested `bun test` subprocess returned only its banner before a summary was captured) and `pair-agent-tunnel-eval.test.ts` (20 s timeout, `Unable to connect`). Both look like separate issues worth their own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)