### PR TITLE
feat(codex): raise reasoning-effort defaults and unify wrapper timeouts at 570s

### DIFF
--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -982,13 +982,13 @@ Parse the user's input to determine which mode to run:
    - Otherwise, ask: "What would you like to ask Codex?"
 4. `/codex <anything else>` — **Consult mode** (Step 2C), where the remaining text is the prompt
 
-**Reasoning effort override:** If the user's input contains `--xhigh` anywhere,
-note it and remove it from the prompt text before passing to Codex. When `--xhigh`
-is present, use `model_reasoning_effort="xhigh"` for all modes regardless of the
-per-mode default below. Otherwise, use the per-mode defaults:
-- Review (2A): `high` — bounded diff input, needs thoroughness
-- Challenge (2B): `high` — adversarial but bounded by diff
-- Consult (2C): `medium` — large context, interactive, needs speed
+**Reasoning effort override:** If the user's input contains `--max` (or its legacy
+alias `--xhigh`) anywhere, note it and remove it from the prompt text before passing
+to Codex. When present, use `model_reasoning_effort="max"` for all modes regardless
+of the per-mode default below. Otherwise, use the per-mode defaults:
+- Review (2A): `max` — bounded diff input, needs thoroughness
+- Challenge (2B): `max` — adversarial but bounded by diff
+- Consult (2C): `high` — large context, interactive; `high` balances depth and latency
 
 ---
 
@@ -1051,15 +1051,15 @@ contradicting this skill's read-only contract (#2496, #2524):
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 cd "$_REPO_ROOT"
-# The 330s wrapper sits BELOW the 360s Bash gate so the wrapper fires FIRST
+# The 570s wrapper sits BELOW the 600s Bash gate so the wrapper fires FIRST
 # and a stall surfaces as a diagnosable exit 124 with an explicit message,
 # never as a silent harness kill that downstream reads as "no findings".
-_gstack_codex_timeout_wrapper 330 codex review --base <base> -c 'sandbox_mode="read-only"' -c 'model_reasoning_effort="high"' -c 'web_search="cached"' < /dev/null 2>"$TMPERR"
+_gstack_codex_timeout_wrapper 570 codex review --base <base> -c 'sandbox_mode="read-only"' -c 'model_reasoning_effort="max"' -c 'web_search="cached"' < /dev/null 2>"$TMPERR"
 _CODEX_EXIT=$?
 if [ "$_CODEX_EXIT" = "124" ]; then
-  _gstack_codex_log_event "codex_timeout" "330"
+  _gstack_codex_log_event "codex_timeout" "570"
   _gstack_codex_log_hang "review" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
-  echo "Codex stalled past 5.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+  echo "Codex stalled past 9.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
 elif [ "$_CODEX_EXIT" != "0" ]; then
   # Surface non-zero exits (parse errors, arg-shape breaks, etc.) so the
   # calling agent doesn't read "no output" as a silent model/API stall and
@@ -1070,7 +1070,7 @@ elif [ "$_CODEX_EXIT" != "0" ]; then
 fi
 ```
 
-If the user passed `--xhigh`, use `"xhigh"` instead of `"high"`.
+The `--max` override (legacy `--xhigh`) is a no-op here — this mode already runs at `"max"`.
 
 **Custom-instructions path (user typed `/codex review <focus>`):** custom instructions
 cannot ride along with `--base` — that is exactly the combination the CLI rejects — and
@@ -1095,13 +1095,13 @@ _PROMPT_FILE=$(mktemp "$TMP_ROOT/codex-prompt-XXXXXX")
   git diff "<base>...HEAD" 2>/dev/null
   printf '\nDIFF_END\n'
 } > "$_PROMPT_FILE"
-_gstack_codex_timeout_wrapper 330 codex exec -s read-only "$(cat "$_PROMPT_FILE")" -c 'model_reasoning_effort="high"' -c 'web_search="cached"' < /dev/null 2>"$TMPERR"
+_gstack_codex_timeout_wrapper 570 codex exec -s read-only "$(cat "$_PROMPT_FILE")" -c 'model_reasoning_effort="max"' -c 'web_search="cached"' < /dev/null 2>"$TMPERR"
 _CODEX_EXIT=$?
 rm -f "$_PROMPT_FILE"
 if [ "$_CODEX_EXIT" = "124" ]; then
-  _gstack_codex_log_event "codex_timeout" "330"
+  _gstack_codex_log_event "codex_timeout" "570"
   _gstack_codex_log_hang "review" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
-  echo "Codex stalled past 5.5 minutes."
+  echo "Codex stalled past 9.5 minutes."
 fi
 ```
 
@@ -1115,8 +1115,8 @@ instructions. The `codex exec` route loses that tuning but gains custom-instruct
 support; the prompt explicitly demands `[P1]` / `[P2]` markers so the gate logic in step 4
 still works. There is no third option that gets both — the CLI forbids it.
 
-Use `timeout: 360000` on the Bash call for either path. The Bash gate sits ABOVE the
-330s wrapper deliberately: the wrapper fires first with its explicit exit-124 message,
+Use `timeout: 600000` on the Bash call for either path. The Bash gate sits ABOVE the
+570s wrapper deliberately: the wrapper fires first with its explicit exit-124 message,
 instead of the harness killing the call silently.
 
 3. Capture the output. Then parse cost from stderr:
