### PR TITLE
fix(browse): set windowsHide on the Node Bun.spawn polyfill

### DIFF
--- a/browse/src/bun-polyfill.cjs
+++ b/browse/src/bun-polyfill.cjs
@@ -75,6 +75,7 @@ globalThis.Bun = {
       timeout: options.timeout,
       env: options.env,
       cwd: options.cwd,
+      windowsHide: true,
     });
 
     return {
@@ -91,6 +92,7 @@ globalThis.Bun = {
       stdio,
       env: options.env,
       cwd: options.cwd,
+      windowsHide: true,
     });
 
     return {


### PR DESCRIPTION
On Windows the browse server runs under Node (detached, stdio ignore), so it has no console. Bun.spawn is shimmed to child_process.spawn in bun-polyfill.cjs without windowsHide, so spawning 'bun run terminal-agent.ts' makes Windows allocate a fresh console — a Windows Terminal window titled C:\\Users\\<user>\\.bun\\bin\\bun.exe that stays open for the life of the agent and stacks up on every respawn.

<!--
gstack is AI-coded and proud of it. The bar is EVIDENCE OF REAL USE, not lines
of code. A PR with no proof behind it gets closed, no matter how clean it looks.
Fill every section below. See CONTRIBUTING.md → "The evidence bar".
-->

## Why (in your own words)

<!-- One paragraph: what breaks for a user today, and what this change does about
it. Not a restatement of the diff. -->

## Live evidence

<!-- REQUIRED. Paste the command(s) you ran and their real output — before and
after. For a bug: the reproduction, failing then fixed. For a skill change: the
actual transcript / `claude -p` output. For anything visual: before/after
screenshots. "bun test passes" alone is not enough — show the behavior you
changed. -->

```
# what you ran + what it produced
```

## Scope

- **Changed:**
- **Verified live by:**
- **Did NOT test:**

## Liveness proof (required)

<!-- Attach a screenshot of your own machine with the text `GSTACK PR` typed LIVE
into a real surface — terminal prompt, a shell command, your browser
address/search bar, an editor buffer. It must be TYPED INTO A LIVE UI, not drawn,
overlaid, or edited onto the image. A painted-on `GSTACK PR` is an automatic
close. This confirms a human opened this PR. -->

## Checklist

- [ ] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [ ] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [ ] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [ ] New public command / external service / host adapter has an accepted issue linked (or N/A)
- [ ] Linked issue or reproduction: #
