### PR TITLE
fix(redact): parcel IDs are not phone numbers

### DIFF
--- a/lib/redact-patterns.ts
+++ b/lib/redact-patterns.ts
@@ -168,6 +168,58 @@ function looksLikeCompactTimestamp(span: string): boolean {
   );
 }
 
+/** Context window for pairing a normalized parcel ID with its punctuated form. */
+const PARCEL_CONTEXT_CHARS = 400;
+
+/**
+ * County tax-map parcel ID (APN). Ohio's dominant form is NN-NNNNNNN.NNN, and
+ * some counties use a hyphen before the 3-4 digit suffix instead of a dot.
+ */
+const PARCEL_PUNCT_RE = /\b\d{2}-\d{4,8}[.\-]\d{3,4}\b/g;
+
+/**
+ * A parcel ID reads as a national-format phone number to pii.phone.e164 — the
+ * same collision class as the digit-only UUID that `insideUuid` already guards.
+ * Land/title repos carry these by the hundred, so the false positives are not
+ * incidental: they arrive on every branch that touches title, and a guardrail
+ * that cries wolf on the domain's primary identifier trains people to wave the
+ * warning through, which is how a real HIGH finding eventually gets ignored.
+ *
+ * Deliberately narrow, in two tiers:
+ *
+ * 1. The DOTTED form is exempt on its own shape. No phone convention places a
+ *    dot before a trailing 3-4 digit group after a 4-8 digit middle, so this
+ *    cannot swallow a real number. The hyphen-only variants (22-0001-000) are
+ *    NOT exempted by shape — those genuinely are phone-shaped.
+ *
+ * 2. A DIGITS-ONLY span is phone-shaped in isolation, so it earns the exemption
+ *    only by evidence: it must be the exact digit-normalization of a punctuated
+ *    parcel ID within the surrounding window. Fixtures and marts always carry
+ *    the pair ({parcel_id: "12-3456789.000", norm: "123456789000"}), and a bare
+ *    phone number has no such twin nearby — so this reads the document's own
+ *    evidence rather than guessing from digits.
+ */
+export function looksLikeParcelId(span: string, match: RegExpExecArray): boolean {
+  if (/^\d{2}-\d{4,8}\.\d{3,4}$/.test(span)) return true;
+  if (!/^\d{10,14}$/.test(span)) return false;
+
+  const input = match.input ?? "";
+  const spanStartInMatch = match[1] !== undefined ? match[0].indexOf(match[1]) : 0;
+  const spanStart = match.index + Math.max(0, spanStartInMatch);
+  const spanEnd = spanStart + span.length;
+  const window = input.slice(
+    Math.max(0, spanStart - PARCEL_CONTEXT_CHARS),
+    spanEnd + PARCEL_CONTEXT_CHARS,
+  );
+
+  PARCEL_PUNCT_RE.lastIndex = 0;
+  let p: RegExpExecArray | null;
+  while ((p = PARCEL_PUNCT_RE.exec(window)) !== null) {
+    if (p[0].replace(/\D/g, "") === span) return true;
+  }
+  return false;
+}
+
 // ── Placeholder suppression (per-matched-span, NOT per-line) ─────────────────
 
 /**
@@ -527,11 +579,13 @@ export const PATTERNS: RedactPattern[] = [
     regex: /(?<![\w.])(\+?[1-9]\d{0,2}[ \-.]?\(?\d{2,4}\)?[ \-.]?\d{3,4}[ \-.]?\d{3,4})(?![\w.])/,
     autoRedactable: true,
     redactToken: "<REDACTED-PHONE>",
-    // A digit-only UUID's hyphen groups read as national phone formatting.
+    // A digit-only UUID's hyphen groups read as national phone formatting, and
+    // so does a county tax-map parcel ID (see looksLikeParcelId).
     validate: (span, match) =>
       !insideUuid(match) &&
       span.replace(/\D/g, "").length >= 10 &&
-      !looksLikeCompactTimestamp(span),
+      !looksLikeCompactTimestamp(span) &&
+      !looksLikeParcelId(span, match),
   },
   {
     id: "pii.ssn",

--- a/test/redact-parcel-id-false-positive.test.ts
+++ b/test/redact-parcel-id-false-positive.test.ts
@@ -1,0 +1,77 @@
+/**
+ * pii.phone.e164 vs county tax-map parcel IDs (APNs).
+ *
+ * A parcel ID reads as a national-format phone number to the e164 pattern —
+ * the same collision class as the digit-only UUID `insideUuid` already guards.
+ * Land, title and property-tax repos carry these by the hundred, so the noise
+ * is not incidental; it arrives on every branch that touches the domain.
+ *
+ * The guard has to be narrow, so this file pins BOTH directions: parcels stay
+ * clean, and every real phone shape stays flagged. The negative controls are
+ * the point — a guard that exempted long digit runs wholesale would pass the
+ * "parcels clean" half and quietly gut the pattern.
+ */
+import { describe, test, expect } from "bun:test";
+import { scan } from "../lib/redact-engine";
+import { looksLikeParcelId } from "../lib/redact-patterns";
+
+const flagsPhone = (s: string): boolean =>
+  scan(s, { repoVisibility: "private" }).findings.some((f) => f.id === "pii.phone.e164");
+
+describe("pii.phone.e164 — real phone numbers stay flagged", () => {
+  const REAL_PHONES: [string, string][] = [
+    ["US dashed", "call 415-555-0123 now"],
+    ["US parens", "phone: (415) 555-0123"],
+    ["US dotted", "p 415.555.0123"],
+    ["E.164 US", "tel: +14155550123"],
+    ["E.164 US spaced", "contact +1 415 555 0123"],
+    ["E.164 UK", "ring +44 20 7946 0958"],
+    ["E.164 DE", "fon +49 30 901820"],
+    ["E.164 PT 12-digit", "reach +351912345678"],
+    ["bare 11-digit", "operator 14155550123 ext"],
+  ];
+  for (const [label, input] of REAL_PHONES) {
+    test(label, () => {
+      expect(flagsPhone(input)).toBe(true);
+    });
+  }
+});
+
+describe("pii.phone.e164 — parcel IDs are not phone numbers", () => {
+  test("dotted APN is exempt on shape alone", () => {
+    expect(flagsPhone('  parcel_id: "12-3456789.000",')).toBe(false);
+  });
+
+  test("a normalized APN is exempt when paired with its punctuated form", () => {
+    expect(
+      flagsPhone('  parcel_id: "12-3456789.000",\n  norm: "123456789000",'),
+    ).toBe(false);
+  });
+
+  test("8-digit middle is still an APN", () => {
+    expect(flagsPhone('apn "30-00414123.0001"')).toBe(false);
+  });
+});
+
+describe("pii.phone.e164 — the guard stays narrow", () => {
+  /**
+   * The load-bearing control. A bare digit run is phone-shaped in isolation, so
+   * it may only be exempted by EVIDENCE — a punctuated APN in the surrounding
+   * window. With no such twin, the finding must survive. If this ever goes
+   * green-by-exemption, the guard has become a blanket hole in the pattern.
+   */
+  test("a bare digit run with no punctuated APN nearby is still flagged", () => {
+    expect(flagsPhone('norm: "123456789000",')).toBe(true);
+  });
+
+  test("hyphen-only APN variants are NOT exempted by shape", () => {
+    // 22-0001-000 is genuinely phone-shaped; only the dotted form earns a
+    // shape-based pass. This one may only be cleared by the evidence tier.
+    expect(looksLikeParcelId("22-0001-000", /(.*)/.exec("22-0001-000")!)).toBe(false);
+  });
+
+  test("evidence pairing requires an exact digit match, not a prefix", () => {
+    // A near-miss APN in the window must not clear a different digit run.
+    expect(flagsPhone('  parcel_id: "12-3456789.000",\n  other: "999888777666",')).toBe(true);
+  });
+});


