### PR TITLE
feat(plan-tune): registry-independent autonomy signal from followed_recommendation (partial #2623)

### DIFF
--- a/bin/gstack-developer-profile
+++ b/bin/gstack-developer-profile
@@ -328,7 +328,8 @@ do_derive() {
       const sigmod = await import('./scripts/psychographic-signals.ts');
       const fs = require('fs');
       const { QUESTIONS } = regmod;
-      const { SIGNAL_MAP, applySignal, newDimensionTotals, normalizeToDimensionValue } = sigmod;
+      const { SIGNAL_MAP, applySignal, newDimensionTotals, normalizeToDimensionValue,
+              recommendationSignal, recommendationEligibleCount, SIGNAL_MAP_VERSION } = sigmod;
 
       const profilePath = process.env.PROFILE_FILE_PATH;
       const eventsPath = process.env.EVENTS_PATH;
@@ -343,25 +344,45 @@ do_derive() {
       const skills = new Set();
       const qids = new Set();
       const days = new Set();
+      // Provenance: UNIQUE ROWS contributing to each dimension, not signal
+      // applications — one row can apply several deltas, and conflating them
+      // would overstate the evidence, which is the opposite of the point.
+      const contributors = {};
+      for (const d of Object.keys(totals)) contributors[d] = new Set();
+      const events = [];
       let count = 0;
+      let rowIndex = -1;
       for (const line of lines) {
         let e;
         try { e = JSON.parse(line); } catch { continue; }
         if (!e.question_id || !e.user_choice) continue;
+        rowIndex++;
         count++;
+        events.push(e);
         skills.add(e.skill);
         qids.add(e.question_id);
         if (e.ts) days.add(String(e.ts).slice(0,10));
         const def = QUESTIONS[e.question_id];
         if (def && def.signal_key) {
-          applySignal(totals, def.signal_key, e.user_choice);
+          const applied = applySignal(totals, def.signal_key, e.user_choice) || [];
+          for (const d of applied) contributors[d.dim]?.add(rowIndex);
         }
       }
+
+      // Registry-independent autonomy signal. ONE bounded delta from the whole
+      // history — never a per-event delta, which would saturate the sigmoid.
+      const recDelta = recommendationSignal(events);
+      const recN = recommendationEligibleCount(events);
+      totals[recDelta.dim] = (totals[recDelta.dim] ?? 0) + recDelta.delta;
 
       const values = {};
       for (const [dim, total] of Object.entries(totals)) {
         values[dim] = +normalizeToDimensionValue(total).toFixed(3);
       }
+
+      const contributingEvents = {};
+      for (const d of Object.keys(totals)) contributingEvents[d] = contributors[d].size;
+      contributingEvents[recDelta.dim] += recN;
 
       profile.inferred = {
         values,
@@ -371,6 +392,11 @@ do_derive() {
           question_ids_covered: qids.size,
           days_span: days.size,
         },
+        // Distinguishes 'no evidence' from 'balanced evidence'. Without it a
+        // dead pipeline and a perfectly-balanced one both print 0.5, which is
+        // how five 0.5s sat next to sample_size 1286 looking healthy.
+        contributing_events: contributingEvents,
+        derivation_version: SIGNAL_MAP_VERSION,
       };
 
       // Recompute gap.
@@ -386,7 +412,7 @@ do_derive() {
       const tmp = profilePath + '.tmp';
       fs.writeFileSync(tmp, JSON.stringify(profile, null, 2));
       fs.renameSync(tmp, profilePath);
-      console.log('DERIVE: ok — ' + count + ' events, ' + skills.size + ' skills, ' + qids.size + ' questions');
+      console.log('DERIVE: ok — ' + count + ' events, ' + skills.size + ' skills, ' + qids.size + ' questions, ' + recN + ' recommendation-eligible');
     }).catch(err => { console.error('DERIVE:', err.message); process.exit(1); });
   "
 }
@@ -411,13 +437,16 @@ do_trace() {
       const sigmod = await import('./scripts/psychographic-signals.ts');
       const fs = require('fs');
       const { QUESTIONS } = regmod;
-      const { SIGNAL_MAP } = sigmod;
+      const { SIGNAL_MAP, recommendationSignal, recommendationEligibleCount,
+              isRecommendationEligible } = sigmod;
       const target = process.env.TRACE_DIM;
       const lines = fs.readFileSync(process.env.EVENTS_PATH, 'utf-8').trim().split('\n').filter(Boolean);
       const rows = [];
+      const events = [];
       for (const line of lines) {
         let e;
         try { e = JSON.parse(line); } catch { continue; }
+        events.push(e);
         const def = QUESTIONS[e.question_id];
         if (!def || !def.signal_key) continue;
         const deltas = SIGNAL_MAP[def.signal_key]?.[e.user_choice] || [];
@@ -427,12 +456,30 @@ do_trace() {
           }
         }
       }
-      if (rows.length === 0) {
+      // The registry-independent autonomy signal contributes one AGGREGATE
+      // delta, so it has no per-event rows to list. Report it explicitly or
+      // --trace autonomy would still say 'no events contribute' while the
+      // derived value had visibly moved.
+      const recDelta = recommendationSignal(events);
+      const recN = target === 'autonomy' ? recommendationEligibleCount(events) : 0;
+      const recFollowed = target === 'autonomy'
+        ? events.filter(e => isRecommendationEligible(e) && e.followed_recommendation === true).length
+        : 0;
+
+      if (rows.length === 0 && recN === 0) {
         console.log('TRACE: no events contribute to ' + target);
       } else {
-        console.log('TRACE: ' + rows.length + ' events for ' + target);
+        // Count the aggregate's eligible rows in the header too: reporting
+        // '0 events' directly above a line describing 1,240 of them is worse
+        // than the 'no events' message this replaced.
+        console.log('TRACE: ' + (rows.length + recN) + ' events for ' + target);
         for (const r of rows) {
           console.log('  ' + (r.ts || '').slice(0,19) + '  ' + r.question_id + '  → ' + r.choice + '  (' + (r.delta > 0 ? '+' : '') + r.delta + ')');
+        }
+        if (recN > 0) {
+          const rate = (recFollowed / recN * 100).toFixed(1);
+          console.log('  aggregate  followed_recommendation  ' + recFollowed + '/' + recN +
+            ' (' + rate + '%)  (' + (recDelta.delta > 0 ? '+' : '') + recDelta.delta.toFixed(4) + ')');
         }
       }
     });

