### PR TITLE
fix(browse): keep the terminal-agent alive past the CLI that spawns it

### DIFF
--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -134,6 +134,11 @@ globalThis.Bun = {
       stdio,
       env: options.env,
       cwd: options.cwd,
+      // Forwarded for the same reason as windowsHide: a caller that asks for
+      // a child outliving it (spawnTerminalAgent, #2637) gets Node's default
+      // of "dies with the parent" on this path unless the flag crosses the
+      // shim. Defaults to false, matching both Node and Bun.
+      detached: options.detached === true,
       // stdio:'ignore' silences a child's output but does not suppress its
       // console window on Windows. The terminal-agent respawn (server.ts
       // watchdog, 60s ticker) popped a visible bun.exe window on every

--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -1406,6 +1406,12 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
         const newPid = spawnTerminalAgent({
           stateFile: config.stateFile,
           serverPort: newState.port,
+          // The daemon, not this CLI process: the CLI exits within seconds,
+          // and the agent's owner watchdog is what reaps it when the server
+          // it serves goes away. Omitting this sent the literal string
+          // "undefined" through BROWSE_OWNER_PID, which parses to NaN and
+          // leaves the watchdog inert for every CLI-spawned agent (#2637).
+          ownerPid: newState.pid,
           cwd: config.projectDir,
         });
         if (newPid) {
@@ -1498,6 +1504,7 @@ Refs:           After 'snapshot', use @e1, @e2... as selectors:
           spawnTerminalAgent({
             stateFile: config.stateFile,
             serverPort: respawned.port,
+            ownerPid: respawned.pid,
             cwd: config.projectDir,
           });
         } catch (err: any) {

--- a/browse/src/terminal-agent-control.ts
+++ b/browse/src/terminal-agent-control.ts
@@ -50,6 +50,17 @@ export function resolveTerminalAgentScript(searchHints: { metaDir?: string; exec
  * Used by both the CLI cold-start path (cli.ts) and the v1.44 watchdog in
  * server.ts. Centralizing here removes a copy-paste between them and means
  * spawn-env additions (BROWSE_OWNER_PID being the first) land in one place.
+ *
+ * "Detached" is load-bearing, not decorative (#2637). The CLI exits seconds
+ * after `connect` prints its status, and on Windows a child goes down with
+ * its parent's console/job object unless it was spawned detached —
+ * `proc.unref()` does not cover that. Without it the agent named in
+ * "Terminal agent started (PID: N)" is already dead when the sidebar asks
+ * for a terminal: `terminal-port` is never written and /pty-session answers
+ * 503 "terminal-agent not ready" until the 60s watchdog in server.ts
+ * respawns the agent under the (detached) daemon. What reaps a detached
+ * agent is `ownerPid` — the owner watchdog in terminal-agent.ts, which is
+ * why that field is required rather than optional.
  */
 export function spawnTerminalAgent(opts: {
   stateFile: string;
@@ -80,6 +91,8 @@ export function spawnTerminalAgent(opts: {
       ...(opts.extraEnv || {}),
     },
     stdio: ['ignore', 'ignore', 'ignore'],
+    // Outlives its spawner — see the doc comment above (#2637).
+    detached: true,
     // Explicit for the Node fallback path (dist/bun-polyfill.cjs), where the
     // host default is the opposite of Bun's. A visible console window on every
     // watchdog respawn is the symptom when this is missing.

--- a/browse/test/terminal-agent-detached-spawn.test.ts
+++ b/browse/test/terminal-agent-detached-spawn.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression pins for #2637: the terminal-agent must outlive the process that
+ * spawned it, and must know which server owns it.
+ *
+ * Two defects sat behind one symptom. `browse connect` spawns the agent and
+ * exits seconds later; on Windows the child went down with the CLI's
+ * console/job object because the spawn never asked to be detached, so
+ * `terminal-port` was never written and the sidebar 503'd with
+ * "terminal-agent not ready" until the 60s watchdog respawned the agent under
+ * the (detached) server. Underneath that, both CLI call sites omitted
+ * `ownerPid`, which reached the child as the string "undefined" and left the
+ * owner watchdog inert — the orphan class the owner-PID tie exists to close.
+ *
+ * Static tripwires here, process-boundary proof in the behavioral test below.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const SRC_DIR = path.join(import.meta.dir, '../src');
+const SRC = (f: string) => fs.readFileSync(path.join(SRC_DIR, f), 'utf-8');
+
+/** Same convention as windows-spawn-hide.test.ts: documented history must
+ *  not trip a source assertion, and prose must not push a flag out of a
+ *  fixed-size match window. */
+const stripComments = (src: string) =>
+  src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+const spawned: any[] = [];
+const tempDirs: string[] = [];
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 10_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await Bun.sleep(25);
+  }
+  return predicate();
+}
+
+afterEach(() => {
+  for (const proc of spawned.splice(0)) {
+    try { proc.kill?.('SIGKILL'); } catch {}
+  }
+  for (const dir of tempDirs.splice(0)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  }
+});
+
+describe('terminal-agent spawn lifecycle (#2637)', () => {
+  test('spawnTerminalAgent asks for a detached child', () => {
+    // Comments stripped first: the flags carry long explanations, and a
+    // window sized around prose is a window that breaks on the next edit.
+    const src = stripComments(SRC('terminal-agent-control.ts'));
+    const idx = src.indexOf('(Bun as any).spawn(');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(src.slice(idx, idx + 500)).toMatch(/detached:\s*true/);
+  });
+
+  test('the Node polyfill forwards detached instead of dropping it', () => {
+    // dist/bun-polyfill.cjs is the Windows server-side runtime. A flag the
+    // shim swallows is a flag the watchdog respawn path silently loses.
+    const src = stripComments(SRC('bun-polyfill.cjs'));
+    const idx = src.indexOf('spawn(cmd, options = {})');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(src.slice(idx, idx + 500)).toMatch(/detached:\s*options\.detached\s*===\s*true/);
+  });
+
+  test('SWEEP: every spawnTerminalAgent call site passes ownerPid', () => {
+    // Census, not a fixed list: a new call site that forgets ownerPid fails
+    // here rather than shipping an agent whose owner watchdog never arms.
+    const offenders: string[] = [];
+    for (const file of fs.readdirSync(SRC_DIR).filter((f) => f.endsWith('.ts'))) {
+      const raw = fs.readFileSync(path.join(SRC_DIR, file), 'utf-8');
+      const code = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+      const re = /spawnTerminalAgent\(\{/g;
+      for (const m of code.matchAll(re)) {
+        const slice = code.slice(m.index!, m.index! + 500);
+        const call = slice.slice(0, slice.indexOf('});') + 3);
+        if (!/ownerPid:/.test(call)) {
+          offenders.push(`${file}: ${call.split('\n').slice(0, 2).join(' ').trim()}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test('the agent outlives the process that spawned it', async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-term-detach-'));
+    tempDirs.push(stateDir);
+    const stateFile = path.join(stateDir, 'browse.json');
+    fs.writeFileSync(stateFile, JSON.stringify({ token: 'test-token' }));
+
+    // A spawner that starts the agent and exits immediately — the shape of
+    // `browse connect`. The owner is THIS test process (a stand-in for the
+    // long-lived daemon), not the spawner, so the owner watchdog stays armed
+    // and the only thing that could take the agent down is losing its parent.
+    const spawnerPath = path.join(stateDir, 'spawner.ts');
+    const controlPath = path.join(SRC_DIR, 'terminal-agent-control.ts').split(path.sep).join('/');
+    fs.writeFileSync(spawnerPath, [
+      `import { spawnTerminalAgent } from ${JSON.stringify(controlPath)};`,
+      `const pid = spawnTerminalAgent({`,
+      `  stateFile: ${JSON.stringify(stateFile)},`,
+      `  serverPort: 0,`,
+      `  ownerPid: Number(process.env.OWNER_PID),`,
+      `  cwd: ${JSON.stringify(stateDir)},`,
+      `});`,
+      `console.log(String(pid ?? ''));`,
+    ].join('\n'));
+
+    const spawner = Bun.spawn(['bun', 'run', spawnerPath], {
+      env: { ...process.env, OWNER_PID: String(process.pid) },
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    spawned.push(spawner);
+    const out = (await new Response(spawner.stdout).text()).trim();
+    await spawner.exited;
+
+    const agentPid = Number(out);
+    expect(Number.isFinite(agentPid)).toBe(true);
+    expect(agentPid).toBeGreaterThan(0);
+    spawned.push({ kill: () => { try { process.kill(agentPid, 'SIGKILL'); } catch {} } });
+
+    // The spawner is gone. The agent must still be here and must have
+    // published the port the sidebar's /pty-session gate reads.
+    expect(isAlive(spawner.pid!)).toBe(false);
+    const portFile = path.join(stateDir, 'terminal-port');
+    expect(await waitFor(() => fs.existsSync(portFile))).toBe(true);
+    expect(isAlive(agentPid)).toBe(true);
+
+    const port = parseInt(fs.readFileSync(portFile, 'utf-8').trim(), 10);
+    expect(Number.isFinite(port)).toBe(true);
+    expect(port).toBeGreaterThan(0);
+  }, 30_000);
+});


### PR DESCRIPTION
Fixes #2637.

## Why (in your own words)

On Windows the sidebar Terminal pane is broken for the first ~20-60s of every session. `browse connect` prints `Terminal agent started (PID: N)`, then exits — and the agent goes down with it, because the spawn never asked to be detached. `terminal-port` is never written, so `/pty-session` answers `503 terminal-agent not ready` and the pane shows `Cannot start: 503 {"error":"terminal-agent not ready"}`. The only reason the terminal ever works is the 60s watchdog in `server.ts` respawning the agent under the detached daemon, where it survives. So the agent gets spawned at least twice per session and the PID `connect` reports is always dead.

Underneath that, both CLI call sites omitted `ownerPid`, which the helper declares as required. It reached the child as the string `"undefined"`, `parseInt` gave `NaN`, and the `BROWSE_OWNER_PID > 0` guard left the owner watchdog inert for every CLI-spawned agent. That one is not Windows-specific: on macOS and Linux the CLI-spawned agent already survived, so it has been running with no owner watchdog — exactly the "adopted by PID 1 and live forever" orphan the owner-PID tie was added to prevent.

The two are entangled, which is why they land together: detaching without arming the owner watchdog would trade a dead agent for an immortal one.

## Live evidence

Before, on `main` (Windows 11 26200, gstack 1.67.2.0):

```
$ browse connect
Connected to real Chrome
Status: healthy
Mode: headed
PID: 11156
[browse] Terminal agent started (PID: 29976)

$ tasklist /FI "PID eq 29976"
INFO: No tasks are running which match the specified criteria.

$ ls .gstack/terminal-port
ls: cannot access '.gstack/terminal-port': No such file or directory
```

Sidebar at that moment: `Cannot start: 503 {"error":"terminal-agent not ready"}`. ~60s later the watchdog covers for it:

```
$ tail -1 .gstack/browse-daemon.log
[browse] terminal-agent respawned by watchdog (PID: 27056)
```

Isolating it — same argv and env, spawned from a parent that stays alive, gives a healthy agent, so the agent itself was never the problem:

```
pid: 36384
OUT: [terminal-agent] listening on 127.0.0.1:16190 pid=36384 gen=MTu56F6PjVR8P0UMqhBCqQ
still alive after 8s
```

And a direct A/B of the flag under real Bun on Windows — one child spawned with `detached: true`, one without, both `unref()`'d, parent exits immediately:

```
detached child pid=26860
plain child pid=8216

# after the parent and its shell are gone:
$ tasklist /FI "PID eq 26860"
bun.exe                      26860 Console                    1     57,348 K
$ tasklist /FI "PID eq 8216"
INFO: No tasks are running which match the specified criteria.
```

The plain child died before it reached its first write. `unref()` alone does not cover this.

After, with the rebuilt binary on the same machine:

```
$ browse connect
Connected to real Chrome
Status: healthy
Mode: headed
PID: 36924
[browse] Terminal agent started (PID: 41652)

$ tasklist /FI "PID eq 41652"
bun.exe                      41652 Console                    1     65,768 K

$ cat .gstack/terminal-port          # ~250ms after connect returned
48170
$ cat .gstack/terminal-agent-pid
{"pid":41652,"gen":"s9REM2t_OY7X6GD3Zx4eOw","startedAt":1787113308756}
```

The PID `connect` names is now the PID that serves the terminal. The port lands about a quarter second after the command returns — the agent's own boot time — instead of one watchdog tick later, so the sidebar's first `/pty-session` finds it and the 503 window is gone.

And the owner watchdog, which was inert on this path, now reaps the agent when the daemon it serves goes away:

```
$ taskkill /PID 36924 /F      # kill the daemon that owns the agent
SUCCESS: The process with PID 36924 has been terminated.

# ~10s later (watchdog interval is 15s):
$ tasklist /FI "PID eq 41652"
INFO: No tasks are running which match the specified criteria.

$ ls .gstack/ | grep terminal
                              # terminal-port and terminal-agent-pid both removed
```

Regression tests, red on `main` and green with the fix:

```
BEFORE (fix reverted, tests kept):
 0 pass
 4 fail
Ran 4 tests across 1 file. [10.10s]

AFTER:
 4 pass
 0 fail
Ran 4 tests across 1 file. [249.00ms]
```

The behavioral one is a real process-boundary test, not a source grep: it spawns the agent from a process that then exits, with a long-lived third process as the owner, and asserts the agent is still alive and has published its port. On unfixed code it fails by timing out waiting for `terminal-port` — the same way the bug presents.

Full free suite (`bun run test`) on this Windows machine: 13 failures across `test/gen-skill-docs.test.ts`, `test/host-config.test.ts`, and `test/skill-validation.test.ts`. All 13 reproduce identically on a pristine `main` checkout here (808 pass / 13 fail, same three files), so they are pre-existing Windows-environment failures — `bin/gstack-slug` not being executable on Windows, host mktemp templates, generated-file freshness. None of them touch `browse/`.

One other thing worth flagging, unrelated to this change: the run exits 124 because a shard hangs. The hang is an orphaned `design/src/daemon.ts` that survives its test and holds the run's stdout pipe open. Killing that PID lets the run flush and finish. Happy to file it separately.

## Scope

- **Changed:** `detached: true` on the agent spawn in `terminal-agent-control.ts`; `detached` forwarded through the `Bun.spawn` shim in `bun-polyfill.cjs` (the Windows server-side runtime, which otherwise swallows it); `ownerPid` passed at both `cli.ts` call sites (connect + supervisor respawn). Plus `browse/test/terminal-agent-detached-spawn.test.ts`.
- **Verified live by:** rebuilding the binary and running `browse connect` on Windows 11 (26200) with the sidebar open — see above.
- **Did NOT test:** macOS and Linux. On POSIX the detach is a deliberate behavior change (the agent lands in its own process group, so a Ctrl-C in the CLI's terminal no longer reaches it); the now-armed owner watchdog is what reaps it instead. Also untested: the supervisor respawn path at `cli.ts:1504`, which is the same call shape as connect but needs a daemon crash to reach.

## Liveness proof (required)

_Screenshot to be attached by me in a follow-up comment._

## Checklist

- [ ] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A) — N/A, no new surface
- [x] Linked issue or reproduction: #2637
