### PR TITLE
fix(cdp): route browser-scoped CDP calls through a real browser session

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -1090,6 +1090,37 @@ export class BrowserManager {
     return this.pages.get(tabId) ?? null;
   }
 
+  /**
+   * Ephemeral browser-level CDP session, for dispatching true Browser-domain
+   * methods (e.g. Browser.grantPermissions) that Chromium does not apply
+   * correctly when sent through a page/target-attached session — some
+   * Browser.* methods silently no-op (return success, no effect) when routed
+   * that way instead of via the top-level browser connection.
+   * Used by the CDP bridge (cdp-bridge.ts) for scope: 'browser' entries.
+   * Returns null if the Playwright build/connection mode doesn't expose
+   * newBrowserCDPSession. Caller owns the session and must detach() it.
+   */
+  async getBrowserCdpSession(): Promise<{
+    send: (method: string, params?: unknown) => Promise<unknown>;
+    detach: () => Promise<void>;
+  } | null> {
+    const browser: Browser | null = this.browser ?? (this.context ? this.context.browser() : null);
+    if (!browser) return null;
+    // `newBrowserCDPSession` is browser-wide. Not exposed on every Playwright
+    // TypeScript surface, but present at runtime on the Browser instance —
+    // use a typed cast to avoid @ts-expect-error (same pattern as the
+    // SystemInfo.getProcessInfo memory-snapshot usage above).
+    type BrowserWithCDP = Browser & {
+      newBrowserCDPSession?: () => Promise<{
+        send: (method: string, params?: unknown) => Promise<unknown>;
+        detach: () => Promise<void>;
+      }>;
+    };
+    const maybeFactory = (browser as BrowserWithCDP).newBrowserCDPSession;
+    if (typeof maybeFactory !== 'function') return null;
+    return await maybeFactory.call(browser);
+  }
+
   // ─── Two-tier mutex (Codex T7) ─────────────────────────────
   // Per-tab and global locks for the CDP bridge. tab-scoped methods take the
   // per-tab mutex; browser-scoped methods take the global lock that blocks all

