### PR TITLE
fix(memory-ingest): pass --include-gitignored to gbrain import

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -1416,7 +1416,20 @@ function runGbrainImport(
     // inside Next.js / Prisma / Rails projects with their own
     // .env.local (codex review #7 — defense in depth on top of the
     // parent gstack-gbrain-sync seeding the bun grandchild's env).
-    const child = spawnGbrainAsync(["import", stagingDir, "--no-embed", "--json"]);
+    // --include-gitignored is load-bearing, not a convenience. Pages are
+    // staged into ~/.gstack/.staging-ingest-<pid>-<ts>/, and ~/.gstack is a
+    // git repo whose .gitignore is `*`. `gbrain import` honours .gitignore,
+    // so without this flag it collects files=0 and imports NOTHING, while
+    // still reporting `written: N` from the staged count. Silent data loss
+    // on every run. A working run logs `import.collect_files done ... files=N`
+    // with N > 0 and takes minutes, not seconds.
+    const child = spawnGbrainAsync([
+      "import",
+      stagingDir,
+      "--no-embed",
+      "--include-gitignored",
+      "--json",
+    ]);
     _activeImportChild = child;
     let stdout = "";
     let stderr = "";

--- a/test/memory-ingest-include-gitignored.test.ts
+++ b/test/memory-ingest-include-gitignored.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression pin: `gstack-memory-ingest` must pass `--include-gitignored` to
+ * `gbrain import`.
+ *
+ * gstack-artifacts-init writes an ignore-everything `.gitignore` (a bare `*`,
+ * headed "Do not edit") at the root of `~/.gstack`. The memory ingest stages
+ * pages into `~/.gstack/.staging-ingest-<pid>-<ts>/`, which is INSIDE that
+ * repo, and gbrain's markdown collector honours .gitignore. So the collector
+ * walks the staging dir, matches every file against `*`, and collects zero.
+ *
+ * The failure is silent: `gbrain import` exits 0 having imported nothing,
+ * while the ingest still prints `written: N` from the STAGED count rather
+ * than the imported count. A run that indexes nothing is indistinguishable
+ * from a healthy one, and the memory corpus quietly stops growing.
+ *
+ * Two tests here:
+ *  1. Source pin (same shape as memory-ingest-no-put_page.test.ts): the flag
+ *     is present in active code, so removing it trips the build.
+ *  2. Behavioural proof of the underlying collision, using git's own ignore
+ *     machinery. No gbrain and no network required.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { execFileSync } from "child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { readFileSync } from "fs";
+
+const SOURCE_PATH = join(import.meta.dir, "..", "bin", "gstack-memory-ingest.ts");
+
+/** Strip comments so the pin only inspects executable code. */
+function stripComments(src: string): string {
+  const noBlock = src.replace(/\/\*[\s\S]*?\*\//g, "");
+  return noBlock.replace(/\/\/[^\n]*/g, "");
+}
+
+describe("gstack-memory-ingest: gbrain import must not be filtered by .gitignore", () => {
+  it("passes --include-gitignored in active code", () => {
+    const stripped = stripComments(readFileSync(SOURCE_PATH, "utf-8"));
+    expect(stripped).toContain("--include-gitignored");
+  });
+
+  it("keeps the flag on the same import invocation as the staging dir", () => {
+    const stripped = stripComments(readFileSync(SOURCE_PATH, "utf-8"));
+    // Match the spawn call's argument array and assert both the subcommand
+    // and the flag live in it, so the flag can't drift onto another call.
+    const call = stripped.match(/spawnGbrainAsync\(\s*\[[^\]]*"import"[^\]]*\]/s);
+    expect(call).not.toBeNull();
+    expect(call![0]).toContain("--include-gitignored");
+  });
+
+  it("demonstrates the collision: an ignore-everything root hides staged pages", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gstack-ingest-gitignore-"));
+    try {
+      const git = (...args: string[]) =>
+        execFileSync("git", args, { cwd: dir, encoding: "utf-8" });
+      git("init", "-q", ".");
+
+      const staging = join(dir, ".staging-ingest-12345-1700000000000", "learnings");
+      mkdirSync(staging, { recursive: true });
+      writeFileSync(join(staging, "page.md"), "# a staged page\n", "utf-8");
+
+      // Exactly what gstack-artifacts-init writes at the root of ~/.gstack.
+      writeFileSync(join(dir, ".gitignore"), "*\n", "utf-8");
+
+      // `git ls-files --others --exclude-standard` is the same view a
+      // gitignore-honouring collector takes: untracked and not ignored.
+      const collectable = git("ls-files", "--others", "--exclude-standard")
+        .split("\n")
+        .filter(Boolean);
+
+      // The staged page is invisible. This is the silent data loss.
+      expect(collectable).toHaveLength(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## The bug

`gstack-artifacts-init` writes an ignore-everything `.gitignore` at the root of `~/.gstack`:

```
# gstack-artifacts sync: ignore-everything base. Paths are included explicitly via
# .brain-allowlist and `git add -f` from gstack-brain-sync. Do not edit.
*
```

`gstack-memory-ingest` stages pages into `~/.gstack/.staging-ingest-<pid>-<ts>/`, which is inside that repo, and gbrain's markdown collector honours `.gitignore`. So the collector walks the staging directory, matches every staged file against `*`, and collects nothing.

**The failure is silent.** `gbrain import` exits 0 having imported nothing, while the ingest reports `written: N` from the *staged* count rather than the imported count. A run that indexes nothing is indistinguishable from a healthy one, and the memory corpus quietly stops growing.

## Reproduction

No gbrain or network needed. `git ls-files --others --exclude-standard` is the same view a gitignore-honouring collector takes:

```bash
git init .
mkdir -p .staging-ingest-12345/learnings
echo x > .staging-ingest-12345/learnings/page.md
printf '*\n' > .gitignore
git ls-files --others --exclude-standard   # -> empty
```

Observed on gstack 1.61.0.0 / 1.62.0.0 with gbrain 0.45.9.0 against a Supabase engine, but nothing here is engine or version specific.

## The fix

Pass `--include-gitignored` on the `gbrain import` call, so the import is independent of whatever `.gitignore` sits above the staging directory.

The alternative is adding a negation to the generated `.gitignore`:

```
!.staging-ingest-*/
!.staging-ingest-*/**
```

That does work (verified), but the file is gstack-owned and explicitly marked "Do not edit", so any regeneration silently reintroduces the bug. The flag fixes it at the call site instead, where the staging directory's location is actually known.

Staging dirs are created and deleted within a single ingest run and are never committed, so the `.brain-allowlist` plus `git add -f` path used by `gstack-brain-sync` is unaffected.

## Tests

`test/memory-ingest-include-gitignored.test.ts`, following the shape of the existing `memory-ingest-no-put_page.test.ts` source pin:

1. `--include-gitignored` is present in active code (comments stripped).
2. The flag sits on the same `spawnGbrainAsync` call as the `import` subcommand, so it cannot drift onto another call.
3. A behavioural test for the collision itself, so the reason for the flag survives even if the call site is refactored.

Both source pins fail against the unpatched file; the behavioural test documents the collision and passes either way. The three sibling memory-ingest suites (`gstack-memory-ingest`, `memory-ingest-no-put_page`, `memory-ingest-timeout`, 28 tests) still pass.