--- a/scripts/psychographic-signals.ts
+++ b/scripts/psychographic-signals.ts
@@ -58,7 +58,7 @@ export const ALL_DIMENSIONS: readonly Dimension[] = [
  * Semantic version of the signal map. Increment when deltas change so that
  * cached profiles can detect staleness and recompute from events.
  */
-export const SIGNAL_MAP_VERSION = '0.1.0';
+export const SIGNAL_MAP_VERSION = '0.2.0';
 
 export interface DimensionDelta {
   dim: Dimension;
@@ -286,4 +286,146 @@ export function normalizeToDimensionValue(total: number): number {
   // Simple sigmoid: each 1.0 of accumulated delta approaches saturation.
   // 0.5 is neutral. Positive deltas push toward 1, negative toward 0.
   return 1 / (1 + Math.exp(-total * 3));
+}
+
+// ---------------------------------------------------------------------------
+// Registry-independent signal: followed_recommendation -> autonomy
+// ---------------------------------------------------------------------------
+//
+// Why this exists
+// ---------------
+// SIGNAL_MAP attribution requires three exact-string matches to all land:
+// question_id in QUESTIONS, that entry carrying a signal_key, and user_choice
+// matching a key in SIGNAL_MAP[signal_key]. Measured on a real 1,286-row log,
+// the third one matched ZERO rows -- the AskUserQuestion capture hook records
+// the UI LABEL ("Restore the parallel typecheck job") while SIGNAL_MAP is keyed
+// by stable option keys ('accept', 'expand', 'fix-now'), and the host's
+// AskUserQuestion payload has no slot for a stable key. So every dimension sat
+// at exactly 0.5 while sample_size read 1286 and every calibration gate passed.
+//
+// `followed_recommendation` is different: gstack-question-log computes it at
+// write time from (user_choice, recommended), so it is already present on ~95%
+// of rows and needs no registry entry, no marker, and no skill change. It is
+// the only signal that can read existing history retroactively.
+//
+// Why the shape is O(1) and not a per-event delta
+// -----------------------------------------------
+// normalizeToDimensionValue is a sigmoid over an ACCUMULATED total, tuned for
+// tens of signals. A per-event delta at this file's usual +/-0.03..0.06 would
+// reach 0.9994 by 50 events and 1.0 by 100 -- as uninformative as the 0.5 it
+// replaced. This contributes ONE bounded delta computed from the whole history.
+//
+// Honest calibration note
+// -----------------------
+// RECOMMENDATION_SIGNAL_WEIGHT is an unvalidated starting constant, in the
+// spirit of this file's header ("v1 deltas are best-guess starting points").
+// It was picked on ONE user's data because it lands near their declared value,
+// which is post-hoc. It is also confounded: a high follow rate may measure how
+// good the agent's recommendations are as much as how much the user delegates.
+// Treat the output as a weak prior, not a measurement.
+
+/** Weight of the recommendation-following signal. See the calibration note. */
+export const RECOMMENDATION_SIGNAL_WEIGHT = 0.5;
+
+/**
+ * Eligible-row count at which the signal reaches full strength.
+ *
+ * Deliberately keyed on ELIGIBLE rows, not on `inferred.sample_size`. The
+ * documented calibration gate (docs/designs/PLAN_TUNING_V0.md) reads
+ * sample_size, which counts EVERY logged row -- so 3 eligible rows beside 1,200
+ * unrelated ones passes that gate and would otherwise render a confident
+ * autonomy score from three answers.
+ */
+export const RECOMMENDATION_MIN_SAMPLE = 20;
+
+/** Minimal shape this signal reads off a question-log row. */
+export interface RecommendationEvent {
+  followed_recommendation?: unknown;
+  source?: unknown;
+  question_id?: unknown;
+}
+
+/**
+ * True when a row's autonomy evidence is already counted by the registry path.
+ *
+ * PRECEDENCE: totals.autonomy is written by BOTH the per-event SIGNAL_MAP path
+ * and this aggregate. A row can be a 'decision-autonomy' registry event AND
+ * carry followed_recommendation, which would feed one decision into the
+ * dimension twice. The more specific path wins; this one steps aside.
+ */
+function countedByRegistry(questionId: unknown): boolean {
+  if (typeof questionId !== 'string') return false;
+  const def = (QUESTIONS as Record<string, { signal_key?: string }>)[questionId];
+  if (!def || !def.signal_key) return false;
+  const deltas = SIGNAL_MAP[def.signal_key];
+  if (!deltas) return false;
+  for (const choiceDeltas of Object.values(deltas)) {
+    for (const { dim } of choiceDeltas) {
+      if (dim === 'autonomy') return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Rows this signal is allowed to read.
+ *
+ * question-log.jsonl is plain append-only JSONL that a user or a future writer
+ * can hand-edit, so every clause below fails CLOSED on anything unexpected:
+ *
+ *  - followed_recommendation must be a STRICT boolean. The string "false" is
+ *    truthy; a truthiness check would silently count it as a follow and bias
+ *    autonomy upward with no error.
+ *  - source must be PRESENT and not 'auto-decided'. gstack-question-log
+ *    defaults source to 'agent' on write, so a row lacking it was never written
+ *    by that binary. Excluding 'auto-decided' is load-bearing: the preference
+ *    hook auto-picks the recommendation, which would otherwise feed "the user
+ *    delegates" evidence straight back into the dimension that licenses
+ *    auto-deciding.
+ *  - the row must not already be counted by the registry path (see above).
+ */
+export function isRecommendationEligible(e: RecommendationEvent): boolean {
+  if (typeof e.followed_recommendation !== 'boolean') return false;
+  if (typeof e.source !== 'string' || e.source === 'auto-decided') return false;
+  if (countedByRegistry(e.question_id)) return false;
+  return true;
+}
+
+/**
+ * Aggregate followed_recommendation across the whole log into ONE autonomy
+ * delta.
+ *
+ * Laplace (add-one) smoothing on the rate, then a confidence ramp on the
+ * eligible count:
+ *
+ *     smoothed   = (followed + 1) / (n + 2)
+ *     confidence = min(1, n / RECOMMENDATION_MIN_SAMPLE)
+ *     delta      = WEIGHT * confidence * (2 * smoothed - 1)
+ *
+ * Smoothing returns exactly 0.5 at n = 0, so "no eligible rows" needs no
+ * special case: it yields delta 0, which the sigmoid renders as neutral.
+ */
+export function recommendationSignal(
+  events: readonly RecommendationEvent[],
+): DimensionDelta {
+  let followed = 0;
+  let n = 0;
+  for (const e of events) {
+    if (!isRecommendationEligible(e)) continue;
+    n += 1;
+    if (e.followed_recommendation === true) followed += 1;
+  }
+  const smoothed = (followed + 1) / (n + 2);
+  const confidence = Math.min(1, n / RECOMMENDATION_MIN_SAMPLE);
+  const delta = RECOMMENDATION_SIGNAL_WEIGHT * confidence * (2 * smoothed - 1);
+  return { dim: 'autonomy', delta };
+}
+
+/** Eligible-row count, for provenance reporting. Counts UNIQUE ROWS. */
+export function recommendationEligibleCount(
+  events: readonly RecommendationEvent[],
+): number {
+  let n = 0;
+  for (const e of events) if (isRecommendationEligible(e)) n += 1;
+  return n;
 }

--- a/test/gstack-developer-profile.test.ts
+++ b/test/gstack-developer-profile.test.ts
@@ -16,6 +16,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { spawnSync } from 'child_process';
+import { QUESTIONS } from '../scripts/question-registry';
+import { SIGNAL_MAP } from '../scripts/psychographic-signals';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const BIN_DEV = path.join(ROOT, 'bin', 'gstack-developer-profile');
@@ -46,7 +48,13 @@ function runDev(...args: string[]): { stdout: string; stderr: string; status: nu
 
 function logQuestion(payload: Record<string, unknown>): number {
   const res = spawnSync(BIN_LOG, [JSON.stringify(payload)], {
-    env: { ...process.env, GSTACK_HOME: tmpHome },
+    // gstack-question-log fires `--derive` in the background (nohup) after every
+    // append. Those writes land on developer-profile.json via tmp+rename, so
+    // they race the explicit runDev('--derive') a test then makes — observed as
+    // an intermittently EMPTY stdout from the foreground derive. This env var
+    // exists for exactly this case; without it, any test that logs several rows
+    // and then derives is flaky by construction.
+    env: { ...process.env, GSTACK_HOME: tmpHome, GSTACK_QUESTION_LOG_NO_DERIVE: '1' },
     encoding: 'utf-8',
     cwd: ROOT,
   });
@@ -292,6 +300,265 @@ describe('gstack-developer-profile --derive', () => {
     expect(v1).toEqual(v2);
   });
 
+  // ---------------------------------------------------------------------
+  // Registry-independent autonomy signal — WIRING only.
+  // The formula lives in test/plan-tune.test.ts; these prove derive and trace
+  // actually call it and agree with each other.
+  // ---------------------------------------------------------------------
+
+  /** Path of the project question-log inside the temp GSTACK_HOME. */
+  function logPath(): string {
+    const projects = path.join(tmpHome, 'projects');
+    const slug = fs.readdirSync(projects)[0];
+    return path.join(projects, slug, 'question-log.jsonl');
+  }
+
+  /**
+   * Append pre-formed rows straight to the log.
+   *
+   * Bulk cases here exercise --derive, not the log writer's validation, and
+   * spawning gstack-question-log 260 times costs ~28s against <1s for a single
+   * write. Semantics-sensitive cases still go through logQuestion so that
+   * followed_recommendation is computed by the binary that owns it.
+   */
+  function appendRows(rows: Array<Record<string, unknown>>) {
+    // Seed via the real binary so the slug directory and file exist.
+    logQuestion({
+      skill: 'ship',
+      question_id: 'seed-row',
+      question_summary: 'seed',
+      user_choice: 'accept',
+      session_id: 'seed',
+    });
+    const body = rows.map((r) => JSON.stringify({ ts: '2026-04-01T10:00:00Z', ...r })).join('\n') + '\n';
+    fs.appendFileSync(logPath(), body);
+  }
+
+  function bulk(n: number, row: Record<string, unknown>): Array<Record<string, unknown>> {
+    return Array.from({ length: n }, (_, i) => ({ ...row, session_id: `b${i}` }));
+  }
+
+  function logFollowed(n: number, followed: number, extra: Record<string, unknown> = {}) {
+    for (let i = 0; i < n; i++) {
+      logQuestion({
+        skill: 'ship',
+        question_id: 'adhoc-recommendation-case',
+        question_summary: 'q',
+        user_choice: i < followed ? 'accept' : 'reject',
+        recommended: 'accept',
+        session_id: `s${i}`,
+        ts: `2026-04-01T10:00:0${i % 10}Z`,
+        ...extra,
+      });
+    }
+  }
+
+  test('derive moves autonomy off 0.5 when the user follows recommendations', () => {
+    logFollowed(30, 30);
+    runDev('--derive');
+    const p = readProfile() as { inferred: { values: Record<string, number> } };
+    expect(p.inferred.values.autonomy).toBeGreaterThan(0.5);
+    // Other dimensions are untouched by this signal.
+    expect(p.inferred.values.scope_appetite).toBeCloseTo(0.5, 2);
+  });
+
+  test('derive moves autonomy below 0.5 when the user overrides recommendations', () => {
+    logFollowed(30, 0);
+    runDev('--derive');
+    const p = readProfile() as { inferred: { values: Record<string, number> } };
+    expect(p.inferred.values.autonomy).toBeLessThan(0.5);
+  });
+
+  test('derive is idempotent with the recommendation signal applied', () => {
+    logFollowed(30, 28);
+    runDev('--derive');
+    const v1 = (readProfile() as any).inferred.values;
+    runDev('--derive');
+    const v2 = (readProfile() as any).inferred.values;
+    expect(v1).toEqual(v2);
+  });
+
+  test('derive writes contributing_events and derivation_version', () => {
+    // The point of these fields: an inferred 0.5 with 0 contributors means
+    // "no evidence", not "balanced evidence". Without them the two are
+    // indistinguishable, which is how a dead pipeline hid behind a healthy
+    // sample_size for two months.
+    //
+    // MUTATE THIS by deleting the contributing_events write; this reds.
+    logFollowed(25, 25);
+    runDev('--derive');
+    const p = readProfile() as {
+      inferred: {
+        contributing_events: Record<string, number>;
+        derivation_version: string;
+        sample_size: number;
+      };
+    };
+    expect(p.inferred.contributing_events.autonomy).toBe(25);
+    // A dimension with no evidence reports 0, not a missing key.
+    expect(p.inferred.contributing_events.scope_appetite).toBe(0);
+    expect(p.inferred.derivation_version).toBeTruthy();
+  });
+
+  test('contributing_events counts UNIQUE ROWS, never signal applications', () => {
+    // A single row can apply several deltas. Counting applications would
+    // overstate the evidence, which is the opposite of this field's purpose.
+    //
+    // The fixture MUST exercise the registry path, not just the rate signal:
+    // an earlier version of this test used rate-only rows, so the registry
+    // contributor count was 0 and multiplying it by anything changed nothing.
+    // 'review-fix-now' applies deltas to more than one dimension from ONE row,
+    // which is exactly the over-count this guards.
+    const multiDimId = Object.values(QUESTIONS).find((q) => {
+      if (!q.signal_key) return false;
+      const choices = SIGNAL_MAP[q.signal_key] ?? {};
+      return Object.values(choices).some((ds) => ds.length > 1);
+    });
+    expect(multiDimId).toBeDefined();
+    const choice = Object.entries(SIGNAL_MAP[multiDimId!.signal_key!])
+      .find(([, ds]) => ds.length > 1)![0];
+
+    appendRows(
+      bulk(10, {
+        skill: multiDimId!.skill,
+        question_id: multiDimId!.id,
+        user_choice: choice,
+        recommended: choice,
+        followed_recommendation: true,
+        source: 'agent',
+      }),
+    );
+    runDev('--derive');
+    const p = readProfile() as {
+      inferred: { contributing_events: Record<string, number>; sample_size: number };
+    };
+    // Sanity: the registry path really did contribute here, or the assertion
+    // below would pass vacuously the way the old fixture did.
+    const touched = Object.values(p.inferred.contributing_events).filter((n) => n > 0);
+    expect(touched.length).toBeGreaterThanOrEqual(2);
+    for (const n of Object.values(p.inferred.contributing_events)) {
+      expect(n).toBeLessThanOrEqual(p.inferred.sample_size);
+    }
+  });
+
+  test('auto-decided rows do not feed the autonomy signal', () => {
+    // Guards the feedback loop: the preference hook auto-picks the
+    // recommendation, so counting it as delegation evidence would let the
+    // dimension that licenses auto-deciding inflate itself.
+    logFollowed(30, 30, { source: 'auto-decided' });
+    runDev('--derive');
+    const p = readProfile() as {
+      inferred: { values: Record<string, number>; contributing_events: Record<string, number> };
+    };
+    expect(p.inferred.values.autonomy).toBeCloseTo(0.5, 2);
+    expect(p.inferred.contributing_events.autonomy).toBe(0);
+  });
+
+  test('rows without a recommendation contribute nothing', () => {
+    // No `recommended` field means gstack-question-log computes no
+    // followed_recommendation, so there is nothing for the signal to read.
+    for (let i = 0; i < 20; i++) {
+      logQuestion({
+        skill: 'ship',
+        question_id: 'adhoc-no-recommendation',
+        question_summary: 'q',
+        user_choice: 'accept',
+        session_id: `s${i}`,
+      });
+    }
+    runDev('--derive');
+    const p = readProfile() as {
+      inferred: { values: Record<string, number>; contributing_events: Record<string, number> };
+    };
+    expect(p.inferred.values.autonomy).toBeCloseTo(0.5, 2);
+    expect(p.inferred.contributing_events.autonomy).toBe(0);
+  });
+
+  test('REGRESSION: registry autonomy rows are excluded from the rate tally', () => {
+    // totals.autonomy is written by BOTH the per-event SIGNAL_MAP path and the
+    // O(1) rate aggregate, so one decision could feed it twice. Precedence:
+    // a row already counted by the registry path is excluded from the rate.
+    //
+    // N=200, not N=1: a single-event check measures coefficient size, not
+    // interaction at scale. One /plan-eng-review session produces ~5 mapped
+    // events, so 200 is roughly forty sessions — a real steady state.
+    //
+    // MUTATE THIS by deleting the countedByRegistry() check in
+    // isRecommendationEligible; the eligible count jumps to 260 and this reds.
+    appendRows([
+      ...bulk(200, {
+        skill: 'land-and-deploy',
+        question_id: 'land-and-deploy-merge-confirm',
+        user_choice: 'apply-fix',
+        recommended: 'apply-fix',
+        followed_recommendation: true,
+        source: 'agent',
+      }),
+      ...bulk(60, {
+        skill: 'ship',
+        question_id: 'adhoc-rate-evidence',
+        user_choice: 'reject',
+        recommended: 'accept',
+        followed_recommendation: false,
+        source: 'hook',
+      }),
+    ]);
+
+    const r = runDev('--derive');
+    expect(r.stdout).toContain('60 recommendation-eligible');
+
+    const p = readProfile() as {
+      inferred: { values: Record<string, number>; contributing_events: Record<string, number> };
+    };
+    // 200 registry rows + 60 rate rows = 260 UNIQUE rows touching autonomy.
+    expect(p.inferred.contributing_events.autonomy).toBe(260);
+  });
+
+  test('KNOWN LIMITATION: the per-event registry path still swamps the rate signal', () => {
+    // This pins a bug we are NOT fixing in this change, so that the day someone
+    // does fix it, this test reds and they re-baseline deliberately.
+    //
+    // normalizeToDimensionValue is a sigmoid over an ACCUMULATED total, so the
+    // per-event path grows without bound: 200 'decision-autonomy' events at
+    // +0.04 total 8.0, and sigmoid(3 * 8.0) is 1.0 to float precision.
+    // Precedence stops the same ROW being counted twice; it does nothing about
+    // volume. Measured: with 200 mapped events pointing one way and 60 rate
+    // rows pointing the OTHER way, the derived value is 1.0 — while the rate
+    // evidence alone would read 0.190. The signal is not merely diluted, it is
+    // erased, and the conclusion flips.
+    //
+    // The real fix is to normalize per-event accumulation (a mean, or damping)
+    // so no dimension can saturate. That re-prices every delta in
+    // psychographic-signals.ts and belongs in its own change.
+    appendRows([
+      ...bulk(200, {
+        skill: 'land-and-deploy',
+        question_id: 'land-and-deploy-merge-confirm',
+        user_choice: 'apply-fix',
+        recommended: 'apply-fix',
+        followed_recommendation: true,
+        source: 'agent',
+      }),
+      ...bulk(60, {
+        skill: 'ship',
+        question_id: 'adhoc-rate-evidence',
+        user_choice: 'reject',
+        recommended: 'accept',
+        followed_recommendation: false,
+        source: 'hook',
+      }),
+    ]);
+    runDev('--derive');
+    const p = readProfile() as { inferred: { values: Record<string, number> } };
+    expect(p.inferred.values.autonomy).toBe(1);
+  });
+
+  test('derive reports the recommendation-eligible count on stdout', () => {
+    logFollowed(12, 12);
+    const r = runDev('--derive');
+    expect(r.stdout).toContain('12 recommendation-eligible');
+  });
+
   test('derive ignores events for questions not in registry (ad-hoc ids)', () => {
     logQuestion({
       skill: 'plan-ceo-review',
@@ -339,6 +606,47 @@ describe('gstack-developer-profile --trace <dim>', () => {
     });
     const r = runDev('--trace', 'autonomy');
     expect(r.stdout).toContain('no events contribute to autonomy');
+  });
+
+  test('names the aggregate for autonomy instead of reporting no events', () => {
+    // Without this, --trace autonomy would still say "no events contribute"
+    // while --profile showed a moved number — the explain tool disagreeing
+    // with the thing it explains.
+    for (let i = 0; i < 25; i++) {
+      logQuestion({
+        skill: 'ship',
+        question_id: 'adhoc-recommendation-case',
+        question_summary: 'q',
+        user_choice: 'accept',
+        recommended: 'accept',
+        session_id: `s${i}`,
+      });
+    }
+    const r = runDev('--trace', 'autonomy');
+    expect(r.stdout).toContain('25 events for autonomy');
+    expect(r.stdout).toContain('followed_recommendation');
+    expect(r.stdout).toContain('25/25');
+    expect(r.stdout).not.toContain('no events contribute');
+  });
+
+  test('trace and derive agree on the eligible count', () => {
+    // Two separate bun -e blocks read the log. If the eligibility rule ever
+    // drifts between them, the explain tool lies about the derived number.
+    for (let i = 0; i < 18; i++) {
+      logQuestion({
+        skill: 'ship',
+        question_id: 'adhoc-recommendation-case',
+        question_summary: 'q',
+        user_choice: i < 15 ? 'accept' : 'reject',
+        recommended: 'accept',
+        session_id: `s${i}`,
+      });
+    }
+    const traced = runDev('--trace', 'autonomy');
+    expect(traced.stdout).toContain('15/18');
+    runDev('--derive');
+    const p = readProfile() as { inferred: { contributing_events: Record<string, number> } };
+    expect(p.inferred.contributing_events.autonomy).toBe(18);
   });
 
   test('errors without dimension argument', () => {

--- a/test/plan-tune.test.ts
+++ b/test/plan-tune.test.ts
@@ -34,6 +34,12 @@ import {
   newDimensionTotals,
   normalizeToDimensionValue,
   ALL_DIMENSIONS,
+  recommendationSignal,
+  recommendationEligibleCount,
+  isRecommendationEligible,
+  RECOMMENDATION_MIN_SAMPLE,
+  RECOMMENDATION_SIGNAL_WEIGHT,
+  type RecommendationEvent,
 } from '../scripts/psychographic-signals';
 import {
   ARCHETYPES,
@@ -286,6 +292,178 @@ describe('psychographic signal map', () => {
     const { extra } = validateRegistrySignalKeys();
     // Allow up to 3 "reserved" extras before flagging. Tighten later.
     expect(extra.length).toBeLessThanOrEqual(3);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Registry-independent autonomy signal (followed_recommendation)
+//
+// Math only. The derive/trace wiring is covered end-to-end in
+// test/gstack-developer-profile.test.ts; a failure here should point at the
+// formula, not at a subprocess round-trip.
+// -----------------------------------------------------------------------
+
+describe('recommendationSignal', () => {
+  const rows = (
+    n: number,
+    followed: number,
+    extra: Partial<RecommendationEvent> = {},
+  ): RecommendationEvent[] =>
+    Array.from({ length: n }, (_, i) => ({
+      followed_recommendation: i < followed,
+      source: 'hook',
+      question_id: 'adhoc-unregistered',
+      ...extra,
+    }));
+
+  const derived = (evs: RecommendationEvent[]): number =>
+    normalizeToDimensionValue(recommendationSignal(evs).delta);
+
+  test('always attributes to autonomy', () => {
+    expect(recommendationSignal(rows(20, 20)).dim).toBe('autonomy');
+    expect(recommendationSignal([]).dim).toBe('autonomy');
+  });
+
+  test('following the recommendation pushes autonomy up', () => {
+    expect(recommendationSignal(rows(20, 20)).delta).toBeGreaterThan(0);
+    expect(derived(rows(20, 20))).toBeGreaterThan(0.5);
+  });
+
+  test('ignoring the recommendation pushes autonomy down', () => {
+    expect(recommendationSignal(rows(20, 0)).delta).toBeLessThan(0);
+    expect(derived(rows(20, 0))).toBeLessThan(0.5);
+  });
+
+  test('REGRESSION: 200 all-followed events must not saturate', () => {
+    // The whole design rests on this. normalizeToDimensionValue is a sigmoid
+    // over an ACCUMULATED total, so a per-event delta at this file's usual
+    // +/-0.03..0.06 reaches 0.9994 by 50 events and 1.0 by 100 — as
+    // uninformative as the 0.5 it replaced. A rate-based O(1) contribution
+    // stays bounded no matter how long the log gets.
+    //
+    // MUTATE THIS by making recommendationSignal accumulate per event
+    // (delta * n); this assertion is what reds.
+    const value = derived(rows(200, 200));
+    expect(value).toBeLessThan(0.95);
+    expect(value).toBeGreaterThan(0.5);
+
+    // And it must stay bounded as the log grows: 200 rows and 2,000 rows at
+    // the same rate land in the same place.
+    expect(Math.abs(derived(rows(2000, 2000)) - value)).toBeLessThan(0.01);
+  });
+
+  test('zero eligible rows is exactly neutral, with no special case', () => {
+    // Laplace smoothing returns 0.5 at n=0, so "no data" needs no null branch.
+    // MUTATE THIS by removing the +1/+2 smoothing: (0/0) is NaN and this reds.
+    expect(recommendationSignal([]).delta).toBe(0);
+    expect(derived([])).toBeCloseTo(0.5, 10);
+  });
+
+  test('confidence ramp is keyed on the ELIGIBLE count, not the row count', () => {
+    // The bug this pins: the documented calibration gate reads
+    // inferred.sample_size, which counts EVERY logged row. A log of 3 eligible
+    // rows beside 1,200 ineligible ones passes that gate, so a ramp keyed on
+    // total rows would render a confident score from three answers.
+    //
+    // The fixture is deliberately lopsided — 3 eligible among 1,203 — so a ramp
+    // keyed on the wrong population reads "full confidence" and reds.
+    const ineligible = rows(1200, 1200, { source: 'auto-decided' });
+    const thin = [...ineligible, ...rows(3, 3)];
+
+    expect(recommendationEligibleCount(thin)).toBe(3);
+    expect(derived(thin)).toBeLessThan(derived(rows(20, 20)));
+    expect(derived(thin)).toBeLessThan(0.60);
+  });
+
+  test('confidence rises monotonically with eligible count, then plateaus', () => {
+    const at = (n: number) => derived(rows(n, n));
+    expect(at(3)).toBeLessThan(at(10));
+    expect(at(10)).toBeLessThan(at(20));
+    // At and beyond MIN_SAMPLE the ramp is capped, so growth is smoothing-only.
+    expect(at(RECOMMENDATION_MIN_SAMPLE * 10) - at(RECOMMENDATION_MIN_SAMPLE))
+      .toBeLessThan(0.05);
+  });
+
+  test('the weight bounds the maximum contribution', () => {
+    // An all-followed infinite log can never exceed the weight itself.
+    expect(recommendationSignal(rows(5000, 5000)).delta)
+      .toBeLessThanOrEqual(RECOMMENDATION_SIGNAL_WEIGHT);
+    expect(recommendationSignal(rows(5000, 0)).delta)
+      .toBeGreaterThanOrEqual(-RECOMMENDATION_SIGNAL_WEIGHT);
+  });
+});
+
+describe('recommendationSignal eligibility', () => {
+  const base = { followed_recommendation: true, source: 'hook', question_id: 'adhoc' };
+
+  test('accepts a well-formed row', () => {
+    expect(isRecommendationEligible({ ...base })).toBe(true);
+  });
+
+  test('requires a STRICT boolean, never truthiness', () => {
+    // question-log.jsonl is hand-editable JSONL. The string "false" is truthy;
+    // a truthiness check would count it as a follow and bias autonomy upward
+    // with no error at all.
+    expect(isRecommendationEligible({ ...base, followed_recommendation: 'false' })).toBe(false);
+    expect(isRecommendationEligible({ ...base, followed_recommendation: 'true' })).toBe(false);
+    expect(isRecommendationEligible({ ...base, followed_recommendation: 1 })).toBe(false);
+    expect(isRecommendationEligible({ ...base, followed_recommendation: undefined })).toBe(false);
+    // Both real booleans are eligible; only the VALUE differs.
+    expect(isRecommendationEligible({ ...base, followed_recommendation: false })).toBe(true);
+  });
+
+  test('excludes auto-decided rows to avoid a feedback loop', () => {
+    // The preference hook auto-picks the recommendation. Counting that as
+    // evidence of delegation would feed the dimension that licenses
+    // auto-deciding straight back into itself.
+    expect(isRecommendationEligible({ ...base, source: 'auto-decided' })).toBe(false);
+  });
+
+  test('excludes rows with a MISSING source rather than assuming they are safe', () => {
+    // gstack-question-log defaults source to 'agent' on write, so a row with no
+    // source was never written by that binary — treat it as untrusted.
+    expect(isRecommendationEligible({ ...base, source: undefined })).toBe(false);
+    expect(isRecommendationEligible({ ...base, source: 42 })).toBe(false);
+  });
+
+  test('PRECEDENCE: excludes rows already counted by the registry autonomy path', () => {
+    // totals.autonomy is written by BOTH the per-event SIGNAL_MAP path and this
+    // aggregate, so one decision could feed it twice. Derive the id from the
+    // registry rather than hard-coding it, so this keeps working if the entry
+    // is renamed.
+    const autonomyId = Object.values(QUESTIONS).find(
+      (q) => q.signal_key && Object.values(SIGNAL_MAP[q.signal_key] ?? {})
+        .some((ds) => ds.some((d) => d.dim === 'autonomy')),
+    )?.id;
+    expect(autonomyId).toBeDefined();
+    expect(isRecommendationEligible({ ...base, question_id: autonomyId })).toBe(false);
+  });
+
+  test('does NOT exclude registry rows that feed other dimensions', () => {
+    // The precedence rule is autonomy-specific. An architecture-care question
+    // still carries usable recommendation-following evidence.
+    const nonAutonomyId = Object.values(QUESTIONS).find(
+      (q) => q.signal_key && !Object.values(SIGNAL_MAP[q.signal_key] ?? {})
+        .some((ds) => ds.some((d) => d.dim === 'autonomy')),
+    )?.id;
+    expect(nonAutonomyId).toBeDefined();
+    expect(isRecommendationEligible({ ...base, question_id: nonAutonomyId })).toBe(true);
+  });
+
+  test('unregistered and malformed question_ids stay eligible', () => {
+    expect(isRecommendationEligible({ ...base, question_id: 'hook-abc123' })).toBe(true);
+    expect(isRecommendationEligible({ ...base, question_id: undefined })).toBe(true);
+    expect(isRecommendationEligible({ ...base, question_id: 42 })).toBe(true);
+  });
+
+  test('eligible count matches the rows the signal actually used', () => {
+    const mixed: RecommendationEvent[] = [
+      { ...base },
+      { ...base, source: 'auto-decided' },
+      { ...base, followed_recommendation: 'false' },
+      { ...base, followed_recommendation: false },
+    ];
+    expect(recommendationEligibleCount(mixed)).toBe(2);
   });
 });
 


### PR DESCRIPTION
Partial fix for #2623.

## What this does

Adds **one registry-independent signal** — `followed_recommendation` → `autonomy` —
so `/plan-tune` can read existing history for one of five dimensions.

**It does not fix #2623.** Gates 1 and 3 there need a design call I did not want
to make on your behalf, and four of five dimensions still sit at 0.5 after this
lands. The title says "signal", not "fix", deliberately.

## Why this signal specifically

It is the only one that reads existing history retroactively.
`gstack-question-log` already computes `followed_recommendation` at write time
from `(user_choice, recommended)`, so it is present on ~95% of rows today and
needs no registry entry, no `<gstack-qid:>` marker and no skill change.

Measured on a real 1,286-row log: **autonomy 0.5 → 0.797** (1,187 of 1,240
eligible rows followed, 95.7%). Other dimensions unchanged.

## Three design points worth reviewing

**1. The contribution is O(1), not a per-event delta.** `normalizeToDimensionValue`
is a sigmoid over an *accumulated* total, so a per-event delta at this file's
usual ±0.03..0.06 reaches 0.9994 by 50 events and 1.0 by 100 — as uninformative
as the 0.5 it replaces. This computes one bounded delta from the whole history:

```
smoothed   = (followed + 1) / (n + 2)          # Laplace
confidence = min(1, n / 20)                    # n = ELIGIBLE rows
delta      = 0.5 * confidence * (2*smoothed - 1)
```

**2. The ramp is keyed on the eligible count, not `sample_size`.** My first draft
dropped the ramp, reasoning that the documented 20-event calibration gate already
handles thin evidence. It does not: `sample_size` counts *every* logged row
(`bin/gstack-developer-profile:351`), so 3 eligible rows beside 1,200 unrelated
ones passes that gate and would render a confident score from three answers.

**3. `W = 0.5` is an unvalidated starting constant, and I have said so in the
code.** It was picked on one user's data because it lands near their declared
value, which is post-hoc. It is also confounded: a high follow rate may measure
how good the agent's recommendations are as much as how much the user delegates.
The comment frames it the way this file's header already frames v1 deltas —
"best-guess starting points". Happy to re-pick it on broader data.

## Eligibility fails closed

`question-log.jsonl` is hand-editable JSONL, so every clause rejects rather than
coerces: strict boolean (the string `"false"` is truthy and would silently count
as a follow), `source` present and not `auto-decided` (the preference hook
auto-picks the recommendation, which would feed the dimension that licenses
auto-deciding straight back into itself), and precedence over the registry
autonomy path so one decision is never counted twice.

## Also included: derivation provenance

`inferred` now carries per-dimension `contributing_events` (unique rows) and
`derivation_version`. `normalizeToDimensionValue(0)` is exactly 0.5, so today a
dead dimension and a perfectly balanced one print the same number — which is how
#2623 hid for two months behind `sample_size: 1286`. With this, `--derive` on an
unpatched log shows `contributing_events: 0` across the board, which makes that
issue reproducible in one command.

Both fields are additive and sit beside `diversity` in the existing shape.

## Known limitation, pinned rather than fixed

The per-event registry path can still swamp this signal, because it accumulates
unbounded. With 200 mapped `decision-autonomy` events one way and 60 rate rows
the other, the derived value is **1.0** where the rate evidence alone reads
**0.190** — not diluted, erased, and the conclusion flips.

I did not fix that here: bounding per-event accumulation re-prices every delta in
`psychographic-signals.ts` and deserves its own change. Instead there is a test
named `KNOWN LIMITATION: the per-event registry path still swamps the rate
signal` that pins the current behaviour, so whoever fixes it gets a red test and
re-baselines deliberately. Detail in #2623.

## Tests

`test/plan-tune.test.ts` gets the math (in-process, beside the existing
`psychographic signal map` block); `test/gstack-developer-profile.test.ts` gets
the wiring. 117 pass across the two files.

Every new assertion is mutation-verified — 11 mutations, each reds its named
test: per-event accumulation, ramp keyed on total rows, smoothing removed,
truthiness instead of strict boolean, missing-source allowed, precedence dropped,
aggregate not applied, provenance write deleted, applications counted instead of
unique rows, and two that strip the trace aggregate.

One of those mutations caught a weak test of mine: the `UNIQUE ROWS` case
originally used a rate-only fixture, so the registry contributor count was 0 and
multiplying it changed nothing. It now uses a question whose `signal_key` writes
more than one dimension from a single row.

## One test-harness change

`logQuestion` now sets `GSTACK_QUESTION_LOG_NO_DERIVE=1`. `gstack-question-log`
fires `--derive` in the background after every append
(`bin/gstack-question-log:242-250`), which races the explicit `--derive` a test
then makes — I saw it as intermittently empty stdout. That env var exists for
exactly this; without it, any test that logs several rows and then derives is
flaky by construction.

## Pre-existing failures, not from this change

`bun run test:free` has 3 failures on this branch, all in
`browse/test/path-validation.test.ts` and `browse/test/data-platform.test.ts`.
They reproduce identically on a clean worktree at `c86e647` with none of my
changes, and this PR touches no file under `browse/`. Looks like macOS
`/private/tmp` symlink resolution.

`VERSION` is deliberately untouched — `version-gate.yml` only triggers on that
path, so I have left the bump to you.
