### PR TITLE
fix(slug): a dot-prefixed project slug silently blocks memory-ingest forever

### DIFF
--- a/bin/gstack-memory-ingest.ts
+++ b/bin/gstack-memory-ingest.ts
@@ -697,12 +697,37 @@ function resolveGitRemote(cwd: string): string {
   }
 }
 
+/**
+ * Make a string safe to use as ONE path component of a page slug.
+ *
+ * Page slugs become real directories in the staging tree we hand to
+ * `gbrain import` (see stagedRelPath). A component with a leading dot becomes
+ * a HIDDEN directory, which markdown collectors skip — the page is staged but
+ * never collected, so the accounting guard in ingestPass refuses to advance
+ * state on EVERY subsequent run. `.` and `..` are worse: as path components
+ * they escape upward out of the staging dir.
+ *
+ * This is defense in depth. bin/gstack-slug already strips leading dots from
+ * the project slug, but slug components also arrive from git remotes and from
+ * on-disk directory names that predate that fix, so the invariant is enforced
+ * again at the point where a component is turned into a path.
+ */
+export function safeSlugComponent(s: string): string {
+  const cleaned = s
+    .replace(/[/\\]/g, "-")
+    .replace(/^\.+/, "")
+    .replace(/[^A-Za-z0-9._-]/g, "-");
+  return cleaned || "_unattributed";
+}
+
 function repoSlug(remote: string): string {
   if (!remote) return "_unattributed";
   // github.com/foo/bar → foo-bar
   const parts = remote.split("/");
-  if (parts.length >= 3) return `${parts[parts.length - 2]}-${parts[parts.length - 1]}`;
-  return remote.replace(/\//g, "-");
+  if (parts.length >= 3) {
+    return safeSlugComponent(`${parts[parts.length - 2]}-${parts[parts.length - 1]}`);
+  }
+  return safeSlugComponent(remote.replace(/\//g, "-"));
 }
 
 function dateOnly(ts: string | undefined): string {
@@ -773,9 +798,13 @@ function buildArtifactPage(path: string, type: MemoryType): PageRecord {
   const raw = readFileSync(path, "utf-8");
 
   // Extract repo slug from path: ~/.gstack/projects/<slug>/...
+  // The on-disk directory name is NOT trusted as a path component: a project
+  // dir named `.gstack` (created whenever a gstack bin runs with a cwd inside
+  // ~/.gstack, once that directory is a git repo) would otherwise stage pages
+  // under a hidden directory that gbrain import never collects.
   let slug_repo = "_unattributed";
   const m = path.match(/\/\.gstack\/projects\/([^/]+)\//);
-  if (m) slug_repo = m[1];
+  if (m) slug_repo = safeSlugComponent(m[1]);
 
   const date = new Date(stats.mtimeMs).toISOString().slice(0, 10);
   const baseName = basename(path, path.endsWith(".jsonl") ? ".jsonl" : ".md");

--- a/bin/gstack-slug
+++ b/bin/gstack-slug
@@ -169,6 +169,19 @@ SLUG="${SLUG:-$(basename "$PROJECT_DIR" | tr -cd 'a-zA-Z0-9._-')}"
 #     every path (the fresh-compute design already prevents poisoned-cache
 #     injection, but the invariant should not depend on that reasoning).
 SLUG=$(printf '%s' "$SLUG" | tr -cd 'a-zA-Z0-9._-')
+# 3c. Strip LEADING dots. The slug is used as a PATH COMPONENT, both for
+#     ~/.gstack/projects/<slug>/ and — via gstack-memory-ingest's page slugs —
+#     as a directory inside the staging tree handed to `gbrain import`. A
+#     leading dot makes that component a HIDDEN directory, which markdown
+#     collectors skip: the staged pages are silently never imported, and
+#     memory-ingest's accounting guard then refuses to advance state on EVERY
+#     subsequent run ("gbrain import accounted for N of M staged page(s)").
+#     Reachable without any adversary: `~/.gstack` is itself a git repo once a
+#     user wires artifacts sync, so any gstack bin invoked with a cwd inside it
+#     resolves basename(PROJECT_ROOT) == ".gstack". `.` and `..` are worse
+#     still — as path components they resolve to the project dir's parent.
+SLUG=$(printf '%s' "$SLUG" | sed 's/^\.*//')
+SLUG="${SLUG:-unknown}"
 
 if [[ -n "$SLUG" && "$SLUG_FROM_ENV" -eq 0 ]]; then
   CURRENT_CACHE=""

--- a/test/gstack-slug-sanitize.test.ts
+++ b/test/gstack-slug-sanitize.test.ts
@@ -104,3 +104,56 @@ describe('slug cache hygiene', () => {
     }
   });
 });
+
+// A slug is a PATH COMPONENT: ~/.gstack/projects/<slug>/, and via
+// gstack-memory-ingest it also becomes a directory inside the staging tree
+// handed to `gbrain import`. A leading dot makes that component a HIDDEN
+// directory. Markdown collectors skip hidden entries while walking, so pages
+// staged under one are never collected and memory-ingest's accounting guard
+// then refuses to advance state on EVERY run ("gbrain import accounted for
+// N of M staged page(s)"). No adversary needed: once a user wires artifacts
+// sync, ~/.gstack is itself a git repo, so any gstack bin invoked with a cwd
+// inside it resolves basename(PROJECT_ROOT) == ".gstack".
+describe('slug leading-dot hygiene', () => {
+  function slugFor(dirName: string): string {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'slug-dot-home-'));
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'slug-dot-'));
+    try {
+      const proj = path.join(fs.realpathSync(parent), dirName);
+      fs.mkdirSync(proj, { recursive: true });
+      // package.json is a STRONG project-identity marker, so the walk-up
+      // resolves this directory as the project root and takes its basename.
+      fs.writeFileSync(path.join(proj, 'package.json'), '{}');
+      const { GSTACK_PROJECT_SLUG: _drop, ...ambient } = process.env;
+      const r = spawnSync(['bash', SLUG_BIN], {
+        cwd: proj,
+        env: { ...ambient, GSTACK_HOME: home },
+      });
+      expect(r.exitCode).toBe(0);
+      const line = r.stdout.toString().split('\n').find((l) => l.startsWith('SLUG='));
+      expect(line).toBeDefined();
+      return line!.slice('SLUG='.length);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
+  }
+
+  test('a dot-prefixed project directory does not produce a hidden slug', () => {
+    expect(slugFor('.gstack')).toBe('gstack');
+  });
+
+  test('leading dots are stripped, interior dots are preserved', () => {
+    expect(slugFor('..hidden.thing')).toBe('hidden.thing');
+  });
+
+  test('a slug never starts with a dot, whatever the directory is named', () => {
+    for (const name of ['.gstack', '.config', '...', '.a']) {
+      expect(slugFor(name)).not.toMatch(/^\./);
+    }
+  });
+
+  test('an all-dots directory name falls back instead of emitting an empty slug', () => {
+    expect(slugFor('...')).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Why (in your own words)

If you turn on artifacts sync, `~/.gstack` becomes a git repo. From that moment,
running any `gstack-*` bin with a cwd inside it makes `gstack-slug` resolve
`basename(PROJECT_ROOT)` to `.gstack`, and gstack creates a project directory
literally named `~/.gstack/projects/.gstack/`.

That name is legal today: the sanitizer filters to `[a-zA-Z0-9._-]`, which keeps a
leading dot. But the slug is used as a **path component** — both for
`~/.gstack/projects/<slug>/` and, via `gstack-memory-ingest`, as a directory inside
the staging tree handed to `gbrain import`. A leading dot makes that component a
hidden directory, and markdown collectors skip hidden entries while walking. The
pages are staged, never collected, and the accounting guard in `ingestPass` then
refuses to advance state — permanently, on every subsequent run.

The user-visible result is transcript ingest that errors on every skill start and
never progresses. The error message points at `.gitignore`, which is a dead end.

`.` and `..` survived the old filter too. As path components those resolve to the
parent directory.

## Live evidence

Reproduced on a fresh install (gstack v1.67.1.0, gbrain 0.46.15.0, local PGLite).

**Before — every run, forever:**

```
$ bun run bin/gstack-memory-ingest.ts --incremental --quiet
[memory-ingest] ERR: gbrain import accounted for 1 of 3 staged page(s)
  (imported=0, unchanged=1). gbrain collected 1 file(s) from the staging dir.
  Refusing to advance state — the unaccounted pages would be marked ingested
  without landing in the brain. If the count is 0, check whether
  /Users/tim/.gstack/.staging-ingest-63033-... is inside a git repo that
  ignores it (gbrain import honours .gitignore).
[memory-ingest] 0 written, 3 failed in 997ms
```

**Isolating it.** I patched `cleanupStagingDir` locally to keep the staging tree,
then listed it. All 8 files exist with unique paths, so this is not a slug
collision:

```
learnings/.gstack/2026-08-17-learnings.md        <-- hidden dir
learnings/tim/2026-08-17-learnings.md
timelines/.gstack/2026-08-17-timeline.md         <-- hidden dir
timelines/tim/2026-08-17-timeline.md
transcripts/claude-code/_unattributed/2026-08-17-1ba1a088-fa9.md
transcripts/claude-code/_unattributed/2026-08-17-9301781b-fa0.md
transcripts/claude-code/_unattributed/2026-08-17-95fc9439-339.md
transcripts/claude-code/_unattributed/2026-08-17-ae9c0a35-c6e.md
```

Exactly 2 hidden-directory pages, exactly the 2 the guard reports missing.

**Ruling out the message's own suggestion.** `.gitignore` is not the cause. A
controlled `gbrain import` against an identical tree, once outside any git repo
and once inside `~/.gstack` (whose `.gitignore` is `*`), collects everything both
times:

```
$ gbrain import <tmpdir> --no-embed --json
Found 3 markdown files
{"status":"success","imported":0,"skipped":3,"errors":0,"total_files":3}
```

**After — same machine, after removing the dot-named project dir:**

```
$ bun run bin/gstack-memory-ingest.ts --bulk --quiet
  written:               6
  failed:                0

$ bun run bin/gstack-memory-ingest.ts --incremental --quiet
(no output — nothing left to do)
```

**Regression tests fail without the fix.** 4 new tests in
`test/gstack-slug-sanitize.test.ts`:

```
$ git stash push bin/gstack-slug && bun test test/gstack-slug-sanitize.test.ts
 3 pass
 4 fail          <-- the new tests

$ git stash pop && bun test test/gstack-slug-sanitize.test.ts
 7 pass
 0 fail
```

## Scope

- **Changed:** `bin/gstack-slug` strips leading dots from the resolved slug before
  it is cached or emitted (root fix). `bin/gstack-memory-ingest.ts` adds
  `safeSlugComponent()` and applies it in `repoSlug()` and to the
  `projects/<slug>/` match in `buildArtifactPage()` (defense in depth, because
  components also arrive from git remotes and from directories created before this
  fix). `test/gstack-slug-sanitize.test.ts` gains 4 regression tests.
- **Verified live by:** reproducing the permanent-failure loop on a real install,
  isolating the two hidden-directory pages out of the staging tree, ruling out
  `.gitignore` with a controlled `gbrain import`, then confirming a clean
  `written: 6 / failed: 0` and a quiet incremental run afterwards.
- **Did NOT test:** Windows path handling. Non-PGLite (Supabase) engines. Whether
  gbrain's collector should also be taught to descend into hidden directories when
  given an explicit root — that is a gbrain-side call and is deliberately not part
  of this PR.

### Pre-existing test failures (with receipts)

`bun run test` reports 5 failures on this branch, all in `browse/test/`
(`commands.test.ts`, `path-validation.test.ts`, `data-platform.test.ts`) around
path-traversal validation. They are not from this change. Stashing all three
changed files and running the same three files on clean `main` reproduces exactly
the same 5:

```
$ git stash push bin/gstack-slug bin/gstack-memory-ingest.ts test/gstack-slug-sanitize.test.ts
$ bun test browse/test/commands.test.ts browse/test/path-validation.test.ts browse/test/data-platform.test.ts
 283 pass
 5 fail
```

Every other shard passes.

## Liveness proof (required)

<img width="793" height="426" alt="image" src="https://github.com/user-attachments/assets/6dd80f08-d51d-4e68-9712-8b6a1908d541" />


## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A) — N/A
- [x] Linked issue or reproduction: reproduction is in "Live evidence" above; no existing issue found