@@ -1361,10 +1361,10 @@ With focus (e.g., "security"):
 Review the changes on this branch against the base branch. Run `git diff origin/<base>` to see the diff. Focus specifically on SECURITY. Your job is to find every way an attacker could exploit this code. Think about injection vectors, auth bypasses, privilege escalation, data exposure, and timing attacks. Be adversarial."
 
 2. Run codex exec with **JSONL output** to capture reasoning traces and tool calls.
-Use `timeout: 660000` on the Bash call — the gate sits ABOVE the 600s wrapper so the
+Use `timeout: 660000` on the Bash call — the gate sits ABOVE the 570s wrapper so the
 wrapper fires first with its explicit stall message:
 
-If the user passed `--xhigh`, use `"xhigh"` instead of `"high"`.
+The `--max` override (legacy `--xhigh`) is a no-op here — this mode already runs at `"max"`.
 
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
@@ -1376,7 +1376,7 @@ fi
 # Fix 1+2: wrap with timeout (gtimeout/timeout fallback chain via probe helper),
 # capture stderr to $TMPERR for auth error detection (was: 2>/dev/null).
 TMPERR=${TMPERR:-$(mktemp "$TMP_ROOT/codex-err-XXXXXX")}
-_gstack_codex_timeout_wrapper 600 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' -c 'web_search="cached"' --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
+_gstack_codex_timeout_wrapper 570 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="max"' -c 'web_search="cached"' --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
 import sys, json
 turn_completed_count = 0
 for line in sys.stdin:
@@ -1410,9 +1410,9 @@ if turn_completed_count == 0:
 _CODEX_EXIT=${PIPESTATUS[0]}
 # Fix 1: hang detection — log + surface actionable message
 if [ "$_CODEX_EXIT" = "124" ]; then
-  _gstack_codex_log_event "codex_timeout" "600"
+  _gstack_codex_log_event "codex_timeout" "570"
   _gstack_codex_log_hang "challenge" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
-  echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+  echo "Codex stalled past 9.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
 elif [ "$_CODEX_EXIT" != "0" ]; then
   # Surface non-zero exits so the calling agent doesn't read "no output" as
   # a silent model/API stall. See #1327.
@@ -1520,10 +1520,10 @@ For non-plan consult prompts (user typed `/codex <question>`), still prepend the
 
 4. Run codex exec with **JSONL output** to capture reasoning traces. Use
 `timeout: 660000` on the Bash call (for both new and resumed sessions) — the gate
-sits ABOVE the 600s wrapper so the wrapper fires first with its explicit stall
+sits ABOVE the 570s wrapper so the wrapper fires first with its explicit stall
 message:
 
