### PR TITLE
ios-qa: drop the app name from the DebugBridge release-guard comment

### DIFF
--- a/ios-qa/templates/DebugBridgeTouch.m.template
+++ b/ios-qa/templates/DebugBridgeTouch.m.template
@@ -31,10 +31,10 @@
 // header both PROMISED "DEBUG-only; never shipped to App Store" and "never link in
 // Release" — and nothing enforced it. Only `#if TARGET_OS_IOS` was tested, so a
 // Release build for iOS compiled the whole implementation in. Measured on a real
-// app (Seize Day, 2026-08-15), `nm -j` on a Release binary returned 15 DebugBridge
-// symbols including +[DebugBridgeTouch sendTapAtPoint:inWindow:], plus
-// IOHIDEventCreateDigitizer, AXSSetAutomationEnabled and IOKit.framework strings.
-// That is a Guideline 2.5.1 private-API exposure in a shippable binary.
+// iOS app, `nm -j` on a Release binary returned 15 DebugBridge symbols including
+// +[DebugBridgeTouch sendTapAtPoint:inWindow:], plus IOHIDEventCreateDigitizer,
+// AXSSetAutomationEnabled and IOKit.framework strings. That is a Guideline 2.5.1
+// private-API exposure in a shippable binary, caught in a pre-submission audit.
 //
 // Package.swift's stated guard — `.when(configuration: .debug)` on the consuming
 // target's dependency — only exists for SwiftPM consumers. An app integrating this

--- a/test/fixtures/ios-qa/FixtureApp/Sources/DebugBridgeTouch/DebugBridgeTouch.m
+++ b/test/fixtures/ios-qa/FixtureApp/Sources/DebugBridgeTouch/DebugBridgeTouch.m
@@ -31,10 +31,10 @@
 // header both PROMISED "DEBUG-only; never shipped to App Store" and "never link in
 // Release" — and nothing enforced it. Only `#if TARGET_OS_IOS` was tested, so a
 // Release build for iOS compiled the whole implementation in. Measured on a real
-// app (Seize Day, 2026-08-15), `nm -j` on a Release binary returned 15 DebugBridge
-// symbols including +[DebugBridgeTouch sendTapAtPoint:inWindow:], plus
-// IOHIDEventCreateDigitizer, AXSSetAutomationEnabled and IOKit.framework strings.
-// That is a Guideline 2.5.1 private-API exposure in a shippable binary.
+// iOS app, `nm -j` on a Release binary returned 15 DebugBridge symbols including
+// +[DebugBridgeTouch sendTapAtPoint:inWindow:], plus IOHIDEventCreateDigitizer,
+// AXSSetAutomationEnabled and IOKit.framework strings. That is a Guideline 2.5.1
+// private-API exposure in a shippable binary, caught in a pre-submission audit.
 //
 // Package.swift's stated guard — `.when(configuration: .debug)` on the consuming
 // target's dependency — only exists for SwiftPM consumers. An app integrating this


### PR DESCRIPTION
Follow-up to #2585.

The evidence paragraph added there named the specific app the symbols were measured on. The measurement is what carries the weight, not whose binary it came from, and the app name reads as though a released build carried private API. It did not: the symbols were found in a local Release build during a pre-submission audit and never reached review.

This replaces the name with "a real iOS app" and adds the four words that close the misreading. The same paragraph exists verbatim in the rendered test fixture (`test/fixtures/ios-qa/FixtureApp/Sources/DebugBridgeTouch/DebugBridgeTouch.m`), so both copies move together.

No behaviour change. Comment text only.
