### PR TITLE
fix(redact): tolerate EEXIST from recursive mkdir in install-prepush-hook on bun/Windows

### DIFF
--- a/bin/gstack-redact
+++ b/bin/gstack-redact
@@ -37,6 +37,7 @@ import {
   type ScanOptions,
   type Finding,
 } from "../lib/redact-engine";
+import { mkdirpSync } from "../lib/fs-utils";
 
 const MAX_STDIN_BYTES = 16 * 1024 * 1024; // hard ceiling before the engine cap
 
@@ -55,7 +56,9 @@ function hooksPath(): string {
 
 function installPrepushHook(): void {
   const dir = hooksPath();
-  fs.mkdirSync(dir, { recursive: true });
+  // mkdirpSync, not bare mkdirSync: bun on Windows throws EEXIST from a
+  // recursive mkdir when .git/hooks already exists (#2635).
+  mkdirpSync(dir);
   const hookPath = path.join(dir, "pre-push");
   const prepushBin = path.join(import.meta.dir, "gstack-redact-prepush");
 

--- a/lib/fs-utils.ts
+++ b/lib/fs-utils.ts
@@ -1,0 +1,27 @@
+import { mkdirSync, statSync } from "fs";
+
+/**
+ * mkdir -p that tolerates the target directory already existing.
+ *
+ * Node's mkdirSync(dir, { recursive: true }) is a no-op when dir already
+ * exists, but bun on Windows throws EEXIST in the same situation (#2635),
+ * which crashed `gstack-redact install-prepush-hook` on any repo whose
+ * .git/hooks already existed. Swallow EEXIST only when statSync confirms the
+ * path is an existing directory; anything else - a regular file occupying the
+ * path, a stat failure, a different errno - rethrows the original error, so a
+ * real collision still fails loudly.
+ */
+export function mkdirpSync(dir: string): void {
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException | null)?.code === "EEXIST") {
+      try {
+        if (statSync(dir).isDirectory()) return;
+      } catch {
+        // stat failed - fall through and rethrow the original mkdir error
+      }
+    }
+    throw e;
+  }
+}