-If the user passed `--xhigh`, use `"xhigh"` instead of `"medium"`.
+If the user passed `--max` (or legacy `--xhigh`), use `"max"` instead of `"high"`.
 
 For a **new session:**
 ```bash
@@ -1534,7 +1534,7 @@ if [ -z "$PYTHON_CMD" ]; then
   exit 1
 fi
 # Fix 1: wrap with timeout (gtimeout/timeout fallback chain via probe helper)
-_gstack_codex_timeout_wrapper 600 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="medium"' -c 'web_search="cached"' --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
+_gstack_codex_timeout_wrapper 570 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' -c 'web_search="cached"' --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
 import sys, json
 for line in sys.stdin:
     line = line.strip()
@@ -1566,9 +1566,9 @@ for line in sys.stdin:
 # Fix 1: hang detection for Consult new-session (mirrors Challenge + resume)
 _CODEX_EXIT=${PIPESTATUS[0]}
 if [ "$_CODEX_EXIT" = "124" ]; then
-  _gstack_codex_log_event "codex_timeout" "600"
+  _gstack_codex_log_event "codex_timeout" "570"
   _gstack_codex_log_hang "consult" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
-  echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+  echo "Codex stalled past 9.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
 elif [ "$_CODEX_EXIT" != "0" ]; then
   # Surface non-zero exits so the calling agent doesn't read "no output" as
   # a silent model/API stall. See #1327.
@@ -1588,15 +1588,15 @@ if [ -z "$PYTHON_CMD" ]; then
 fi
 cd "$_REPO_ROOT" || exit 1
 # Fix 1: wrap with timeout (gtimeout/timeout fallback chain via probe helper)
-_gstack_codex_timeout_wrapper 600 codex exec resume <session-id> "<prompt>" -c 'sandbox_mode="read-only"' -c 'model_reasoning_effort="medium"' -c 'web_search="cached"' --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
+_gstack_codex_timeout_wrapper 570 codex exec resume <session-id> "<prompt>" -c 'sandbox_mode="read-only"' -c 'model_reasoning_effort="high"' -c 'web_search="cached"' --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
 <same python streaming parser as above, with flush=True on all print() calls>
 "
 # Fix 1: same hang detection pattern as new-session block
 _CODEX_EXIT=${PIPESTATUS[0]}
 if [ "$_CODEX_EXIT" = "124" ]; then
-  _gstack_codex_log_event "codex_timeout" "600"
+  _gstack_codex_log_event "codex_timeout" "570"
   _gstack_codex_log_hang "consult-resume" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
-  echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+  echo "Codex stalled past 9.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
 elif [ "$_CODEX_EXIT" != "0" ]; then
   # Surface non-zero exits so the calling agent doesn't read "no output" as
   # a silent model/API stall. See #1327.
@@ -1653,13 +1653,15 @@ uses them. If the user wants a specific model, pass it through — but the flag 
 by mode (see below).
 
 **Reasoning effort (per-mode defaults):**
-- **Review (2A):** `high` — bounded diff input, needs thoroughness but not max tokens
-- **Challenge (2B):** `high` — adversarial but bounded by diff size
-- **Consult (2C):** `medium` — large context (plans, codebase), interactive, needs speed
+- **Review (2A):** `max` — bounded diff input; reviewer depth is the whole point
+- **Challenge (2B):** `max` — adversarial but bounded by diff size
+- **Consult (2C):** `high` — large context (plans, codebase), interactive
 
-`xhigh` uses ~23x more tokens than `high` and causes 50+ minute hangs on large context
-tasks (OpenAI issues #8545, #8402, #6931). Users can override with `--xhigh` flag
-(e.g., `/codex review --xhigh`) when they want maximum reasoning and are willing to wait.
+Top-tier efforts burn ~23x more tokens than `high` and have caused 50+ minute hangs on
+large-context tasks (OpenAI issues #8545, #8402, #6931) — that is why Consult stays one
+notch down, and why the 570s wrappers matter: a runaway run dies with a diagnosable
+stall message, not a silent hang. Users can force `max` in any mode with the `--max`
+flag (legacy alias `--xhigh`; e.g., `/codex consult --max`) when they accept the wait.
 
 **Web search:** All codex commands pass `-c 'web_search="cached"'` so `codex exec`
 invocations can look up docs and APIs during review. This is OpenAI's cached index —
@@ -1697,12 +1699,12 @@ If token count is not available, display: `Tokens: unknown`
 - **Binary not found:** Detected in Step 0. Stop with install instructions.
 - **Auth error:** Codex prints an auth error to stderr. Surface the error:
   "Codex authentication failed. Run `codex login` in your terminal to authenticate via ChatGPT."
-- **Timeout (Bash outer gate):** Every Bash gate sits ABOVE its inner wrapper (360s gate
-  over the 330s review wrapper; 660s gate over the 600s challenge/consult wrappers), so
+- **Timeout (Bash outer gate):** Every Bash gate sits ABOVE its inner wrapper (600s gate
+  over the 570s review wrapper; 660s gate over the 570s challenge/consult wrappers), so
   the wrapper's exit-124 path normally fires first with its explicit message. If the Bash
   call itself times out anyway (wrapper unavailable AND codex hung), tell the user:
   "Codex timed out. The prompt may be too large or the API may be slow. Try again or use a smaller scope."
-- **Timeout (inner `timeout` wrapper, exit 124):** If the shell `timeout 600` wrapper fires first, the skill's hang-detection block auto-logs a telemetry event + operational learning and prints: "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check `~/.codex/logs/`." No extra action needed.
+- **Timeout (inner `timeout` wrapper, exit 124):** If the shell `timeout 570` wrapper fires first, the skill's hang-detection block auto-logs a telemetry event + operational learning and prints: "Codex stalled past 9.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check `~/.codex/logs/`." No extra action needed.
 - **`the argument '[PROMPT]' cannot be used with '--base <BRANCH>'`:** a prompt argument
   leaked into a scoped `codex review`. This fails instantly, before any API call, so it
   looks like a hang-free "no output" — do not misread it as a model stall. Drop the
@@ -1744,8 +1746,8 @@ If token count is not available, display: `Tokens: unknown`
 - **Add synthesis after, not instead of.** Any Claude commentary comes after the full output.
 - **Bash gate above the wrapper.** Every Bash call to codex sets its `timeout`
   parameter ABOVE the inner `_gstack_codex_timeout_wrapper` budget (Review:
-  `timeout: 360000` over the 330s wrapper; Challenge/Consult: `timeout: 660000`
-  over the 600s wrappers) so the wrapper fires first with a diagnosable exit 124.
+  `timeout: 600000` over the 570s wrapper; Challenge/Consult: `timeout: 660000`
+  over the 570s wrappers) so the wrapper fires first with a diagnosable exit 124.
 - **No double-reviewing.** If the user already ran `/review`, Codex provides a second
   independent opinion. Do not re-run Claude Code's own review.
 - **Detect skill-file rabbit holes.** After receiving Codex output, scan for signs

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -155,13 +155,13 @@ Parse the user's input to determine which mode to run:
    - Otherwise, ask: "What would you like to ask Codex?"
 4. `/codex <anything else>` — **Consult mode** (Step 2C), where the remaining text is the prompt
 
-**Reasoning effort override:** If the user's input contains `--xhigh` anywhere,
-note it and remove it from the prompt text before passing to Codex. When `--xhigh`
-is present, use `model_reasoning_effort="xhigh"` for all modes regardless of the
-per-mode default below. Otherwise, use the per-mode defaults:
-- Review (2A): `high` — bounded diff input, needs thoroughness
-- Challenge (2B): `high` — adversarial but bounded by diff
-- Consult (2C): `medium` — large context, interactive, needs speed
+**Reasoning effort override:** If the user's input contains `--max` (or its legacy
+alias `--xhigh`) anywhere, note it and remove it from the prompt text before passing
+to Codex. When present, use `model_reasoning_effort="max"` for all modes regardless
+of the per-mode default below. Otherwise, use the per-mode defaults:
+- Review (2A): `max` — bounded diff input, needs thoroughness
+- Challenge (2B): `max` — adversarial but bounded by diff
+- Consult (2C): `high` — large context, interactive; `high` balances depth and latency
 
 ---
 
@@ -224,15 +224,15 @@ contradicting this skill's read-only contract (#2496, #2524):
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
 cd "$_REPO_ROOT"
-# The 330s wrapper sits BELOW the 360s Bash gate so the wrapper fires FIRST
+# The 570s wrapper sits BELOW the 600s Bash gate so the wrapper fires FIRST
 # and a stall surfaces as a diagnosable exit 124 with an explicit message,
 # never as a silent harness kill that downstream reads as "no findings".
-_gstack_codex_timeout_wrapper 330 codex review --base <base> -c 'sandbox_mode="read-only"' -c 'model_reasoning_effort="high"' {{CODEX_WEB_SEARCH_FLAG}} < /dev/null 2>"$TMPERR"
+_gstack_codex_timeout_wrapper 570 codex review --base <base> -c 'sandbox_mode="read-only"' -c 'model_reasoning_effort="max"' {{CODEX_WEB_SEARCH_FLAG}} < /dev/null 2>"$TMPERR"
 _CODEX_EXIT=$?
 if [ "$_CODEX_EXIT" = "124" ]; then
-  _gstack_codex_log_event "codex_timeout" "330"
+  _gstack_codex_log_event "codex_timeout" "570"
   _gstack_codex_log_hang "review" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
-  echo "Codex stalled past 5.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+  echo "Codex stalled past 9.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
 elif [ "$_CODEX_EXIT" != "0" ]; then
   # Surface non-zero exits (parse errors, arg-shape breaks, etc.) so the
   # calling agent doesn't read "no output" as a silent model/API stall and
@@ -243,7 +243,7 @@ elif [ "$_CODEX_EXIT" != "0" ]; then
 fi
 ```
 
