### PR TITLE
fix: Windows support - Node.js CLI fallback for Smart App Control

### DIFF
--- a/browse/scripts/build-node-cli.sh
+++ b/browse/scripts/build-node-cli.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Build a Node.js-compatible CLI bundle for Windows.
+#
+# `bun build --compile` emits an executable with no Authenticode signature, and
+# Windows Smart App Control in enforcement mode refuses to load unsigned
+# binaries. Every locally compiled browse.exe is unique to the machine that
+# built it, so it can never accumulate the reputation SAC accepts either. The
+# result is that browse.exe cannot launch at all: every $B command dies, taking
+# /browse, /qa, /design-review, /benchmark and /canary with it. SAC has no
+# per-file allowlist and cannot be re-enabled once disabled without a clean
+# Windows reinstall.
+#
+# bun.exe and node.exe are both signed (Codeblog CORP and OpenJS Foundation),
+# so they run fine. The server half already exploits that: build-node-server.sh
+# plus the IS_WINDOWS branch in src/cli.ts spawns `node server-node.mjs`. This
+# script builds the missing other half, so no unsigned binary has to launch.
+
+set -e
+
+GSTACK_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SRC_DIR="$GSTACK_DIR/browse/src"
+DIST_DIR="$GSTACK_DIR/browse/dist"
+
+echo "Building Node-compatible CLI bundle..."
+
+# Step 1: Transpile cli.ts to a single .mjs bundle (externalize runtime deps).
+# Same externals as build-node-server.sh.
+bun build "$SRC_DIR/cli.ts" \
+  --target=node \
+  --outfile "$DIST_DIR/cli-node.mjs" \
+  --external playwright \
+  --external playwright-core \
+  --external diff \
+  --external "bun:sqlite" \
+  --external "@ngrok/ngrok"
+
+# Step 2: Post-process
+# Replace import.meta.dir with a resolvable reference
+perl -pi -e 's/import\.meta\.dir/__browseNodeSrcDir/g' "$DIST_DIR/cli-node.mjs"
+
+# Step 3: Create the final file with polyfill header injected after the first line.
+# bun-polyfill.cjs already covers Bun.spawn, Bun.spawnSync and Bun.sleep, which is
+# everything the CLI's import graph uses except Bun.stdin (reached only by `chain`
+# when it reads from stdin), so shim that one here.
+{
+  head -1 "$DIST_DIR/cli-node.mjs"
+  echo '// ── Windows Node.js compatibility (auto-generated) ──'
+  echo 'import { fileURLToPath as _ftp } from "node:url";'
+  echo 'import { dirname as _dn } from "node:path";'
+  echo 'import { createRequire as _cr } from "node:module";'
+  echo 'const __browseNodeSrcDir = _dn(_dn(_ftp(import.meta.url))) + "/src";'
+  echo '{'
+  echo '  const _r = _cr(import.meta.url);'
+  echo '  _r("./bun-polyfill.cjs");'
+  echo '  if (globalThis.Bun && !globalThis.Bun.stdin) {'
+  echo '    globalThis.Bun.stdin = {'
+  echo '      text() {'
+  echo '        return new Promise((resolve, reject) => {'
+  echo '          let data = "";'
+  echo '          process.stdin.setEncoding("utf8");'
+  echo '          process.stdin.on("data", (chunk) => { data += chunk; });'
+  echo '          process.stdin.on("end", () => resolve(data));'
+  echo '          process.stdin.on("error", reject);'
+  echo '        });'
+  echo '      },'
+  echo '    };'
+  echo '  }'
+  echo '}'
+  echo '// ── end compatibility ──'
+  tail -n +2 "$DIST_DIR/cli-node.mjs"
+} > "$DIST_DIR/cli-node.tmp.mjs"
+
+mv "$DIST_DIR/cli-node.tmp.mjs" "$DIST_DIR/cli-node.mjs"
+
+# Step 4: Copy polyfill to dist/
+cp "$SRC_DIR/bun-polyfill.cjs" "$DIST_DIR/bun-polyfill.cjs"
+
+echo "Node CLI bundle ready: $DIST_DIR/cli-node.mjs"
+
+# Step 5: Launcher wrappers, Windows only.
+#
+# On macOS and Linux, build.sh compiles the real binary to browse/dist/browse,
+# so writing a wrapper there would clobber it. On Windows that same step emits
+# browse.exe instead, leaving the extensionless path free — which is what keeps
+# the SETUP block in browse/SKILL.md working unchanged, since it resolves $B to
+# browse/dist/browse and gates on -x.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    cat > "$DIST_DIR/browse" <<'WRAPPER'
+#!/usr/bin/env bash
+# Node launcher for gstack browse (Windows / Smart App Control).
+#
+# dist/browse.exe is unsigned, so Smart App Control blocks it. node.exe is
+# signed, so running the CLI as a Node bundle works.
+#
+# Rebuild with: bash browse/scripts/build-node-cli.sh
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI="$DIR/cli-node.mjs"
+
+if [ ! -f "$CLI" ]; then
+  echo "cli-node.mjs missing. Run: bash browse/scripts/build-node-cli.sh" >&2
+  exit 1
+fi
+
+# node.exe is a native Windows binary and cannot read MSYS-style /c/... paths.
+if command -v cygpath >/dev/null 2>&1; then
+  CLI="$(cygpath -w "$CLI")"
+fi
+
+exec node "$CLI" "$@"
+WRAPPER
+
+    cat > "$DIST_DIR/browse.cmd" <<'WRAPPER'
+@echo off
+REM Node launcher for gstack browse (Windows / Smart App Control).
+REM dist\browse.exe is unsigned and blocked by Smart App Control; node.exe is signed.
+REM Rebuild with: bash browse/scripts/build-node-cli.sh
+node "%~dp0cli-node.mjs" %*
+WRAPPER
+
+    chmod +x "$DIST_DIR/browse"
+    echo "Launcher wrappers written: $DIST_DIR/browse, $DIST_DIR/browse.cmd"
+    ;;
+  *)
+    echo "Skipping launcher wrappers (non-Windows: dist/browse is the compiled binary)."
+    ;;
+esac

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,6 +30,7 @@ esac
 "$BUN_CMD" build --compile make-pdf/src/cli.ts --outfile make-pdf/dist/pdf
 "$BUN_CMD" build --compile bin/gstack-global-discover.ts --outfile bin/gstack-global-discover
 bash browse/scripts/build-node-server.sh