--- a/test/fs-utils.test.ts
+++ b/test/fs-utils.test.ts
@@ -1,0 +1,90 @@
+/**
+ * mkdirpSync + install-prepush-hook under bun-on-Windows EEXIST semantics
+ * (#2635).
+ *
+ * bun on Windows throws EEXIST from fs.mkdirSync(dir, { recursive: true })
+ * when dir already exists - Node treats it as a no-op - which crashed
+ * `gstack-redact install-prepush-hook` on any repo whose .git/hooks already
+ * existed. The CLI regression test below emulates those Windows semantics via
+ * a `bun --preload` fixture (test/helpers/emulate-bun-windows-eexist.ts), so
+ * the crash path runs on any platform, including CI Linux.
+ */
+import { describe, test, expect } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+import { mkdirpSync } from "../lib/fs-utils";
+
+const REDACT = path.resolve(import.meta.dir, "..", "bin", "gstack-redact");
+const EEXIST_PRELOAD = path.resolve(
+  import.meta.dir,
+  "helpers",
+  "emulate-bun-windows-eexist.ts",
+);
+
+function tmpdir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "fs-utils-"));
+}
+
+describe("mkdirpSync", () => {
+  test("creates missing nested directories", () => {
+    const base = tmpdir();
+    try {
+      const dir = path.join(base, "a", "b", "c");
+      mkdirpSync(dir);
+      expect(fs.statSync(dir).isDirectory()).toBe(true);
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("tolerates the directory already existing", () => {
+    const base = tmpdir();
+    try {
+      mkdirpSync(base); // exists -> must be a no-op, not EEXIST
+      mkdirpSync(base); // and idempotent on repeat calls
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("still throws EEXIST when a regular file occupies the path", () => {
+    const base = tmpdir();
+    try {
+      const file = path.join(base, "occupied");
+      fs.writeFileSync(file, "x");
+      expect(() => mkdirpSync(file)).toThrow(/EEXIST/);
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("install-prepush-hook under bun-on-Windows EEXIST semantics (#2635)", () => {
+  test("install succeeds when .git/hooks already exists, existing hook preserved", () => {
+    const base = tmpdir();
+    try {
+      const repo = path.join(base, "repo");
+      spawnSync("git", ["init", "-q", repo]);
+      const hookDir = path.join(repo, ".git", "hooks");
+      fs.mkdirSync(hookDir, { recursive: true });
+      const hookPath = path.join(hookDir, "pre-push");
+      fs.writeFileSync(hookPath, "#!/usr/bin/env bash\necho mine\n", { mode: 0o755 });
+
+      // Under the emulated bun-on-Windows fs, the bare
+      // fs.mkdirSync(dir, { recursive: true }) in installPrepushHook() throws
+      // EEXIST (the #2635 crash). With mkdirpSync it must install cleanly.
+      const r = spawnSync("bun", ["--preload", EEXIST_PRELOAD, REDACT, "install-prepush-hook"], {
+        cwd: repo,
+        encoding: "utf8",
+      });
+      expect(r.status).toBe(0);
+      expect(r.stderr ?? "").not.toContain("EEXIST");
+      expect(fs.readFileSync(hookPath, "utf8")).toContain("gstack-redact pre-push (managed)");
+      expect(fs.readFileSync(path.join(hookDir, "pre-push.local"), "utf8")).toContain("echo mine");
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/helpers/emulate-bun-windows-eexist.ts
+++ b/test/helpers/emulate-bun-windows-eexist.ts
@@ -1,0 +1,20 @@
+/**
+ * Bun --preload fixture that emulates bun-on-Windows fs.mkdirSync semantics
+ * (see #2635): a recursive mkdir on an already-existing directory throws
+ * EEXIST, where Node (and bun on Linux/macOS) treat it as a no-op success.
+ *
+ * Loaded into a child process with `bun --preload <this file> <script>`, it
+ * lets the #2635 regression test exercise the exact Windows crash path on any
+ * platform. The patch is deliberately transparent - it changes nothing except
+ * throwing EEXIST where Windows bun would.
+ */
+const fs = require("fs");
+const orig = fs.mkdirSync;
+fs.mkdirSync = (p: string, opts: any) => {
+  if (opts?.recursive && fs.existsSync(p) && fs.statSync(p).isDirectory()) {
+    const e = new Error(`EEXIST: file already exists, mkdir '${p}'`);
+    (e as any).code = "EEXIST";
+    throw e;
+  }
+  return orig(p, opts);
+};


### PR DESCRIPTION
**Linked issue**: #2635

## Why (in your own words)

On Windows, bun's `fs.mkdirSync(dir, { recursive: true })` throws `EEXIST` when the directory already exists - Node treats the same call as a no-op. Since virtually every real repo already has a `.git/hooks` directory, `gstack-redact install-prepush-hook` crashes on Windows before writing the hook, leaving the repo without the credential-scan guard while the operator believes it is armed (#2635). This change makes that one mkdir defensive: `EEXIST` is tolerated only when the path is confirmed to be an existing directory; a regular file occupying the path, a stat failure, or any other errno still throws, so real collisions still fail loudly.

## Live evidence

`bun --preload` fixture (committed as `test/helpers/emulate-bun-windows-eexist.ts`) emulates bun-on-Windows `mkdirSync` semantics - recursive mkdir on an existing directory throws EEXIST - so the exact crash path runs on any platform. Transparent emulation; no other fs behavior is altered.

Before (baseline `main` @ 9da66929, in a repo with pre-existing `.git/hooks` + a non-managed `pre-push`):

```
$ bun --preload test/helpers/emulate-bun-windows-eexist.ts bin/gstack-redact install-prepush-hook
EEXIST: file already exists, mkdir '.git/hooks'
 code: "EEXIST"
      at installPrepushHook (bin/gstack-redact:58:6)
exit=1            # hook never written; repo left unguarded
```

After (this fix, same repo setup):

```
$ bun --preload test/helpers/emulate-bun-windows-eexist.ts bin/gstack-redact install-prepush-hook
gstack-redact: preserved existing hook as pre-push.local (chained).
gstack-redact: installed pre-push hook at .git/hooks/pre-push
exit=0            # managed hook written; original preserved as pre-push.local
```

Committed regression test (`test/fs-utils.test.ts`) reproduces the above at test level and fails on baseline / passes on the fix; unit tests additionally pin that a regular file occupying the mkdir path still throws `EEXIST`.

## Scope

- **Changed:** `bin/gstack-redact` (`installPrepushHook` uses the new helper), `lib/fs-utils.ts` (new `mkdirpSync`), `test/fs-utils.test.ts` + `test/helpers/emulate-bun-windows-eexist.ts` (new tests).
- **Verified live by:** the before/after CLI run above; `bun test test/fs-utils.test.ts` (4/4); `bun test test/redact-prepush-hook.test.ts test/gstack-redact-cli.test.ts` (41/41, install/uninstall/chaining unchanged); full free suite `bun run test` - no new failures (5 pre-existing `browse/test/*` failures reproduce on clean `main`, browser-launch environmental).
- **Did NOT test:** a real Windows machine (none available). The Windows crash path is exercised through the transparent `--preload` emulation above; the issue reporter's stack trace matches it frame-for-frame.

## Checklist

- [x] Not a generated-file-only diff(pure source + tests)
- [x] No ETHOS.md edits, no voice / founder perspective / YC changes
- [x] No new public command / external service / host adapter(N/A)
- [x] Linked issue: #2635

## Notes

- Deliberately scoped to the one call site from #2635. The same bare `mkdirSync(recursive)` pattern exists elsewhere (e.g. #2048's `browse`/`mkdirSecure`, and open PR #2329 adds a `mkdirpSync` under `scripts/` for the doc generators) - if you'd rather unify, `lib/fs-utils.ts` is a natural home and I'm happy to extend it in a follow-up.
