### PR TITLE
fix(gen-skill-docs): quote YAML inline scalars containing '...' (strict parsers reject bare ellipsis)

### DIFF
--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -413,6 +413,7 @@ export function toYamlInlineScalar(s: string): string {
     s !== s.trim() ||                       // leading/trailing whitespace
     /:(\s|$)/.test(s) ||                    // "foo: bar" / trailing colon → mapping ambiguity
     /\s#/.test(s) ||                        // " #" → inline comment
+    /\.\.\./.test(s) ||                     // "..." → document-end marker; strict parsers reject mid-scalar (catalog-trim truncation appends it)
     /^[\s>|&*!%@`"'#,\[\]{}?-]/.test(s);    // leading YAML indicator char
   return needsQuote ? JSON.stringify(s) : s;
 }

--- a/test/catalog-trim.test.ts
+++ b/test/catalog-trim.test.ts
@@ -23,7 +23,36 @@ import {
   buildTrimmedDescription,
   buildWhenToInvokeSection,
   applyCatalogTrim,
+  toYamlInlineScalar,
 } from '../scripts/gen-skill-docs';
+
+describe('toYamlInlineScalar', () => {
+  const parses = (out: string) => Bun.YAML.parse(`d: ${out}`);
+
+  test("scalar containing '...' (YAML document-end marker) is quoted and round-trips", () => {
+    const out = toYamlInlineScalar('Truncated lead ends with... more (gstack)');
+    expect(out.startsWith('"')).toBe(true);
+    expect((parses(out) as { d: string }).d).toContain('...');
+  });
+
+  test("interior ': ' is quoted (nested-mapping ambiguity, #1778)", () => {
+    const out = toYamlInlineScalar('Ship workflow: detect and merge');
+    expect(out.startsWith('"')).toBe(true);
+    expect((parses(out) as { d: string }).d).toBe('Ship workflow: detect and merge');
+  });
+
+  test('plain safe scalar passes through unquoted', () => {
+    expect(toYamlInlineScalar('Simple description here')).toBe('Simple description here');
+  });
+
+  test('leading YAML indicator char is quoted', () => {
+    expect(toYamlInlineScalar('- leading dash').startsWith('"')).toBe(true);
+  });
+
+  test('trailing whitespace is quoted', () => {
+    expect(toYamlInlineScalar('has trailing space ').startsWith('"')).toBe(true);
+  });
+});
 
 describe('splitCatalogDescription', () => {
   test('extracts lead sentence + routing prose from simple multi-line description', () => {


### PR DESCRIPTION
## Problem

`toYamlInlineScalar` doesn't quote scalars containing `...` — a YAML document-end marker that strict parsers (including `Bun.YAML`) reject mid-scalar. The catalog-trim path appends `...` to any >200-char description lead, so the first skill whose description gets truncated generates a SKILL.md with unparseable frontmatter.

## Fix

One condition added to `needsQuote` (`/\.\.\./ `), plus a `toYamlInlineScalar` unit-test describe in `test/catalog-trim.test.ts` covering ellipsis quoting, interior-colon quoting (#1778), plain-scalar passthrough, leading-indicator, and trailing-whitespace cases.

## Verification

`bun test test/catalog-trim.test.ts test/gen-skill-docs.test.ts`: 426/426 pass. `gen:skill-docs --host all --dry-run`: 0 STALE (no current description truncates, so generated output is byte-identical — the fix is prophylactic until the first long description lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)