### PR TITLE
fix(evals): the GITHUB_ prefix no longer admits operator credentials into hermetic children

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,13 +196,18 @@ runner, the Agent SDK runner, plus the codex and gemini runners) spawns its chil
 through `test/helpers/hermetic-env.ts`: an allowlist-scrubbed environment, a fresh
 seeded `CLAUDE_CONFIG_DIR`, a temp `GSTACK_HOME`, and `--strict-mcp-config`. Your
 operator `~/.claude` config, MCP servers (gbrain, Conductor), skills, `~/.gstack`
-decision logs, and `CONDUCTOR_*` env never leak into the child, so local eval
-signal matches CI instead of disagreeing for reasons unrelated to the code under
-test. The hermetic `CLAUDE_CONFIG_DIR` seeds no skills by default; a PTY test
-that types a `/skill` slash command passes `seedSkills: true` to the PTY runner,
-which swaps in `hermeticSkillsConfigDir()` — a seeded skill registry that
-symlinks the LIVE working tree's SKILL.md files (by design: the skills are the
-subject under test, so a snapshot would measure stale copies). Set
+decision logs, `CONDUCTOR_*` env, and your credentials (`GH_TOKEN`,
+`GITHUB_*_TOKEN`, `OPENAI_API_KEY`, `SSH_AUTH_SOCK`, …) never leak into the
+child, so local eval signal matches CI instead of disagreeing for reasons
+unrelated to the code under test. The `GITHUB_`/`EVALS_` prefix rules carry CI
+metadata only — a credential-shaped name (tail segment `TOKEN`, `SECRET`,
+`KEY`, …) is never admitted by a prefix; a runner that genuinely needs one
+names it exactly via `extraAllow`. The hermetic `CLAUDE_CONFIG_DIR` seeds no
+skills by default; a PTY test that types a `/skill` slash command passes
+`seedSkills: true` to the PTY runner, which swaps in
+`hermeticSkillsConfigDir()` — a seeded skill registry that symlinks the LIVE
+working tree's SKILL.md files (by design: the skills are the subject under
+test, so a snapshot would measure stale copies). Set
 `EVALS_HERMETIC=0` to debug against your real operator state (this also
 drops `--strict-mcp-config`). The wiring is pinned by `test/hermetic-wiring.test.ts`
 (a free static tripwire), two gate-tier isolation canaries in

--- a/test/helpers/hermetic-env.test.ts
+++ b/test/helpers/hermetic-env.test.ts
@@ -4,6 +4,8 @@
  * Pins three contracts:
  * 1. Allowlist semantics: contamination vars dropped, basics/auth/network
  *    kept, overrides merge last, EVALS_HERMETIC=0 is byte-identical legacy.
+ *    Includes the credential-shape screen on prefix rules — GITHUB_ is a CI
+ *    metadata prefix, never a way in for GITHUB_TOKEN.
  * 2. Seed-config shape: 20-char key suffix, trusted dirs, undefined-key safe.
  * 3. Dir lifecycle: /.claude suffix (extractPlanFilePath contract —
  *    claude-pty-runner.ts:191), sync singleton reuse, pid-aware GC.