-If the user passed `--xhigh`, use `"xhigh"` instead of `"high"`.
+The `--max` override (legacy `--xhigh`) is a no-op here — this mode already runs at `"max"`.
 
 **Custom-instructions path (user typed `/codex review <focus>`):** custom instructions
 cannot ride along with `--base` — that is exactly the combination the CLI rejects — and
@@ -268,13 +268,13 @@ _PROMPT_FILE=$(mktemp "$TMP_ROOT/codex-prompt-XXXXXX")
   git diff "<base>...HEAD" 2>/dev/null
   printf '\nDIFF_END\n'
 } > "$_PROMPT_FILE"
-_gstack_codex_timeout_wrapper 330 codex exec -s read-only "$(cat "$_PROMPT_FILE")" -c 'model_reasoning_effort="high"' {{CODEX_WEB_SEARCH_FLAG}} < /dev/null 2>"$TMPERR"
+_gstack_codex_timeout_wrapper 570 codex exec -s read-only "$(cat "$_PROMPT_FILE")" -c 'model_reasoning_effort="max"' {{CODEX_WEB_SEARCH_FLAG}} < /dev/null 2>"$TMPERR"
 _CODEX_EXIT=$?
 rm -f "$_PROMPT_FILE"
 if [ "$_CODEX_EXIT" = "124" ]; then
-  _gstack_codex_log_event "codex_timeout" "330"
+  _gstack_codex_log_event "codex_timeout" "570"
   _gstack_codex_log_hang "review" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
-  echo "Codex stalled past 5.5 minutes."
+  echo "Codex stalled past 9.5 minutes."
 fi
 ```
 
@@ -288,8 +288,8 @@ instructions. The `codex exec` route loses that tuning but gains custom-instruct
 support; the prompt explicitly demands `[P1]` / `[P2]` markers so the gate logic in step 4
 still works. There is no third option that gets both — the CLI forbids it.
 
-Use `timeout: 360000` on the Bash call for either path. The Bash gate sits ABOVE the
-330s wrapper deliberately: the wrapper fires first with its explicit exit-124 message,
+Use `timeout: 600000` on the Bash call for either path. The Bash gate sits ABOVE the
+570s wrapper deliberately: the wrapper fires first with its explicit exit-124 message,
 instead of the harness killing the call silently.
 
 3. Capture the output. Then parse cost from stderr:
@@ -412,10 +412,10 @@ With focus (e.g., "security"):
 Review the changes on this branch against the base branch. Run `git diff origin/<base>` to see the diff. Focus specifically on SECURITY. Your job is to find every way an attacker could exploit this code. Think about injection vectors, auth bypasses, privilege escalation, data exposure, and timing attacks. Be adversarial."
 
 2. Run codex exec with **JSONL output** to capture reasoning traces and tool calls.
-Use `timeout: 660000` on the Bash call — the gate sits ABOVE the 600s wrapper so the
+Use `timeout: 660000` on the Bash call — the gate sits ABOVE the 570s wrapper so the
 wrapper fires first with its explicit stall message:
 
-If the user passed `--xhigh`, use `"xhigh"` instead of `"high"`.
+The `--max` override (legacy `--xhigh`) is a no-op here — this mode already runs at `"max"`.
 
 ```bash
 _REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "ERROR: not in a git repo" >&2; exit 1; }
