### PR TITLE
fix(test): hermetic-wiring skill-seeding tripwire can never pass on default ~/.claude installs

### DIFF
--- a/test/hermetic-wiring.test.ts
+++ b/test/hermetic-wiring.test.ts
@@ -125,10 +125,21 @@ describe('hermetic wiring tripwire', () => {
     expect(configDir.startsWith(runRoot + path.sep)).toBe(true);
     expect(configDir.startsWith(operatorClaude)).toBe(false);
     const skillsDir = path.join(configDir, 'skills');
+    const repoRootReal = fs.realpathSync(ROOT) + path.sep;
     for (const entry of fs.readdirSync(skillsDir)) {
       const target = fs.readlinkSync(path.join(skillsDir, entry, 'SKILL.md'));
-      expect(target.startsWith(operatorClaude), `${entry}: symlink escapes to ${target}`).toBe(false);
-      expect(fs.realpathSync(target).startsWith(fs.realpathSync(ROOT) + path.sep), `${entry}: symlink outside repo: ${target}`).toBe(true);
+      const resolved = fs.realpathSync(target);
+      // Targets inside the live repo checkout are the blessed edge — exempt
+      // them BEFORE the operator-~/.claude ban. On the default global-git
+      // install the repo itself lives at ~/.claude/skills/gstack, so every
+      // CORRECT symlink carries the operatorClaude prefix and an unexempted
+      // ban can never pass (regression 2026-08-15: pristine v1.64.1.0 fails
+      // this test in any worktree under ~/.claude/skills/ and passes
+      // elsewhere — realpath both sides so a symlinked HOME can't dodge it).
+      if (!resolved.startsWith(repoRootReal)) {
+        expect(resolved.startsWith(operatorClaude), `${entry}: symlink escapes to ${target}`).toBe(false);
+      }
+      expect(resolved.startsWith(repoRootReal), `${entry}: symlink outside repo: ${target}`).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Problem

The tripwire `skill seeding stays under runRoot and reads the live repo tree, never operator ~/.claude` asserts every seeded symlink target must NOT start with `~/.claude` — and then that it MUST resolve into the live repo tree. On the default global-git install the repo itself lives at `~/.claude/skills/gstack`, so every **correct** symlink carries the banned prefix: the two assertions can never both hold.

## Evidence

Pristine `c118e240` (v1.64.1.0), verified 2026-08-15 on macOS arm64:
- worktree under `~/.claude/skills/` → the seeding test **fails** (`pair-agent: symlink escapes to .../pair-agent/SKILL.md`)
- worktree anywhere else → **passes**

CI never sees this because dev checkouts don't live under `~/.claude` — but every user following the README install path who runs the suite does.

## Fix

Targets that `realpath` into the resolved repo ROOT are exempted **before** the operator-`~/.claude` ban (both sides realpath'd, so a symlinked $HOME can't dodge the tripwire). Genuine escapes — a target under `~/.claude` but outside the repo — still fail with the specific escape message.

## Verification

`bun test test/hermetic-wiring.test.ts`: 5/5 pass both at `~/.claude/skills/gstack` and at a non-`~/.claude` worktree of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)