### PR TITLE
fix(brain-cache): honest 'missing' instead of fabricated-empty digests on gbrain failure

### DIFF
--- a/bin/gstack-brain-cache
+++ b/bin/gstack-brain-cache
@@ -521,6 +521,21 @@ function fetchRecentDecisions(projectSlug: string | null): string | null {
     '--json',
   ]);
   if (!result?.pages) {
+    // F10 bug fix: this branch used to return the hardcoded
+    // "_No prior skill runs recorded._" string here, which is indistinguishable
+    // from a genuine zero-rows result. That silently converted a gbrain-
+    // unreachable FAILURE into a "successful" cached digest — refreshEntity()
+    // would write it and stamp last_refresh, so the false negative survived
+    // every subsequent TTL cycle forever. Returning null instead lets cmdGet's
+    // existing missing/stale-fallback machinery report the true state, exactly
+    // like every sibling fetcher (fetchGoals, fetchSimplePage) already does on
+    // failure.
+    return null;
+  }
+  // A malformed payload ({pages: {}} etc.) must classify as failure, not crash
+  // refreshEntity mid-refresh — same honest-missing polarity as the F10 fix.
+  if (!Array.isArray(result.pages)) return null;
+  if (result.pages.length === 0) {
     return `# Recent decisions (project: ${projectSlug})\n\n_No prior skill runs recorded._\n`;
   }
   const lines = result.pages.map((p) => `- ${p.title || p.slug}`);
@@ -576,7 +591,17 @@ function fetchSalience(projectSlug: string | null): string | null {
     '--limit', '10',
     '--json',
   ]);
-  if (!result?.pages) return `# Recent salience\n\n_No salient pages in last 14d._\n`;
+  // F10 bug fix (sibling of fetchRecentDecisions above): a gbrain-unreachable
+  // failure used to render the identical hardcoded "no salient pages" string
+  // as a genuine empty result, which refreshEntity() then cached as if it
+  // were verified truth. Unlike recent-decisions there is no project-local
+  // fallback for salience — it is specifically gbrain's emotional-weight-
+  // ranked *brain* pages, not project decision/work data, and conflating the
+  // two would defeat the D9 privacy allowlist's purpose. So on failure we
+  // return null and let the cache report 'missing' (same as product.md,
+  // goals.md, etc. already do on this machine) instead of asserting a claim
+  // we have no way to verify.
+  if (!result?.pages) return null;
 
   // D9 privacy gate: strip entries outside the allowlist BEFORE rendering.
   // Sensitive personal content (family, therapy, reflection) is never written


### PR DESCRIPTION
## Problem

`fetchRecentDecisions` and `fetchSalience` in `bin/gstack-brain-cache` return hardcoded empty digests (`_No prior skill runs recorded._` / `_No salient pages in last 14d._`) when `!result?.pages` — i.e. when the gbrain call **failed**, not when it genuinely returned zero rows. `refreshEntity()` then caches that digest and stamps `last_refresh`, so a gbrain-unreachable failure becomes a 'successful' empty answer that survives every TTL cycle, indistinguishable from real emptiness.

## Fix

- Both fetchers return `null` on `!result?.pages`, letting `cmdGet`'s existing missing/stale-fallback machinery report the true state — the same polarity `fetchGoals`/`fetchSimplePage` already have.
- Genuine `pages.length === 0` still renders the honest empty digest.
- New `Array.isArray(result.pages)` guard: a malformed payload (`{pages: {}}`) classifies as failure instead of throwing inside `refreshEntity` (which has no try/catch) and crashing the CLI `get`.

## Verification

`bun test test/brain-cache-roundtrip.test.ts test/brain-cache-stale-but-usable.test.ts`: 33/33 pass; `bun bin/gstack-brain-cache --help` smoke-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)