@@ -427,7 +427,7 @@ fi
 # Fix 1+2: wrap with timeout (gtimeout/timeout fallback chain via probe helper),
 # capture stderr to $TMPERR for auth error detection (was: 2>/dev/null).
 TMPERR=${TMPERR:-$(mktemp "$TMP_ROOT/codex-err-XXXXXX")}
-_gstack_codex_timeout_wrapper 600 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' {{CODEX_WEB_SEARCH_FLAG}} --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
+_gstack_codex_timeout_wrapper 570 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="max"' {{CODEX_WEB_SEARCH_FLAG}} --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
 import sys, json
 turn_completed_count = 0
 for line in sys.stdin:
@@ -461,9 +461,9 @@ if turn_completed_count == 0:
 _CODEX_EXIT=${PIPESTATUS[0]}
 # Fix 1: hang detection — log + surface actionable message
 if [ "$_CODEX_EXIT" = "124" ]; then
-  _gstack_codex_log_event "codex_timeout" "600"
+  _gstack_codex_log_event "codex_timeout" "570"
   _gstack_codex_log_hang "challenge" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
-  echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+  echo "Codex stalled past 9.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
 elif [ "$_CODEX_EXIT" != "0" ]; then
   # Surface non-zero exits so the calling agent doesn't read "no output" as
   # a silent model/API stall. See #1327.
@@ -571,10 +571,10 @@ For non-plan consult prompts (user typed `/codex <question>`), still prepend the
 
 4. Run codex exec with **JSONL output** to capture reasoning traces. Use
 `timeout: 660000` on the Bash call (for both new and resumed sessions) — the gate
-sits ABOVE the 600s wrapper so the wrapper fires first with its explicit stall
+sits ABOVE the 570s wrapper so the wrapper fires first with its explicit stall
 message:
 
