### PR TITLE
fix(setup): install namespaced /gstack-review OpenCode command without shadowing the builtin /review

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Or target a specific agent with `./setup --host <name>`:
 | Agent | Flag | What you get |
 |-------|------|--------------|
 | OpenAI Codex CLI | `--host codex` | Full install → `${CODEX_HOME:-~/.codex}/skills/gstack-*/` |
-| OpenCode | `--host opencode` | Full install → `~/.config/opencode/skills/gstack-*/` |
+| OpenCode | `--host opencode` | Full install → `~/.config/opencode/skills/gstack-*/` + `~/.config/opencode/commands/gstack-review.md` |
 | Cursor | `--host cursor` | Full install → `~/.cursor/skills/gstack-*/` |
 | Factory Droid | `--host factory` | Full install → `~/.factory/skills/gstack-*/` |
 | Kiro | `--host kiro` | Full install → `~/.kiro/skills/gstack-*/` |
@@ -405,6 +405,7 @@ rm -rf ~/.kiro/skills/gstack* 2>/dev/null
 rm -rf ~/.openclaw/skills/gstack* 2>/dev/null
 rm -rf ~/.cursor/skills/gstack* 2>/dev/null
 rm -rf ~/.config/opencode/skills/gstack* 2>/dev/null
+rm -f ~/.config/opencode/commands/gstack-review.md 2>/dev/null
 
 # 6. Remove temp files
 rm -f /tmp/gstack-* 2>/dev/null

--- a/setup
+++ b/setup
@@ -70,6 +70,7 @@ FACTORY_SKILLS="$HOME/.factory/skills"
 FACTORY_GSTACK="$FACTORY_SKILLS/gstack"
 OPENCODE_SKILLS="$HOME/.config/opencode/skills"
 OPENCODE_GSTACK="$OPENCODE_SKILLS/gstack"
+OPENCODE_COMMANDS="$HOME/.config/opencode/commands"
 CURSOR_SKILLS="$HOME/.cursor/skills"
 CURSOR_GSTACK="$CURSOR_SKILLS/gstack"
 
@@ -1495,6 +1496,45 @@ link_opencode_skill_dirs() {
   fi
 }
 