+bash browse/scripts/build-node-cli.sh
 bash scripts/write-version-files.sh browse/dist/.version design/dist/.version make-pdf/dist/.version
 chmod +x browse/dist/browse browse/dist/find-browse design/dist/design make-pdf/dist/pdf bin/gstack-global-discover
 rm -f .*.bun-build


### PR DESCRIPTION
Fixes #2595

> **Updated.** The first version of this PR used Node + esbuild and claimed Smart App Control blocks `bun.exe`. That was wrong: bun is signed and runs fine. The PR now uses bash + `bun build`, matching `build-node-server.sh`, and adds no new dependency. Details in the comment below.

## Problem

`bun build --compile` emits an executable with no Authenticode signature, and Windows Smart App Control in enforcement mode refuses to load unsigned binaries:

```
PS> browse.exe status
Program 'browse.exe' failed to run: An Application Control policy has blocked this file
```

Confirmed in `Microsoft-Windows-CodeIntegrity/Operational` (event 3077, plus Smart App Control block 3118). Every `$B` command dies, taking `/browse`, `/qa`, `/design-review`, `/benchmark` and `/canary` with it.

Under Git Bash the same block surfaces as `Permission denied`, which sends you looking at file permissions instead of code integrity.

Smart App Control has no per-file allowlist, and cannot be re-enabled once disabled without a clean Windows reinstall. Self-signing is not trusted. So there is no user-side workaround.

## The precise cause

Measured on the affected machine with `Get-AuthenticodeSignature`:

| Binary | Signature | Smart App Control |
|---|---|---|
| `bun.exe` | Valid, CN=Codeblog CORP | allowed |
| `node.exe` | Valid, CN=OpenJS Foundation | allowed |
| `browse.exe` | **NotSigned** | **blocked** |