-If the user passed `--xhigh`, use `"xhigh"` instead of `"medium"`.
+If the user passed `--max` (or legacy `--xhigh`), use `"max"` instead of `"high"`.
 
 For a **new session:**
 ```bash
@@ -585,7 +585,7 @@ if [ -z "$PYTHON_CMD" ]; then
   exit 1
 fi
 # Fix 1: wrap with timeout (gtimeout/timeout fallback chain via probe helper)
-_gstack_codex_timeout_wrapper 600 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="medium"' {{CODEX_WEB_SEARCH_FLAG}} --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
+_gstack_codex_timeout_wrapper 570 codex exec "<prompt>" -C "$_REPO_ROOT" -s read-only -c 'model_reasoning_effort="high"' {{CODEX_WEB_SEARCH_FLAG}} --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
 import sys, json
 for line in sys.stdin:
     line = line.strip()
@@ -617,9 +617,9 @@ for line in sys.stdin:
 # Fix 1: hang detection for Consult new-session (mirrors Challenge + resume)
 _CODEX_EXIT=${PIPESTATUS[0]}
 if [ "$_CODEX_EXIT" = "124" ]; then
-  _gstack_codex_log_event "codex_timeout" "600"
+  _gstack_codex_log_event "codex_timeout" "570"
   _gstack_codex_log_hang "consult" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
-  echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+  echo "Codex stalled past 9.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
 elif [ "$_CODEX_EXIT" != "0" ]; then
   # Surface non-zero exits so the calling agent doesn't read "no output" as
   # a silent model/API stall. See #1327.
@@ -639,15 +639,15 @@ if [ -z "$PYTHON_CMD" ]; then
 fi
 cd "$_REPO_ROOT" || exit 1
 # Fix 1: wrap with timeout (gtimeout/timeout fallback chain via probe helper)
-_gstack_codex_timeout_wrapper 600 codex exec resume <session-id> "<prompt>" -c 'sandbox_mode="read-only"' -c 'model_reasoning_effort="medium"' {{CODEX_WEB_SEARCH_FLAG}} --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
+_gstack_codex_timeout_wrapper 570 codex exec resume <session-id> "<prompt>" -c 'sandbox_mode="read-only"' -c 'model_reasoning_effort="high"' {{CODEX_WEB_SEARCH_FLAG}} --json < /dev/null 2>"$TMPERR" | PYTHONUNBUFFERED=1 "$PYTHON_CMD" -u -c "
 <same python streaming parser as above, with flush=True on all print() calls>
 "
 # Fix 1: same hang detection pattern as new-session block
 _CODEX_EXIT=${PIPESTATUS[0]}
 if [ "$_CODEX_EXIT" = "124" ]; then
-  _gstack_codex_log_event "codex_timeout" "600"
+  _gstack_codex_log_event "codex_timeout" "570"
   _gstack_codex_log_hang "consult-resume" "$(wc -c < "$TMPERR" 2>/dev/null || echo 0)"
-  echo "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
+  echo "Codex stalled past 9.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check ~/.codex/logs/."
 elif [ "$_CODEX_EXIT" != "0" ]; then
   # Surface non-zero exits so the calling agent doesn't read "no output" as
   # a silent model/API stall. See #1327.
@@ -704,13 +704,15 @@ uses them. If the user wants a specific model, pass it through — but the flag 
 by mode (see below).
 
 **Reasoning effort (per-mode defaults):**
-- **Review (2A):** `high` — bounded diff input, needs thoroughness but not max tokens
-- **Challenge (2B):** `high` — adversarial but bounded by diff size
-- **Consult (2C):** `medium` — large context (plans, codebase), interactive, needs speed
+- **Review (2A):** `max` — bounded diff input; reviewer depth is the whole point
+- **Challenge (2B):** `max` — adversarial but bounded by diff size
+- **Consult (2C):** `high` — large context (plans, codebase), interactive
 
-`xhigh` uses ~23x more tokens than `high` and causes 50+ minute hangs on large context
-tasks (OpenAI issues #8545, #8402, #6931). Users can override with `--xhigh` flag
-(e.g., `/codex review --xhigh`) when they want maximum reasoning and are willing to wait.
+Top-tier efforts burn ~23x more tokens than `high` and have caused 50+ minute hangs on
+large-context tasks (OpenAI issues #8545, #8402, #6931) — that is why Consult stays one
+notch down, and why the 570s wrappers matter: a runaway run dies with a diagnosable
+stall message, not a silent hang. Users can force `max` in any mode with the `--max`
+flag (legacy alias `--xhigh`; e.g., `/codex consult --max`) when they accept the wait.
 
 **Web search:** All codex commands pass `{{CODEX_WEB_SEARCH_FLAG}}` so `codex exec`
 invocations can look up docs and APIs during review. This is OpenAI's cached index —
@@ -748,12 +750,12 @@ If token count is not available, display: `Tokens: unknown`
 - **Binary not found:** Detected in Step 0. Stop with install instructions.
 - **Auth error:** Codex prints an auth error to stderr. Surface the error:
   "Codex authentication failed. Run `codex login` in your terminal to authenticate via ChatGPT."
-- **Timeout (Bash outer gate):** Every Bash gate sits ABOVE its inner wrapper (360s gate
-  over the 330s review wrapper; 660s gate over the 600s challenge/consult wrappers), so
+- **Timeout (Bash outer gate):** Every Bash gate sits ABOVE its inner wrapper (600s gate
+  over the 570s review wrapper; 660s gate over the 570s challenge/consult wrappers), so
   the wrapper's exit-124 path normally fires first with its explicit message. If the Bash
   call itself times out anyway (wrapper unavailable AND codex hung), tell the user:
   "Codex timed out. The prompt may be too large or the API may be slow. Try again or use a smaller scope."
-- **Timeout (inner `timeout` wrapper, exit 124):** If the shell `timeout 600` wrapper fires first, the skill's hang-detection block auto-logs a telemetry event + operational learning and prints: "Codex stalled past 10 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check `~/.codex/logs/`." No extra action needed.
+- **Timeout (inner `timeout` wrapper, exit 124):** If the shell `timeout 570` wrapper fires first, the skill's hang-detection block auto-logs a telemetry event + operational learning and prints: "Codex stalled past 9.5 minutes. Common causes: model API stall, long prompt, network issue. Try re-running. If persistent, split the prompt or check `~/.codex/logs/`." No extra action needed.
 - **`the argument '[PROMPT]' cannot be used with '--base <BRANCH>'`:** a prompt argument
   leaked into a scoped `codex review`. This fails instantly, before any API call, so it
   looks like a hang-free "no output" — do not misread it as a model stall. Drop the
@@ -795,8 +797,8 @@ If token count is not available, display: `Tokens: unknown`
 - **Add synthesis after, not instead of.** Any Claude commentary comes after the full output.
 - **Bash gate above the wrapper.** Every Bash call to codex sets its `timeout`
   parameter ABOVE the inner `_gstack_codex_timeout_wrapper` budget (Review:
-  `timeout: 360000` over the 330s wrapper; Challenge/Consult: `timeout: 660000`
-  over the 600s wrappers) so the wrapper fires first with a diagnosable exit 124.
+  `timeout: 600000` over the 570s wrapper; Challenge/Consult: `timeout: 660000`
+  over the 570s wrappers) so the wrapper fires first with a diagnosable exit 124.
 - **No double-reviewing.** If the user already ran `/review`, Codex provides a second
   independent opinion. Do not re-run Claude Code's own review.
 - **Detect skill-file rabbit holes.** After receiving Codex output, scan for signs

--- a/test/codex-effort-timeout-consistency.test.ts
+++ b/test/codex-effort-timeout-consistency.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect } from 'bun:test';
+import * as path from 'path';
+import * as fs from 'fs';
+
+// The codex skill states its wrapper budget and reasoning-effort defaults in
+// MANY places: five bash invocation sites, five telemetry log labels, six
+// user-facing stall messages, two per-mode defaults tables, three per-site
+// override sentences, and Bash-gate prose. Nothing generates these from a
+// single source, so they drift — this file pins them to EACH OTHER.
+// Deliberately value-agnostic: it asserts the surfaces agree, not what the
+// numbers are, so retuning the budget or defaults means changing every
+// surface together — this test tells you which one you missed — without
+// having to touch the test. The flip side, accepted: a coherent retune of
+// everything at once passes without a test edit. Known match looseness,
+// also accepted: any 6+-digit `timeout:` in these two docs is treated as a
+// codex Bash gate, and prose naming an obsolete "NNNs wrapper" (even
+// historically) must be reworded or it trips the prose check.
+
+const ROOT = path.resolve(import.meta.dir, '..');
+
+// Tier order per the OpenAI API's own invalid-enum error message
+// ("Supported values are: 'none', 'minimal', 'low', 'medium', 'high',
+// 'xhigh', and 'max'"), verified against codex-cli 0.144.3.
+const TIERS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
+
+const FILES: Array<[string, string]> = [
+  ['codex/SKILL.md.tmpl', fs.readFileSync(path.join(ROOT, 'codex/SKILL.md.tmpl'), 'utf8')],
+  ['codex/SKILL.md', fs.readFileSync(path.join(ROOT, 'codex/SKILL.md'), 'utf8')],
+];
+
+for (const [name, doc] of FILES) {
+  describe(`codex effort/timeout consistency: ${name}`, () => {
+    const budgets = [...doc.matchAll(/_gstack_codex_timeout_wrapper (\d+) /g)].map((m) => Number(m[1]));
+    const budget = budgets[0];
+
+    test('all five wrapper budgets exist and are unified', () => {
+      expect(budgets).toHaveLength(5);
+      expect(new Set(budgets).size).toBe(1);
+    });
+
+    test('every codex_timeout telemetry label states the wrapper budget', () => {
+      const labels = [...doc.matchAll(/_gstack_codex_log_event "codex_timeout" "(\d+)"/g)].map((m) => Number(m[1]));
+      expect(labels).toHaveLength(5);
+      for (const label of labels) expect(label).toBe(budget);
+    });
+
+    test('every stall message states the wrapper budget in minutes', () => {
+      const mins = [...doc.matchAll(/Codex stalled past ([\d.]+) minutes/g)].map((m) => Number(m[1]));
+      expect(mins.length).toBeGreaterThanOrEqual(5);
+      for (const m of mins) expect(m).toBe(budget / 60);
+    });
+
+    test('every documented Bash gate sits strictly above the wrapper budget', () => {
+      const gatesMs = [...doc.matchAll(/timeout: (\d{6,})/g)].map((m) => Number(m[1]));
+      expect(gatesMs.length).toBeGreaterThanOrEqual(2);
+      for (const gate of gatesMs) expect(gate).toBeGreaterThan(budget * 1000);
+    });
+
+    test('every prose reference to "the NNNs wrapper" states the actual budget', () => {
+      const refs = [...doc.matchAll(/(\d+)s (?:review |challenge\/consult )?wrapper/g)].map((m) => Number(m[1]));
+      expect(refs.length).toBeGreaterThanOrEqual(4);
+      for (const r of refs) expect(r).toBe(budget);
+    });
+
+    // The five invocation sites appear in a fixed order in the doc:
+    // Review default path, Review custom-instructions path, Challenge,
+    // Consult new-session, Consult resume.
+    const efforts = [...doc.matchAll(/-c 'model_reasoning_effort="(\w+)"'/g)].map((m) => m[1]);
+    const [reviewA, reviewB, challenge, consultA, consultB] = efforts;
+
+    test('five invocation sites, valid tiers, paired paths agree', () => {
+      expect(efforts).toHaveLength(5);
+      for (const e of efforts) expect(TIERS).toContain(e);
+      expect(reviewA).toBe(reviewB);
+      expect(consultA).toBe(consultB);
+    });
+
+    test('both per-mode defaults tables agree with the invocation sites', () => {
+      const mode = (label: string) => {
+        const found = [...doc.matchAll(new RegExp(`${label}:\\*{0,2} \`(\\w+)\``, 'g'))].map((m) => m[1]);
+        expect(found).toHaveLength(2); // override block + Model/effort section
+        expect(found[0]).toBe(found[1]);
+        return found[0];
+      };
+      expect(mode('Review \\(2A\\)')).toBe(reviewA);
+      expect(mode('Challenge \\(2B\\)')).toBe(challenge);
+      expect(mode('Consult \\(2C\\)')).toBe(consultA);
+    });
+
+    test('the escalation flag forces a tier >= every per-mode default', () => {
+      const forced = doc.match(/use `model_reasoning_effort="(\w+)"` for all modes/);
+      expect(forced).not.toBeNull();
+      const forcedTier = TIERS.indexOf(forced![1]);
+      for (const e of efforts) {
+        expect(forcedTier).toBeGreaterThanOrEqual(TIERS.indexOf(e));
+      }
+    });
+
+    // The three per-site override sentences, in doc order: Review and
+    // Challenge (whose defaults equal the forced tier) carry a no-op
+    // sentence; Consult carries an escalation sentence.
+    test('per-site override sentences agree with the sites and the forced tier', () => {
+      const forced = doc.match(/use `model_reasoning_effort="(\w+)"` for all modes/)![1];
+      const noops = [...doc.matchAll(/override \(legacy `--xhigh`\) is a no-op here — this mode already runs at `"(\w+)"`/g)].map((m) => m[1]);
+      expect(noops).toEqual([reviewA, challenge]);
+      for (const v of noops) expect(v).toBe(forced);
+      const escalations = [...doc.matchAll(/use `"(\w+)"` instead of `"(\w+)"`/g)];
+      expect(escalations).toHaveLength(1);
+      expect(escalations[0][1]).toBe(forced);
+      expect(escalations[0][2]).toBe(consultA);
+    });
+
+    test('error-handling prose names the wrapper budget in its `timeout N` reference', () => {
+      const refs = [...doc.matchAll(/`timeout (\d+)` wrapper/g)].map((m) => Number(m[1]));
+      expect(refs.length).toBeGreaterThanOrEqual(1);
+      for (const r of refs) expect(r).toBe(budget);
+    });
+  });
+}


