### PR TITLE
fix: document iOS QA bridge compatibility fallback

### DIFF
--- a/ios-qa/SKILL.md
+++ b/ios-qa/SKILL.md
@@ -876,7 +876,20 @@ fi
 
 ## Phase 1: Read source, plan codegen
 
-1. Walk the app source (passed as `--source <dir>`) and identify all `@Observable`
+1. Before changing the app or replacing an installed build, verify that the
+   bridge is compatible with the project:
+   - The generator currently supports file-scope `@Observable` classes only;
+     `ObservableObject`, `@StateObject`, and other observation models do not
+     produce accessors.
+   - The documented dependency wiring assumes a SwiftPM app manifest. For an
+     `.xcodeproj` or `.xcworkspace`, do not invent package or target wiring.
+   If either requirement is unmet, stop the bridge bootstrap without modifying
+   the app. Preserve any installed production or TestFlight build. Prefer an
+   existing real-device XCUITest harness; when a separate QA build is needed,
+   use an isolated bundle identifier and non-production entitlements so it can
+   coexist with the production app. Report fixture-driven state, provider UI,
+   and actual external-provider success as distinct evidence tiers.
+2. Walk the app source (passed as `--source <dir>`) and identify all `@Observable`
    classes. Note any property immediately preceded by the generator marker
    comment `// @Snapshotable` — those are the snapshot-eligible fields. The
    marker is a comment so it composes with the `@Observable` macro. Each
@@ -887,7 +900,7 @@ fi
    Optional compositions. Keys must be unique across observable classes.
    Codegen stops with a source diagnostic instead of emitting a broken or
    lossy harness when any of these constraints is violated.
-2. Show the user the accessor list and ask whether to install the DebugBridge
+3. Show the user the accessor list and ask whether to install the DebugBridge
    SPM dependency into their `Package.swift` (one AskUserQuestion).
 
 ## Phase 2: Bootstrap the device bridge

--- a/ios-qa/SKILL.md.tmpl
+++ b/ios-qa/SKILL.md.tmpl
@@ -96,7 +96,20 @@ fi
 
 ## Phase 1: Read source, plan codegen
 
-1. Walk the app source (passed as `--source <dir>`) and identify all `@Observable`
+1. Before changing the app or replacing an installed build, verify that the
+   bridge is compatible with the project:
+   - The generator currently supports file-scope `@Observable` classes only;
+     `ObservableObject`, `@StateObject`, and other observation models do not
+     produce accessors.
+   - The documented dependency wiring assumes a SwiftPM app manifest. For an
+     `.xcodeproj` or `.xcworkspace`, do not invent package or target wiring.
+   If either requirement is unmet, stop the bridge bootstrap without modifying
+   the app. Preserve any installed production or TestFlight build. Prefer an
+   existing real-device XCUITest harness; when a separate QA build is needed,
+   use an isolated bundle identifier and non-production entitlements so it can
+   coexist with the production app. Report fixture-driven state, provider UI,
+   and actual external-provider success as distinct evidence tiers.
+2. Walk the app source (passed as `--source <dir>`) and identify all `@Observable`
    classes. Note any property immediately preceded by the generator marker
    comment `// @Snapshotable` — those are the snapshot-eligible fields. The
    marker is a comment so it composes with the `@Observable` macro. Each
@@ -107,7 +120,7 @@ fi
    Optional compositions. Keys must be unique across observable classes.
    Codegen stops with a source diagnostic instead of emitting a broken or
    lossy harness when any of these constraints is violated.
-2. Show the user the accessor list and ask whether to install the DebugBridge
+3. Show the user the accessor list and ask whether to install the DebugBridge
    SPM dependency into their `Package.swift` (one AskUserQuestion).
 
 ## Phase 2: Bootstrap the device bridge


### PR DESCRIPTION
## Summary
- add a compatibility preflight before installing the iOS QA DebugBridge
- stop without app modification when the project uses unsupported observation models or non-SwiftPM target wiring
- preserve installed production/TestFlight apps and prefer an existing real-device XCUITest harness with an isolated QA bundle
- distinguish fixture state, provider UI, and actual provider success in QA evidence

## Proven gap
A physical-device pass on an Xcode-project iOS app using `ObservableObject`/`@StateObject` found that the current generator produces accessors only for file-scope `@Observable`, while the documented dependency wiring assumes an app-level `Package.swift`. Following the prior bootstrap path would either produce no useful accessors or require invented project wiring.

## Validation
- generated skill docs and host freshness checks run locally
- skill health check run (iOS QA outputs fresh; unrelated pre-existing missing Claude-generated-file warning remains)
- `bun test --timeout 20000 ios-qa/scripts/gen-accessors.test.ts` — 57 passed, 0 failed
