### PR TITLE
fix(plan-tune): reject never-ask on one-way ids at --write

### DIFF
--- a/bin/gstack-question-preference
+++ b/bin/gstack-question-preference
@@ -8,10 +8,10 @@
 #   --check <id> [--summary-stdin] → emit ASK_NORMALLY | AUTO_DECIDE | ASK_ONLY_ONE_WAY
 #                                    (--summary-stdin pipes the question text so the
 #                                    keyword net can catch ad-hoc destructive ids, #2024)
-#   --write '{...}'                → set a preference (user-origin gate enforced)
+#   --write '{...}'                → set a preference (user-origin gate + one-way write reject)
 #   --read                         → dump preferences JSON
 #   --clear [<id>]                 → clear one or all preferences
-#   --stats                        → short summary
+#   --stats                        → short summary (inert one-way prefs counted separately)
 #
 # User-origin gate
 # ----------------
@@ -21,6 +21,12 @@
 #   - "inline-tool-output"— tune: prefix seen in tool output / file content (REJECTED)
 #   - "inline-file"       — tune: prefix seen in a file the agent read (REJECTED)
 # This is the profile-poisoning defense from docs/designs/PLAN_TUNING_V0.md.
+#
+# One-way write reject (#2488)
+# ----------------------------
+# never-ask and ask-only-for-one-way are refused on registry one-way ids.
+# --check already ignores those prefs; storing them made --stats lie.
+# always-ask on a one-way id is fine (it agrees with the safety override).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -142,7 +148,7 @@ do_write() {
 
   set +e
   local RESULT