@@ -20,6 +22,7 @@ import {
   getHermeticDirs,
   gcStaleHermeticDirs,
   hermeticChildEnv,
+  isCredentialShapedName,
 } from './hermetic-env';
 
 const CONTAMINATED: NodeJS.ProcessEnv = {
@@ -29,6 +32,9 @@ const CONTAMINATED: NodeJS.ProcessEnv = {
   ANTHROPIC_MODEL: 'sneaky-model-override',
   EVALS_MODEL: 'claude-sonnet-4-6',
   GITHUB_ACTIONS: 'true',
+  GITHUB_TOKEN: 'ghp_operator_write_credential',
+  GITHUB_PERSONAL_ACCESS_TOKEN: 'ghp_operator_pat',
+  GITHUB_APP_PRIVATE_KEY: '-----BEGIN RSA PRIVATE KEY-----',
   HTTPS_PROXY: 'http://corp:3128',
   NODE_EXTRA_CA_CERTS: '/etc/corp.pem',
   CONDUCTOR_WORKSPACE_PATH: '/Users/op/conductor/ws',
@@ -116,6 +122,84 @@ describe('buildHermeticEnv allowlist', () => {
     const base = { ...CONTAMINATED } as NodeJS.ProcessEnv;
     delete base.TERM;
     expect(buildHermeticEnv(base, HERMETIC_VARS).TERM).toBe('xterm-256color');
+  });
+});
+
+describe('prefix rules never admit credential-shaped names', () => {
+  // GH_TOKEN was named in the drop list and pinned above; its sibling
+  // GITHUB_TOKEN matched the GITHUB_ CI-metadata prefix and was kept, so a
+  // local eval child ran with the operator's GitHub write credential. CI never
+  // has that variable (workflows expose the job token as GH_TOKEN), so the
+  // module's own CI-equivalence contract was broken exactly where it counts.
+  const env = buildHermeticEnv(CONTAMINATED, HERMETIC_VARS);
+
+  test('GITHUB_ credentials are dropped even though GITHUB_ is an allowed prefix', () => {
+    for (const k of ['GITHUB_TOKEN', 'GITHUB_PERSONAL_ACCESS_TOKEN', 'GITHUB_APP_PRIVATE_KEY']) {
+      expect(env[k]).toBeUndefined();
+    }
+    // No credential VALUE survives anywhere in the built env, under any name.
+    const serialized = JSON.stringify(env);
+    for (const v of ['ghp_operator_write_credential', 'ghp_operator_pat', 'BEGIN RSA PRIVATE KEY']) {
+      expect(serialized.includes(v)).toBe(false);
+    }
+  });
+
+  test('real GitHub Actions metadata still survives the screen', () => {
+    // The prefix exists for these. Screening must cost none of them — this is
+    // the full documented runner-env set, so a widened rule fails here first.
+    const ACTIONS_METADATA = [
+      'GITHUB_ACTION', 'GITHUB_ACTIONS', 'GITHUB_ACTOR', 'GITHUB_ACTOR_ID',
+      'GITHUB_API_URL', 'GITHUB_BASE_REF', 'GITHUB_ENV', 'GITHUB_EVENT_NAME',
+      'GITHUB_EVENT_PATH', 'GITHUB_GRAPHQL_URL', 'GITHUB_HEAD_REF', 'GITHUB_JOB',
+      'GITHUB_OUTPUT', 'GITHUB_PATH', 'GITHUB_REF', 'GITHUB_REF_NAME',
+      'GITHUB_REF_PROTECTED', 'GITHUB_REF_TYPE', 'GITHUB_REPOSITORY',
+      'GITHUB_REPOSITORY_ID', 'GITHUB_REPOSITORY_OWNER', 'GITHUB_RETENTION_DAYS',
+      'GITHUB_RUN_ATTEMPT', 'GITHUB_RUN_ID', 'GITHUB_RUN_NUMBER',
+      'GITHUB_SERVER_URL', 'GITHUB_SHA', 'GITHUB_STEP_SUMMARY',
+      'GITHUB_TRIGGERING_ACTOR', 'GITHUB_WORKFLOW', 'GITHUB_WORKFLOW_REF',
+      'GITHUB_WORKFLOW_SHA', 'GITHUB_WORKSPACE',
+    ];
+    const base = { ...CONTAMINATED } as NodeJS.ProcessEnv;
+    for (const k of ACTIONS_METADATA) base[k] = `v-${k}`;
+    const e = buildHermeticEnv(base, HERMETIC_VARS);
+    for (const k of ACTIONS_METADATA) expect(e[k]).toBe(`v-${k}`);
+    // Same for every eval knob the harness reads through the EVALS_ prefix.
+    for (const k of ['EVALS_TIER', 'EVALS_RUN_ID', 'EVALS_CONCURRENCY', 'EVALS_SELECTION_JSON']) {
+      base[k] = 'set';
+    }
+    const e2 = buildHermeticEnv(base, HERMETIC_VARS);
+    for (const k of ['EVALS_TIER', 'EVALS_RUN_ID', 'EVALS_CONCURRENCY', 'EVALS_SELECTION_JSON']) {
+      expect(e2[k]).toBe('set');
+    }
+  });
+
+  test('extraAllow still re-admits a runner credential — screen is prefix-rule only', () => {
+    // The gemini runner passes GEMINI_* precisely to carry GEMINI_API_KEY; an
+    // exact ALLOW_EXACT auth name (ANTHROPIC_API_KEY) is equally deliberate.
+    // Screening those would break the documented per-runner opt-in.
+    const base = { ...CONTAMINATED, GEMINI_API_KEY: 'g-secret' } as NodeJS.ProcessEnv;
+    const e = buildHermeticEnv(base, HERMETIC_VARS, undefined, { extraAllow: ['GEMINI_*'] });
+    expect(e.GEMINI_API_KEY).toBe('g-secret');
+    expect(e.ANTHROPIC_API_KEY).toBe(CONTAMINATED.ANTHROPIC_API_KEY);
+    // Opting in to GEMINI_* does not re-open the GITHUB_ hole.
+    expect(e.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  test('isCredentialShapedName matches the tail segment, not a substring', () => {
+    for (const k of [
+      'GITHUB_TOKEN', 'GITHUB_PERSONAL_ACCESS_TOKEN', 'GITHUB_APP_PRIVATE_KEY',
+      'GITHUB_CLIENT_SECRET', 'GITHUB_WEBHOOK_SECRET', 'GITHUB_PAT',
+      'GITHUB_OAUTH_TOKEN', 'TOKEN', 'EVALS_API_KEY',
+    ]) {
+      expect(isCredentialShapedName(k)).toBe(true);
+    }
+    for (const k of [
+      'GITHUB_PATH',        // PATH, not PAT — the near-miss that matters
+      'GITHUB_PATTERN', 'GITHUB_TOKENIZER', 'GITHUB_KEYRING', 'GITHUB_SECRETS_URL',
+      'GITHUB_ACTIONS', 'GITHUB_SHA', 'GITHUB_WORKSPACE', 'EVALS_TIER',
+    ]) {
+      expect(isCredentialShapedName(k)).toBe(false);
+    }
   });
 });
 

--- a/test/helpers/hermetic-env.ts
+++ b/test/helpers/hermetic-env.ts
@@ -17,7 +17,8 @@
  *   │ GSTACK_ANTHROPIC_API_KEY    │── promotedEnv() ─────► ANTHROPIC_API_KEY
  *   │ CONDUCTOR_*, CLAUDECODE,    │
  *   │ CLAUDE_*, GSTACK_*, MCP_*,  │── dropped ───────────► ∅
- *   │ GBRAIN_*, GH_TOKEN, ...     │
+ *   │ GBRAIN_*, GH_TOKEN,         │
+ *   │ GITHUB_*_TOKEN, ...         │
  *   └─────────────────────────────┘
  *      + per-runner extraAllow (codex: OpenAI vars; gemini: Google vars)
  *      + CLAUDE_CONFIG_DIR=<runRoot>/.claude  GSTACK_HOME=<runRoot>/gstack-home
@@ -69,6 +70,44 @@ const ALLOW_EXACT = new Set([
  * opts.extraAllow. */
 const ALLOW_PREFIXES = ['EVALS_', 'GITHUB_'];
 
+/**
+ * Credential words a PREFIX rule must never admit, matched on the LAST
+ * _-delimited segment of the name.
+ *
+ * `GITHUB_` is in ALLOW_PREFIXES for CI metadata (GITHUB_ACTIONS, GITHUB_SHA,
+ * GITHUB_WORKSPACE…), but the same prefix also matches the operator
+ * credentials people actually export locally — GITHUB_TOKEN,
+ * GITHUB_PERSONAL_ACCESS_TOKEN, GITHUB_APP_PRIVATE_KEY. `GH_TOKEN` was named
+ * in the drop list above and pinned by a test; its sibling sailed through the
+ * prefix, so a local eval child ran with the operator's GitHub write
+ * credential in its environment — the exact contamination this module exists
+ * to prevent, and one CI never has (the workflows expose the job token as
+ * GH_TOKEN, which the allowlist already drops). Local signal was therefore
+ * NOT CI-equivalent for the one variable class that matters most.
+ *
+ * A shape rule, not a name denylist: any future GITHUB_*_TOKEN / _SECRET /
+ * _KEY is covered without an edit. Vocabulary matches the credential suffixes
+ * the shipped scanner already uses (ENV_KV_SUFFIX in lib/redact-patterns.ts),
+ * plus PAT. Segment-tail matching keeps real Actions vars: GITHUB_PATH ends in
+ * the segment PATH, not PAT.
+ *
+ * Screened for the module's own prefixes only. An ALLOW_EXACT entry
+ * (ANTHROPIC_API_KEY) or an `opts.extraAllow` entry (the codex runner's
+ * OPENAI_API_KEY, the gemini runner's GEMINI_*) is a deliberate, reviewed
+ * admission by a runner that needs that credential, and still wins.
+ */
+const CREDENTIAL_TAILS = new Set([
+  'KEY', 'KEYS', 'TOKEN', 'TOKENS', 'SECRET', 'SECRETS', 'PASSWORD', 'PASSWD',
+  'PASS', 'CREDENTIAL', 'CREDENTIALS', 'AUTH', 'PAT', 'DSN', 'COOKIE',
+  'SESSION', 'PRIVATE',
+]);
+
+/** True when the last _-delimited segment of `name` is a credential word. */
+export function isCredentialShapedName(name: string): boolean {
+  const segments = name.split('_');
+  return CREDENTIAL_TAILS.has(segments[segments.length - 1].toUpperCase());
+}
+
 export interface HermeticEnvOpts {
   /** Per-runner additional allowed names (exact match) or prefixes (entries
    * ending in '*'). Example: codex runner passes ['OPENAI_API_KEY', 'CODEX_*']. */
@@ -114,7 +153,7 @@ export function buildHermeticEnv(
     const allowed =
       ALLOW_EXACT.has(k) ||
       extraExact.has(k) ||
-      ALLOW_PREFIXES.some((p) => k.startsWith(p)) ||
+      (ALLOW_PREFIXES.some((p) => k.startsWith(p)) && !isCredentialShapedName(k)) ||
       extraPrefixes.some((p) => k.startsWith(p));
     if (allowed) out[k] = v;
   }


### PR DESCRIPTION
## Why (in your own words)

CONTRIBUTING promises that when you run evals locally, "your operator `~/.claude`
config, MCP servers, skills, `~/.gstack` decision logs, and `CONDUCTOR_*` env never
leak into the child, so local eval signal matches CI". `test/helpers/hermetic-env.ts`
enforces that with an allowlist, and it deliberately drops operator credentials —
`GH_TOKEN`, `OPENAI_API_KEY`, `SSH_AUTH_SOCK` are named in the module doc and pinned
by `hermetic-env.test.ts`.

But the allowlist also has prefix rules, `ALLOW_PREFIXES = ['EVALS_', 'GITHUB_']`,
and `GITHUB_` is there for CI metadata (`GITHUB_ACTIONS`, `GITHUB_SHA`,
`GITHUB_WORKSPACE`). That same prefix matches the credentials developers actually
export in their shells: `GITHUB_TOKEN`, `GITHUB_PERSONAL_ACCESS_TOKEN`,
`GITHUB_APP_PRIVATE_KEY`. So `GH_TOKEN` was blocked and its sibling walked straight
through, and every locally-spawned eval child — `claude -p`, the PTY runner, the
Agent SDK runner, codex, gemini — ran with the operator's GitHub *write* credential
in its environment.

This is also precisely a CI-equivalence failure, which is the module's whole reason
to exist: no workflow in `.github/workflows/` sets an env var named `GITHUB_TOKEN`
(the job token is passed as `GH_TOKEN`, which the allowlist already drops), so CI
children never had it. Only local children did. The repo already treats this exact
variable as a hazard elsewhere — `test/free-tests-workflow-wiring.test.ts` pins
`persist-credentials: false` because "a default-grant GITHUB_TOKEN persisted into
.git/config by checkout would hand that code whatever the repo default allows."
Handing it to the eval child directly is the same threat, one layer over.

The fix screens prefix admissions by name shape instead of adding names to a
denylist, so a future `GITHUB_*_TOKEN` needs no edit.

## Live evidence

**1. On my real shell — before and after.** Names only, no values printed. I have
`GITHUB_PERSONAL_ACCESS_TOKEN` exported, like a lot of people do.

```
$ bun .probe/real-env.ts            # on main
kept from THIS shell: GITHUB_PERSONAL_ACCESS_TOKEN, HOME, PATH, SHELL, TERM
credential-shaped among them: GITHUB_PERSONAL_ACCESS_TOKEN

$ bun .probe/real-env.ts            # on this branch
kept from THIS shell: HOME, PATH, SHELL, TERM
credential-shaped among them: (none)
```

**2. Synthetic operator env — the leak and the metadata that must survive it.**

```
$ bun .probe/leak-repro.ts          # on main
dropped  GH_TOKEN
KEPT     GITHUB_TOKEN                    <-- operator write credential
KEPT     GITHUB_PERSONAL_ACCESS_TOKEN    <-- operator PAT
KEPT     GITHUB_APP_PRIVATE_KEY          <-- app private key
KEPT     GITHUB_ACTIONS
KEPT     GITHUB_SHA
KEPT     GITHUB_PATH
KEPT     GITHUB_WORKSPACE

$ bun .probe/leak-repro.ts          # on this branch
dropped  GH_TOKEN
dropped  GITHUB_TOKEN
dropped  GITHUB_PERSONAL_ACCESS_TOKEN
dropped  GITHUB_APP_PRIVATE_KEY
KEPT     GITHUB_ACTIONS
KEPT     GITHUB_SHA
KEPT     GITHUB_PATH                     <-- PATH, not PAT: the near-miss holds
KEPT     GITHUB_WORKSPACE
```

**3. Red / green on the new tripwires.** Reverting only the screen (keeping the
exported predicate so the file still imports) turns the new tests red:

```
$ bun test test/helpers/hermetic-env.test.ts     # screen reverted
(fail) prefix rules never admit credential-shaped names > GITHUB_ credentials are dropped even though GITHUB_ is an allowed prefix
(fail) prefix rules never admit credential-shaped names > extraAllow still re-admits a runner credential — screen is prefix-rule only
 22 pass
 2 fail

$ bun test test/helpers/hermetic-env.test.ts     # branch as submitted
 24 pass
 0 fail
 131 expect() calls
```

**4. No regressions in the hermetic surface.** Every test file that touches the
module, main vs branch, same machine, back to back:

```
$ bun test test/helpers/hermetic-env.test.ts test/hermetic-wiring.test.ts \
      test/hermetic-skills-seeding.test.ts test/pty-skill-seeding-wiring.test.ts \
      test/helpers/session-runner.test.ts test/helpers/gemini-session-runner.test.ts

main    45 pass, 2 fail
branch  49 pass, 2 fail      (+4 = the new tests)
```

The 2 failures are identical on both sides and pre-existing on Windows —
`EPERM: operation not permitted, symlink` in `hermeticSkillsConfigDir`, which needs
Developer Mode or an elevated shell. Untouched by this change.

## Scope

- **Changed:**
  - `test/helpers/hermetic-env.ts` — prefix admissions are screened by
    `isCredentialShapedName()` (new, exported). The last `_`-delimited segment of the
    name is checked against the credential vocabulary the shipped scanner already uses
    (`ENV_KV_SUFFIX` in `lib/redact-patterns.ts`), plus `PAT`. Screened for the
    module's own `ALLOW_PREFIXES` only — an `ALLOW_EXACT` entry (`ANTHROPIC_API_KEY`)
    or an `opts.extraAllow` entry (codex's `OPENAI_API_KEY`, gemini's `GEMINI_*`) is a
    deliberate per-runner admission and still wins, so the documented opt-in keeps
    working.
  - `test/helpers/hermetic-env.test.ts` — 4 tests: the credentials are dropped and no
    credential *value* survives under any name; the full documented GitHub Actions
    runner-env set plus the `EVALS_*` knobs still survive the screen; `extraAllow`
    still re-admits `GEMINI_API_KEY` without re-opening the `GITHUB_` hole;
    `isCredentialShapedName` matches the tail segment, not a substring
    (`GITHUB_PATH`, `GITHUB_TOKENIZER`, `GITHUB_KEYRING` all stay allowed).
  - `CONTRIBUTING.md` — the "Hermetic by default" paragraph claims credentials never
    leak; it now says so explicitly and states the prefix-vs-exact rule.

- **Verified live by:** running the reproduction above on my own shell (Windows 11,
  Git Bash, bun 1.3.14) against main and against this branch; red/green on the new
  tripwires; before/after comparison of every hermetic-touching test file.

- **Did NOT test:** a paid eval run. This changes only which variables reach the
  child, and no test helper, runner, or workflow in the repo reads `GITHUB_TOKEN` —
  `grep -rn GITHUB_TOKEN test/ scripts/ lib/ bin/` returns nothing outside
  `.github/workflows/`, where it appears only as `secrets.GITHUB_TOKEN` passed to
  `password:` or to a `GH_TOKEN:` env. Windows note: I could not use the full
  `bun run test` suite as a gate — it reports ~1100 pre-existing failures on a clean
  clone here (#2597), so I compared the affected file set directly instead.

## Liveness proof (required)

`GSTACK PR` typed live at a real PowerShell prompt on my machine — the shell's own
`CommandNotFoundException` is the proof it was parsed, not painted on.

![GSTACK PR typed live into Windows PowerShell](https://raw.githubusercontent.com/ntdatt812/gstack/liveness-asset/pr-liveness.png)

<sub>Hosted on a separate `liveness-asset` branch of my fork so the PR diff stays at
the three files above.</sub>

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A) — N/A
- [ ] Linked issue or reproduction: reproduction in "Live evidence" above (no issue filed — found while setting up the repo on Windows)
