### PR TITLE
fix(evidence): subtract Bun-auto-loaded dotenv keys from the child environment

### DIFF
--- a/bin/gstack-evidence
+++ b/bin/gstack-evidence
@@ -34,7 +34,7 @@
  * in the ledger; it cannot prove that an expected lane ever ran.
  */
 
-import { mkdirSync, openSync, writeSync, closeSync, readdirSync, statSync, unlinkSync, chmodSync } from "fs";
+import { mkdirSync, openSync, writeSync, closeSync, readdirSync, readFileSync, statSync, unlinkSync, chmodSync } from "fs";
 import { join, dirname } from "path";
 import { spawnSync } from "child_process";
 import { appendJsonl, readJsonl } from "../lib/jsonl-store";
@@ -67,6 +67,33 @@ function sha256(text: string): string {
   const h = new Bun.CryptoHasher("sha256");
   h.update(text);
   return h.digest("hex");
+}
+
+// Bun auto-loads .env/.env.local/.env.<NODE_ENV> from the cwd into process.env
+// before user code runs, and an env-less Bun.spawn hands that pollution to the
+// child test runner — flipping verdicts in any repo whose suites depend on
+// those vars being unset (both directions: false red AND false green). Subtract
+// exactly the keys those files define; the developer's real environment (PATH,
+// credentials, tool config) passes through untouched. Never throws: per the
+// transparency invariant, bookkeeping must not turn a run red.
+function childEnv(): Record<string, string | undefined> {
+  const env = { ...process.env };
+  try {
+    const mode = process.env.NODE_ENV || "development";
+    for (const f of [".env", `.env.${mode}`, ".env.local", `.env.${mode}.local`]) {
+      let text: string;
+      try {
+        text = readFileSync(f, "utf-8");
+      } catch {
+        continue;
+      }
+      for (const line of text.split("\n")) {
+        const m = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/.exec(line);
+        if (m) delete env[m[1]];
+      }
+    }
+  } catch {}
+  return env;
 }
 
 function git(args: string[]): string | undefined {
@@ -189,7 +216,7 @@ async function cmdRun(argv: string[]): Promise<number> {
   let exitCode: number;
   let proc: ReturnType<typeof Bun.spawn> | undefined;
   try {
-    proc = Bun.spawn(spawnArgv, { stdin: "inherit", stdout: "pipe", stderr: "pipe" });
+    proc = Bun.spawn(spawnArgv, { stdin: "inherit", stdout: "pipe", stderr: "pipe", env: childEnv() });
   } catch (e: any) {
     // Spawn failure (ENOENT on argv-direct form): record exit 127, propagate 127.
     exitCode = 127;

--- a/test/evidence.test.ts
+++ b/test/evidence.test.ts
@@ -76,6 +76,28 @@ describe('gstack-evidence run', () => {
     expect(fs.readFileSync(rec.log_path, 'utf-8')).toContain('ok');
   });
 
+  test('dotenv keys Bun auto-loaded from the cwd do not reach the child (#2624)', () => {
+    // Bun loads .env/.env.local into process.env before the wrapper's own code
+    // runs; without an explicit env, Bun.spawn hands those values to the test
+    // runner and flips verdicts in repos whose suites need them unset.
+    fs.writeFileSync(path.join(repoDir, '.env.local'), 'GSTACK_TEST_INJECTED=oops\nexport GSTACK_TEST_EXPORTED=oops2\n');
+    fs.writeFileSync(path.join(repoDir, '.env'), 'GSTACK_TEST_PLAIN=oops3\n');
+    const r = run(['run', '--label', 'envtest', '--', 'echo "[${GSTACK_TEST_INJECTED-}|${GSTACK_TEST_EXPORTED-}|${GSTACK_TEST_PLAIN-}]"']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('[||]');
+  });
+
+  test('real environment variables still pass through to the child (#2624)', () => {
+    const r = spawnSync(EVIDENCE, ['run', '--label', 'envtest', '--', 'echo "val=${GSTACK_TEST_REAL-}"'], {
+      cwd: repoDir,
+      env: { ...process.env, GSTACK_HOME: gstackHome, GSTACK_TEST_REAL: 'kept' },
+      encoding: 'utf-8',
+      timeout: 60000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('val=kept');
+  });
+
   test('propagates a failing exit code and records it', () => {
     const r = run(['run', '--label', 'tests', '--', 'exit 3']);
     expect(r.status).toBe(3);


### PR DESCRIPTION
## Why (in your own words)

`gstack-evidence` exists to be believed — it's the mechanical arm of /ship's "no completion claims without fresh verification evidence." But in any repo with a `.env.local` (most JS repos), it records the wrong verdict: the script runs under Bun, Bun auto-loads dotenv files from the cwd into `process.env` before user code runs, and the `Bun.spawn` call passed no `env`, so the child test runner inherited values the developer never exported. Suites that assert behavior when those vars are *unset* go falsely red; injected values can equally mask a real failure as a false green. This change subtracts exactly the keys those dotenv files define and passes an explicit `env` — the developer's real environment (PATH, credentials, tool config) still flows through untouched. The helper never throws, per the file's transparency invariant.

Fixes #2624.

## Live evidence

Repro repo containing `.env.local` with `INJECTED_SECRET=oops`; the wrapped command asserts the var is unset.

Before (main, `c86e6472`):

```
$ gstack-evidence run --label repro -- 'test -z "$INJECTED_SECRET" && echo CLEAN || { echo "POLLUTED: $INJECTED_SECRET"; exit 1; }'
POLLUTED: oops
gstack-evidence: recorded label=repro exit=1 log=.../logs/2026-08-18T18-31-53-777Z-repro-....log
wrapper-exit=1
```

After (this branch, same command, same repo):

```
CLEAN
gstack-evidence: recorded label=repro exit=0 log=.../logs/2026-08-18T18-39-13-589Z-repro-....log
wrapper-exit=0
```

Red-green on the new test: with the fix stashed (main's binary), `dotenv keys Bun auto-loaded from the cwd do not reach the child` fails; with the fix, `bun test test/evidence.test.ts` → 26 pass, 0 fail.

## Scope

- **Changed:** `bin/gstack-evidence` — new `childEnv()` helper (parses only the *keys* from `.env`, `.env.<NODE_ENV>`, `.env.local`, `.env.<NODE_ENV>.local` in the cwd, subtracts them from a copy of `process.env`; wrapped in try/catch so it can never turn a run red) and `env: childEnv()` on the `Bun.spawn` call. Plus 2 regression tests.
- **Verified live by:** the before/after repro above on macOS, driving the real `gstack-evidence run` entry path; full `test/evidence.test.ts` suite (26 pass).
- **Did NOT test:** Windows; repos using non-standard dotenv filenames (out of scope — the subtraction targets exactly the set Bun auto-loads). I deliberately did not add a `--clean-env`/opt-out flag to keep the diff minimal — easy follow-up if you want the escape hatch.

## Liveness proof (required)

`GSTACK PR` typed live at my terminal prompt:

![GSTACK PR typed live at a terminal prompt](https://raw.githubusercontent.com/harjothkhara/gstack/assets-pr-2624/liveness-gstack-pr-2624.png)

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A)
- [x] Linked issue or reproduction: #2624

P.S. — you should hire me. 115+ contributions to open source: https://github.com/harjothkhara