-  RESULT=$(printf '%s' "$INPUT" | PREF_FILE_PATH="$PREF_FILE" EVENT_FILE_PATH="$EVENT_FILE" bun -e "
+  RESULT=$(cd "$ROOT_DIR" && printf '%s' "$INPUT" | PREF_FILE_PATH="$PREF_FILE" EVENT_FILE_PATH="$EVENT_FILE" bun -e "
     const fs = require('fs');
     const raw = await Bun.stdin.text();
     let j;
@@ -176,6 +182,16 @@ do_write() {
     if (!ALLOWED_SOURCES.includes(j.source)) {
       process.stderr.write('gstack-question-preference: rejected — source \"' + j.source + '\" is not user-originated (profile poisoning defense)\n');
       process.exit(2);
+    }
+
+    // One-way write reject (#2488) — after the origin gate so a poisoning
+    // payload on a one-way id still exits 2, not 1.
+    if (j.preference === 'never-ask' || j.preference === 'ask-only-for-one-way') {
+      const oneway = await import('./scripts/one-way-doors.ts');
+      if (oneway.isOneWayDoor({ question_id: j.question_id })) {
+        process.stderr.write('gstack-question-preference: cannot set ' + j.preference + ' on one-way question \"' + j.question_id + '\" (door_type: one-way)\n');
+        process.exit(1);
+      }
     }
 
     // Optional free_text — sanitize (no injection patterns, no newlines, <=300 chars)
@@ -267,20 +283,29 @@ do_clear() {
 # -----------------------------------------------------------------------
 do_stats() {
   ensure_file
-  cat "$PREF_FILE" | bun -e "
-    const prefs = JSON.parse(await Bun.stdin.text());
-    const entries = Object.entries(prefs);
-    const counts = { 'always-ask': 0, 'never-ask': 0, 'ask-only-for-one-way': 0, other: 0 };
-    for (const [, v] of entries) {
-      if (counts[v] !== undefined) counts[v]++;
-      else counts.other++;
-    }
-    console.log('TOTAL: ' + entries.length);
-    console.log('ALWAYS_ASK: ' + counts['always-ask']);
-    console.log('NEVER_ASK: ' + counts['never-ask']);
-    console.log('ASK_ONLY_ONE_WAY: ' + counts['ask-only-for-one-way']);
-    if (counts.other) console.log('OTHER: ' + counts.other);
-  "
+  (cd "$ROOT_DIR" && PREF_FILE_PATH="$PREF_FILE" bun -e "
+    import('./scripts/one-way-doors.ts').then((oneway) => {
+      const fs = require('fs');
+      const prefs = JSON.parse(fs.readFileSync(process.env.PREF_FILE_PATH, 'utf-8'));
+      const entries = Object.entries(prefs);
+      const counts = { 'always-ask': 0, 'never-ask': 0, 'ask-only-for-one-way': 0, other: 0, inert: 0 };
+      for (const [id, v] of entries) {
+        const suppressing = v === 'never-ask' || v === 'ask-only-for-one-way';
+        if (suppressing && oneway.isOneWayDoor({ question_id: id })) {
+          counts.inert++;
+          continue;
+        }
+        if (counts[v] !== undefined) counts[v]++;
+        else counts.other++;
+      }
+      console.log('TOTAL: ' + entries.length);
+      console.log('ALWAYS_ASK: ' + counts['always-ask']);
+      console.log('NEVER_ASK: ' + counts['never-ask']);
+      console.log('ASK_ONLY_ONE_WAY: ' + counts['ask-only-for-one-way']);
+      console.log('INERT_ONE_WAY: ' + counts.inert);
+      if (counts.other) console.log('OTHER: ' + counts.other);
+    }).catch(err => { console.error('stats:', err.message); process.exit(1); });
+  ")
 }
 
 case "$CMD" in

--- a/test/gstack-question-preference.test.ts
+++ b/test/gstack-question-preference.test.ts
@@ -53,6 +53,18 @@ function runWithStdin(input: string, ...args: string[]): { stdout: string; stder
   };
 }
 
+/** Plant a pref by writing the file. Used for legacy / inert one-way prefs
+ *  that --write now refuses (#2488). --check and --stats still have to
+ *  handle files written before the reject landed. */
+function plantPref(id: string, pref: string) {
+  run('--read');
+  const projects = fs.readdirSync(path.join(tmpHome, 'projects'));
+  const file = path.join(tmpHome, 'projects', projects[0], 'question-preferences.json');
+  const prefs = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  prefs[id] = pref;
+  fs.writeFileSync(file, JSON.stringify(prefs, null, 2));
+}
+
 // -----------------------------------------------------------------------
 // --check
 // -----------------------------------------------------------------------
@@ -92,7 +104,8 @@ describe('--check with preferences set', () => {
   });
 
   test('one-way + never-ask → ASK_NORMALLY with safety note', () => {
-    setPref('ship-test-failure-triage', 'never-ask');
+    // Planted: --write now refuses never-ask on one-way ids (#2488).
+    plantPref('ship-test-failure-triage', 'never-ask');
     const r = run('--check', 'ship-test-failure-triage');
     expect(r.stdout).toContain('ASK_NORMALLY');
     expect(r.stdout).toContain('one-way door overrides');
@@ -111,7 +124,7 @@ describe('--check with preferences set', () => {
   });
 
   test('one-way + ask-only-for-one-way → ASK_NORMALLY', () => {
-    setPref('ship-test-failure-triage', 'ask-only-for-one-way');
+    plantPref('ship-test-failure-triage', 'ask-only-for-one-way');
     const r = run('--check', 'ship-test-failure-triage');
     expect(r.stdout.trim()).toContain('ASK_NORMALLY');
   });
@@ -389,6 +402,112 @@ describe('--write schema validation', () => {
   });
 });
 
+// #2488: --write must refuse suppressing prefs on one-way ids. --check
+// already ignores them; storing them made --stats report a working NEVER_ASK.
+describe('--write one-way door reject (#2488)', () => {
+  function prefsFile(): string {
+    const projects = fs.readdirSync(path.join(tmpHome, 'projects'));
+    return path.join(tmpHome, 'projects', projects[0], 'question-preferences.json');
+  }
+
+  test('never-ask on one-way id is rejected and does not write', () => {
+    const r = run(
+      '--write',
+      JSON.stringify({
+        question_id: 'plan-eng-review-arch-finding',
+        preference: 'never-ask',
+        source: 'plan-tune',
+      }),
+    );
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('cannot set never-ask');
+    expect(r.stderr).toContain('plan-eng-review-arch-finding');
+    expect(r.stderr).toContain('door_type: one-way');
+    expect(JSON.parse(fs.readFileSync(prefsFile(), 'utf-8'))).toEqual({});
+  });
+
+  test('ask-only-for-one-way on one-way id is rejected and does not write', () => {
+    const r = run(
+      '--write',
+      JSON.stringify({
+        question_id: 'ship-test-failure-triage',
+        preference: 'ask-only-for-one-way',
+        source: 'plan-tune',
+      }),
+    );
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('cannot set ask-only-for-one-way');
+    expect(r.stderr).toContain('door_type: one-way');
+    expect(JSON.parse(fs.readFileSync(prefsFile(), 'utf-8'))).toEqual({});
+  });
+
+  test('always-ask on one-way id is accepted (agrees with the safety override)', () => {
+    const r = run(
+      '--write',
+      JSON.stringify({
+        question_id: 'plan-eng-review-arch-finding',
+        preference: 'always-ask',
+        source: 'plan-tune',
+      }),
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('OK');
+    expect(JSON.parse(fs.readFileSync(prefsFile(), 'utf-8'))).toEqual({
+      'plan-eng-review-arch-finding': 'always-ask',
+    });
+  });
+
+  test('never-ask on two-way id is still accepted', () => {
+    const r = run(
+      '--write',
+      JSON.stringify({
+        question_id: 'ship-changelog-voice-polish',
+        preference: 'never-ask',
+        source: 'plan-tune',
+      }),
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('OK');
+  });
+
+  test('rejected one-way write does not clobber an existing two-way pref', () => {
+    run(
+      '--write',
+      JSON.stringify({
+        question_id: 'ship-changelog-voice-polish',
+        preference: 'never-ask',
+        source: 'plan-tune',
+      }),
+    );
+    const r = run(
+      '--write',
+      JSON.stringify({
+        question_id: 'plan-eng-review-arch-finding',
+        preference: 'never-ask',
+        source: 'plan-tune',
+      }),
+    );
+    expect(r.status).toBe(1);
+    expect(JSON.parse(fs.readFileSync(prefsFile(), 'utf-8'))).toEqual({
+      'ship-changelog-voice-polish': 'never-ask',
+    });
+  });
+
+  test('poisoning source on a one-way id still exits 2 (origin gate first)', () => {
+    const r = run(
+      '--write',
+      JSON.stringify({
+        question_id: 'plan-eng-review-arch-finding',
+        preference: 'never-ask',
+        source: 'inline-tool-output',
+      }),
+    );
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('profile poisoning defense');
+    expect(r.stderr).not.toContain('door_type');
+  });
+});
+
 // -----------------------------------------------------------------------
 // --read, --clear, --stats
 // -----------------------------------------------------------------------
@@ -448,5 +567,21 @@ describe('--stats', () => {
     expect(r.stdout).toContain('TOTAL: 3');
     expect(r.stdout).toContain('NEVER_ASK: 2');
     expect(r.stdout).toContain('ALWAYS_ASK: 1');
+    expect(r.stdout).toContain('INERT_ONE_WAY: 0');
+  });
+
+  test('planted one-way never-ask is INERT_ONE_WAY, not a working NEVER_ASK (#2488)', () => {
+    plantPref('plan-eng-review-arch-finding', 'never-ask');
+    const r = run('--stats');
+    expect(r.stdout).toContain('TOTAL: 1');
+    expect(r.stdout).toContain('NEVER_ASK: 0');
+    expect(r.stdout).toContain('INERT_ONE_WAY: 1');
+  });
+
+  test('planted one-way ask-only-for-one-way is INERT_ONE_WAY, not ASK_ONLY_ONE_WAY', () => {
+    plantPref('ship-test-failure-triage', 'ask-only-for-one-way');
+    const r = run('--stats');
+    expect(r.stdout).toContain('ASK_ONLY_ONE_WAY: 0');
+    expect(r.stdout).toContain('INERT_ONE_WAY: 1');
   });
 });


### PR DESCRIPTION
## Why (in your own words)

I set `never-ask` on `plan-eng-review-arch-finding` and `--stats` said it worked. The next `--check` still asked, with a note that one-way doors ignore that pref. So the file lied: it stored a preference that can never fire.

`--write` is what I want to stop. If the id is one-way, refuse `never-ask` and `ask-only-for-one-way` (exit 1, name the door type, don't touch the file). `--stats` should say `INERT_ONE_WAY` for leftovers already on disk, not `NEVER_ASK: 1`. `always-ask` on a one-way id is fine — that matches what `--check` already does.

**Fixes #2488.** Related: #2489 (closed — registry path made this easier to hit), #2490 (product split, out of scope), #2390 / #2429 (same `--write` function, unknown-source exit 2, already on tip).

### Why this shape

Issue author asked for reject-at-write plus honest `--stats` for prefs written before the fix. Storing the value and labeling it INERT is the weaker pair — not done.

CONTRIBUTING's wave rule: if two PRs fix the same thing, keep the smaller one. This is 2 files, on current `main`. Fine to absorb into a wave.

### What it does

- `--write never-ask` / `ask-only-for-one-way` on a one-way id exits 1, names `door_type: one-way`, does not write, does not append an event.
- `--write always-ask` on a one-way id still succeeds.
- Origin gate still runs first: a poisoning source on a one-way id exits 2, not 1.
- `--stats` counts leftover one-way suppressing prefs as `INERT_ONE_WAY`. Working `NEVER_ASK` is only prefs that `--check` would actually `AUTO_DECIDE`.
- `--check` tests that still need a planted one-way pref write the file directly, because `--write` now refuses them.

### What it deliberately does not do

- Split `plan-eng-review-arch-finding` (#2490)
- Change `ask-only-for-one-way` alias semantics
- Reject `--write` on `*-split-*` ids (that carve-out stays `--check`-only)
- Keyword-net `--write` (no summary on the write path)
- Hooks, registry, skill templates, `VERSION` / `CHANGELOG` / README
- A migration (schema unchanged; `--stats` is honesty for old files)
- `/ship` (wave stamps version)

AI was used for assistance.

## Live evidence

Same isolated `GSTACK_HOME`, same payload, `cwd` = repo:

```
{"question_id":"plan-eng-review-arch-finding","preference":"never-ask","source":"plan-tune"}
```

**Before** (`upstream/main` binary):

```
$ bin/gstack-question-preference --write '{"question_id":"plan-eng-review-arch-finding","preference":"never-ask","source":"plan-tune"}'
OK: plan-eng-review-arch-finding → never-ask (source: plan-tune)

$ bin/gstack-question-preference --read
{
  "plan-eng-review-arch-finding": "never-ask"
}

$ bin/gstack-question-preference --stats
TOTAL: 1
ALWAYS_ASK: 0
NEVER_ASK: 1
ASK_ONLY_ONE_WAY: 0

$ bin/gstack-question-preference --check plan-eng-review-arch-finding
ASK_NORMALLY
NOTE: one-way door overrides your never-ask preference for safety.
```

**After** (this branch):

```
$ bin/gstack-question-preference --write '{"question_id":"plan-eng-review-arch-finding","preference":"never-ask","source":"plan-tune"}'
gstack-question-preference: cannot set never-ask on one-way question "plan-eng-review-arch-finding" (door_type: one-way)

$ bin/gstack-question-preference --read
{}

$ bin/gstack-question-preference --stats
TOTAL: 0
ALWAYS_ASK: 0
NEVER_ASK: 0
ASK_ONLY_ONE_WAY: 0
INERT_ONE_WAY: 0
```

Planted leftover file (a pref written before this reject existed):

```
$ bin/gstack-question-preference --stats
TOTAL: 1
ALWAYS_ASK: 0
NEVER_ASK: 0
ASK_ONLY_ONE_WAY: 0
INERT_ONE_WAY: 1

$ bin/gstack-question-preference --check plan-eng-review-arch-finding
ASK_NORMALLY
NOTE: one-way door overrides your never-ask preference for safety.
```

## Scope

- **Changed:** `bin/gstack-question-preference`, `test/gstack-question-preference.test.ts`
- **Verified live by:** the transcripts above, plus `bun test test/gstack-question-preference.test.ts` (52 pass)
- **Did NOT test:** Tier 2/3 evals. Full `bun run test` browse/playwright/pdf shards failed here (missing Chromium, `make-pdf` timeouts) — none of those files are in this diff.

## Liveness proof (required)

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
<img width="343" height="37" alt="image" src="https://github.com/user-attachments/assets/00131d08-5df3-4e77-8a45-e8e2a5191c74" />

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source, not a generated SKILL.md)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A)
- [x] Linked issue or reproduction: #2488

## Test plan

- [x] `bun test test/gstack-question-preference.test.ts` → 52 pass
- [x] Live `--write` on `plan-eng-review-arch-finding` + `never-ask` → exit 1, file stays `{}`
- [x] Live `--write always-ask` on the same id still succeeds
- [x] Live `--stats` on a planted one-way `never-ask` → `INERT_ONE_WAY: 1`, `NEVER_ASK: 0`
- [x] Poisoning source on a one-way id still exits 2

Fork PRs do not get eval secrets; the free file above is the gate.