### PR TITLE
feat(browse): allow CPU and network throttling for performance measurement

### DIFF
--- a/browse/src/cdp-allowlist.ts
+++ b/browse/src/cdp-allowlist.ts
@@ -155,6 +155,20 @@ export const CDP_ALLOWLIST: ReadonlyArray<CdpAllowEntry> = Object.freeze([
     output: 'trusted',
     justification: 'UA override on the active tab. NOTE: changes affect future requests; fine for tests.',
   },
+  {
+    domain: 'Emulation',
+    method: 'setCPUThrottlingRate',
+    scope: 'tab',
+    output: 'trusted',
+    justification: 'CPU slowdown multiplier on the active tab, for measuring performance on a realistic low-end client instead of the developer workstation. Same domain and mutating character as setDeviceMetricsOverride; affects only timing, reads nothing, exfiltrates nothing.',
+  },
+  {
+    domain: 'Network',
+    method: 'emulateNetworkConditions',
+    scope: 'tab',
+    output: 'trusted',
+    justification: 'Bandwidth/latency emulation on the active tab, for measuring page behaviour on a slow connection. Constrains traffic rather than reading it — no request bodies, headers or cookies are exposed.',
+  },
   // ─── Page capture (output, not navigation) ─────────────────
   {
     domain: 'Page',


### PR DESCRIPTION
Adds `Emulation.setCPUThrottlingRate` and `Network.emulateNetworkConditions` to `CDP_ALLOWLIST`.

**Motivation.** Diagnosing a real "uploading a photo takes 1–2 minutes" report, the only machine available was a fast developer workstation. Client-side processing measured 1.4 s where the user experienced minutes, so the conclusion had to be reached *arithmetically* rather than observed. Throttling would have let the measurement reproduce the reporter's conditions directly — which is the difference between a diagnosis and an inference.

**Both fit the existing posture rather than widening it:**

- `Emulation` already allows `setDeviceMetricsOverride`, `clearDeviceMetricsOverride` and `setUserAgentOverride` — equally mutating, equally tab-scoped.
- Neither reads page content. `setCPUThrottlingRate` affects only timing; `emulateNetworkConditions` *constrains* traffic rather than inspecting it, so no request bodies, headers or cookies are exposed. Both are `output: 'trusted'` because they return no page-derived data.
- `scope: 'tab'` for both, matching the surrounding `Emulation` entries.

Each entry carries all four required fields, so `cdp-allowlist.test.ts` should pass unchanged.