### PR TITLE
fix(browse): one ambiguous ref no longer kills the whole annotated screenshot

### DIFF
--- a/browse/src/snapshot.ts
+++ b/browse/src/snapshot.ts
@@ -353,6 +353,14 @@ export async function handleSnapshot(
 
   const snapshotText = output.join('\n');
 
+  // `-o` only means something to the two modes that PRODUCE an image. Passed
+  // alone it used to be silently ignored: exit 0, no file, no explanation —
+  // which reads as "the screenshot feature is broken" rather than "you forgot a
+  // flag", and cost a real debugging session before anyone noticed.
+  if (opts.outputPath && !opts.annotate && !opts.heatmap) {
+    output.push(`[warning] -o/--output was ignored: it names the file for an annotated screenshot, so it needs -a/--annotate (or -C/--cursor-interactive). For a plain screenshot use: browse screenshot ${opts.outputPath}`);
+  }
+
   // ─── Annotated screenshot (-a) ────────────────────────────
   if (opts.annotate) {
     const screenshotPath = opts.outputPath || `${TEMP_DIR}/browse-annotated.png`;
@@ -389,13 +397,32 @@ export async function handleSnapshot(
       const boxes: Array<{ ref: string; box: { x: number; y: number; width: number; height: number } }> = [];
       for (const [ref, entry] of refMap) {
         try {
-          const box = await entry.locator.boundingBox({ timeout: 1000 });
+          // `.first()` because a ref's locator can resolve to MORE than one
+          // element, and Playwright strict mode throws on that. It happens
+          // whenever a node has no accessible name: the locator degrades to
+          // `getByRole(role)` with no name filter, and the `.nth()`
+          // disambiguation above cannot help because its count comes from the
+          // FILTERED aria snapshot while getByRole matches the unfiltered DOM.
+          // Measured on a real page: the tree surfaced 2 unnamed paragraphs, the
+          // DOM had 9. Landmarks (banner/main/contentinfo) and paragraphs are
+          // correctly unnamed per ARIA, so this is the common case, not an edge.
+          //
+          // Before this, ONE such ref aborted the entire annotated screenshot
+          // (see the catch below) — which silently cost /qa, /canary and
+          // /land-and-deploy the screenshots their reports reference.
+          const box = await entry.locator.first().boundingBox({ timeout: 1000 });
           if (box) {
             boxes.push({ ref: `@${ref}`, box });
           }
         } catch (err: any) {
-          // Element may be offscreen, hidden, or page navigated — skip
-          if (!err?.message?.includes('Timeout') && !err?.message?.includes('timeout') && !err?.message?.includes('closed') && !err?.message?.includes('Target') && !err?.message?.includes('Execution context')) throw err;
+          // Element may be offscreen, hidden, or page navigated — skip.
+          //
+          // The allowlist is deliberately not exhaustive-by-message any more: a
+          // box we cannot measure is a box we do not draw, never a reason to
+          // lose every other annotation on the page. The heatmap path below has
+          // always used a bare `catch {}` for exactly this reason; annotate was
+          // the only path that could be killed by a single unmeasurable ref.
+          if (process.env.BROWSE_DEBUG) console.error(`[annotate] skipped @${ref}: ${err?.message?.split('\n')[0]}`);
         }
       }
 


### PR DESCRIPTION
## The symptom

`browse snapshot -a` exits 1 with `Selector matched multiple elements` on most real-world pages. Because `-a` is hardcoded in `qa/SKILL.md` (3 sites), `canary/SKILL.md` (3 sites) and `land-and-deploy/SKILL.md`, those skills **silently produce reports whose screenshots do not exist** — the command fails, the report still references a path, and a stale file from a previous run makes it look fine.

Plain `browse screenshot <path>` is unaffected, which is what makes this easy to miss.

## Root cause

Refs are built as `getByRole(role, { name })` and disambiguated with `.nth()` when a role+name pair repeats (`snapshot.ts:210-229`). That works for duplicate *named* elements.

It cannot fire for a node with **no accessible name**. The locator degrades to `getByRole(role)` with no name filter, and the count driving `.nth()` comes from the **filtered aria snapshot** while `getByRole` matches the **unfiltered DOM**. Measured on a live page: the tree surfaced 2 unnamed `paragraph` nodes; the DOM had 9.

`boundingBox()` then trips Playwright strict mode. The catch at `snapshot.ts:396-399` allowlisted only `Timeout` / `closed` / `Target` / `Execution context`, so the strict-mode error was re-thrown and **one ambiguous ref aborted every remaining annotation**.

Worth stressing: landmarks (`banner`, `main`, `contentinfo`) and `paragraph` are *correctly* unnamed per ARIA. On the page I reproduced against, 7 refs had no name and the three `<nav>` elements were all properly labelled — so this fires on well-built pages, not broken ones. It is the common case.

## The fix

- **`.first()` before `boundingBox()`** — an ambiguous ref draws a box on its first match instead of aborting. The heatmap path at what is now line ~538 has always tolerated this with a bare `catch {}`; annotate was the only path that could be killed outright.
- **The catch no longer re-throws on unrecognised messages.** A box that cannot be measured is a box that is not drawn, never a reason to lose the rest of the page. `BROWSE_DEBUG=1` prints what was skipped.
- **`-o` without `-a`/`-H` now warns** instead of silently doing nothing (exit 0, no file). That silence reads as "screenshots are broken" rather than "you forgot a flag", and cost a real debugging session.

## Verification

Rebuilt both ways and ran the identical command against the identical page, with a positive control that refs actually existed (51 present, so the test could not pass vacuously):

| build | result |
|---|---|
| upstream `main` | `Selector matched multiple elements` — **no file written** |
| with this change | exit 0 — **229 KB PNG, 1280×1468** |

The only variable between the two runs is this diff.

## Note

No test added. `browse/test/` has no fixture that reproduces this — it needs a page with an unnamed landmark whose role also appears more often in the DOM than in the aria snapshot. Happy to add one if you'd like a particular shape.