### PR DESCRIPTION
## The problem

A county tax-map parcel ID (APN) reads as a national-format phone number to `pii.phone.e164` — the same collision class as the digit-only UUID that `insideUuid` already guards.

```
parcel_id: "12-3456789.000"   →  MEDIUM pii.phone.e164
norm:      "123456789000"     →  MEDIUM pii.phone.e164
```

The regex is deliberately loose to catch international formats, and an APN satisfies it in both its punctuated and normalized forms.

This isn't a rare edge. Land, title and property-tax repos carry APNs by the hundred — one title branch tripped 2 MEDIUM findings on nothing but synthetic fixtures, and the same shape recurs in every fixture, mart and smoke in the domain. A guardrail that cries wolf on the domain's primary identifier is one people learn to wave through, which is how a real HIGH finding eventually gets ignored. That's the reason to fix it rather than live with the noise.

## The guard

`looksLikeParcelId(span, match)`, wired into the existing `validate` alongside `insideUuid` and `looksLikeCompactTimestamp`, following the same context-window approach `insideUuid` uses. Two deliberately separate tiers:

1. **Dotted form, exempt on shape.** No phone convention puts a dot before a trailing 3–4 digit group after a 4–8 digit middle, so this cannot swallow a real number. Hyphen-only variants (`22-0001-000`) are **not** shape-exempted — those genuinely are phone-shaped.

2. **Digits-only form, exempt only on evidence.** A bare digit run is phone-shaped in isolation, so it must be the exact digit-normalization of a punctuated APN within a 400-char window. Fixtures and marts always carry the pair; a real phone number has no such twin nearby. This reads the document's own evidence instead of guessing from digits.

## Verification

**A/B against the unmodified engine** over inputs spanning every rule family — AWS key, PEM, GitHub PAT, email, public IP, credit card, SSN, compact timestamp, UUID, and nine phone formats. Exactly **one** behavior changed: the APN pair. Everything else byte-identical.

**New test pins both directions** (`test/redact-parcel-id-false-positive.test.ts`, 15 cases):
- 9 real phone shapes stay flagged — US dashed/parens/dotted, E.164 US/UK/DE/PT, bare 11-digit
- 3 APN shapes clean
- 3 narrowness controls, including the load-bearing one: **a bare digit run with no punctuated APN nearby is still flagged**

**Proven red under mutation.** Stubbing the guard to `return true` — the dangerous blanket-exemption failure, which would quietly gut the pattern — fails 12 of 15. Stubbing to `return false` fails 3. Restored: 15/15 with the source byte-identical.

**Existing suites green:** `redact-pattern-lint` 49/49, `gstack-config-redact-keys` 6/6, `browse/proxy-redact` 8/8.

HIGH detection is untouched — PEM, GitHub PAT and Slack token all still block.