+# OpenCode 1.18.3 ships builtin /review (subtask: true) which shadows a skill
+# whose frontmatter name is `review`. Do not write commands/review.md — that
+# would steal the builtin. Write a namespaced file so /gstack-review loads
+# the skill by its short name. Same for `init`. Non-colliding skills already
+# register as slash commands from the skill itself.
+install_opencode_collision_commands() {
+  local skills_dir="$1"
+  local commands_dir="$2"
+  local skill_dir skill_file name dest
+  local wrote=()
+
+  [ -d "$skills_dir" ] || return 0
+
+  for skill_dir in "$skills_dir"/gstack-*/; do
+    skill_file="$skill_dir/SKILL.md"
+    [ -f "$skill_file" ] || continue
+    name=$(awk 'BEGIN{fm=0} /^---$/{fm++; next} fm==1 && $1=="name:"{print $2; exit}' "$skill_file")
+    case "$name" in
+      review|init) ;;
+      *) continue ;;
+    esac
+    mkdir -p "$commands_dir"
+    dest="$commands_dir/gstack-${name}.md"
+    cat > "$dest" <<EOF
+---
+description: Run the gstack ${name} skill
+subtask: false
+---
+
+Use the skill tool with name "${name}" (the skill frontmatter name). Follow that skill, including its preamble.
+EOF
+    wrote+=("gstack-${name}")
+  done
+
+  if [ ${#wrote[@]} -gt 0 ]; then
+    echo "  opencode commands: ${wrote[*]}"
+  fi
+}
+
 # ─── Helper: create a minimal ~/.cursor/skills/gstack runtime root ──────────
 # Cursor scans ~/.cursor/skills. Same shape as the Codex/Factory/OpenCode
 # runtime roots: root SKILL.md from the generated tree + runtime assets only.
@@ -1911,6 +1951,7 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   mkdir -p "$OPENCODE_SKILLS"
   create_opencode_runtime_root "$SOURCE_GSTACK_DIR" "$OPENCODE_GSTACK"
   link_opencode_skill_dirs "$SOURCE_GSTACK_DIR" "$OPENCODE_SKILLS"
+  install_opencode_collision_commands "$OPENCODE_SKILLS" "$OPENCODE_COMMANDS"
   echo "gstack ready (opencode)."
   echo "  browse: $BROWSE_BIN"
   echo "  opencode skills: $OPENCODE_SKILLS"

--- a/setup
+++ b/setup
@@ -1499,8 +1499,10 @@ link_opencode_skill_dirs() {
 # OpenCode 1.18.3 ships builtin /review (subtask: true) which shadows a skill
 # whose frontmatter name is `review`. Do not write commands/review.md — that
 # would steal the builtin. Write a namespaced file so /gstack-review loads
-# the skill by its short name. Same for `init`. Non-colliding skills already
-# register as slash commands from the skill itself.
+# the skill by its short name. Non-colliding skills already register as slash
+# commands from the skill itself. Banner goes after frontmatter so OpenCode
+# still parses description/subtask; grep '<!-- AUTO-GENERATED from' matches
+# the #2142/#2444 ownership gate used by every other installer.
 install_opencode_collision_commands() {
   local skills_dir="$1"
   local commands_dir="$2"
@@ -1514,16 +1516,24 @@ install_opencode_collision_commands() {
     [ -f "$skill_file" ] || continue
     name=$(awk 'BEGIN{fm=0} /^---$/{fm++; next} fm==1 && $1=="name:"{print $2; exit}' "$skill_file")
     case "$name" in
-      review|init) ;;
+      review) ;;
       *) continue ;;
     esac
-    mkdir -p "$commands_dir"
     dest="$commands_dir/gstack-${name}.md"
+    if [ -e "$dest" ] || [ -L "$dest" ]; then
+      if ! grep -q '<!-- AUTO-GENERATED from' "$dest" 2>/dev/null; then
+        echo "  left in place (existing dir not gstack-managed — no generated banner): $dest" >&2
+        continue
+      fi
+    fi
+    mkdir -p "$commands_dir"
     cat > "$dest" <<EOF
 ---
 description: Run the gstack ${name} skill
 subtask: false
 ---
+
+<!-- AUTO-GENERATED from setup — do not edit directly -->
 
 Use the skill tool with name "${name}" (the skill frontmatter name). Follow that skill, including its preamble.
 EOF
@@ -1955,6 +1965,7 @@ if [ "$INSTALL_OPENCODE" -eq 1 ]; then
   echo "gstack ready (opencode)."
   echo "  browse: $BROWSE_BIN"
   echo "  opencode skills: $OPENCODE_SKILLS"
+  echo "  opencode: /review is OpenCode's builtin — use /gstack-review for gstack's review skill"
 fi
 
 # 6d. Install for Cursor

--- a/test/setup-opencode-collision-commands.test.ts
+++ b/test/setup-opencode-collision-commands.test.ts
@@ -83,7 +83,7 @@ describe('setup: OpenCode collision commands — static (#2629)', () => {
     expect(end).toBeGreaterThan(start);
     const block = SETUP_SRC.slice(start, end);
     expect(block).toContain('link_opencode_skill_dirs');
-    expect(block).toContain('install_opencode_collision_commands "$OPENCODE_SKILLS"');
+    expect(block).toContain('install_opencode_collision_commands "$OPENCODE_SKILLS" "$OPENCODE_COMMANDS"');
     const linkAt = block.indexOf('link_opencode_skill_dirs');
     const installAt = block.indexOf('install_opencode_collision_commands');
     expect(installAt).toBeGreaterThan(linkAt);
@@ -98,6 +98,17 @@ describe('setup: OpenCode collision commands — static (#2629)', () => {
     expect(fn).not.toMatch(/review\|init/);
     expect(fn).toContain(GENERATED_BANNER);
     expect(fn).toContain('left in place (existing dir not gstack-managed — no generated banner)');
+  });
+
+  test('OPENCODE_COMMANDS is the canonical ~/.config/opencode/commands path', () => {
+    const line = SETUP_SRC.split('\n').find((l) => l.startsWith('OPENCODE_COMMANDS='));
+    expect(line).toBe('OPENCODE_COMMANDS="$HOME/.config/opencode/commands"');
+  });
+
+  test('README documents the OpenCode command install path and manual uninstall', () => {
+    const readme = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf-8');
+    expect(readme).toContain('~/.config/opencode/commands/gstack-review.md');
+    expect(readme).toContain('rm -f ~/.config/opencode/commands/gstack-review.md');
   });
 });
 
@@ -167,6 +178,36 @@ describe.skipIf(process.platform === 'win32')('setup: OpenCode collision command
       const body = read('gstack-review.md')!;
       expect(body).not.toContain('stale body');
       assertGeneratedCommand(body, 'review');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('wires OPENCODE_COMMANDS through a temporary HOME to the canonical commands path', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-oc-home-'));
+    const home = path.join(tmp, 'home');
+    const canonical = path.join(home, '.config', 'opencode', 'commands');
+    try {
+      const ocSkills = SETUP_SRC.split('\n').find((l) => l.startsWith('OPENCODE_SKILLS='));
+      const ocCommands = SETUP_SRC.split('\n').find((l) => l.startsWith('OPENCODE_COMMANDS='));
+      if (!ocSkills || !ocCommands) throw new Error('Could not locate OPENCODE_* assignments in setup');
+
+      const script = [
+        `HOME="${home}"`,
+        ocSkills,
+        ocCommands,
+        extractFn('install_opencode_collision_commands'),
+        'mkdir -p "$OPENCODE_SKILLS/gstack-review"',
+        `cat > "$OPENCODE_SKILLS/gstack-review/SKILL.md" <<'SKILL'\n${skillMd('review')}SKILL`,
+        'install_opencode_collision_commands "$OPENCODE_SKILLS" "$OPENCODE_COMMANDS"',
+      ].join('\n');
+      const run = spawnSync('bash', ['-c', script], { encoding: 'utf-8', timeout: 15000 });
+      expect(run.status).toBe(0);
+      expect(fs.existsSync(path.join(canonical, 'gstack-review.md'))).toBe(true);
+      expect(fs.existsSync(path.join(canonical, 'review.md'))).toBe(false);
+      expect(fs.existsSync(path.join(canonical, 'init.md'))).toBe(false);
+      expect(fs.existsSync(path.join(home, '.config', 'opencode', 'NOT-A-REAL-DIR'))).toBe(false);
+      assertGeneratedCommand(fs.readFileSync(path.join(canonical, 'gstack-review.md'), 'utf-8'), 'review');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/setup-opencode-collision-commands.test.ts
+++ b/test/setup-opencode-collision-commands.test.ts
@@ -7,7 +7,7 @@
  * with `commands/review.md`; it writes a namespaced `gstack-review.md`
  * (`subtask: false`) so `/gstack-review` loads the skill by its short name.
  *
- * Non-colliding skills (qa, ship, …) already become skill-sourced commands
+ * Non-colliding skills (qa, ship, ...) already become skill-sourced commands
  * without `subtask` — do not batch-generate command files for them.
  */
 import { describe, test, expect } from 'bun:test';
@@ -18,6 +18,8 @@ import * as path from 'path';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const SETUP_SRC = fs.readFileSync(path.join(ROOT, 'setup'), 'utf-8');
+
+const GENERATED_BANNER = '<!-- AUTO-GENERATED from';
 
 function extractFn(name: string): string {
   const start = SETUP_SRC.indexOf(`${name}() {`);
@@ -60,6 +62,19 @@ function installCollisionCommands(skills: Record<string, string>, extraCommandFi
   return { tmp, commandsDir, run, files, read };
 }
 
+function assertGeneratedCommand(body: string, skillName: string) {
+  expect(body).toMatch(/^---\n/);
+  expect(body).toContain('subtask: false');
+  expect(body).not.toMatch(/agent:\s*plan/);
+  expect(body).toContain('skill');
+  expect(body).toContain(`"${skillName}"`);
+  expect(body).toContain('preamble');
+  const fmEnd = body.indexOf('\n---\n', 4);
+  expect(fmEnd).toBeGreaterThan(0);
+  const bannerAt = body.indexOf(GENERATED_BANNER);
+  expect(bannerAt).toBeGreaterThan(fmEnd);
+}
+
 describe('setup: OpenCode collision commands — static (#2629)', () => {
   test('OpenCode install invokes the collision-command installer after linking skills', () => {
     const start = SETUP_SRC.indexOf('# 6c. Install for OpenCode');
@@ -72,12 +87,17 @@ describe('setup: OpenCode collision commands — static (#2629)', () => {
     const linkAt = block.indexOf('link_opencode_skill_dirs');
     const installAt = block.indexOf('install_opencode_collision_commands');
     expect(installAt).toBeGreaterThan(linkAt);
+    expect(block).toContain('/gstack-review');
+    expect(block).toContain('/review is OpenCode');
   });
 
   test('collision installer writes only namespaced gstack-<name>.md files', () => {
     const fn = extractFn('install_opencode_collision_commands');
     expect(fn).toContain('"$commands_dir/gstack-${name}.md"');
     expect(fn).not.toMatch(/\$commands_dir\/(?:review|init)\.md/);
+    expect(fn).not.toMatch(/review\|init/);
+    expect(fn).toContain(GENERATED_BANNER);
+    expect(fn).toContain('left in place (existing dir not gstack-managed — no generated banner)');
   });
 });
 
@@ -86,28 +106,17 @@ describe.skipIf(process.platform === 'win32')('setup: OpenCode collision command
     const { tmp, run, files, read } = installCollisionCommands({
       'gstack-review': 'review',
       'gstack-qa': 'qa',
-      'gstack-init': 'init',
     }, { 'review.md': 'USER-OWNED-REVIEW\n' });
     try {
       expect(run.status).toBe(0);
       expect(run.stderr).toBe('');
-      expect(files).toEqual(['gstack-init.md', 'gstack-review.md', 'review.md']);
+      expect(files).toEqual(['gstack-review.md', 'review.md']);
       expect(read('review.md')).toBe('USER-OWNED-REVIEW\n');
       expect(read('init.md')).toBeNull();
+      expect(read('gstack-init.md')).toBeNull();
       expect(read('gstack-qa.md')).toBeNull();
       expect(read('qa.md')).toBeNull();
-
-      const review = read('gstack-review.md')!;
-      expect(review).toMatch(/^---\n/);
-      expect(review).toContain('subtask: false');
-      expect(review).not.toMatch(/agent:\s*plan/);
-      expect(review).toContain('skill');
-      expect(review).toContain('"review"');
-      expect(review).toContain('preamble');
-
-      const init = read('gstack-init.md')!;
-      expect(init).toContain('subtask: false');
-      expect(init).toContain('"init"');
+      assertGeneratedCommand(read('gstack-review.md')!, 'review');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -121,6 +130,43 @@ describe.skipIf(process.platform === 'win32')('setup: OpenCode collision command
       expect(run.status).toBe(0);
       expect(files).toEqual([]);
       expect(fs.existsSync(commandsDir)).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('leaves a user-owned gstack-review.md without the generated banner in place', () => {
+    const { tmp, run, read } = installCollisionCommands({
+      'gstack-review': 'review',
+    }, { 'gstack-review.md': '# my own command\n' });
+    try {
+      expect(run.status).toBe(0);
+      expect(read('gstack-review.md')).toBe('# my own command\n');
+      expect(run.stderr).toContain('left in place (existing dir not gstack-managed — no generated banner)');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('refreshes a bannered gstack-review.md on re-run', () => {
+    const stale = [
+      '---',
+      'description: stale',
+      'subtask: false',
+      '---',
+      '',
+      `${GENERATED_BANNER} setup — do not edit directly -->`,
+      'stale body',
+      '',
+    ].join('\n');
+    const { tmp, run, read } = installCollisionCommands({
+      'gstack-review': 'review',
+    }, { 'gstack-review.md': stale });
+    try {
+      expect(run.status).toBe(0);
+      const body = read('gstack-review.md')!;
+      expect(body).not.toContain('stale body');
+      assertGeneratedCommand(body, 'review');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/setup-opencode-collision-commands.test.ts
+++ b/test/setup-opencode-collision-commands.test.ts
@@ -1,0 +1,128 @@
+/**
+ * OpenCode builtin slash-command collisions (#2629).
+ *
+ * OpenCode 1.18.3 ships a builtin `/review` with `subtask: true`. gstack's
+ * generated skill keeps frontmatter `name: review`, so OpenCode never
+ * registers the skill as `/review`. setup must not overwrite that builtin
+ * with `commands/review.md`; it writes a namespaced `gstack-review.md`
+ * (`subtask: false`) so `/gstack-review` loads the skill by its short name.
+ *
+ * Non-colliding skills (qa, ship, …) already become skill-sourced commands
+ * without `subtask` — do not batch-generate command files for them.
+ */
+import { describe, test, expect } from 'bun:test';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const SETUP_SRC = fs.readFileSync(path.join(ROOT, 'setup'), 'utf-8');
+
+function extractFn(name: string): string {
+  const start = SETUP_SRC.indexOf(`${name}() {`);
+  const end = SETUP_SRC.indexOf('\n}\n', start);
+  if (start < 0 || end < 0) throw new Error(`Could not locate ${name}() in setup`);
+  return SETUP_SRC.slice(start, end + 2);
+}
+
+function skillMd(name: string): string {
+  return `---\nname: ${name}\ndescription: fixture ${name}\n---\n\n# ${name}\n`;
+}
+
+function installCollisionCommands(skills: Record<string, string>, extraCommandFiles: Record<string, string> = {}) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-oc-cmd-'));
+  const skillsDir = path.join(tmp, 'skills');
+  const commandsDir = path.join(tmp, 'commands');
+  fs.mkdirSync(skillsDir, { recursive: true });
+  for (const [dirName, frontmatterName] of Object.entries(skills)) {
+    const d = path.join(skillsDir, dirName);
+    fs.mkdirSync(d, { recursive: true });
+    fs.writeFileSync(path.join(d, 'SKILL.md'), skillMd(frontmatterName));
+  }
+  if (Object.keys(extraCommandFiles).length > 0) {
+    fs.mkdirSync(commandsDir, { recursive: true });
+    for (const [fileName, body] of Object.entries(extraCommandFiles)) {
+      fs.writeFileSync(path.join(commandsDir, fileName), body);
+    }
+  }
+
+  const script = [
+    extractFn('install_opencode_collision_commands'),
+    `install_opencode_collision_commands "${skillsDir}" "${commandsDir}"`,
+  ].join('\n');
+  const run = spawnSync('bash', ['-c', script], { encoding: 'utf-8', timeout: 15000 });
+  const files = fs.existsSync(commandsDir) ? fs.readdirSync(commandsDir).sort() : [];
+  const read = (name: string) => {
+    const p = path.join(commandsDir, name);
+    return fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : null;
+  };
+  return { tmp, commandsDir, run, files, read };
+}
+
+describe('setup: OpenCode collision commands — static (#2629)', () => {
+  test('OpenCode install invokes the collision-command installer after linking skills', () => {
+    const start = SETUP_SRC.indexOf('# 6c. Install for OpenCode');
+    const end = SETUP_SRC.indexOf('# 6d. Install for Cursor', start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const block = SETUP_SRC.slice(start, end);
+    expect(block).toContain('link_opencode_skill_dirs');
+    expect(block).toContain('install_opencode_collision_commands "$OPENCODE_SKILLS"');
+    const linkAt = block.indexOf('link_opencode_skill_dirs');
+    const installAt = block.indexOf('install_opencode_collision_commands');
+    expect(installAt).toBeGreaterThan(linkAt);
+  });
+
+  test('collision installer writes only namespaced gstack-<name>.md files', () => {
+    const fn = extractFn('install_opencode_collision_commands');
+    expect(fn).toContain('"$commands_dir/gstack-${name}.md"');
+    expect(fn).not.toMatch(/\$commands_dir\/(?:review|init)\.md/);
+  });
+});
+
+describe.skipIf(process.platform === 'win32')('setup: OpenCode collision commands — behavior (#2629)', () => {
+  test('writes namespaced gstack-review.md with subtask: false; leaves builtins and qa alone', () => {
+    const { tmp, run, files, read } = installCollisionCommands({
+      'gstack-review': 'review',
+      'gstack-qa': 'qa',
+      'gstack-init': 'init',
+    }, { 'review.md': 'USER-OWNED-REVIEW\n' });
+    try {
+      expect(run.status).toBe(0);
+      expect(run.stderr).toBe('');
+      expect(files).toEqual(['gstack-init.md', 'gstack-review.md', 'review.md']);
+      expect(read('review.md')).toBe('USER-OWNED-REVIEW\n');
+      expect(read('init.md')).toBeNull();
+      expect(read('gstack-qa.md')).toBeNull();
+      expect(read('qa.md')).toBeNull();
+
+      const review = read('gstack-review.md')!;
+      expect(review).toMatch(/^---\n/);
+      expect(review).toContain('subtask: false');
+      expect(review).not.toMatch(/agent:\s*plan/);
+      expect(review).toContain('skill');
+      expect(review).toContain('"review"');
+      expect(review).toContain('preamble');
+
+      const init = read('gstack-init.md')!;
+      expect(init).toContain('subtask: false');
+      expect(init).toContain('"init"');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('does not mkdir commands/ when no colliding skills are installed', () => {
+    const { tmp, commandsDir, run, files } = installCollisionCommands({
+      'gstack-qa': 'qa',
+    });
+    try {
+      expect(run.status).toBe(0);
+      expect(files).toEqual([]);
+      expect(fs.existsSync(commandsDir)).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Why (in your own words)

`./setup --host opencode` links gstack's generated skills into `~/.config/opencode/skills/`, but never writes anything under `~/.config/opencode/commands/`. OpenCode 1.18.3 ships a built-in `/review` slash command with `subtask: true`, and its command-registration loop skips any skill whose frontmatter `name:` matches an existing command — so gstack's `review` skill (frontmatter `name: review`) never becomes a working `/review`. Typing `/review` runs the builtin subtask instead, and with `plan` as the primary agent that comes back as "Task cancelled." (`skill({ name: "review" })` still works, so the skill itself is fine.)

This change makes the collision explicit and safe: setup installs a namespaced `~/.config/opencode/commands/gstack-review.md` command (`subtask: false`) that loads the gstack review skill by its frontmatter name, so `/gstack-review` works and OpenCode's builtin `/review` is left untouched. Non-colliding skills (qa, ship, ...) are deliberately not turned into command files — OpenCode already registers those from the skill `name`. Files that don't carry the generated banner are never overwritten.

## Live evidence

BEFORE — `origin/main` @ `51932ece` (v1.68.2.0). The OpenCode install path has no `commands/` handling at all; only `skills/` is linked:

```
$ git show origin/main:setup | grep -c "opencode/commands"
0
```

AFTER — this branch, the real `install_opencode_collision_commands` run against a throwaway `$HOME` with a `gstack-review` skill installed:

```
$ install_opencode_collision_commands "$OPENCODE_SKILLS" "$OPENCODE_COMMANDS"
opencode commands: gstack-review

$ find $HOME/.config/opencode/commands -type f
$TMP/home/.config/opencode/commands/gstack-review.md

$ cat $HOME/.config/opencode/commands/gstack-review.md
---
description: Run the gstack review skill
subtask: false
---

<!-- AUTO-GENERATED from setup — do not edit directly -->

Use the skill tool with name "review" (the skill frontmatter name). Follow that skill, including its preamble.
```

`review.md` and `init.md` are not created, so OpenCode's builtin commands keep working unchanged.

Behavior tests (bun 1.3.13):

```
$ bun test test/setup-opencode-collision-commands.test.ts
 9 pass
 0 fail
 60 expect() calls
```

The wiring is pinned: a static test asserts `OPENCODE_COMMANDS` is exactly `$HOME/.config/opencode/commands`, and a behavior test drives the real constant and the real function through a temporary `$HOME`. Mutating that constant to a wrong directory makes the suite fail (verified: 7 pass / 2 fail, non-zero exit), so a future regression in the target path is caught.

## Scope

- **Changed**: `setup` (new `install_opencode_collision_commands` + wiring in the OpenCode install block), `test/setup-opencode-collision-commands.test.ts`, `README.md` (install table + manual-uninstall entry for the new command file).
- **Verified live by**: the behavior tests above, run against the real setup source in a throwaway `$HOME`. This host cannot drive the interactive OpenCode TUI (no configured provider or credentials).
- **Did NOT test**: full Tier 1 `bun run test` — this environment's Playwright/browse lane fails with "Target page, context or browser has been closed", unrelated to this diff (the #2629 tests pass in the shard logs). Interactive `/gstack-review` inside the real OpenCode TUI, and Windows (the bash behavior tests follow the repo's existing `skipIf(win32)` convention).

## Linked issue

Fixes #2629