bun and node both run fine. The toolchain is not the problem. The problem is the *artifact*: every locally compiled `browse.exe` is unsigned, and because it is unique to the machine that built it, it can never accumulate the file reputation Smart App Control accepts as an alternative to a signature.

That is why this cannot be fixed by rebuilding, and why it will hit every user who has Smart App Control on, which is the default for many clean Windows 11 installs.

## Why this is a small fix

The server half already exploits the fact that `node.exe` is signed. #255 added `build-node-server.sh` and the `IS_WINDOWS` branch in `src/cli.ts` that spawns `node server-node.mjs`, because Bun cannot drive Playwright's Chromium there.

So Windows was already **"signed Node runs the server"** while an unsigned binary was still required to start it. This PR adds the missing other half.

`src/cli.ts` imports only Node built-ins at the top. Across its whole import graph the only Bun APIs used are:

| API | Already in `bun-polyfill.cjs`? |
|---|---|
| `Bun.spawn` | yes |
| `Bun.spawnSync` | yes |
| `Bun.sleep` | yes |
| `Bun.stdin` | no (reached only by `chain` reading stdin) |

Three of four are already covered, and `import.meta.dir` needs the same rewrite `build-node-server.sh` already does.

## Changes

Two files, 130 insertions, no deletions.

- **`browse/scripts/build-node-cli.sh`** (new) mirrors `build-node-server.sh` structure exactly: same `bun build --target=node` invocation, same externals, same `perl -pi -e` rewrite of `import.meta.dir`, same polyfill header injection. Adds a `Bun.stdin` shim.
- On Windows it also writes `dist/browse` and `dist/browse.cmd` launchers. `dist/browse` keeps the SETUP block in `browse/SKILL.md` working unchanged, since it resolves `$B` to that path and gates on `-x`. **No SKILL.md or template change needed.**
- **`scripts/build.sh`** calls it on the line after the server bundle.

`browse/dist/` is gitignored, so `build-node-cli.sh` is the only new tracked file. No new dependencies.

### One thing to check in review

**The wrapper writes are Windows-gated** (`case "$(uname -s)"`). On macOS and Linux `build.sh:27` compiles the real binary to `browse/dist/browse`, so writing a wrapper there would clobber it. On Windows that step emits `browse.exe` instead, leaving the extensionless path free. I reasoned this from `build.sh` rather than observing it, so it is worth a second pair of eyes.

## Verification

Windows 11 Pro 26200, Smart App Control enforcing, Node v24.19.0, bun 1.3.14.

**`bun test` on this branch is identical to `main`:**

| | pass | skip | fail | errors |
|---|---|---|---|---|
| `main` | 5241 | 450 | 1435 | 12 |
| this branch | 5241 | 450 | 1435 | 12 |

Same 7126 tests across 507 files. This change is test-neutral.

Separately worth knowing: **1435 tests fail on a fresh clone on Windows before any change**, largely from binaries that are not built yet. Happy to open a separate issue with detail if that is useful.

Functional checks, both shells:

| Check | Result |
|---|---|
| `browse/SKILL.md` SETUP block, verbatim | `READY: .../dist/browse` |
| `$B goto` + `text`, static page | full text returned |
| `$B goto` + `wait --networkidle` + `text`, JS-rendered SPA | full text returned |
| `$B snapshot -i` | `@e1 [link] "Learn more"` |
| `$B screenshot` | 10,403 byte PNG written |
| `$B console --errors` | CSP errors captured |
| `$B status` from cold | server started, `Status: healthy` |
| exit codes on `goto` / `text` | 0 |
| PowerShell via `dist/browse.cmd` | working |
| Git Bash via `dist/browse` | working |

`browse.exe` is untouched and still builds.

## What I could not verify

**Non-Windows builds were not executed.** The macOS/Linux path is reasoned from `build.sh`, not observed. The wrapper stage is gated behind a `uname -s` check, so the intended effect there is one extra bundle in `dist/` and nothing else, but a maintainer running `bun run build` on macOS would confirm that cheaply.