--- a/browse/src/cdp-allowlist.ts
+++ b/browse/src/cdp-allowlist.ts
@@ -133,6 +133,14 @@ export const CDP_ALLOWLIST: ReadonlyArray<CdpAllowEntry> = Object.freeze([
     output: 'untrusted',
     justification: 'Trace dump may contain URLs and page data; wrap.',
   },
+  // ─── Browser (permissions) ──────────────────────────────────
+  {
+    domain: 'Browser',
+    method: 'grantPermissions',
+    scope: 'browser',
+    output: 'trusted',
+    justification: 'Grant a named permission (e.g. geolocation, notifications) so permission-gated APIs do not auto-deny in headless mode, enabling end-to-end testing of permission-dependent UI. Browser-scoped since it is a Browser-domain method affecting permission state beyond a single tab; returns no page content.',
+  },
   // ─── Emulation (viewport/device) ───────────────────────────
   {
     domain: 'Emulation',
@@ -161,6 +169,13 @@ export const CDP_ALLOWLIST: ReadonlyArray<CdpAllowEntry> = Object.freeze([
     scope: 'tab',
     output: 'trusted',
     justification: 'Media type/feature override (prefers-color-scheme, prefers-reduced-motion, prefers-contrast, forced-colors) so a11y and dark-mode CSS branches are testable. Returns an empty result; no page content. NOTE: like setUserAgentOverride the override persists on the tab until cleared with an empty features array.',
+  },
+  {
+    domain: 'Emulation',
+    method: 'setGeolocationOverride',
+    scope: 'tab',
+    output: 'trusted',
+    justification: 'Override the active tab\'s reported geolocation (lat/long/accuracy) for testing location-dependent UI. Input-only mutation, empty result, no page content leak. Persists on the tab until cleared, same pattern as setUserAgentOverride/setEmulatedMedia. Pair with Browser.grantPermissions to avoid the default permission-denied path in headless mode.',
   },
   // ─── Page capture (output, not navigation) ─────────────────
   {

--- a/browse/src/cdp-bridge.ts
+++ b/browse/src/cdp-bridge.ts
@@ -149,31 +149,90 @@ export async function dispatchCdpCall(input: CdpDispatchInput): Promise<CdpDispa
   logTelemetry({ event: 'cdp_method_called', domain: input.domain, method: input.method, allowed: true, scope: entry.scope });
 
   try {
-    const page = input.bm.getPageForTab(input.tabId);
-    if (!page) {
-      throw new Error(
-        `Cannot dispatch: tab ${input.tabId} not found.\n` +
-          'Cause: tab was closed between command queue and dispatch.\n' +
-          'Action: $B tabs to list current tabs.'
-      );
+    // Browser-domain methods (e.g. Browser.grantPermissions) must go over a
+    // real browser-level CDP connection — Chromium silently no-ops some of
+    // them (success response, no actual effect) when routed through a
+    // page/target-attached session instead. Tab-scoped methods keep using
+    // the cached per-page session as before.
+    let session: { send: (method: string, params?: unknown) => Promise<unknown>; detach: () => Promise<void> };
+    let ephemeral = false;
+    let params = input.params;
+
+    if (entry.scope === 'browser') {
+      const browserSession = await input.bm.getBrowserCdpSession();
+      if (!browserSession) {
+        throw new Error(
+          `Cannot dispatch: no browser-level CDP session available for ${qualified}.\n` +
+            'Cause: this Playwright build/connection mode does not expose newBrowserCDPSession.\n' +
+            'Action: file a bug — this Browser-domain method cannot be dispatched in this environment.'
+        );
+      }
+      session = browserSession;
+      ephemeral = true;
+
+      // Browser.grantPermissions defaults to Chromium's "default" browser
+      // context when browserContextId is omitted — but Playwright always
+      // creates its own dedicated (non-default) context for every launch,
+      // so an un-scoped grant silently applies to a context nothing in the
+      // daemon actually uses and the caller sees "success" with zero effect.
+      // Auto-resolve the calling tab's real browserContextId (via its
+      // already-attached page session, which any target can query about
+      // itself) so callers never need to discover/pass it manually.
+      if (qualified === 'Browser.grantPermissions' && params.browserContextId === undefined) {
+        const page = input.bm.getPageForTab(input.tabId);
+        if (page) {
+          try {
+            const tabSession = await getCdpSession(page);
+            const targetInfo = (await tabSession.send('Target.getTargetInfo')) as {
+              targetInfo?: { browserContextId?: string };
+            };
+            const browserContextId = targetInfo?.targetInfo?.browserContextId;
+            if (browserContextId) {
+              params = { ...params, browserContextId };
+            }
+          } catch {
+            // Best-effort resolution — if it fails, fall through and let
+            // Chromium apply its default-context behavior rather than
+            // failing the whole call outright.
+          }
+        }
+      }
+    } else {
+      const page = input.bm.getPageForTab(input.tabId);
+      if (!page) {
+        throw new Error(
+          `Cannot dispatch: tab ${input.tabId} not found.\n` +
+            'Cause: tab was closed between command queue and dispatch.\n' +
+            'Action: $B tabs to list current tabs.'
+        );
+      }
+      try {
+        session = await getCdpSession(page);
+      } catch (e: any) {
+        throw new Error(
+          `CDPSessionInvalidated: ${e.message}\n` +
+            'Cause: Playwright context was recreated (e.g., viewport scale change) and the prior CDP session is stale.\n' +
+            'Action: retry the command; the bridge will create a fresh session.'
+        );
+      }
     }
-    let session;
+
     try {
-      session = await getCdpSession(page);
-    } catch (e: any) {
-      throw new Error(
-        `CDPSessionInvalidated: ${e.message}\n` +
-          'Cause: Playwright context was recreated (e.g., viewport scale change) and the prior CDP session is stale.\n' +
-          'Action: retry the command; the bridge will create a fresh session.'
+      // Race the call against a hard timeout.
+      const callPromise = session.send(qualified, params);
+      const timeoutPromise = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error(`CDPBridgeTimeout: ${qualified} did not return within ${CDP_TIMEOUT_MS}ms`)), CDP_TIMEOUT_MS),
       );
+      const raw = await Promise.race([callPromise, timeoutPromise]);
+      return { raw, entry };
+    } finally {
+      // Ephemeral browser-level sessions aren't cached anywhere (unlike the
+      // per-page cache in getCdpSession), so they must be detached here or
+      // the Chromium-side connection leaks.
+      if (ephemeral) {
+        await session.detach().catch(() => undefined);
+      }
     }
-    // Race the call against a hard timeout.
-    const callPromise = session.send(qualified, input.params);
-    const timeoutPromise = new Promise((_, reject) =>
-      setTimeout(() => reject(new Error(`CDPBridgeTimeout: ${qualified} did not return within ${CDP_TIMEOUT_MS}ms`)), CDP_TIMEOUT_MS),
-    );
-    const raw = await Promise.race([callPromise, timeoutPromise]);
-    return { raw, entry };
   } finally {
     release();
   }


### PR DESCRIPTION
## Summary

Adds `Browser.grantPermissions` and `Emulation.setGeolocationOverride` to `CDP_ALLOWLIST`, for automated testing of permission-gated UI (e.g. a geolocation-dependent widget).

While wiring these up, found that `dispatchCdpCall` in `cdp-bridge.ts` routed **every** CDP call — regardless of the allowlist's `tab`/`browser` scope tag — through a page-attached `CDPSession`. The `scope` field only controlled locking tier, not which connection the command was actually sent on. Some `Browser`-domain methods (`grantPermissions` confirmed) silently no-op (success response, zero effect) when sent this way instead of via the top-level browser connection.

## Fixes

- `browser-manager.ts`: new `getBrowserCdpSession()` using Playwright's `newBrowserCDPSession()`, mirroring the existing pattern already used for `SystemInfo.getProcessInfo` in the memory-snapshot code.
- `cdp-bridge.ts`: `scope: 'browser'` entries now dispatch via this real browser-level session instead of a page session. `scope: 'tab'` entries are unchanged.
- `cdp-bridge.ts`: `Browser.grantPermissions` additionally auto-resolves and injects the calling tab's actual `browserContextId` when the caller doesn't supply one. CDP's `grantPermissions` defaults to Chromium's "default" browser context when omitted, but Playwright always creates its own dedicated non-default context — an unscoped grant was silently applying to a context nothing in the daemon uses.

## Known limitation — needs maintainer input

Even with both fixes applied and verified (confirmed via `Target.getTargetInfo` logging that the correct `browserContextId` is resolved and sent), `Browser.grantPermissions` still has **no observable effect** in my environment:

- Verified via both `navigator.permissions.query()` state and actual `getCurrentPosition()` behavior
- Tested across two permission types (`geolocation`, `notifications`)
- Tested with explicit and auto-resolved `browserContextId`, and with/without an explicit `origin`

A standalone bare Playwright script (`chromium.launch()` outside the gstack daemon) couldn't be used to isolate this further in my environment — it hung on launch, likely an unrelated Playwright/Chromium config difference on my machine.

Given gstack uses a custom-patched Chromium build (per `stealth.ts`'s "Pack 1 Chromium" references), this may be a fork-specific regression rather than a bug in this TypeScript layer — flagging for maintainers who have visibility into that build. `Emulation.setGeolocationOverride` itself is unaffected by this — it's correctly tab-scoped and dispatches fine on its own; it's only the permission gate in front of it that doesn't lift.

## Test plan

- [x] `bun run build` succeeds, no type errors
- [x] `bun test browse/test/cdp-allowlist.test.ts` — 7/7 pass
- [x] Manually verified the routing fix: `Target.getBrowserContexts` sent via the new browser-level session correctly returns the real (non-default) context ID, confirming the session now actually reaches the browser-level connection
- [x] Manually verified the `browserContextId` auto-injection resolves and sends the exact ID matching the calling tab's own `Target.getTargetInfo`
- [ ] Could not get the full `bun run test` suite to complete in my environment (hung with near-zero CPU usage after 10+ minutes on a fresh run) — unclear if environment-specific or a real issue; flagging rather than silently skipping this