### PR DESCRIPTION
## What

Raises the codex skill's per-mode reasoning-effort defaults to the API's new top tier and unifies all five `_gstack_codex_timeout_wrapper` budgets at 570s, with every dependent number (Bash gates, log labels, stall messages, prose) updated so the skill stays internally consistent.

| | Before | After |
|---|---|---|
| Review (2A) effort | `high` | `max` |
| Challenge (2B) effort | `high` | `max` |
| Consult (2C) effort | `medium` | `high` |
| Review wrapper budget | 330s | 570s |
| Challenge/Consult wrapper budget | 600s | 570s |
| Review Bash gate guidance | `timeout: 360000` | `timeout: 600000` |
| Challenge/Consult Bash gate | `timeout: 660000` | unchanged (already > 570s) |
| Escalation flag | `--xhigh` → forces `xhigh` | `--max` → forces `max` (`--xhigh` kept as legacy alias) |

Edited `codex/SKILL.md.tmpl`; `codex/SKILL.md` is the `bun run gen:skill-docs` regeneration of it (only these two files change).

## Why

**`max` is a real tier now.** Verified against codex-cli 0.144.3: the CLI passes the value through unvalidated, and the API's own invalid-enum error enumerates the supported set —

```
[ReasoningEffortParam] [reasoning.effort] [invalid_enum_value] Invalid value: 'bogus_probe'.
Supported values are: 'none', 'minimal', 'low', 'medium', 'high', 'xhigh', and 'max'.
```

