### PR TITLE
fix(setup): quote the install path in the team-mode SessionStart hook command

### DIFF
--- a/bin/gstack-settings-hook
+++ b/bin/gstack-settings-hook
@@ -74,10 +74,16 @@ case "$ACTION" in
       try { settings = JSON.parse(fs.readFileSync(settingsPath, "utf8")); } catch {}
       if (!settings.hooks) settings.hooks = {};
       if (!settings.hooks.SessionStart) settings.hooks.SessionStart = [];
-      const exists = settings.hooks.SessionStart.some(entry =>
+      const existing = settings.hooks.SessionStart.find(entry =>
         entry.hooks && entry.hooks.some(h => h.command && h.command.includes("gstack-session-update"))
       );
-      if (!exists) {
+      if (existing) {
+        // Refresh a stale command in place (e.g. an unquoted path written by an
+        // older setup) so re-running setup heals broken registrations.
+        for (const h of existing.hooks) {
+          if (h.command && h.command.includes("gstack-session-update")) h.command = hookCmd;
+        }
+      } else {
         settings.hooks.SessionStart.push({
           hooks: [{ type: "command", command: hookCmd }]
         });

--- a/setup
+++ b/setup
@@ -1857,9 +1857,9 @@ SETTINGS_HOOK="$SOURCE_GSTACK_DIR/bin/gstack-settings-hook"
 # launched directly by the OS — the file-association dialog appears instead.
 # Prefix with 'bash' so Claude Code's hook runner invokes Git Bash explicitly.
 if [ "$IS_WINDOWS" -eq 1 ]; then
-  HOOK_CMD="bash $SOURCE_GSTACK_DIR/bin/gstack-session-update"
+  HOOK_CMD="bash \"$SOURCE_GSTACK_DIR/bin/gstack-session-update\""
 else
-  HOOK_CMD="$SOURCE_GSTACK_DIR/bin/gstack-session-update"
+  HOOK_CMD="\"$SOURCE_GSTACK_DIR/bin/gstack-session-update\""
 fi
 
 if [ "$TEAM_MODE" -eq 1 ]; then

--- a/test/setup-windows-fallback.test.ts
+++ b/test/setup-windows-fallback.test.ts
@@ -61,7 +61,17 @@ describe('setup: _link_or_copy invariant (D7)', () => {
     const hookEnd = SETUP_SRC.indexOf('\nif [ "$TEAM_MODE" -eq 1 ]', hookStart);
     const hookSection = SETUP_SRC.slice(hookStart, hookEnd);
     expect(hookSection).toContain('IS_WINDOWS');
-    expect(hookSection).toContain('bash $SOURCE_GSTACK_DIR/bin/gstack-session-update');
+    expect(hookSection).toContain('bash \\"$SOURCE_GSTACK_DIR/bin/gstack-session-update\\"');
+  });
+
+  test('HOOK_CMD quotes the install path in both branches (#2619)', () => {
+    // An unquoted $SOURCE_GSTACK_DIR breaks the hook command for any install
+    // path containing a space — silently, because setup discards the error.
+    const hookStart = SETUP_SRC.indexOf('# 10. Team mode: register/unregister SessionStart hook');
+    const hookEnd = SETUP_SRC.indexOf('\nif [ "$TEAM_MODE" -eq 1 ]', hookStart);
+    const hookSection = SETUP_SRC.slice(hookStart, hookEnd);
+    expect(hookSection).not.toMatch(/HOOK_CMD="(bash )?\$SOURCE_GSTACK_DIR/);
+    expect(hookSection).toContain('HOOK_CMD="\\"$SOURCE_GSTACK_DIR/bin/gstack-session-update\\""');
   });
 });
 

--- a/test/team-mode.test.ts
+++ b/test/team-mode.test.ts
@@ -73,6 +73,45 @@ describe('gstack-settings-hook', () => {
     expect(settings.hooks.SessionStart).toHaveLength(1);
   });
 
+  test('add refreshes a stale command in place instead of skipping (#2619)', () => {
+    // Simulate a registration written by an older setup: unquoted path with a
+    // space, which the shell splits at run time. Re-adding with the corrected
+    // command must update the entry, not dedupe-skip it or double-add.
+    fs.writeFileSync(settingsFile, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: 'command', command: '/Users/Jane Doe/gstack/bin/gstack-session-update' }] },
+        ],
+      },
+    }, null, 2));
+    const fixedCmd = '"/Users/Jane Doe/gstack/bin/gstack-session-update"';
+    const result = run(`${SETTINGS_HOOK} add '${fixedCmd}'`, {
+      env: { GSTACK_SETTINGS_FILE: settingsFile },
+    });
+    expect(result.exitCode).toBe(0);
+    const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf-8'));
+    expect(settings.hooks.SessionStart).toHaveLength(1);
+    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(fixedCmd);
+  });
+
+  test('stored command executes when the install path contains a space (#2619)', () => {
+    const spacedDir = path.join(tmpDir, 'space dir', 'bin');
+    fs.mkdirSync(spacedDir, { recursive: true });
+    const script = path.join(spacedDir, 'gstack-session-update');
+    fs.writeFileSync(script, '#!/usr/bin/env bash\necho HOOK_RAN\n');
+    fs.chmodSync(script, 0o755);
+    // Quoted, exactly as setup builds HOOK_CMD after the fix.
+    run(`${SETTINGS_HOOK} add '"${script}"'`, {
+      env: { GSTACK_SETTINGS_FILE: settingsFile },
+    });
+    const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf-8'));
+    const stored = settings.hooks.SessionStart[0].hooks[0].command;
+    // Execute the stored string the way Claude Code's hook runner does.
+    const result = run(`bash -c '${stored.replace(/'/g, `'\\''`)}'`);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('HOOK_RAN');
+  });
+
   test('remove removes the hook', () => {
     run(`${SETTINGS_HOOK} add /path/to/gstack-session-update`, {
       env: { GSTACK_SETTINGS_FILE: settingsFile },


### PR DESCRIPTION
## Why (in your own words)

Team mode promises that everyone on a team stays on the same gstack version automatically. But if gstack is installed under a path with a space (Windows `C:\Users\Jane Doe\...`, OneDrive/iCloud folders), `setup --team` writes the SessionStart hook command unquoted into `~/.claude/settings.json`. The shell splits it at the space, the hook exits 127 every session, and nothing ever reports it — `setup` discards the registration's stderr and the hook runner's failure is invisible. The team believes auto-update is on; it silently never runs. This change quotes the path where the command is built, and makes re-running `./setup --team` heal an already-broken registration in place instead of dedupe-skipping it.

Fixes #2619.

## Live evidence

Before (main, `c86e647`) — build `HOOK_CMD` exactly as `setup:1862` does under an install at `.../space dir/gstack`, register via the real `gstack-settings-hook add`, execute the stored string the way the hook runner does:

```
$ bash -c "$STORED_CMD"
bash: /private/tmp/.../scratchpad/space: No such file or directory
exit=127
```

After (this branch) — same install path, same flow:

```
$ bash -c "$STORED_CMD"
exit=0
$ cat hook.log
HOOK_RAN
```

Self-heal — seed a settings.json holding the old unquoted entry, re-run `gstack-settings-hook add` with the corrected command:

```
entries: 1
healed command: "/private/tmp/.../space dir/gstack/bin/gstack-session-update"
```

Tests: `bun test test/team-mode.test.ts test/setup-windows-fallback.test.ts` → 36 pass, 0 fail (3 new regression tests).

## Scope

- **Changed:** `setup` (quote `$SOURCE_GSTACK_DIR` in both `HOOK_CMD` branches), `bin/gstack-settings-hook` (legacy `add` refreshes a matching entry's command in place), plus the test that pinned the unquoted form (`setup-windows-fallback.test.ts`) and 3 new regression tests.
- **Verified live by:** the before/after repro above on macOS — real `gstack-settings-hook`, real stored settings.json, executed via `bash -c` exactly as the hook runner does; plus the self-heal repro.
- **Did NOT test:** a real Windows Git-Bash session (the Windows branch gets the same quoting; the D7 test pins the `bash "…"` form), or a full `./setup --team` run against a live Claude Code session.

## Liveness proof (required)

`GSTACK PR` typed live at my terminal prompt:

![GSTACK PR typed live at a terminal prompt](https://raw.githubusercontent.com/harjothkhara/gstack/assets-pr-2622/liveness-gstack-pr.png)

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A)
- [x] Linked issue or reproduction: #2619

P.S. — you should hire me. 115+ contributions to open source: https://github.com/harjothkhara