— and a `model_reasoning_effort="max"` run completes normally. The skill's whole premise is codex as the maximally-rigorous second opinion ("200 IQ autistic developer"); its value scales directly with reasoning depth, and the bounded-diff modes (Review/Challenge) are exactly where the extra depth pays for its latency. Consult stays one notch down (`high`) because it's interactive and large-context.

**Timeouts follow effort.** Deeper reasoning runs longer; the Review lanes' 330s budget is the first thing to break under `max`. All five sites unify at 570s — comfortably under the Challenge/Consult 660s Bash gate, with the Review gate guidance raised to 600000ms to preserve the skill's own gate-above-wrapper invariant (a 570s wrapper under the old 360s gate would invert it, and a stall would surface as a silent harness kill instead of the diagnosable exit-124 path the hang-detection blocks exist for).

**Flag coherence.** With `max` as the Review/Challenge default, a user typing `--xhigh` would be *downgrading* those modes — surprising for an escalation flag. Both flags now force `max`, keeping the "crank it" semantic; `--xhigh` remains accepted so habits don't break.

## Consistency sweep + tripwire

Everything that encoded the old numbers moved together: the gate-ordering comment at the Review site, all five `codex_timeout` telemetry labels (`"330"`/`"600"` → `"570"`), the six user-facing stall messages (5.5/10 minutes → 9.5 minutes), **both** per-mode defaults tables (the override block *and* the Model/effort section — including its ~23x-tokens / 50-minute-hang rationale, which is kept and now explains why Consult stays a notch down), the three per-site override sentences, the Error Handling gate table, and the "Bash gate above the wrapper" rule. `test/codex-hardening.test.ts`'s only `330` is a historical comment about a fixed bug, deliberately left as history.

Because the budget and defaults are stated across ~20 surfaces with no single source, this drift class is now pinned: **`test/codex-effort-timeout-consistency.test.ts`** (new, runs in the free tier) asserts the five bash sites, five telemetry labels, six stall messages, both defaults tables, the override sentences, and the Bash-gate prose all agree — and that the escalation flag never forces a tier below a mode's default. Negative-tested: it fails 4 checks against a deliberately half-updated state and passes at HEAD. (An adversarial codex review of an earlier draft of this branch found exactly this drift — bash sites updated, second table stale — which is what motivated the test.)

## Trade-off, stated plainly

This raises per-invocation cost and latency for every gstack user on the affected modes — that's the point of the PR, but it's a defaults change, not a pure fix. If you'd rather not move the defaults for everyone, I'm happy to rework this as a config knob (e.g. `gstack-config get codex_effort`, defaults unchanged) with the timeout/gate consistency fixes kept as-is — say the word and I'll amend.

## Testing

- `bun run test` (Tier 1, full free suite): 6,916/6,918 on this branch. The two failures — `browse/test/stop-dead-daemon.test.ts` and `ios-qa/scripts/gen-accessors.test.ts` — are unrelated to this diff and shard-load flakes on my machine: both pass in isolation at clean `origin/main` *and* on this branch (60/60 both runs).
- New tripwire + `test/codex-hardening.test.ts` + `test/gen-skill-docs.test.ts`: 474/474.
- Runtime probes of codex-cli 0.144.3 confirming enum validity of `max` (above).
- Regeneration verified: `bun run gen:skill-docs` after the tmpl edit produces exactly the committed `codex/SKILL.md`; `git status` clean apart from the committed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
