### PR TITLE
fix: verify source-scoped GBrain call graphs

### DIFF
--- a/bin/gstack-gbrain-install
+++ b/bin/gstack-gbrain-install
@@ -42,10 +42,10 @@ set -euo pipefail
 # --pinned-commit <sha> overrides for reproducibility.
 PINNED_COMMIT=""
 PINNED_TAG=""
-# Minimum gbrain version gstack's integration is known to work with. The
-# `sources list --json` wrapped-object shape + federated sources landed by 0.20;
-# older predates the surface gstack drives. Hard-fail below this floor (#1744).
-MIN_GBRAIN_VERSION="0.20.0"
+# Minimum gbrain version gstack's integration is known to work with. Source-
+# scoped call-graph readiness (`status` + `ready`) landed in 0.42.14 and is the
+# fail-closed completion signal used by /sync-gbrain. Hard-fail below this floor.
+MIN_GBRAIN_VERSION="0.42.14"
 GBRAIN_REPO_URL="https://github.com/garrytan/gbrain.git"
 DEFAULT_INSTALL_DIR="${GBRAIN_INSTALL_DIR:-$HOME/gbrain}"
 INSTALL_DIR="$DEFAULT_INSTALL_DIR"
@@ -252,7 +252,7 @@ version_lt() {
 if version_lt "$actual_norm" "$MIN_GBRAIN_VERSION"; then
   echo "" >&2
   echo "gstack-gbrain-install: gbrain $actual_version is below the minimum gstack-tested version ($MIN_GBRAIN_VERSION)." >&2
-  echo "  gstack's sync integration needs the v0.20+ source/list surface." >&2
+  echo "  gstack's sync integration needs the v0.42.14+ source-scoped call-graph readiness surface." >&2
   echo "  Fix: update the gbrain clone at $INSTALL_DIR to a newer release (git pull), then" >&2
   echo "  re-run /setup-gbrain. Or pass --pinned-commit <sha> to install a specific newer commit." >&2
   echo "" >&2

--- a/bin/gstack-gbrain-repo-policy
+++ b/bin/gstack-gbrain-repo-policy
@@ -7,6 +7,10 @@
 #     if no URL is passed. Exits 0 with one of: read-write, read-only,
 #     deny, unset.
 #
+#   gstack-gbrain-repo-policy peek <remote-url>
+#     Read the effective tier without migrating or rewriting the store.
+#     Intended for dry-run previews. Corrupt/unreadable stores fail closed.
+#
 #   gstack-gbrain-repo-policy get --batch
 #     Read remote URLs from stdin (one per line); print one tier per line
 #     in input order: read-write, read-only, deny, or none (no entry / no
@@ -238,6 +242,36 @@ cmd_get() {
   jq -r --arg key "$key" '.[$key] // "unset"' "$POLICY_FILE"
 }
 
+# peek <url> — strictly non-mutating lookup for dry-run callers. Legacy
+# `allow` is interpreted as its effective v2 value (`read-write`) in memory,
+# but the store is never migrated. Corrupt/unreadable stores fail closed and
+# are never quarantined or replaced.
+cmd_peek() {
+  local url="${1:-}"
+  [ -z "$url" ] && die "usage: peek <remote-url>"
+  if [ ! -f "$POLICY_FILE" ]; then
+    echo "unset"
+    return 0
+  fi
+  require_jq
+  if [ ! -r "$POLICY_FILE" ]; then
+    die "Cannot read $POLICY_FILE"
+  fi
+  if ! jq empty "$POLICY_FILE" 2>/dev/null; then
+    die "policy store $POLICY_FILE is corrupt (invalid JSON) — refusing non-mutating read"
+  fi
+  local key
+  key=$(normalize "$url")
+  if [ -z "$key" ]; then
+    echo "unset"
+    return 0
+  fi
+  jq -r --arg key "$key" '
+    (.[$key] // "unset") as $tier
+    | if $tier == "allow" then "read-write" else $tier end
+  ' "$POLICY_FILE"
+}
+
 cmd_set() {
   local url="${1:-}"
   local tier="${2:-}"
@@ -276,10 +310,11 @@ cmd_normalize() {
 
 case "${1:-}" in
   get) shift; cmd_get "$@" ;;
+  peek) shift; cmd_peek "$@" ;;
   set) shift; cmd_set "$@" ;;
   list) shift; cmd_list "$@" ;;
   normalize) shift; cmd_normalize "$@" ;;
   --help|-h|help) sed -n '2,54p' "$0" | sed 's/^# \{0,1\}//' ;;
-  "") die "usage: gstack-gbrain-repo-policy {get|set|list|normalize|--help}" ;;
+  "") die "usage: gstack-gbrain-repo-policy {get|peek|set|list|normalize|--help}" ;;
   *) die "unknown subcommand: $1" ;;
 esac

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -40,9 +40,12 @@ import { detectEngineTier, withErrorContext, canonicalizeRemote } from "../lib/g
 import { ensureSourceRegistered, sourcePageCount, parseSourcesList, type CycleStatus } from "../lib/gbrain-sources";
 import { detectAutopilot, decideSourceRemove, decideCodeSync } from "../lib/gbrain-guards";
 import { writeReceipt } from "../lib/egress-receipt";
-import { localEngineStatus, readGbrainVersion, type LocalEngineStatus } from "../lib/gbrain-local-status";
+import { configuredEngine, localEngineStatus, readGbrainVersion, type LocalEngineStatus } from "../lib/gbrain-local-status";
 import { buildGbrainEnv, spawnGbrain, execGbrainJson, NEEDS_SHELL_ON_WINDOWS, bashScriptInvocation } from "../lib/gbrain-exec";
-import { repoPolicyTier as sharedRepoPolicyTier } from "../lib/gbrain-repo-policy-client";
+import {
+  repoPolicyTier as sharedRepoPolicyTier,
+  repoPolicyTierReadOnly as sharedRepoPolicyTierReadOnly,
+} from "../lib/gbrain-repo-policy-client";
 import { checkOwnedStagingDir } from "../lib/staging-guard";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -104,8 +107,8 @@ const LOCK_PATH = join(GSTACK_HOME, ".sync-gbrain.lock");
 const STALE_LOCK_MS = 5 * 60 * 1000;
 
 // The legacy --dream flag runs GBrain's official source-scoped, resumable
-// edges-backfill operation. It remains LOCK-FREE after the sync lock releases,
-// so a dedicated marker prevents sibling worktrees from duplicating the work.
+// edges-backfill operation. It runs after the main sync lock releases, with a
+// dedicated engine/source-aware marker preventing unsafe duplicate work.
 const DEFAULT_DREAM_TIMEOUT_MS = 45 * 60 * 1000;
 const DREAM_MARKER_STALE_MS = DEFAULT_DREAM_TIMEOUT_MS;
 const CALL_GRAPH_READINESS_PROBE = "__gstack_call_graph_readiness_5f3c9d__";
@@ -153,10 +156,16 @@ export function isGbrainCallGraphVersionSupported(raw: string): boolean {
  * module-load-time const captures the real ~/.gstack before a test can redirect.
  */
 export function dreamMarkerPath(sourceId: string): string {
-  const sourceKey = createHash("sha256").update(sourceId).digest("hex").slice(0, 16);
+  // PGLite is single-process, so every source sharing that engine must use one
+  // marker. Unknown configs take the same conservative path. Postgres-backed
+  // engines can safely backfill independent sources in parallel.
+  const engine = configuredEngine(process.env);
+  const markerName = engine === "postgres"
+    ? `.call-graph-backfill-${createHash("sha256").update(sourceId).digest("hex").slice(0, 16)}.lock`
+    : ".call-graph-backfill.lock";
   return join(
     process.env.GSTACK_HOME || join(homedir(), ".gstack"),
-    `.call-graph-backfill-${sourceKey}.lock`,
+    markerName,
   );
 }
 
@@ -737,10 +746,9 @@ function releaseLock(): void {
 }
 
 /**
- * Acquire this source's call-graph marker. Returns false when a FRESH marker
- * already exists (another worktree is backfilling the same source) — the caller
- * then SKIPs rather than launching duplicate work. Different sources never
- * block one another. A stale
+ * Acquire the call-graph marker. PGLite uses one engine-wide marker because it
+ * is single-process; Postgres uses source-scoped markers so independent sources
+ * can proceed concurrently. A stale
  * marker (older than DREAM_MARKER_STALE_MS, i.e. a crashed run) is taken over.
  * Mirrors acquireLock but with the dream TTL and its own path.
  */
@@ -876,8 +884,13 @@ function warnProbeTimeout(stage: "code" | "memory" | "dream"): void {
  * win32 gets the invoke-via-bash path). A spawn failure is still fail-closed
  * but says so, instead of the misleading "store could not be read".
  */
-export function repoPolicyTier(url: string | null): "read-write" | "read-only" | "deny" | "unset" | "error" {
-  const res = sharedRepoPolicyTier(url, process.env);
+export function repoPolicyTier(
+  url: string | null,
+  readOnly: boolean = false,
+): "read-write" | "read-only" | "deny" | "unset" | "error" {
+  const res = readOnly
+    ? sharedRepoPolicyTierReadOnly(url, process.env)
+    : sharedRepoPolicyTier(url, process.env);
   if (res.error === "spawn-failed") {
     process.stderr.write(
       "[gstack-gbrain-sync] the repo-policy helper could not be spawned (bash missing from PATH?) — " +
@@ -907,7 +920,7 @@ async function runCodeImport(args: CliArgs): Promise<StageResult> {
   // Per-repo trust tier — checked BEFORE the dry-run branch so previews report
   // the refusal honestly instead of claiming they would sync.
   const policyUrl = originUrl();
-  const tier = repoPolicyTier(policyUrl);
+  const tier = repoPolicyTier(policyUrl, args.mode === "dry-run");
   if (tier === "read-only") {
     // Honoring an explicit user setting (search allowed, page writes never) is
     // a clean skip, not a stage failure — code ingest writes pages.
@@ -1484,7 +1497,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
   // dry-run branch: previews must report the same refusal/skip as real runs,
   // while still avoiding every GBrain command.
   const policyUrl = originUrl();
-  const tier = repoPolicyTier(policyUrl);
+  const tier = repoPolicyTier(policyUrl, args.mode === "dry-run");
   if (tier === "read-only") {
     return {
       name: "dream",
@@ -1837,16 +1850,23 @@ async function main(): Promise<void> {
   if (args.mode !== "dry-run" && shouldRunDream(args, null)) {
     const tier = repoPolicyTier(originUrl());
     if (tier === "read-write" || tier === "unset") {
-      const gbrainVersion = readGbrainVersion(process.env);
-      if (!isGbrainCallGraphVersionSupported(gbrainVersion)) {
-        const detail = gbrainVersion
-          ? `found ${gbrainVersion}`
-          : "version could not be determined";
-        console.error(
-          `[gbrain-sync] call-graph backfill requires gbrain >= ${MIN_GBRAIN_CALL_GRAPH_VERSION} (${detail}). ` +
-          "Run /setup-gbrain to upgrade before syncing.",
-        );
-        process.exit(1);
+      const localStatus = localEngineStatus({ noCache: false });
+      // Thin clients have no local graph engine by design. Other unhealthy
+      // local states keep their existing stage-level skip/remediation path.
+      if (localStatus !== "ok" && localStatus !== "timeout") {
+        // No local call-graph compatibility requirement to enforce here.
+      } else {
+        const gbrainVersion = readGbrainVersion(process.env);
+        if (!isGbrainCallGraphVersionSupported(gbrainVersion)) {
+          const detail = gbrainVersion
+            ? `found ${gbrainVersion}`
+            : "version could not be determined";
+          console.error(
+            `[gbrain-sync] call-graph backfill requires gbrain >= ${MIN_GBRAIN_CALL_GRAPH_VERSION} (${detail}). ` +
+            "Run /setup-gbrain to upgrade before syncing.",
+          );
+          process.exit(1);
+        }
       }
     }
   }
@@ -1906,7 +1926,7 @@ async function main(): Promise<void> {
     cleanup();
   }
 
-  // ── Call-graph backfill — LOCK-FREE, after the sync lock releases ───────────
+  // ── Call-graph backfill — separately guarded after the sync lock releases ──
   let dreamStage: StageResult | null = null;
   if (args.mode === "dry-run") {
     // Preview only; never probes doctor or spawns. `--dry-run` and `--full` are

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -108,7 +108,7 @@ const HOME = homedir();
 const LEGACY_GSTACK_HOME = process.env.GSTACK_HOME || join(HOME, ".gstack");
 const GSTACK_STATE_ROOT = process.env.GSTACK_STATE_ROOT || LEGACY_GSTACK_HOME;
 const STATE_PATH = join(GSTACK_STATE_ROOT, ".gbrain-sync-state.json");
-const LOCK_PATH = join(GSTACK_STATE_ROOT, ".sync-gbrain.lock");
+const LOCK_PATH = join(LEGACY_GSTACK_HOME, ".sync-gbrain.lock");
 const STALE_LOCK_MS = 5 * 60 * 1000;
 
 // The legacy --dream flag runs GBrain's official source-scoped, resumable
@@ -156,7 +156,7 @@ export function isGbrainCallGraphVersionSupported(raw: string): boolean {
 
 /**
  * Marker path computed fresh per call (not a module const) so tests can mutate
- * GSTACK_STATE_ROOT / GSTACK_HOME at runtime — same pattern as cacheFilePath() in
+ * GSTACK_HOME at runtime — same pattern as cacheFilePath() in
  * lib/gbrain-local-status.ts. Avoids the ESM static-import hoist trap where a
  * module-load-time const captures the real ~/.gstack before a test can redirect.
  */
@@ -169,7 +169,7 @@ export function dreamMarkerPath(sourceId: string): string {
     ? `.call-graph-backfill-${createHash("sha256").update(sourceId).digest("hex").slice(0, 16)}.lock`
     : ".call-graph-backfill.lock";
   return join(
-    process.env.GSTACK_STATE_ROOT || process.env.GSTACK_HOME || join(homedir(), ".gstack"),
+    process.env.GSTACK_HOME || join(homedir(), ".gstack"),
     markerName,
   );
 }
@@ -711,7 +711,7 @@ interface LockInfo {
 }
 
 function acquireLock(): boolean {
-  mkdirSync(GSTACK_STATE_ROOT, { recursive: true });
+  mkdirSync(LEGACY_GSTACK_HOME, { recursive: true });
   if (existsSync(LOCK_PATH)) {
     // Check if stale.
     try {

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -40,7 +40,7 @@ import { detectEngineTier, withErrorContext, canonicalizeRemote } from "../lib/g
 import { ensureSourceRegistered, sourcePageCount, parseSourcesList, type CycleStatus } from "../lib/gbrain-sources";
 import { detectAutopilot, decideSourceRemove, decideCodeSync } from "../lib/gbrain-guards";
 import { writeReceipt } from "../lib/egress-receipt";
-import { localEngineStatus, type LocalEngineStatus } from "../lib/gbrain-local-status";
+import { localEngineStatus, readGbrainVersion, type LocalEngineStatus } from "../lib/gbrain-local-status";
 import { buildGbrainEnv, spawnGbrain, execGbrainJson, NEEDS_SHELL_ON_WINDOWS, bashScriptInvocation } from "../lib/gbrain-exec";
 import { repoPolicyTier as sharedRepoPolicyTier } from "../lib/gbrain-repo-policy-client";
 import { checkOwnedStagingDir } from "../lib/staging-guard";
@@ -109,6 +109,7 @@ const STALE_LOCK_MS = 5 * 60 * 1000;
 const DEFAULT_DREAM_TIMEOUT_MS = 45 * 60 * 1000;
 const DREAM_MARKER_STALE_MS = DEFAULT_DREAM_TIMEOUT_MS;
 const CALL_GRAPH_READINESS_PROBE = "__gstack_call_graph_readiness_5f3c9d__";
+export const MIN_GBRAIN_CALL_GRAPH_VERSION = "0.42.14";
 
 export interface EdgeBackfillSummary {
   source_id: string;
@@ -129,6 +130,21 @@ export interface CallGraphReadiness {
 }
 
 export type CallGraphPassAction = "ready" | "continue" | "stalled" | "not_built" | "unknown" | "invalid";
+
+/** Accept gbrain's 3- or 4-part stable release format, with its CLI prefix. */
+export function isGbrainCallGraphVersionSupported(raw: string): boolean {
+  const match = raw.trim().match(/^(?:gbrain\s*)?v?(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?$/i);
+  if (!match) return false;
+  const have = match.slice(1, 5).map((part) => Number.parseInt(part ?? "0", 10));
+  const need = MIN_GBRAIN_CALL_GRAPH_VERSION.split(".").map((part) => Number.parseInt(part, 10));
+  for (let i = 0; i < 4; i += 1) {
+    const havePart = have[i] ?? 0;
+    const needPart = need[i] ?? 0;
+    if (havePart > needPart) return true;
+    if (havePart < needPart) return false;
+  }
+  return true;
+}
 
 /**
  * Marker path computed fresh per call (not a module const) so tests can mutate
@@ -1463,22 +1479,10 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
   const root = repoRoot();
   const previewSourceId = root ? readPinnedSourceId(root) ?? deriveCodeSourceId(root) : null;
 
-  if (args.mode === "dry-run") {
-    return {
-      name: "dream",
-      ran: false,
-      ok: true,
-      duration_ms: 0,
-      summary: previewSourceId
-        ? `would: gbrain edges-backfill --source ${previewSourceId} --json, then verify source readiness`
-        : "would: refuse call-graph backfill because no repository source can be identified",
-    };
-  }
-
   // Edge backfill mutates call-graph metadata, so it is subject to the same
-  // repository policy as code ingest. Enforce this inside the stage as well as
-  // at orchestration time so explicit --dream and unattended --full runs can
-  // never bypass a deny/read-only decision or an unreadable policy store.
+  // repository policy as code ingest. This check intentionally precedes the
+  // dry-run branch: previews must report the same refusal/skip as real runs,
+  // while still avoiding every GBrain command.
   const policyUrl = originUrl();
   const tier = repoPolicyTier(policyUrl);
   if (tier === "read-only") {
@@ -1502,12 +1506,39 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
     };
   }
 
+  if (args.mode === "dry-run") {
+    return {
+      name: "dream",
+      ran: false,
+      ok: true,
+      duration_ms: 0,
+      summary: previewSourceId
+        ? `would: gbrain edges-backfill --source ${previewSourceId} --json, then verify source readiness`
+        : "would: refuse call-graph backfill because no repository source can be identified",
+    };
+  }
+
   const gbrainEnv = buildGbrainEnv({ announce: !args.quiet });
   const localStatus = localEngineStatus({ noCache: false });
   if (localStatus === "timeout") {
     warnProbeTimeout("dream");
   } else if (localStatus !== "ok") {
     return skipStageForLocalStatus("dream", localStatus, t0);
+  }
+
+  // Existing installations may predate the current installer floor. Refuse
+  // before any backfill/reindex work instead of failing after a long --full run.
+  const gbrainVersion = readGbrainVersion(process.env);
+  if (!isGbrainCallGraphVersionSupported(gbrainVersion)) {
+    return {
+      name: "dream",
+      ran: true,
+      ok: false,
+      duration_ms: Date.now() - t0,
+      summary: gbrainVersion
+        ? `gbrain ${gbrainVersion} is below the required ${MIN_GBRAIN_CALL_GRAPH_VERSION}; run /setup-gbrain to upgrade before syncing`
+        : `could not verify gbrain >= ${MIN_GBRAIN_CALL_GRAPH_VERSION}; run /setup-gbrain before syncing`,
+    };
   }
 
   if (!root) {
@@ -1798,6 +1829,27 @@ export function formatStage(s: StageResult): string {
 
 async function main(): Promise<void> {
   const args = parseArgs();
+
+  // --full performs its expensive code walk before runDream. Existing users
+  // may still have a GBrain release accepted by an older gstack installer, so
+  // enforce the new floor here as well as inside runDream. Check repo policy
+  // first: deny/read-only previews and invocations must not probe GBrain.
+  if (args.mode !== "dry-run" && shouldRunDream(args, null)) {
+    const tier = repoPolicyTier(originUrl());
+    if (tier === "read-write" || tier === "unset") {
+      const gbrainVersion = readGbrainVersion(process.env);
+      if (!isGbrainCallGraphVersionSupported(gbrainVersion)) {
+        const detail = gbrainVersion
+          ? `found ${gbrainVersion}`
+          : "version could not be determined";
+        console.error(
+          `[gbrain-sync] call-graph backfill requires gbrain >= ${MIN_GBRAIN_CALL_GRAPH_VERSION} (${detail}). ` +
+          "Run /setup-gbrain to upgrade before syncing.",
+        );
+        process.exit(1);
+      }
+    }
+  }
 
   if (!args.quiet) {
     const engine = detectEngineTier();

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -1290,6 +1290,10 @@ function runMemoryIngest(args: CliArgs): StageResult {
   // reboot, user manual cleanup), warn and fall through to a fresh restage.
   const resume = decideResume();
   const childEnv = buildGbrainEnv({ announce: false });
+  // Legacy child writers still consume GSTACK_HOME. Pin it to the portable
+  // root selected by this orchestrator so staging, checkpoint validation, and
+  // transcript state cannot split across plugin-data and ~/.gstack.
+  childEnv.GSTACK_HOME = GSTACK_HOME;
   if (resume.kind === "resume") {
     console.error(
       `[sync:memory] resuming from gbrain checkpoint (${resume.processedIndex}/${resume.totalFiles} files staged at ${resume.stagingDir})`,
@@ -1374,8 +1378,9 @@ function runBrainSyncPush(args: CliArgs): StageResult {
   // an internal or external command"), so this stage failed on EVERY Windows run
   // while looking like a single red line in an otherwise green report. See
   // bashScriptInvocation.
-  const discover = bashScriptInvocation(brainSyncPath, ["--discover-new"]);
-  const once = bashScriptInvocation(brainSyncPath, ["--once"]);
+  const childEnv = { ...process.env, GSTACK_HOME };
+  const discover = bashScriptInvocation(brainSyncPath, ["--discover-new"], { env: childEnv });
+  const once = bashScriptInvocation(brainSyncPath, ["--once"], { env: childEnv });
   if (!discover || !once) {
     return {
       name: "brain-sync",
@@ -1390,8 +1395,18 @@ function runBrainSyncPush(args: CliArgs): StageResult {
     ? ["ignore", "ignore", "ignore"]
     : ["ignore", "inherit", "inherit"];
 
-  spawnSync(discover.cmd, discover.argv, { stdio, timeout: 60 * 1000, shell: discover.shell });
-  const result = spawnSync(once.cmd, once.argv, { stdio, timeout: 60 * 1000, shell: once.shell });
+  spawnSync(discover.cmd, discover.argv, {
+    stdio,
+    timeout: 60 * 1000,
+    shell: discover.shell,
+    env: childEnv,
+  });
+  const result = spawnSync(once.cmd, once.argv, {
+    stdio,
+    timeout: 60 * 1000,
+    shell: once.shell,
+    env: childEnv,
+  });
 
   return {
     name: "brain-sync",

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -101,12 +101,14 @@ interface StageResult {
 // ── Constants ──────────────────────────────────────────────────────────────
 
 const HOME = homedir();
-// Skills resolve the portable root through bin/gstack-paths and pass its
-// GSTACK_STATE_ROOT output to this writer. Keep GSTACK_HOME as the legacy
-// fallback for direct callers and existing tests.
-const GSTACK_HOME = process.env.GSTACK_STATE_ROOT || process.env.GSTACK_HOME || join(HOME, ".gstack");
-const STATE_PATH = join(GSTACK_HOME, ".gbrain-sync-state.json");
-const LOCK_PATH = join(GSTACK_HOME, ".sync-gbrain.lock");
+// The orchestrator's own metadata is portable. Curated artifacts, repository
+// policies, transcript watermarks, and ingest staging remain in the canonical
+// GSTACK_HOME consumed by their existing writers; do not silently relocate
+// those data stores when a plugin supplies GSTACK_STATE_ROOT.
+const LEGACY_GSTACK_HOME = process.env.GSTACK_HOME || join(HOME, ".gstack");
+const GSTACK_STATE_ROOT = process.env.GSTACK_STATE_ROOT || LEGACY_GSTACK_HOME;
+const STATE_PATH = join(GSTACK_STATE_ROOT, ".gbrain-sync-state.json");
+const LOCK_PATH = join(GSTACK_STATE_ROOT, ".sync-gbrain.lock");
 const STALE_LOCK_MS = 5 * 60 * 1000;
 
 // The legacy --dream flag runs GBrain's official source-scoped, resumable
@@ -259,7 +261,7 @@ export type ResumeVerdict =
  *   - checkpoint + staging ok    → resume (gbrain picks up at processedIndex+1)
  *   - checkpoint + staging gone  → warn, fall through to fresh restage
  */
-export function decideResume(gstackHome: string = GSTACK_HOME): ResumeVerdict {
+export function decideResume(gstackHome: string = LEGACY_GSTACK_HOME): ResumeVerdict {
   const cp = readGbrainCheckpoint();
   if (!cp || !cp.dir) return { kind: "no-checkpoint" };
   const stagingDir = cp.dir;
@@ -709,7 +711,7 @@ interface LockInfo {
 }
 
 function acquireLock(): boolean {
-  mkdirSync(GSTACK_HOME, { recursive: true });
+  mkdirSync(GSTACK_STATE_ROOT, { recursive: true });
   if (existsSync(LOCK_PATH)) {
     // Check if stale.
     try {
@@ -1290,10 +1292,6 @@ function runMemoryIngest(args: CliArgs): StageResult {
   // reboot, user manual cleanup), warn and fall through to a fresh restage.
   const resume = decideResume();
   const childEnv = buildGbrainEnv({ announce: false });
-  // Legacy child writers still consume GSTACK_HOME. Pin it to the portable
-  // root selected by this orchestrator so staging, checkpoint validation, and
-  // transcript state cannot split across plugin-data and ~/.gstack.
-  childEnv.GSTACK_HOME = GSTACK_HOME;
   if (resume.kind === "resume") {
     console.error(
       `[sync:memory] resuming from gbrain checkpoint (${resume.processedIndex}/${resume.totalFiles} files staged at ${resume.stagingDir})`,
@@ -1378,9 +1376,8 @@ function runBrainSyncPush(args: CliArgs): StageResult {
   // an internal or external command"), so this stage failed on EVERY Windows run
   // while looking like a single red line in an otherwise green report. See
   // bashScriptInvocation.
-  const childEnv = { ...process.env, GSTACK_HOME };
-  const discover = bashScriptInvocation(brainSyncPath, ["--discover-new"], { env: childEnv });
-  const once = bashScriptInvocation(brainSyncPath, ["--once"], { env: childEnv });
+  const discover = bashScriptInvocation(brainSyncPath, ["--discover-new"]);
+  const once = bashScriptInvocation(brainSyncPath, ["--once"]);
   if (!discover || !once) {
     return {
       name: "brain-sync",
@@ -1395,18 +1392,8 @@ function runBrainSyncPush(args: CliArgs): StageResult {
     ? ["ignore", "ignore", "ignore"]
     : ["ignore", "inherit", "inherit"];
 
-  spawnSync(discover.cmd, discover.argv, {
-    stdio,
-    timeout: 60 * 1000,
-    shell: discover.shell,
-    env: childEnv,
-  });
-  const result = spawnSync(once.cmd, once.argv, {
-    stdio,
-    timeout: 60 * 1000,
-    shell: once.shell,
-    env: childEnv,
-  });
+  spawnSync(discover.cmd, discover.argv, { stdio, timeout: 60 * 1000, shell: discover.shell });
+  const result = spawnSync(once.cmd, once.argv, { stdio, timeout: 60 * 1000, shell: once.shell });
 
   return {
     name: "brain-sync",

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -101,7 +101,10 @@ interface StageResult {
 // ── Constants ──────────────────────────────────────────────────────────────
 
 const HOME = homedir();
-const GSTACK_HOME = process.env.GSTACK_HOME || join(HOME, ".gstack");
+// Skills resolve the portable root through bin/gstack-paths and pass its
+// GSTACK_STATE_ROOT output to this writer. Keep GSTACK_HOME as the legacy
+// fallback for direct callers and existing tests.
+const GSTACK_HOME = process.env.GSTACK_STATE_ROOT || process.env.GSTACK_HOME || join(HOME, ".gstack");
 const STATE_PATH = join(GSTACK_HOME, ".gbrain-sync-state.json");
 const LOCK_PATH = join(GSTACK_HOME, ".sync-gbrain.lock");
 const STALE_LOCK_MS = 5 * 60 * 1000;
@@ -151,7 +154,7 @@ export function isGbrainCallGraphVersionSupported(raw: string): boolean {
 
 /**
  * Marker path computed fresh per call (not a module const) so tests can mutate
- * GSTACK_HOME at runtime — same pattern as cacheFilePath() in
+ * GSTACK_STATE_ROOT / GSTACK_HOME at runtime — same pattern as cacheFilePath() in
  * lib/gbrain-local-status.ts. Avoids the ESM static-import hoist trap where a
  * module-load-time const captures the real ~/.gstack before a test can redirect.
  */
@@ -164,7 +167,7 @@ export function dreamMarkerPath(sourceId: string): string {
     ? `.call-graph-backfill-${createHash("sha256").update(sourceId).digest("hex").slice(0, 16)}.lock`
     : ".call-graph-backfill.lock";
   return join(
-    process.env.GSTACK_HOME || join(homedir(), ".gstack"),
+    process.env.GSTACK_STATE_ROOT || process.env.GSTACK_HOME || join(homedir(), ".gstack"),
     markerName,
   );
 }

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -136,8 +136,12 @@ export type CallGraphPassAction = "ready" | "continue" | "stalled" | "not_built"
  * lib/gbrain-local-status.ts. Avoids the ESM static-import hoist trap where a
  * module-load-time const captures the real ~/.gstack before a test can redirect.
  */
-export function dreamMarkerPath(): string {
-  return join(process.env.GSTACK_HOME || join(homedir(), ".gstack"), ".dream-in-progress");
+export function dreamMarkerPath(sourceId: string): string {
+  const sourceKey = createHash("sha256").update(sourceId).digest("hex").slice(0, 16);
+  return join(
+    process.env.GSTACK_HOME || join(homedir(), ".gstack"),
+    `.call-graph-backfill-${sourceKey}.lock`,
+  );
 }
 
 // Default 35-minute timeout for code-walk + memory-ingest stages. Override via
@@ -717,14 +721,15 @@ function releaseLock(): void {
 }
 
 /**
- * Acquire the dream marker (`~/.gstack/.dream-in-progress`). Returns false when
- * a FRESH marker already exists (another worktree is mid-dream) — the caller
- * then SKIPs rather than launching a duplicate ~35-min global job. A stale
+ * Acquire this source's call-graph marker. Returns false when a FRESH marker
+ * already exists (another worktree is backfilling the same source) — the caller
+ * then SKIPs rather than launching duplicate work. Different sources never
+ * block one another. A stale
  * marker (older than DREAM_MARKER_STALE_MS, i.e. a crashed run) is taken over.
  * Mirrors acquireLock but with the dream TTL and its own path.
  */
-export function acquireDreamMarker(): boolean {
-  const path = dreamMarkerPath();
+export function acquireDreamMarker(sourceId: string): boolean {
+  const path = dreamMarkerPath(sourceId);
   mkdirSync(dirname(path), { recursive: true });
   if (existsSync(path)) {
     try {
@@ -747,9 +752,9 @@ export function acquireDreamMarker(): boolean {
   }
 }
 
-export function releaseDreamMarker(): void {
+export function releaseDreamMarker(sourceId: string): void {
   try {
-    const path = dreamMarkerPath();
+    const path = dreamMarkerPath(sourceId);
     if (!existsSync(path)) return;
     const info = JSON.parse(readFileSync(path, "utf-8")) as LockInfo;
     if (info.pid === process.pid) unlinkSync(path);
@@ -759,9 +764,9 @@ export function releaseDreamMarker(): void {
 }
 
 /** Read the pid recorded in a fresh dream marker, for the "already running" message. */
-function dreamMarkerPid(): number | null {
+function dreamMarkerPid(sourceId: string): number | null {
   try {
-    const info = JSON.parse(readFileSync(dreamMarkerPath(), "utf-8")) as LockInfo;
+    const info = JSON.parse(readFileSync(dreamMarkerPath(sourceId), "utf-8")) as LockInfo;
     return typeof info.pid === "number" ? info.pid : null;
   } catch {
     return null;
@@ -1470,6 +1475,33 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
     };
   }
 
+  // Edge backfill mutates call-graph metadata, so it is subject to the same
+  // repository policy as code ingest. Enforce this inside the stage as well as
+  // at orchestration time so explicit --dream and unattended --full runs can
+  // never bypass a deny/read-only decision or an unreadable policy store.
+  const policyUrl = originUrl();
+  const tier = repoPolicyTier(policyUrl);
+  if (tier === "read-only") {
+    return {
+      name: "dream",
+      ran: false,
+      ok: true,
+      duration_ms: Date.now() - t0,
+      summary: `skipped — repo policy is read-only for ${policyUrl} (call-graph backfill writes metadata)`,
+    };
+  }
+  if (tier === "deny" || tier === "error") {
+    return {
+      name: "dream",
+      ran: true,
+      ok: false,
+      duration_ms: Date.now() - t0,
+      summary: tier === "deny"
+        ? `refused — repo policy is deny for ${policyUrl}; no GBrain interaction is allowed`
+        : "refused — repo policy store exists but could not be read; no GBrain interaction attempted",
+    };
+  }
+
   const gbrainEnv = buildGbrainEnv({ announce: !args.quiet });
   const localStatus = localEngineStatus({ noCache: false });
   if (localStatus === "timeout") {
@@ -1489,8 +1521,8 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
   }
   const sourceId = resolveCodeSourceId(root, gbrainEnv);
 
-  if (!acquireDreamMarker()) {
-    const pid = dreamMarkerPid();
+  if (!acquireDreamMarker(sourceId)) {
+    const pid = dreamMarkerPid(sourceId);
     return {
       name: "dream",
       ran: false,
@@ -1585,20 +1617,31 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
       edgesUnmatched += backfill.edges_unmatched;
 
       if (Date.now() >= deadline) break;
-      const readinessResult = spawnGbrain([
-        "code-callers",
-        CALL_GRAPH_READINESS_PROBE,
-        "--source",
-        sourceId,
-        "--limit",
-        "1",
-        "--json",
-      ], {
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout: Math.max(1, deadline - Date.now()),
-        baseEnv: process.env,
-        announce: false,
-      });
+      let readinessResult: ReturnType<typeof spawnGbrain>;
+      try {
+        readinessResult = spawnGbrain([
+          "code-callers",
+          CALL_GRAPH_READINESS_PROBE,
+          "--source",
+          sourceId,
+          "--limit",
+          "1",
+          "--json",
+        ], {
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: Math.max(1, deadline - Date.now()),
+          baseEnv: process.env,
+          announce: false,
+        });
+      } catch (err) {
+        return {
+          name: "dream",
+          ran: true,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: `gbrain source readiness probe failed to start: ${(err as Error).message}`,
+        };
+      }
       if (readinessResult.error || readinessResult.status !== 0) {
         const err = readinessResult.error as NodeJS.ErrnoException | undefined;
         const why = err?.message ?? (readinessResult.status === null
@@ -1683,7 +1726,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
       summary: `call-graph backfill timed out after ${passes} pass${passes === 1 ? "" : "es"}; progress is resumable`,
     };
   } finally {
-    releaseDreamMarker();
+    releaseDreamMarker(sourceId);
   }
 }
 

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -37,7 +37,7 @@ import { createHash } from "crypto";
 
 import "../lib/conductor-env-shim";
 import { detectEngineTier, withErrorContext, canonicalizeRemote } from "../lib/gstack-memory-helpers";
-import { ensureSourceRegistered, sourcePageCount, parseSourcesList, cycleCompleted, type CycleStatus } from "../lib/gbrain-sources";
+import { ensureSourceRegistered, sourcePageCount, parseSourcesList, type CycleStatus } from "../lib/gbrain-sources";
 import { detectAutopilot, decideSourceRemove, decideCodeSync } from "../lib/gbrain-guards";
 import { writeReceipt } from "../lib/egress-receipt";
 import { localEngineStatus, type LocalEngineStatus } from "../lib/gbrain-local-status";
@@ -56,9 +56,9 @@ export interface CliArgs {
   noMemory: boolean;
   noBrainSync: boolean;
   codeOnly: boolean;
-  /** Force the source-scoped dream cycle (builds this source's call graph). Always runs. */
+  /** Force the source-scoped call-graph backfill. Flag name retained for compatibility. */
   dream: boolean;
-  /** Opt out of the dream cycle that `--full` would otherwise auto-run. */
+  /** Opt out of the call-graph backfill that `--full` would otherwise auto-run. */
   noDream: boolean;
   /** #1734: opt-in to sync a URL-managed source whose code walk may auto-reclone. */
   allowReclone: boolean;
@@ -86,9 +86,9 @@ interface StageResult {
   summary: string;
   /**
    * Stage ran and did not error, but the outcome is a degraded no-op the user
-   * should know about (e.g. dream completed but the schema pack can't extract
-   * code symbols, so the call graph stays empty). Rendered as WARN, counts as
-   * ok for the exit code — it's not a failure, just not the happy path.
+   * should know about (e.g. the source-scoped readiness probe still reports
+   * indexing). Rendered as WARN, counts as ok for the exit code — it's not a
+   * failure, just not the happy path.
    */
   warn?: boolean;
   /** Stage-specific structured detail. Code stage carries source_id + page_count. */
@@ -103,13 +103,32 @@ const STATE_PATH = join(GSTACK_HOME, ".gbrain-sync-state.json");
 const LOCK_PATH = join(GSTACK_HOME, ".sync-gbrain.lock");
 const STALE_LOCK_MS = 5 * 60 * 1000;
 
-// Dream (call-graph build) is brain-global and runs LOCK-FREE after the sync
-// lock releases, so it can't use the sync lock to dedupe across worktrees. A
-// dedicated short-TTL marker prevents two worktrees from launching duplicate
-// ~35-min global jobs. TTL matches the dream timeout default so a crashed run
-// can't wedge the marker longer than one cycle.
-const DEFAULT_DREAM_TIMEOUT_MS = 45 * 60 * 1000; // 45min — dream is the slow stage
+// The legacy --dream flag runs GBrain's official source-scoped, resumable
+// edges-backfill operation. It remains LOCK-FREE after the sync lock releases,
+// so a dedicated marker prevents sibling worktrees from duplicating the work.
+const DEFAULT_DREAM_TIMEOUT_MS = 45 * 60 * 1000;
 const DREAM_MARKER_STALE_MS = DEFAULT_DREAM_TIMEOUT_MS;
+const CALL_GRAPH_READINESS_PROBE = "__gstack_call_graph_readiness_5f3c9d__";
+
+export interface EdgeBackfillSummary {
+  source_id: string;
+  chunks_walked: number;
+  edges_resolved: number;
+  edges_ambiguous: number;
+  edges_unmatched: number;
+  batches: number;
+  ms: number;
+}
+
+export interface CallGraphReadiness {
+  source_id: string;
+  scope: "single";
+  count: number;
+  status: "not_built" | "indexing" | "ready" | "unknown";
+  ready: boolean;
+}
+
+export type CallGraphPassAction = "ready" | "continue" | "stalled" | "not_built" | "unknown" | "invalid";
 
 /**
  * Marker path computed fresh per call (not a module const) so tests can mutate
@@ -247,19 +266,19 @@ Options:
   --no-memory          Skip the gstack-memory-ingest stage (transcripts + artifacts).
   --no-brain-sync      Skip the gstack-brain-sync git pipeline stage.
   --code-only          Only run the code-import stage (alias for --no-memory --no-brain-sync).
-  --dream              Force the source-scoped dream cycle that builds this
-                       source's call graph (gbrain code-callers/code-callees).
+  --dream              Force GBrain's official source-scoped edges-backfill
+                       for code-callers/code-callees, then verify ready=true.
                        Runs lock-free AFTER the sync stages. ~minutes. Default
                        timeout 45min, override GSTACK_SYNC_DREAM_TIMEOUT_MS.
-  --no-dream           Opt out of the dream cycle that --full would auto-run.
+  --no-dream           Opt out of the call-graph backfill that --full auto-runs.
   --allow-reclone      Permit the code walk for URL-managed sources (remote_url set)
                        even though gbrain may auto-reclone the working tree (#1734).
   --help               This text.
 
 Stages run in order: code → memory ingest → curated git push, then (lock-free)
-the optional dream call-graph build. --full auto-runs dream ONLY when the call
-graph was never built; --dream always forces it. Each stage failure is
-non-fatal; subsequent stages still run.
+the optional source-scoped call-graph backfill. --full always backfills after
+reindex unless --no-dream is set; --dream always forces it. Each stage failure
+is non-fatal; subsequent stages still run.
 `);
 }
 
@@ -291,7 +310,7 @@ function parseArgs(): CliArgs {
         noMemory = true;
         noBrainSync = true;
         break;
-      // --dream forces the cycle; --full only chains it at the call site (so
+      // --dream forces the backfill; --full only chains it at the call site (so
       // --no-dream can override) — do NOT set dream from --full here.
       case "--dream": dream = true; break;
       case "--no-dream": noDream = true; break;
@@ -1346,65 +1365,130 @@ function runBrainSyncPush(args: CliArgs): StageResult {
   };
 }
 
-/**
- * Decide whether the dream (call-graph build) cycle should run. PURE so the
- * gate matrix is unit-testable without spawning a real ~35-min dream.
- *
- *   - explicit --dream → always run (force), regardless of cycle state / --no-code.
- *   - --full → run ONLY when the call graph was never built (cycle === "never"),
- *     and only when not opted out via --no-dream / --no-code. "completed" skips
- *     (edges already built); "unknown" skips (a flaky doctor must not trigger a
- *     surprise 35-min cycle — see gbrain-doctor-overstrict).
- *   - everything else → skip.
- *
- * `cycle` is only consulted on the --full auto path; pass null when forcing.
- */
-export function shouldRunDream(args: CliArgs, cycle: CycleStatus | null): boolean {
+/** Decide whether the source-scoped call-graph backfill should run. */
+export function shouldRunDream(args: CliArgs, _cycle: CycleStatus | null): boolean {
   if (args.dream) return true;
-  if (args.mode === "full" && !args.noDream && !args.noCode) {
-    return cycle === "never";
+  return args.mode === "full" && !args.noDream && !args.noCode;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+/** Parse the one exact-source row emitted by `gbrain edges-backfill --json`. */
+export function parseEdgeBackfillSummary(out: string, sourceId: string): EdgeBackfillSummary | null {
+  try {
+    const parsed = JSON.parse(out) as { summary?: unknown };
+    if (!Array.isArray(parsed.summary) || parsed.summary.length !== 1) return null;
+    const row = parsed.summary[0] as Record<string, unknown>;
+    if (
+      row.source_id !== sourceId ||
+      !isNonNegativeInteger(row.chunks_walked) ||
+      !isNonNegativeInteger(row.edges_resolved) ||
+      !isNonNegativeInteger(row.edges_ambiguous) ||
+      !isNonNegativeInteger(row.edges_unmatched) ||
+      !isNonNegativeInteger(row.batches) ||
+      !isNonNegativeInteger(row.ms)
+    ) {
+      return null;
+    }
+    return {
+      source_id: sourceId,
+      chunks_walked: row.chunks_walked,
+      edges_resolved: row.edges_resolved,
+      edges_ambiguous: row.edges_ambiguous,
+      edges_unmatched: row.edges_unmatched,
+      batches: row.batches,
+      ms: row.ms,
+    };
+  } catch {
+    return null;
   }
-  return false;
+}
+
+/** Parse GBrain's official source-scoped readiness envelope for our sentinel. */
+export function parseCallGraphReadiness(out: string, sourceId: string): CallGraphReadiness | null {
+  try {
+    const parsed = JSON.parse(out) as Record<string, unknown>;
+    const statuses = new Set<CallGraphReadiness["status"]>(["not_built", "indexing", "ready", "unknown"]);
+    if (
+      parsed.source_id !== sourceId ||
+      parsed.scope !== "single" ||
+      parsed.count !== 0 ||
+      typeof parsed.status !== "string" ||
+      !statuses.has(parsed.status as CallGraphReadiness["status"]) ||
+      typeof parsed.ready !== "boolean"
+    ) {
+      return null;
+    }
+    return {
+      source_id: sourceId,
+      scope: "single",
+      count: 0,
+      status: parsed.status as CallGraphReadiness["status"],
+      ready: parsed.ready,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Pure continuation gate so no-progress and contradictory signals stay tested. */
+export function nextCallGraphPass(
+  backfill: EdgeBackfillSummary,
+  readiness: CallGraphReadiness,
+): CallGraphPassAction {
+  if (readiness.status === "ready" && readiness.ready) return "ready";
+  if (readiness.ready || readiness.status === "ready") return "invalid";
+  if (readiness.status === "indexing") {
+    return backfill.chunks_walked > 0 ? "continue" : "stalled";
+  }
+  if (readiness.status === "not_built") return "not_built";
+  if (readiness.status === "unknown") return "unknown";
+  return "invalid";
 }
 
 /**
- * Run `gbrain dream` — the brain-global maintenance cycle whose
- * resolve_symbol_edges phase builds the call graph. Runs LOCK-FREE (called
- * after the sync lock releases) so it never freezes sibling worktrees; the
- * `.dream-in-progress` marker dedupes concurrent dreams instead.
- *
- * Returns a StageResult (never throws). SKIP (ran:false, ok:true) for: dry-run
- * preview, local engine not ok, or a fresh marker present. ERR (ran:true,
- * ok:false) for: non-zero/timeout exit, or a spawn-setup failure (missing
- * binary / malformed env) — a broken install must be visible, not disguised as
- * optional maintenance.
+ * Run GBrain's official resumable edge backfill in its default bounded batches,
+ * repeating only while the exact source says it is still indexing and the last
+ * pass made progress. The public flag remains --dream for compatibility.
  */
 export async function runDream(args: CliArgs): Promise<StageResult> {
   const t0 = Date.now();
+  const root = repoRoot();
+  const previewSourceId = root ? readPinnedSourceId(root) ?? deriveCodeSourceId(root) : null;
 
   if (args.mode === "dry-run") {
-    const root = repoRoot();
-    const sourceId = root ? readPinnedSourceId(root) ?? deriveCodeSourceId(root) : null;
     return {
       name: "dream",
       ran: false,
       ok: true,
       duration_ms: 0,
-      summary: sourceId
-        ? `would: gbrain dream --source ${sourceId}  (build this source's call graph)`
-        : "would: gbrain dream  (call-graph build)",
+      summary: previewSourceId
+        ? `would: gbrain edges-backfill --source ${previewSourceId} --json, then verify source readiness`
+        : "would: refuse call-graph backfill because no repository source can be identified",
     };
   }
 
   const gbrainEnv = buildGbrainEnv({ announce: !args.quiet });
   const localStatus = localEngineStatus({ noCache: false });
   if (localStatus === "timeout") {
-    warnProbeTimeout("dream"); // #1964: slow-but-healthy — proceed
+    warnProbeTimeout("dream");
   } else if (localStatus !== "ok") {
     return skipStageForLocalStatus("dream", localStatus, t0);
   }
 
-  // Dedupe concurrent dreams across worktrees (lock-free path).
+  if (!root) {
+    return {
+      name: "dream",
+      ran: true,
+      ok: false,
+      duration_ms: Date.now() - t0,
+      summary: "cannot identify a repository source for the call-graph backfill",
+    };
+  }
+  const sourceId = resolveCodeSourceId(root, gbrainEnv);
+
   if (!acquireDreamMarker()) {
     const pid = dreamMarkerPid();
     return {
@@ -1412,182 +1496,195 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
       ran: false,
       ok: true,
       duration_ms: Date.now() - t0,
-      summary: `dream already running${pid !== null ? ` (pid ${pid})` : ""} — skipped`,
+      summary: `call-graph backfill already running${pid !== null ? ` (pid ${pid})` : ""} — skipped`,
     };
   }
 
   try {
-    const dreamTimeoutMs = resolveStageTimeoutMs(
+    const timeoutMs = resolveStageTimeoutMs(
       process.env.GSTACK_SYNC_DREAM_TIMEOUT_MS,
       "GSTACK_SYNC_DREAM_TIMEOUT_MS",
       DEFAULT_DREAM_TIMEOUT_MS,
     );
+    const deadline = t0 + timeoutMs;
+    let passes = 0;
+    let chunksWalked = 0;
+    let edgesResolved = 0;
+    let edgesAmbiguous = 0;
+    let edgesUnmatched = 0;
 
-    // Scope the cycle to THIS worktree's code source: `gbrain dream --source <id>`.
-    // Verified empirically (not just from `gbrain --help`): plain `gbrain dream`
-    // cycles the brain's default source and never runs the source-scoped `extract`
-    // phase for our code source, so the call graph for the pinned source stays
-    // empty. `gbrain dream --source <id>` runs the per-source cycle (the form
-    // `gbrain doctor` recommends for stale sources) and is what actually populates
-    // code-callers/code-callees for this worktree. Falls back to plain `dream`
-    // only when we can't derive the source id (not in a git repo).
-    const root = repoRoot();
-    const sourceId = root ? resolveCodeSourceId(root, gbrainEnv) : null;
-    const dreamArgs = sourceId ? ["dream", "--source", sourceId] : ["dream"];
+    while (Date.now() < deadline) {
+      passes += 1;
+      if (!args.quiet) {
+        process.stderr.write(`[dream] backfilling call graph for ${sourceId} (pass ${passes})...\n`);
+      }
 
-    // spawnGbrain seeds DATABASE_URL from gbrain's config via buildGbrainEnv.
-    //
-    // We CAPTURE output (pipe) rather than inherit because `gbrain dream` exits 0
-    // even when it SKIPS the cycle — when another cycle already holds gbrain's own
-    // DB lock (e.g. a running `gbrain autopilot`), it prints "Skipped: another
-    // cycle is already running. (locked)" and exits 0. Trusting the exit code
-    // alone would falsely report "call graph built". Trade-off: no live streaming
-    // for a long cycle; we echo the captured output afterward instead.
-    if (!args.quiet) {
-      process.stderr.write("[dream] running gbrain cycle (call-graph build; this can take a few minutes)...\n");
-    }
-    let result: ReturnType<typeof spawnGbrain>;
-    try {
-      result = spawnGbrain(dreamArgs, {
+      let backfillResult: ReturnType<typeof spawnGbrain>;
+      try {
+        backfillResult = spawnGbrain(["edges-backfill", "--source", sourceId, "--json"], {
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: Math.max(1, deadline - Date.now()),
+          baseEnv: process.env,
+          announce: !args.quiet,
+        });
+      } catch (err) {
+        return {
+          name: "dream",
+          ran: true,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: `gbrain edges-backfill failed to start: ${(err as Error).message}`,
+        };
+      }
+
+      if (backfillResult.error || backfillResult.status !== 0) {
+        const err = backfillResult.error as NodeJS.ErrnoException | undefined;
+        const why = err?.code === "ENOENT"
+          ? "gbrain not on PATH"
+          : err?.message ?? (backfillResult.status === null
+            ? "killed by signal or timeout"
+            : "exit " + backfillResult.status);
+        return {
+          name: "dream",
+          ran: true,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: `gbrain edges-backfill failed: ${why}`,
+        };
+      }
+      if (/\[edges-backfill\][^\n]*failed:/i.test(backfillResult.stderr || "")) {
+        return {
+          name: "dream",
+          ran: true,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: "gbrain edges-backfill reported a source failure",
+        };
+      }
+      if (!args.quiet && backfillResult.stderr?.trim()) {
+        process.stderr.write(
+          backfillResult.stderr.endsWith("\n")
+            ? backfillResult.stderr
+            : backfillResult.stderr + "\n",
+        );
+      }
+
+      const backfill = parseEdgeBackfillSummary(backfillResult.stdout || "", sourceId);
+      if (!backfill) {
+        return {
+          name: "dream",
+          ran: true,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: `gbrain edges-backfill returned no exact row for source ${sourceId}`,
+        };
+      }
+      chunksWalked += backfill.chunks_walked;
+      edgesResolved += backfill.edges_resolved;
+      edgesAmbiguous += backfill.edges_ambiguous;
+      edgesUnmatched += backfill.edges_unmatched;
+
+      if (Date.now() >= deadline) break;
+      const readinessResult = spawnGbrain([
+        "code-callers",
+        CALL_GRAPH_READINESS_PROBE,
+        "--source",
+        sourceId,
+        "--limit",
+        "1",
+        "--json",
+      ], {
         stdio: ["ignore", "pipe", "pipe"],
-        timeout: dreamTimeoutMs,
+        timeout: Math.max(1, deadline - Date.now()),
         baseEnv: process.env,
-        announce: !args.quiet,
+        announce: false,
       });
-    } catch (err) {
-      // Spawn-setup failure (missing binary, bad env): ERR, not a benign skip.
-      return {
-        name: "dream",
-        ran: true,
-        ok: false,
-        duration_ms: Date.now() - t0,
-        summary: `gbrain dream failed to start: ${(err as Error).message}`,
-      };
+      if (readinessResult.error || readinessResult.status !== 0) {
+        const err = readinessResult.error as NodeJS.ErrnoException | undefined;
+        const why = err?.message ?? (readinessResult.status === null
+          ? "killed by signal or timeout"
+            : `exit ${readinessResult.status}`);
+        return {
+          name: "dream",
+          ran: true,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: `gbrain source readiness probe failed: ${why}`,
+        };
+      }
+
+      const readiness = parseCallGraphReadiness(readinessResult.stdout || "", sourceId);
+      if (!readiness) {
+        return {
+          name: "dream",
+          ran: true,
+          ok: false,
+          duration_ms: Date.now() - t0,
+          summary: `gbrain readiness returned invalid or wrong-source evidence for ${sourceId}`,
+        };
+      }
+
+      switch (nextCallGraphPass(backfill, readiness)) {
+        case "ready":
+          return {
+            name: "dream",
+            ran: true,
+            ok: true,
+            duration_ms: Date.now() - t0,
+            summary: `call graph ready for ${sourceId} ` +
+              `(${chunksWalked} chunks in ${passes} pass${passes === 1 ? "" : "es"}; ` +
+              `${edgesResolved} resolved, ${edgesAmbiguous} ambiguous, ${edgesUnmatched} unmatched)`,
+          };
+        case "continue":
+          continue;
+        case "stalled":
+          return {
+            name: "dream",
+            ran: true,
+            ok: true,
+            warn: true,
+            duration_ms: Date.now() - t0,
+            summary: `call graph for ${sourceId} still indexing, but the official backfill made no progress`,
+          };
+        case "not_built":
+          return {
+            name: "dream",
+            ran: true,
+            ok: true,
+            warn: true,
+            duration_ms: Date.now() - t0,
+            summary: `call graph not built for ${sourceId} because no code is indexed in that source`,
+          };
+        case "unknown":
+          return {
+            name: "dream",
+            ran: true,
+            ok: true,
+            warn: true,
+            duration_ms: Date.now() - t0,
+            summary: `call-graph readiness is unknown for ${sourceId}; no success claimed`,
+          };
+        case "invalid":
+          return {
+            name: "dream",
+            ran: true,
+            ok: false,
+            duration_ms: Date.now() - t0,
+            summary: `gbrain returned contradictory readiness for ${sourceId}`,
+          };
+      }
     }
 
-    if (result.error) {
-      const e = result.error as NodeJS.ErrnoException;
-      const why = e.code === "ENOENT" ? "gbrain not on PATH" : e.message;
-      return {
-        name: "dream",
-        ran: true,
-        ok: false,
-        duration_ms: Date.now() - t0,
-        summary: `gbrain dream failed to start: ${why}`,
-      };
-    }
-
-    const out = `${result.stdout || ""}${result.stderr || ""}`;
-    if (!args.quiet && out.trim()) {
-      process.stderr.write(out.endsWith("\n") ? out : `${out}\n`);
-    }
-
-    if (result.status !== 0) {
-      return {
-        name: "dream",
-        ran: true,
-        ok: false,
-        duration_ms: Date.now() - t0,
-        summary: `gbrain dream exited ${result.status === null ? "null (killed by signal / timeout)" : result.status}`,
-      };
-    }
-
-    // Exit 0 but the cycle was SKIPPED because gbrain's own lock is held by
-    // another cycle (typically `gbrain autopilot`). Report SKIP, not "built" —
-    // the graph builds on that other cycle, not this invocation.
-    if (/already running|\block(?:ed)?\b|Skipped:/i.test(out)) {
-      return {
-        name: "dream",
-        ran: false,
-        ok: true,
-        duration_ms: Date.now() - t0,
-        summary: "skipped — a gbrain cycle is already running (e.g. autopilot); the call graph builds on that cycle",
-      };
-    }
-
-    // Exit 0 and the cycle actually ran. Parse the cycle's OWN output to report
-    // the truth, not a flat "built": `gbrain dream` exits 0 even when the call
-    // graph could not be built, and a misleading "built" turns a multi-minute
-    // no-op into a silent dead end. gbrain only surfaces these conditions in the
-    // cycle log (there is no pre-flight pack-capability query as of 0.41.x), so
-    // string-matching the log is the available signal; an unrecognized log
-    // degrades to the generic success summary below.
-    const dreamWarn = classifyDreamOutcome(out);
-    if (dreamWarn) {
-      return {
-        name: "dream",
-        ran: true,
-        ok: true,
-        warn: true,
-        duration_ms: Date.now() - t0,
-        summary: dreamWarn,
-      };
-    }
-
-    const edges = parseResolvedEdges(out);
     return {
       name: "dream",
       ran: true,
-      ok: true,
+      ok: false,
       duration_ms: Date.now() - t0,
-      summary:
-        edges !== null
-          ? `call graph built (${edges} edge${edges === 1 ? "" : "s"} resolved)`
-          : "call graph built (resolve_symbol_edges complete)",
+      summary: `call-graph backfill timed out after ${passes} pass${passes === 1 ? "" : "es"}; progress is resumable`,
     };
   } finally {
     releaseDreamMarker();
   }
-}
-
-/**
- * Parse `<n>` from a `resolve_symbol_edges ... resolved <n>` cycle-log line.
- * Returns null when the line is absent (older gbrain / different pack). The
- * `[^\n]*?` is newline-bounded so it matches the `✓ resolve_symbol_edges ...`
- * summary line, not the bracketed `[cycle.resolve_symbol_edges] start` markers.
- */
-export function parseResolvedEdges(out: string): number | null {
-  const m = out.match(/resolve_symbol_edges\b[^\n]*?\bresolved\s+(\d+)/i);
-  return m ? parseInt(m[1], 10) : null;
-}
-
-/**
- * Inspect a completed (exit-0) `gbrain dream` log and return a WARN summary when
- * the cycle ran but could not actually build the call graph. Returns null on the
- * happy path (caller emits the normal "call graph built" summary). Order matters:
- * the pack-capability gap is the most actionable, so it wins over a 0-edge count
- * (both appear together when the pack lacks the code-symbol phase).
- */
-export function classifyDreamOutcome(out: string): string | null {
-  // The active schema pack doesn't declare the code-symbol extraction phase, so
-  // no symbols are extracted and resolve_symbol_edges has nothing to match.
-  // #2341: anchor the match to a GRAPH phase. The bare phrase false-positived
-  // on every base-pack brain — gbrain's only emitters of "active pack does not
-  // declare this phase" are the CONTENT phases (extract_atoms,
-  // synthesize_concepts), which base packs legitimately skip while
-  // resolve_symbol_edges still runs and builds the graph. Matching the bare
-  // phrase sent users pack-churning ("switch schema packs") for nothing and
-  // masked real graph bugs behind a wrong diagnosis.
-  if (/(resolve_symbol_edges|extract_code_symbols)[^\n]*does not declare/i.test(out)) {
-    return (
-      "dream ran, but this source's schema pack does not extract code symbols, " +
-      "so the call graph stays empty. Switch this source to a code-aware schema " +
-      "pack (`gbrain schema use <pack>`) to enable code-callers/code-callees."
-    );
-  }
-  // The embed phase failed for a missing key; symbols can't index without it.
-  if (/embed phase failed/i.test(out) || /requires\s+\S*_API_KEY/i.test(out)) {
-    return (
-      "dream ran, but the embed phase failed (missing embedding API key), so " +
-      "symbols won't index. Ensure the embedding provider's key is set for the " +
-      "gbrain process, then re-run /sync-gbrain --dream."
-    );
-  }
-  // Cycle ran and embedded fine, but matched zero call-graph edges.
-  if (parseResolvedEdges(out) === 0) {
-    return "dream ran but resolved 0 call-graph edges (no code symbols matched for this source yet).";
-  }
-  return null;
 }
 
 // ── State file ─────────────────────────────────────────────────────────────
@@ -1709,14 +1806,12 @@ async function main(): Promise<void> {
     const anyError = stages.some((s) => s.ran && !s.ok);
     exitCode = anyError ? 1 : 0;
   } finally {
-    // Release the sync lock BEFORE the dream cycle. Dream is a source-scoped
-    // cycle that can run several minutes; holding the machine-wide lock that
-    // long would freeze every other worktree's /sync-gbrain. Dream is guarded
-    // by its own marker.
+    // Release the sync lock BEFORE the source-scoped edge backfill. It can run
+    // several minutes and is guarded separately across sibling worktrees.
     cleanup();
   }
 
-  // ── Dream (call-graph build) — LOCK-FREE, after the sync lock releases ─────
+  // ── Call-graph backfill — LOCK-FREE, after the sync lock releases ───────────
   let dreamStage: StageResult | null = null;
   if (args.mode === "dry-run") {
     // Preview only; never probes doctor or spawns. `--dry-run` and `--full` are
@@ -1726,30 +1821,12 @@ async function main(): Promise<void> {
       dreamStage = await runDream(args);
     }
   } else {
-    // Resolve cycle state only on the --full auto path (perf: the steady-state
-    // incremental sync never pays a doctor subprocess). Explicit --dream forces.
-    let cycle: CycleStatus | null = null;
-    if (!args.dream && args.mode === "full" && !args.noDream && !args.noCode) {
-      const root = repoRoot();
-      const gbrainEnv = buildGbrainEnv({ announce: !args.quiet });
-      cycle = root ? cycleCompleted(resolveCodeSourceId(root, gbrainEnv), gbrainEnv) : "unknown";
-    }
-    if (shouldRunDream(args, cycle)) {
+    // A full code reindex can create fresh chunks even when an older cycle was
+    // complete, so it always backfills unless the caller explicitly opts out.
+    if (shouldRunDream(args, null)) {
       dreamStage = await runDream(args);
       mergeDreamIntoState(dreamStage);
       if (dreamStage.ran && !dreamStage.ok) exitCode = 1;
-    } else if (cycle === "unknown") {
-      // --full wanted to auto-build but doctor couldn't confirm the graph state.
-      // Surface a WARN-style SKIP so the user knows to run --dream if needed,
-      // rather than silently doing nothing (a flaky doctor must not trigger a
-      // surprise 35-min run — gbrain-doctor-overstrict).
-      dreamStage = {
-        name: "dream",
-        ran: false,
-        ok: true,
-        duration_ms: 0,
-        summary: "call-graph state unknown (doctor unavailable) — run /sync-gbrain --dream if code-callers returns 0",
-      };
     }
   }
 

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -1564,6 +1564,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
     };
   }
   const sourceId = resolveCodeSourceId(root, gbrainEnv);
+  const sourceDetail = { source_id: sourceId, source_path: root };
 
   if (!acquireDreamMarker(sourceId)) {
     const pid = dreamMarkerPid(sourceId);
@@ -1573,6 +1574,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
       ok: true,
       duration_ms: Date.now() - t0,
       summary: `call-graph backfill already running${pid !== null ? ` (pid ${pid})` : ""} — skipped`,
+      detail: sourceDetail,
     };
   }
 
@@ -1610,6 +1612,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
           ok: false,
           duration_ms: Date.now() - t0,
           summary: `gbrain edges-backfill failed to start: ${(err as Error).message}`,
+          detail: sourceDetail,
         };
       }
 
@@ -1626,6 +1629,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
           ok: false,
           duration_ms: Date.now() - t0,
           summary: `gbrain edges-backfill failed: ${why}`,
+          detail: sourceDetail,
         };
       }
       if (/\[edges-backfill\][^\n]*failed:/i.test(backfillResult.stderr || "")) {
@@ -1635,6 +1639,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
           ok: false,
           duration_ms: Date.now() - t0,
           summary: "gbrain edges-backfill reported a source failure",
+          detail: sourceDetail,
         };
       }
       if (!args.quiet && backfillResult.stderr?.trim()) {
@@ -1653,6 +1658,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
           ok: false,
           duration_ms: Date.now() - t0,
           summary: `gbrain edges-backfill returned no exact row for source ${sourceId}`,
+          detail: sourceDetail,
         };
       }
       chunksWalked += backfill.chunks_walked;
@@ -1684,6 +1690,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
           ok: false,
           duration_ms: Date.now() - t0,
           summary: `gbrain source readiness probe failed to start: ${(err as Error).message}`,
+          detail: sourceDetail,
         };
       }
       if (readinessResult.error || readinessResult.status !== 0) {
@@ -1697,6 +1704,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
           ok: false,
           duration_ms: Date.now() - t0,
           summary: `gbrain source readiness probe failed: ${why}`,
+          detail: sourceDetail,
         };
       }
 
@@ -1708,6 +1716,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
           ok: false,
           duration_ms: Date.now() - t0,
           summary: `gbrain readiness returned invalid or wrong-source evidence for ${sourceId}`,
+          detail: sourceDetail,
         };
       }
 
@@ -1721,6 +1730,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
             summary: `call graph ready for ${sourceId} ` +
               `(${chunksWalked} chunks in ${passes} pass${passes === 1 ? "" : "es"}; ` +
               `${edgesResolved} resolved, ${edgesAmbiguous} ambiguous, ${edgesUnmatched} unmatched)`,
+            detail: { ...sourceDetail, status: readiness.status, ready: readiness.ready },
           };
         case "continue":
           continue;
@@ -1732,6 +1742,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
             warn: true,
             duration_ms: Date.now() - t0,
             summary: `call graph for ${sourceId} still indexing, but the official backfill made no progress`,
+            detail: { ...sourceDetail, status: readiness.status, ready: readiness.ready },
           };
         case "not_built":
           return {
@@ -1741,6 +1752,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
             warn: true,
             duration_ms: Date.now() - t0,
             summary: `call graph not built for ${sourceId} because no code is indexed in that source`,
+            detail: { ...sourceDetail, status: readiness.status, ready: readiness.ready },
           };
         case "unknown":
           return {
@@ -1750,6 +1762,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
             warn: true,
             duration_ms: Date.now() - t0,
             summary: `call-graph readiness is unknown for ${sourceId}; no success claimed`,
+            detail: { ...sourceDetail, status: readiness.status, ready: readiness.ready },
           };
         case "invalid":
           return {
@@ -1758,6 +1771,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
             ok: false,
             duration_ms: Date.now() - t0,
             summary: `gbrain returned contradictory readiness for ${sourceId}`,
+            detail: { ...sourceDetail, status: readiness.status, ready: readiness.ready },
           };
       }
     }
@@ -1768,6 +1782,7 @@ export async function runDream(args: CliArgs): Promise<StageResult> {
       ok: false,
       duration_ms: Date.now() - t0,
       summary: `call-graph backfill timed out after ${passes} pass${passes === 1 ? "" : "es"}; progress is resumable`,
+      detail: sourceDetail,
     };
   } finally {
     releaseDreamMarker(sourceId);

--- a/lib/gbrain-local-status.ts
+++ b/lib/gbrain-local-status.ts
@@ -241,7 +241,7 @@ export function hasRemoteOnlyGbrainMcp(
   return sawRemote && !sawLocal;
 }
 
-function configuredEngine(env?: NodeJS.ProcessEnv): "pglite" | "postgres" | null {
+export function configuredEngine(env?: NodeJS.ProcessEnv): "pglite" | "postgres" | null {
   try {
     const parsed = JSON.parse(readFileSync(gbrainConfigPath(env), "utf-8")) as { engine?: string };
     return parsed.engine === "pglite" || parsed.engine === "postgres" ? parsed.engine : null;

--- a/lib/gbrain-repo-policy-client.ts
+++ b/lib/gbrain-repo-policy-client.ts
@@ -58,13 +58,19 @@ const POLICY_SCRIPT = join(import.meta.dir, "..", "bin", "gstack-gbrain-repo-pol
  * `none` (policy is keyed by origin remote, so nothing can be set for the
  * repo). Everything else shells to the script, which owns normalization.
  */
-export function repoPolicyTier(url: string | null, env: NodeJS.ProcessEnv = process.env): RepoPolicyResult {
+function repoPolicyTierWithCommand(
+  url: string | null,
+  env: NodeJS.ProcessEnv,
+  command: "get" | "peek",
+): RepoPolicyResult {
   if (!hasRepoPolicyStore(env)) return { tier: "none" };
   if (!url) return { tier: "none" };
   // The script is `#!/usr/bin/env bash`; win32 can't exec a shebang file, so
   // invoke through bash there. An ENOENT then means bash is not on PATH.
   const [cmd, args]: [string, string[]] =
-    process.platform === "win32" ? ["bash", [POLICY_SCRIPT, "get", url]] : [POLICY_SCRIPT, ["get", url]];
+    process.platform === "win32"
+      ? ["bash", [POLICY_SCRIPT, command, url]]
+      : [POLICY_SCRIPT, [command, url]];
   const res = spawnSync(cmd, args, {
     encoding: "utf-8",
     timeout: 10_000,
@@ -81,6 +87,18 @@ export function repoPolicyTier(url: string | null, env: NodeJS.ProcessEnv = proc
   if (tier === "deny" || tier === "read-only" || tier === "read-write") return { tier };
   if (tier === "unset") return { tier: "none" };
   return { tier: "none", error: "unreadable" }; // unexpected output — a read failure, not a tier
+}
+
+export function repoPolicyTier(url: string | null, env: NodeJS.ProcessEnv = process.env): RepoPolicyResult {
+  return repoPolicyTierWithCommand(url, env, "get");
+}
+
+/** Strictly non-mutating lookup for dry-run previews. */
+export function repoPolicyTierReadOnly(
+  url: string | null,
+  env: NodeJS.ProcessEnv = process.env,
+): RepoPolicyResult {
+  return repoPolicyTierWithCommand(url, env, "peek");
 }
 
 /**

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -1563,15 +1563,17 @@ Options:
 After answer:
 ```bash
 ~/.claude/skills/gstack/bin/gstack-config set transcript_ingest_mode <choice>
-bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --full --no-brain-sync
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+GSTACK_STATE_ROOT="$GSTACK_STATE_ROOT" \
+  bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --full --no-brain-sync
 ```
 (`--no-brain-sync` because Step 7 already wired that path; this just
 runs the code import + memory ingest stages. Brain-sync will run on the
 next preamble hook.)
 
-If A/D/E, ingest is incremental from this point on; preamble-boundary
-hook runs `bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --incremental --quiet` on every skill
-start (cheap mtime fast-path).
+If A/D/E, ingest is incremental from this point on; the preamble-boundary hook
+runs `eval "$(~/.claude/skills/gstack/bin/gstack-paths)"; GSTACK_STATE_ROOT="$GSTACK_STATE_ROOT" bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --incremental --quiet`
+on every skill start (cheap mtime fast-path).
 
 Reference doc for users: `setup-gbrain/memory.md` (linked from CLAUDE.md
 Step 8).
@@ -1777,10 +1779,12 @@ configured Mac is a first-class doctor path: every step detects existing
 state, repairs only what's missing, and reports here.
 
 ```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
 ~/.claude/skills/gstack/bin/gstack-gbrain-detect 2>/dev/null || true
 ~/.claude/skills/gstack/bin/gstack-config get transcript_ingest_mode 2>/dev/null || echo "off"
 ~/.claude/skills/gstack/bin/gstack-config get artifacts_sync_mode 2>/dev/null || echo "off"
-[ -f ~/.gstack/.gbrain-sync-state.json ] && cat ~/.gstack/.gbrain-sync-state.json || echo "{}"
+[ -f "$GSTACK_STATE_ROOT/.gbrain-sync-state.json" ] && \
+  cat "$GSTACK_STATE_ROOT/.gbrain-sync-state.json" || echo "{}"
 ```
 
 Read `gbrain_mcp_mode` from the detect output and pick the right verdict

--- a/setup-gbrain/SKILL.md.tmpl
+++ b/setup-gbrain/SKILL.md.tmpl
@@ -781,15 +781,17 @@ Options:
 After answer:
 ```bash
 ~/.claude/skills/gstack/bin/gstack-config set transcript_ingest_mode <choice>
-bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --full --no-brain-sync
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+GSTACK_STATE_ROOT="$GSTACK_STATE_ROOT" \
+  bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --full --no-brain-sync
 ```
 (`--no-brain-sync` because Step 7 already wired that path; this just
 runs the code import + memory ingest stages. Brain-sync will run on the
 next preamble hook.)
 
-If A/D/E, ingest is incremental from this point on; preamble-boundary
-hook runs `bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --incremental --quiet` on every skill
-start (cheap mtime fast-path).
+If A/D/E, ingest is incremental from this point on; the preamble-boundary hook
+runs `eval "$(~/.claude/skills/gstack/bin/gstack-paths)"; GSTACK_STATE_ROOT="$GSTACK_STATE_ROOT" bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --incremental --quiet`
+on every skill start (cheap mtime fast-path).
 
 Reference doc for users: `setup-gbrain/memory.md` (linked from CLAUDE.md
 Step 8).
@@ -995,10 +997,12 @@ configured Mac is a first-class doctor path: every step detects existing
 state, repairs only what's missing, and reports here.
 
 ```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
 ~/.claude/skills/gstack/bin/gstack-gbrain-detect 2>/dev/null || true
 ~/.claude/skills/gstack/bin/gstack-config get transcript_ingest_mode 2>/dev/null || echo "off"
 ~/.claude/skills/gstack/bin/gstack-config get artifacts_sync_mode 2>/dev/null || echo "off"
-[ -f ~/.gstack/.gbrain-sync-state.json ] && cat ~/.gstack/.gbrain-sync-state.json || echo "{}"
+[ -f "$GSTACK_STATE_ROOT/.gbrain-sync-state.json" ] && \
+  cat "$GSTACK_STATE_ROOT/.gbrain-sync-state.json" || echo "{}"
 ```
 
 Read `gbrain_mcp_mode` from the detect output and pick the right verdict

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -830,9 +830,9 @@ When the user types `/sync-gbrain`, run this skill. Argument modes (parsed by
 the skill itself, not a dispatcher binary):
 
 - `/sync-gbrain` — incremental sync (default; mtime fast-path; ~50ms steady-state)
-- `/sync-gbrain --full` — full code reindex via `gbrain reindex-code` (~25-35 min on a big repo). Auto-builds the call graph (`gbrain dream`) **only when it was never built**.
-- `/sync-gbrain --dream` — build this source's call graph (`gbrain code-callers`/`code-callees`) via a source-scoped `gbrain dream --source <id>` cycle; ~minutes; runs lock-free after the sync stages. Always forces, even if already built. Only produces a graph on a code-aware schema pack; otherwise the run reports a WARN explaining why the graph is still empty.
-- `/sync-gbrain --no-dream` — skip the dream cycle that `--full` would otherwise auto-run.
+- `/sync-gbrain --full` — full code reindex via `gbrain sync --strategy code --full --yes` (~25-35 min on a big repo), then source-scoped call-graph backfill.
+- `/sync-gbrain --dream` — legacy flag name for GBrain's official `edges-backfill --source <id>` path. It repeats GBrain's default bounded batch while the exact source is still indexing and progress continues, then requires the public `code-callers --source --json` envelope to say `ready: true`.
+- `/sync-gbrain --no-dream` — skip the call-graph backfill that `--full` would otherwise run.
 - `/sync-gbrain --code-only` — only run the code stage; skip memory + brain-sync
 - `/sync-gbrain --dry-run` — preview what would sync; no writes anywhere
 - `/sync-gbrain --no-memory` / `--no-brain-sync` — selectively skip stages
@@ -924,7 +924,7 @@ BEFORE invoking the orchestrator:
   if your pooler is slow." Do NOT treat this as a broken config.
 - **`thin-client`**: proceed to Step 2 — this machine is a thin client of a
   remote-HTTP MCP brain (#2051): no local engine BY DESIGN, so the code,
-  memory, and dream stages will SKIP with a thin-client reason (code indexing
+  memory, and call-graph stages will SKIP with a thin-client reason (code indexing
   runs on the brain server; memory syncs via the remote brain's artifacts
   pull). Only the brain-sync push runs locally. Tell the user in one line:
   "Thin client of a remote brain — local stages skip by design; brain queries
@@ -1023,71 +1023,62 @@ If B: continue to Step 4 with the empty-corpus state recorded.
 
 ## Step 3.5: Call-graph health check (offer `--dream`)
 
-`gbrain code-callers` / `code-callees` (who-calls-this / what-this-calls) return
-`count: 0` until a `gbrain dream` cycle runs the `resolve_symbol_edges` phase for
-this source — not done by the code import in Step 2.
+`code-callers` and `code-callees` carry GBrain's public source-scoped readiness
+signal. Probe it with a collision-resistant symbol so `count` stays zero and the
+command must consult graph readiness instead of short-circuiting on a match:
 
-**One hard prerequisite:** building a call graph requires this source's active
-**schema pack to extract code symbols** (the `extract_atoms` phase). On a pack
-that doesn't declare it (e.g. `gbrain-base` / `gbrain-base-v2`), a `dream` cycle
-completes but `resolve_symbol_edges` matches nothing — the graph stays empty no
-matter how many times you run it. So "build the call graph" is only meaningful on
-a code-aware pack. The `--dream` stage detects this and reports it honestly
-(a WARN row) rather than claiming a build that didn't happen. gbrain exposes pack
-capability only at cycle runtime (no pre-flight query as of 0.41.x), so we can't
-detect it before running. `code-def` / `code-refs` need the same symbol
-extraction; they are NOT free "direct lookups" on a non-code-aware pack.
+~~~bash
+SOURCE_ID=$(cat .gbrain-source 2>/dev/null \
+  || grep -o '"source_id":"[^"]*"' ~/.gstack/.gbrain-sync-state.json 2>/dev/null \
+    | head -1 | sed 's/.*"source_id":"//;s/".*//')
+GRAPH_JSON=$(gbrain code-callers "__gstack_call_graph_readiness_5f3c9d__" \
+  --source "$SOURCE_ID" --limit 1 --json 2>/dev/null || true)
+GRAPH_STATUS=$(printf '%s' "$GRAPH_JSON" | jq -r --arg id "$SOURCE_ID" '
+  if .source_id==$id and .scope=="single" and .count==0
+  then (.status // "unknown") else "unknown" end' 2>/dev/null || echo unknown)
+GRAPH_READY=$(printf '%s' "$GRAPH_JSON" | jq -r --arg id "$SOURCE_ID" '
+  if .source_id==$id and .scope=="single" and .count==0
+  then (.ready // false) else false end' 2>/dev/null || echo false)
+echo "call graph for $SOURCE_ID: status=$GRAPH_STATUS ready=$GRAPH_READY"
+~~~
 
-Detect whether this source's call graph is built via doctor's `cycle_freshness`
-check, matching the cwd `SOURCE_ID` literally:
+If `GRAPH_READY` is not `true`, `GRAPH_STATUS` is `indexing` or `not_built`, the user did
+not pass `--dream`/`--full`, and Step 3 `PAGES > 0`, AskUserQuestion via the format in
+the preamble:
 
-```bash
-SOURCE_ID=$(grep -o '"source_id":"[^"]*"' ~/.gstack/.gbrain-sync-state.json 2>/dev/null \
-  | head -1 | sed 's/.*"source_id":"//;s/".*//')
-CYCLE=$(gbrain doctor --json --fast 2>/dev/null \
-  | jq -r --arg id "$SOURCE_ID" '
-      (.checks[] | select(.name=="cycle_freshness")) as $c
-      | if $c.status=="ok" then "completed"
-        elif ($c.message | index($id)) then "never"
-        else "unknown" end' 2>/dev/null || echo unknown)
-# index($id) = literal substring (NOT test() regex), matching the lib reader in
-# cycleCompleted(). A fail/warn that doesn't name this source → "unknown" (don't
-# mask other-source failures).
-echo "call graph for $SOURCE_ID: $CYCLE"
-```
-
-If `CYCLE == never` AND the user did NOT pass `--dream`/`--full` AND Step 3
-`PAGES > 0`, AskUserQuestion via the format in the preamble:
-
-> D2 — This repo's call graph isn't built. Build it now?
+> D2 — This repo's call graph is not ready. Finish it now?
 >
-> ELI10: `gbrain code-callers`/`code-callees` (who calls this function / what it
-> calls) return nothing until the `resolve_symbol_edges` phase runs for this
-> source. `gbrain dream --source <this source>` runs it (scoped to this
-> worktree's code, takes a few minutes). It only produces a graph if this
-> source's schema pack extracts code symbols; if it doesn't, the run completes
-> but the graph stays empty and the dream row will say so.
+> ELI10: GBrain has indexed the code, but who-calls-this / what-this-calls is
+> not trustworthy until every pending code chunk has passed the edge resolver.
+> The source-scoped backfill is resumable and stops only when this exact source
+> reports ready.
 >
-> Recommendation: A — call-graph queries return 0 until this runs, and the code
-> index is already populated. If A comes back as a WARN ("pack does not extract
-> code symbols"), the fix is a code-aware schema pack, not re-running dream.
+> Recommendation: A — the code index already exists, and the official bounded
+> backfill can finish the missing graph work without running unrelated dream
+> phases or trusting brain-wide totals.
 >
 > Note: options differ in kind, not coverage — no completeness score.
 >
 > A) Run /sync-gbrain --dream now (recommended)
-> B) Skip — I'll run it later
+> B) Skip — I will run it later
 
-If A: re-invoke the orchestrator with `--dream --code-only` (skips memory +
-brain-sync; the dream stage still runs because it's gated on `--dream`). Then
-report the dream stage's ACTUAL row — `OK call graph built (N edges)` vs a
-`WARN` that names why the graph is still empty (non-code-aware pack, missing
-embedding key, or 0 edges matched). Do not claim success on a WARN.
-If B: continue to Step 4 with the call-graph-not-built state recorded for the
-verdict.
+If A: re-invoke the orchestrator with
+`--dream --no-code --no-memory --no-brain-sync`; the graph backfill needs the
+existing code index, not another code sync. The stage runs
+`gbrain edges-backfill --source` in GBrain's default bounded batches, continues
+only while `chunks_walked` is positive, and verifies the same source with
+`code-callers --source --json` after every pass. Report its ACTUAL row:
 
-If `CYCLE == completed` or `unknown`, do not prompt — but note `completed` means
-only that a cycle has run, not that edges exist (a non-code-aware pack reports
-`completed` with an empty graph). Step 5's verdict row surfaces the real state.
+- OK only when `status=ready` and `ready=true` for the exact source.
+- WARN when the source is not built, readiness is unknown, or it remains
+  indexing with no progress. Never call a WARN successful.
+- ERR on timeout, malformed/wrong-source evidence, a child-process failure, or
+  contradictory readiness.
+
+If B: continue to Step 4 with the non-ready state recorded for the verdict.
+
+If `GRAPH_READY` is `true`, do not prompt. If `GRAPH_STATUS` is `unknown`, do not launch
+a write from ambiguous evidence; carry a WARN into Step 5.
 
 ---
 
@@ -1153,10 +1144,10 @@ of the same repo each have their own pin and their own indexed pages, so
 semantic results match the code on disk here.
 
 Call-graph queries (`code-callers`/`code-callees`) also need the graph to be
-built first — run `/sync-gbrain --dream` (or `--full`) if they return
-`count: 0`. This only works if this source's gbrain schema pack extracts code
-symbols; on a non-code-aware pack `--dream` completes but the graph stays empty
-and reports a WARN. `code-def`/`code-refs` need the same extraction.
+built first. Trust their `status` and `ready` fields, not `count: 0` alone:
+zero results with `ready: true` are a genuine empty answer; `indexing` means run
+`/sync-gbrain --dream` (or `--full`). `code-def`/`code-refs` use symbol metadata
+created during code sync and do not depend on edge backfill.
 
 Two indexed corpora available via the `gbrain` CLI:
 - This worktree's code (auto-pinned via `.gbrain-source`).
@@ -1221,7 +1212,7 @@ gbrain status: GREEN
   Engine .......... OK   <pglite|supabase>
   Capability ...... OK   write+search round-trip
   CWD source ...... OK   <gstack-code-{repo_slug}> (page_count=<N>)
-  Call graph ...... OK   <N> edges resolved (code-callers/callees live)
+  Call graph ...... OK   <source_id> status=ready ready=true
   ~/.gstack source. OK   <gstack-brain-{user}> (page_count=<N>) — managed by /setup-gbrain
   Memory sync ..... OK   <artifacts_sync_mode>
   CLAUDE.md ....... OK   ## GBrain Search Guidance present
@@ -1230,27 +1221,22 @@ gbrain status: GREEN
 Run `/sync-gbrain` again any time gbrain feels off; safe and idempotent.
 ```
 
-The **Call graph** row reports the most authoritative signal available:
+The **Call graph** row reports exact-source readiness, never a brain-wide edge
+total or a completed maintenance cycle:
 
-1. **If a dream stage ran this invocation** (`--dream`, or `--full` auto-build),
-   mirror its row verbatim — it's the ground truth for this run:
-   - `OK   <N> edges resolved (code-callers/callees live)`
-   - `WARN dream ran but this source's schema pack does not extract code symbols
-     — switch to a code-aware pack (\`gbrain schema use <pack>\`)`
-   - `WARN dream ran but the embed phase failed (missing embedding key)`
-   - `WARN dream ran but resolved 0 edges (no code symbols matched yet)`
-2. **Otherwise** fall back to the `CYCLE` value from Step 3.5, with honest wording
-   (a completed cycle proves a cycle ran, NOT that edges exist):
-   - `completed` → `OK   cycle complete — code-callers/callees live IF this source's pack extracts code symbols`
-   - `never` → `WARN call graph not built — run /sync-gbrain --dream`
-   - `unknown` → `WARN could not probe call graph (doctor unavailable) — run /sync-gbrain --dream if code-callers returns 0`
+1. If the call-graph stage ran this invocation (`--dream`, or `--full`), mirror its
+   row verbatim:
+   - OK only for the requested source with `status=ready` and `ready=true`.
+   - WARN for `not_built`, `unknown`, or `indexing` with no progress.
+   - ERR for timeout, malformed/wrong-source evidence, child-process failure,
+     or contradictory readiness.
+2. Otherwise use `GRAPH_STATUS` and `GRAPH_READY` from Step 3.5:
+   - `ready` + `true` → `OK   source ready; empty caller/callee results are trustworthy`
+   - `indexing` + `false` → `WARN call graph still indexing — run /sync-gbrain --dream`
+   - `not_built` + `false` → `WARN call graph not built — run /sync-gbrain --full`
+   - `unknown` or any inconsistent pair → `WARN readiness unavailable; no success claimed`
 
-Any `WARN` Call graph row flips the verdict to YELLOW.
-
-If any row is YELLOW or RED, the verdict line says so and the failing rows
-surface a one-line "next action" (e.g., `Capability ...... ERR  capability
-check failed; CLAUDE.md guidance block REMOVED — run /setup-gbrain to repair`).
-A `never`/`unknown` Call graph row flips the verdict to YELLOW.
+Any WARN Call graph row flips the verdict to YELLOW. Any ERR flips it to RED.
 
 ---
 

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -1067,18 +1067,20 @@ signal. Probe it with a collision-resistant symbol so `count` stays zero and the
 command must consult graph readiness instead of short-circuiting on a match:
 
 ~~~bash
-# Read the exact source selected by this invocation. The dream stage persists
-# its path-validated source_id; code-stage detail is the fallback when dream
-# did not run. Never trust a raw .gbrain-source here: it may be stale, copied
-# from another checkout, or missed when the skill starts in a subdirectory.
-SOURCE_ID=$(jq -r '
+# Read only a path-validated result for THIS repository. Sibling worktrees can
+# update the shared state after this invocation; source_path custody makes that
+# race fail closed instead of certifying another checkout's graph. Never trust
+# a raw .gbrain-source here: it may be stale or copied from another checkout.
+_GSTACK_STATE_ROOT="${GSTACK_HOME:-$HOME/.gstack}"
+_REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
+SOURCE_ID=$(jq -r --arg path "$_REPO_TOP" '
   [
-    (.last_stages[]? | select(.name=="dream") | .detail.source_id),
-    (.last_stages[]? | select(.name=="code") | .detail.source_id)
+    (.last_stages[]? | select(.name=="dream" and .detail.source_path==$path) | .detail.source_id),
+    (.last_stages[]? | select(.name=="code" and .detail.source_path==$path) | .detail.source_id)
   ]
   | map(select(type=="string" and length>0))
   | first // empty
-' ~/.gstack/.gbrain-sync-state.json 2>/dev/null)
+' "$_GSTACK_STATE_ROOT/.gbrain-sync-state.json" 2>/dev/null)
 GRAPH_JSON=$(gbrain code-callers "__gstack_call_graph_readiness_5f3c9d__" \
   --source "$SOURCE_ID" --limit 1 --json 2>/dev/null || true)
 GRAPH_STATUS=$(printf '%s' "$GRAPH_JSON" | jq -r --arg id "$SOURCE_ID" '

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -1014,7 +1014,9 @@ Pass user args to the orchestrator. Do not paraphrase them — pass through
 as-is.
 
 ```bash
-bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts <user-args>
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+GSTACK_STATE_ROOT="$GSTACK_STATE_ROOT" \
+  bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts <user-args>
 ```
 
 The orchestrator runs three stages: code → memory → brain-sync (per the

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -865,7 +865,8 @@ modifications to brain or cache.
 Before doing anything, check that /setup-gbrain has been run on this Mac.
 
 ```bash
-~/.claude/skills/gstack/bin/gstack-gbrain-detect 2>/dev/null
+GBRAIN_DETECT_JSON=$(~/.claude/skills/gstack/bin/gstack-gbrain-detect 2>/dev/null)
+printf '%s\n' "$GBRAIN_DETECT_JSON"
 ```
 
 **Brain trust policy gate (v1.48 / Phase 1.5 / D4 — added by T13+T5c):**
@@ -968,6 +969,42 @@ This pre-flight short-circuits the orchestrator before it spends ~80ms
 probing the engine again. The orchestrator independently runs the same
 classifier for defense-in-depth, but Step 1.5's STOP is where the user
 gets the actionable remediation message.
+
+For local engine states `ok` or `timeout`, enforce the call-graph API floor
+before Step 2 can start a full code walk:
+
+```bash
+_GBRAIN_MIN_VERSION=0.42.14
+_GBRAIN_VERSION=$(printf '%s' "$GBRAIN_DETECT_JSON" \
+  | jq -r '.gbrain_version // ""' 2>/dev/null \
+  | sed -E 's/^gbrain[[:space:]]*v?//; s/^v//')
+_GBRAIN_VERSION_OK=false
+if printf '%s\n' "$_GBRAIN_VERSION" \
+    | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+  if awk -v have="$_GBRAIN_VERSION" -v need="$_GBRAIN_MIN_VERSION" '
+    BEGIN {
+      split(have, h, "."); split(need, n, ".");
+      for (i = 1; i <= 4; i++) {
+        hv = (h[i] == "" ? 0 : h[i] + 0);
+        nv = (n[i] == "" ? 0 : n[i] + 0);
+        if (hv > nv) exit 0;
+        if (hv < nv) exit 1;
+      }
+      exit 0;
+    }'; then
+    _GBRAIN_VERSION_OK=true
+  fi
+fi
+echo "GBRAIN_VERSION=$_GBRAIN_VERSION MINIMUM=$_GBRAIN_MIN_VERSION OK=$_GBRAIN_VERSION_OK"
+```
+
+If `_GBRAIN_VERSION_OK` is not `true`, STOP before invoking the orchestrator:
+
+> "This GBrain version is too old for source-scoped call-graph readiness.
+> Run `/setup-gbrain` to upgrade to v0.42.14 or newer, then retry `/sync-gbrain`."
+
+Thin clients skip this local CLI version gate because their code indexing runs
+on the remote brain server and the local call-graph stage is skipped by design.
 
 ---
 

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -1067,9 +1067,18 @@ signal. Probe it with a collision-resistant symbol so `count` stays zero and the
 command must consult graph readiness instead of short-circuiting on a match:
 
 ~~~bash
-SOURCE_ID=$(cat .gbrain-source 2>/dev/null \
-  || grep -o '"source_id":"[^"]*"' ~/.gstack/.gbrain-sync-state.json 2>/dev/null \
-    | head -1 | sed 's/.*"source_id":"//;s/".*//')
+# Read the exact source selected by this invocation. The dream stage persists
+# its path-validated source_id; code-stage detail is the fallback when dream
+# did not run. Never trust a raw .gbrain-source here: it may be stale, copied
+# from another checkout, or missed when the skill starts in a subdirectory.
+SOURCE_ID=$(jq -r '
+  [
+    (.last_stages[]? | select(.name=="dream") | .detail.source_id),
+    (.last_stages[]? | select(.name=="code") | .detail.source_id)
+  ]
+  | map(select(type=="string" and length>0))
+  | first // empty
+' ~/.gstack/.gbrain-sync-state.json 2>/dev/null)
 GRAPH_JSON=$(gbrain code-callers "__gstack_call_graph_readiness_5f3c9d__" \
   --source "$SOURCE_ID" --limit 1 --json 2>/dev/null || true)
 GRAPH_STATUS=$(printf '%s' "$GRAPH_JSON" | jq -r --arg id "$SOURCE_ID" '

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -1019,9 +1019,9 @@ bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts <user-args>
 
 The orchestrator runs three stages: code → memory → brain-sync (per the
 plan's storage tiering). Each stage failure is non-fatal; subsequent stages
-still run. State is persisted to `~/.gstack/.gbrain-sync-state.json` via
-tmp-file + atomic rename. Concurrent runs are blocked by a lock file at
-`~/.gstack/.sync-gbrain.lock` (5-min stale-takeover).
+still run. State is persisted below the portable GStack state root resolved by
+`bin/gstack-paths`, via tmp-file + atomic rename. Concurrent runs are blocked
+by a lock file in the same root (5-min stale-takeover).
 
 ---
 
@@ -1030,8 +1030,13 @@ tmp-file + atomic rename. Concurrent runs are blocked by a lock file at
 After the sync run, query gbrain for the cwd source's page_count:
 
 ```bash
-SOURCE_ID=$(grep -o '"source_id":"[^"]*"' ~/.gstack/.gbrain-sync-state.json 2>/dev/null \
-  | head -1 | sed 's/.*"source_id":"//;s/".*//')
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+_REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
+SOURCE_ID=$(jq -r --arg path "$_REPO_TOP" '
+  [.last_stages[]? | select(.name=="code" and .detail.source_path==$path) | .detail.source_id]
+  | map(select(type=="string" and length>0))
+  | first // empty
+' "$GSTACK_STATE_ROOT/.gbrain-sync-state.json" 2>/dev/null)
 PAGES=$(gbrain sources list --json 2>/dev/null \
   | jq -r --arg id "$SOURCE_ID" '.sources[] | select(.id==$id) | .page_count' 2>/dev/null \
   || echo 0)
@@ -1071,7 +1076,7 @@ command must consult graph readiness instead of short-circuiting on a match:
 # update the shared state after this invocation; source_path custody makes that
 # race fail closed instead of certifying another checkout's graph. Never trust
 # a raw .gbrain-source here: it may be stale or copied from another checkout.
-_GSTACK_STATE_ROOT="${GSTACK_HOME:-$HOME/.gstack}"
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
 _REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
 SOURCE_ID=$(jq -r --arg path "$_REPO_TOP" '
   [
@@ -1080,7 +1085,7 @@ SOURCE_ID=$(jq -r --arg path "$_REPO_TOP" '
   ]
   | map(select(type=="string" and length>0))
   | first // empty
-' "$_GSTACK_STATE_ROOT/.gbrain-sync-state.json" 2>/dev/null)
+' "$GSTACK_STATE_ROOT/.gbrain-sync-state.json" 2>/dev/null)
 GRAPH_JSON=$(gbrain code-callers "__gstack_call_graph_readiness_5f3c9d__" \
   --source "$SOURCE_ID" --limit 1 --json 2>/dev/null || true)
 GRAPH_STATUS=$(printf '%s' "$GRAPH_JSON" | jq -r --arg id "$SOURCE_ID" '

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -817,9 +817,11 @@ refreshed against this repo's current state, and refreshes the agent-side
 guidance in CLAUDE.md so the coding agent knows when to prefer `gbrain`
 search over Grep.
 
-**Architecture (post-codex review):** This skill uses gbrain v0.20.0+'s
-**native code surfaces** (`gbrain sources add`, `gbrain sync --strategy code`,
-`gbrain reindex-code`, `gbrain code-def/code-refs/code-callers/code-callees`).
+**Architecture (post-codex review):** This skill requires gbrain v0.42.14+.
+It uses the **native code surfaces** (`gbrain sources add`,
+`gbrain sync --strategy code`, `gbrain reindex-code`,
+`gbrain code-def/code-refs/code-callers/code-callees`) plus the public
+source-scoped call-graph readiness envelope added in that release.
 It does NOT use `gbrain import` (that path is for markdown directories).
 It does NOT touch `~/.gstack/` indexing (the existing `gstack-gbrain-source-wireup`
 owns that — never double-store).

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -236,9 +236,9 @@ bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts <user-args>
 
 The orchestrator runs three stages: code → memory → brain-sync (per the
 plan's storage tiering). Each stage failure is non-fatal; subsequent stages
-still run. State is persisted to `~/.gstack/.gbrain-sync-state.json` via
-tmp-file + atomic rename. Concurrent runs are blocked by a lock file at
-`~/.gstack/.sync-gbrain.lock` (5-min stale-takeover).
+still run. State is persisted below the portable GStack state root resolved by
+`bin/gstack-paths`, via tmp-file + atomic rename. Concurrent runs are blocked
+by a lock file in the same root (5-min stale-takeover).
 
 ---
 
@@ -247,8 +247,13 @@ tmp-file + atomic rename. Concurrent runs are blocked by a lock file at
 After the sync run, query gbrain for the cwd source's page_count:
 
 ```bash
-SOURCE_ID=$(grep -o '"source_id":"[^"]*"' ~/.gstack/.gbrain-sync-state.json 2>/dev/null \
-  | head -1 | sed 's/.*"source_id":"//;s/".*//')
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+_REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
+SOURCE_ID=$(jq -r --arg path "$_REPO_TOP" '
+  [.last_stages[]? | select(.name=="code" and .detail.source_path==$path) | .detail.source_id]
+  | map(select(type=="string" and length>0))
+  | first // empty
+' "$GSTACK_STATE_ROOT/.gbrain-sync-state.json" 2>/dev/null)
 PAGES=$(gbrain sources list --json 2>/dev/null \
   | jq -r --arg id "$SOURCE_ID" '.sources[] | select(.id==$id) | .page_count' 2>/dev/null \
   || echo 0)
@@ -288,7 +293,7 @@ command must consult graph readiness instead of short-circuiting on a match:
 # update the shared state after this invocation; source_path custody makes that
 # race fail closed instead of certifying another checkout's graph. Never trust
 # a raw .gbrain-source here: it may be stale or copied from another checkout.
-_GSTACK_STATE_ROOT="${GSTACK_HOME:-$HOME/.gstack}"
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
 _REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
 SOURCE_ID=$(jq -r --arg path "$_REPO_TOP" '
   [
@@ -297,7 +302,7 @@ SOURCE_ID=$(jq -r --arg path "$_REPO_TOP" '
   ]
   | map(select(type=="string" and length>0))
   | first // empty
-' "$_GSTACK_STATE_ROOT/.gbrain-sync-state.json" 2>/dev/null)
+' "$GSTACK_STATE_ROOT/.gbrain-sync-state.json" 2>/dev/null)
 GRAPH_JSON=$(gbrain code-callers "__gstack_call_graph_readiness_5f3c9d__" \
   --source "$SOURCE_ID" --limit 1 --json 2>/dev/null || true)
 GRAPH_STATUS=$(printf '%s' "$GRAPH_JSON" | jq -r --arg id "$SOURCE_ID" '

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -82,7 +82,8 @@ modifications to brain or cache.
 Before doing anything, check that /setup-gbrain has been run on this Mac.
 
 ```bash
-~/.claude/skills/gstack/bin/gstack-gbrain-detect 2>/dev/null
+GBRAIN_DETECT_JSON=$(~/.claude/skills/gstack/bin/gstack-gbrain-detect 2>/dev/null)
+printf '%s\n' "$GBRAIN_DETECT_JSON"
 ```
 
 **Brain trust policy gate (v1.48 / Phase 1.5 / D4 — added by T13+T5c):**
@@ -185,6 +186,42 @@ This pre-flight short-circuits the orchestrator before it spends ~80ms
 probing the engine again. The orchestrator independently runs the same
 classifier for defense-in-depth, but Step 1.5's STOP is where the user
 gets the actionable remediation message.
+
+For local engine states `ok` or `timeout`, enforce the call-graph API floor
+before Step 2 can start a full code walk:
+
+```bash
+_GBRAIN_MIN_VERSION=0.42.14
+_GBRAIN_VERSION=$(printf '%s' "$GBRAIN_DETECT_JSON" \
+  | jq -r '.gbrain_version // ""' 2>/dev/null \
+  | sed -E 's/^gbrain[[:space:]]*v?//; s/^v//')
+_GBRAIN_VERSION_OK=false
+if printf '%s\n' "$_GBRAIN_VERSION" \
+    | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+  if awk -v have="$_GBRAIN_VERSION" -v need="$_GBRAIN_MIN_VERSION" '
+    BEGIN {
+      split(have, h, "."); split(need, n, ".");
+      for (i = 1; i <= 4; i++) {
+        hv = (h[i] == "" ? 0 : h[i] + 0);
+        nv = (n[i] == "" ? 0 : n[i] + 0);
+        if (hv > nv) exit 0;
+        if (hv < nv) exit 1;
+      }
+      exit 0;
+    }'; then
+    _GBRAIN_VERSION_OK=true
+  fi
+fi
+echo "GBRAIN_VERSION=$_GBRAIN_VERSION MINIMUM=$_GBRAIN_MIN_VERSION OK=$_GBRAIN_VERSION_OK"
+```
+
+If `_GBRAIN_VERSION_OK` is not `true`, STOP before invoking the orchestrator:
+
+> "This GBrain version is too old for source-scoped call-graph readiness.
+> Run `/setup-gbrain` to upgrade to v0.42.14 or newer, then retry `/sync-gbrain`."
+
+Thin clients skip this local CLI version gate because their code indexing runs
+on the remote brain server and the local call-graph stage is skipped by design.
 
 ---
 

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -284,9 +284,18 @@ signal. Probe it with a collision-resistant symbol so `count` stays zero and the
 command must consult graph readiness instead of short-circuiting on a match:
 
 ~~~bash
-SOURCE_ID=$(cat .gbrain-source 2>/dev/null \
-  || grep -o '"source_id":"[^"]*"' ~/.gstack/.gbrain-sync-state.json 2>/dev/null \
-    | head -1 | sed 's/.*"source_id":"//;s/".*//')
+# Read the exact source selected by this invocation. The dream stage persists
+# its path-validated source_id; code-stage detail is the fallback when dream
+# did not run. Never trust a raw .gbrain-source here: it may be stale, copied
+# from another checkout, or missed when the skill starts in a subdirectory.
+SOURCE_ID=$(jq -r '
+  [
+    (.last_stages[]? | select(.name=="dream") | .detail.source_id),
+    (.last_stages[]? | select(.name=="code") | .detail.source_id)
+  ]
+  | map(select(type=="string" and length>0))
+  | first // empty
+' ~/.gstack/.gbrain-sync-state.json 2>/dev/null)
 GRAPH_JSON=$(gbrain code-callers "__gstack_call_graph_readiness_5f3c9d__" \
   --source "$SOURCE_ID" --limit 1 --json 2>/dev/null || true)
 GRAPH_STATUS=$(printf '%s' "$GRAPH_JSON" | jq -r --arg id "$SOURCE_ID" '

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -231,7 +231,9 @@ Pass user args to the orchestrator. Do not paraphrase them — pass through
 as-is.
 
 ```bash
-bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts <user-args>
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+GSTACK_STATE_ROOT="$GSTACK_STATE_ROOT" \
+  bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts <user-args>
 ```
 
 The orchestrator runs three stages: code → memory → brain-sync (per the

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -284,18 +284,20 @@ signal. Probe it with a collision-resistant symbol so `count` stays zero and the
 command must consult graph readiness instead of short-circuiting on a match:
 
 ~~~bash
-# Read the exact source selected by this invocation. The dream stage persists
-# its path-validated source_id; code-stage detail is the fallback when dream
-# did not run. Never trust a raw .gbrain-source here: it may be stale, copied
-# from another checkout, or missed when the skill starts in a subdirectory.
-SOURCE_ID=$(jq -r '
+# Read only a path-validated result for THIS repository. Sibling worktrees can
+# update the shared state after this invocation; source_path custody makes that
+# race fail closed instead of certifying another checkout's graph. Never trust
+# a raw .gbrain-source here: it may be stale or copied from another checkout.
+_GSTACK_STATE_ROOT="${GSTACK_HOME:-$HOME/.gstack}"
+_REPO_TOP=$(git rev-parse --show-toplevel 2>/dev/null || true)
+SOURCE_ID=$(jq -r --arg path "$_REPO_TOP" '
   [
-    (.last_stages[]? | select(.name=="dream") | .detail.source_id),
-    (.last_stages[]? | select(.name=="code") | .detail.source_id)
+    (.last_stages[]? | select(.name=="dream" and .detail.source_path==$path) | .detail.source_id),
+    (.last_stages[]? | select(.name=="code" and .detail.source_path==$path) | .detail.source_id)
   ]
   | map(select(type=="string" and length>0))
   | first // empty
-' ~/.gstack/.gbrain-sync-state.json 2>/dev/null)
+' "$_GSTACK_STATE_ROOT/.gbrain-sync-state.json" 2>/dev/null)
 GRAPH_JSON=$(gbrain code-callers "__gstack_call_graph_readiness_5f3c9d__" \
   --source "$SOURCE_ID" --limit 1 --json 2>/dev/null || true)
 GRAPH_STATUS=$(printf '%s' "$GRAPH_JSON" | jq -r --arg id "$SOURCE_ID" '

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -47,9 +47,9 @@ When the user types `/sync-gbrain`, run this skill. Argument modes (parsed by
 the skill itself, not a dispatcher binary):
 
 - `/sync-gbrain` — incremental sync (default; mtime fast-path; ~50ms steady-state)
-- `/sync-gbrain --full` — full code reindex via `gbrain reindex-code` (~25-35 min on a big repo). Auto-builds the call graph (`gbrain dream`) **only when it was never built**.
-- `/sync-gbrain --dream` — build this source's call graph (`gbrain code-callers`/`code-callees`) via a source-scoped `gbrain dream --source <id>` cycle; ~minutes; runs lock-free after the sync stages. Always forces, even if already built. Only produces a graph on a code-aware schema pack; otherwise the run reports a WARN explaining why the graph is still empty.
-- `/sync-gbrain --no-dream` — skip the dream cycle that `--full` would otherwise auto-run.
+- `/sync-gbrain --full` — full code reindex via `gbrain sync --strategy code --full --yes` (~25-35 min on a big repo), then source-scoped call-graph backfill.
+- `/sync-gbrain --dream` — legacy flag name for GBrain's official `edges-backfill --source <id>` path. It repeats GBrain's default bounded batch while the exact source is still indexing and progress continues, then requires the public `code-callers --source --json` envelope to say `ready: true`.
+- `/sync-gbrain --no-dream` — skip the call-graph backfill that `--full` would otherwise run.
 - `/sync-gbrain --code-only` — only run the code stage; skip memory + brain-sync
 - `/sync-gbrain --dry-run` — preview what would sync; no writes anywhere
 - `/sync-gbrain --no-memory` / `--no-brain-sync` — selectively skip stages
@@ -141,7 +141,7 @@ BEFORE invoking the orchestrator:
   if your pooler is slow." Do NOT treat this as a broken config.
 - **`thin-client`**: proceed to Step 2 — this machine is a thin client of a
   remote-HTTP MCP brain (#2051): no local engine BY DESIGN, so the code,
-  memory, and dream stages will SKIP with a thin-client reason (code indexing
+  memory, and call-graph stages will SKIP with a thin-client reason (code indexing
   runs on the brain server; memory syncs via the remote brain's artifacts
   pull). Only the brain-sync push runs locally. Tell the user in one line:
   "Thin client of a remote brain — local stages skip by design; brain queries
@@ -240,71 +240,62 @@ If B: continue to Step 4 with the empty-corpus state recorded.
 
 ## Step 3.5: Call-graph health check (offer `--dream`)
 
-`gbrain code-callers` / `code-callees` (who-calls-this / what-this-calls) return
-`count: 0` until a `gbrain dream` cycle runs the `resolve_symbol_edges` phase for
-this source — not done by the code import in Step 2.
+`code-callers` and `code-callees` carry GBrain's public source-scoped readiness
+signal. Probe it with a collision-resistant symbol so `count` stays zero and the
+command must consult graph readiness instead of short-circuiting on a match:
 
-**One hard prerequisite:** building a call graph requires this source's active
-**schema pack to extract code symbols** (the `extract_atoms` phase). On a pack
-that doesn't declare it (e.g. `gbrain-base` / `gbrain-base-v2`), a `dream` cycle
-completes but `resolve_symbol_edges` matches nothing — the graph stays empty no
-matter how many times you run it. So "build the call graph" is only meaningful on
-a code-aware pack. The `--dream` stage detects this and reports it honestly
-(a WARN row) rather than claiming a build that didn't happen. gbrain exposes pack
-capability only at cycle runtime (no pre-flight query as of 0.41.x), so we can't
-detect it before running. `code-def` / `code-refs` need the same symbol
-extraction; they are NOT free "direct lookups" on a non-code-aware pack.
+~~~bash
+SOURCE_ID=$(cat .gbrain-source 2>/dev/null \
+  || grep -o '"source_id":"[^"]*"' ~/.gstack/.gbrain-sync-state.json 2>/dev/null \
+    | head -1 | sed 's/.*"source_id":"//;s/".*//')
+GRAPH_JSON=$(gbrain code-callers "__gstack_call_graph_readiness_5f3c9d__" \
+  --source "$SOURCE_ID" --limit 1 --json 2>/dev/null || true)
+GRAPH_STATUS=$(printf '%s' "$GRAPH_JSON" | jq -r --arg id "$SOURCE_ID" '
+  if .source_id==$id and .scope=="single" and .count==0
+  then (.status // "unknown") else "unknown" end' 2>/dev/null || echo unknown)
+GRAPH_READY=$(printf '%s' "$GRAPH_JSON" | jq -r --arg id "$SOURCE_ID" '
+  if .source_id==$id and .scope=="single" and .count==0
+  then (.ready // false) else false end' 2>/dev/null || echo false)
+echo "call graph for $SOURCE_ID: status=$GRAPH_STATUS ready=$GRAPH_READY"
+~~~
 
-Detect whether this source's call graph is built via doctor's `cycle_freshness`
-check, matching the cwd `SOURCE_ID` literally:
+If `GRAPH_READY` is not `true`, `GRAPH_STATUS` is `indexing` or `not_built`, the user did
+not pass `--dream`/`--full`, and Step 3 `PAGES > 0`, AskUserQuestion via the format in
+the preamble:
 
-```bash
-SOURCE_ID=$(grep -o '"source_id":"[^"]*"' ~/.gstack/.gbrain-sync-state.json 2>/dev/null \
-  | head -1 | sed 's/.*"source_id":"//;s/".*//')
-CYCLE=$(gbrain doctor --json --fast 2>/dev/null \
-  | jq -r --arg id "$SOURCE_ID" '
-      (.checks[] | select(.name=="cycle_freshness")) as $c
-      | if $c.status=="ok" then "completed"
-        elif ($c.message | index($id)) then "never"
-        else "unknown" end' 2>/dev/null || echo unknown)
-# index($id) = literal substring (NOT test() regex), matching the lib reader in
-# cycleCompleted(). A fail/warn that doesn't name this source → "unknown" (don't
-# mask other-source failures).
-echo "call graph for $SOURCE_ID: $CYCLE"
-```
-
-If `CYCLE == never` AND the user did NOT pass `--dream`/`--full` AND Step 3
-`PAGES > 0`, AskUserQuestion via the format in the preamble:
-
-> D2 — This repo's call graph isn't built. Build it now?
+> D2 — This repo's call graph is not ready. Finish it now?
 >
-> ELI10: `gbrain code-callers`/`code-callees` (who calls this function / what it
-> calls) return nothing until the `resolve_symbol_edges` phase runs for this
-> source. `gbrain dream --source <this source>` runs it (scoped to this
-> worktree's code, takes a few minutes). It only produces a graph if this
-> source's schema pack extracts code symbols; if it doesn't, the run completes
-> but the graph stays empty and the dream row will say so.
+> ELI10: GBrain has indexed the code, but who-calls-this / what-this-calls is
+> not trustworthy until every pending code chunk has passed the edge resolver.
+> The source-scoped backfill is resumable and stops only when this exact source
+> reports ready.
 >
-> Recommendation: A — call-graph queries return 0 until this runs, and the code
-> index is already populated. If A comes back as a WARN ("pack does not extract
-> code symbols"), the fix is a code-aware schema pack, not re-running dream.
+> Recommendation: A — the code index already exists, and the official bounded
+> backfill can finish the missing graph work without running unrelated dream
+> phases or trusting brain-wide totals.
 >
 > Note: options differ in kind, not coverage — no completeness score.
 >
 > A) Run /sync-gbrain --dream now (recommended)
-> B) Skip — I'll run it later
+> B) Skip — I will run it later
 
-If A: re-invoke the orchestrator with `--dream --code-only` (skips memory +
-brain-sync; the dream stage still runs because it's gated on `--dream`). Then
-report the dream stage's ACTUAL row — `OK call graph built (N edges)` vs a
-`WARN` that names why the graph is still empty (non-code-aware pack, missing
-embedding key, or 0 edges matched). Do not claim success on a WARN.
-If B: continue to Step 4 with the call-graph-not-built state recorded for the
-verdict.
+If A: re-invoke the orchestrator with
+`--dream --no-code --no-memory --no-brain-sync`; the graph backfill needs the
+existing code index, not another code sync. The stage runs
+`gbrain edges-backfill --source` in GBrain's default bounded batches, continues
+only while `chunks_walked` is positive, and verifies the same source with
+`code-callers --source --json` after every pass. Report its ACTUAL row:
 
-If `CYCLE == completed` or `unknown`, do not prompt — but note `completed` means
-only that a cycle has run, not that edges exist (a non-code-aware pack reports
-`completed` with an empty graph). Step 5's verdict row surfaces the real state.
+- OK only when `status=ready` and `ready=true` for the exact source.
+- WARN when the source is not built, readiness is unknown, or it remains
+  indexing with no progress. Never call a WARN successful.
+- ERR on timeout, malformed/wrong-source evidence, a child-process failure, or
+  contradictory readiness.
+
+If B: continue to Step 4 with the non-ready state recorded for the verdict.
+
+If `GRAPH_READY` is `true`, do not prompt. If `GRAPH_STATUS` is `unknown`, do not launch
+a write from ambiguous evidence; carry a WARN into Step 5.
 
 ---
 
@@ -370,10 +361,10 @@ of the same repo each have their own pin and their own indexed pages, so
 semantic results match the code on disk here.
 
 Call-graph queries (`code-callers`/`code-callees`) also need the graph to be
-built first — run `/sync-gbrain --dream` (or `--full`) if they return
-`count: 0`. This only works if this source's gbrain schema pack extracts code
-symbols; on a non-code-aware pack `--dream` completes but the graph stays empty
-and reports a WARN. `code-def`/`code-refs` need the same extraction.
+built first. Trust their `status` and `ready` fields, not `count: 0` alone:
+zero results with `ready: true` are a genuine empty answer; `indexing` means run
+`/sync-gbrain --dream` (or `--full`). `code-def`/`code-refs` use symbol metadata
+created during code sync and do not depend on edge backfill.
 
 Two indexed corpora available via the `gbrain` CLI:
 - This worktree's code (auto-pinned via `.gbrain-source`).
@@ -438,7 +429,7 @@ gbrain status: GREEN
   Engine .......... OK   <pglite|supabase>
   Capability ...... OK   write+search round-trip
   CWD source ...... OK   <gstack-code-{repo_slug}> (page_count=<N>)
-  Call graph ...... OK   <N> edges resolved (code-callers/callees live)
+  Call graph ...... OK   <source_id> status=ready ready=true
   ~/.gstack source. OK   <gstack-brain-{user}> (page_count=<N>) — managed by /setup-gbrain
   Memory sync ..... OK   <artifacts_sync_mode>
   CLAUDE.md ....... OK   ## GBrain Search Guidance present
@@ -447,27 +438,22 @@ gbrain status: GREEN
 Run `/sync-gbrain` again any time gbrain feels off; safe and idempotent.
 ```
 
-The **Call graph** row reports the most authoritative signal available:
+The **Call graph** row reports exact-source readiness, never a brain-wide edge
+total or a completed maintenance cycle:
 
-1. **If a dream stage ran this invocation** (`--dream`, or `--full` auto-build),
-   mirror its row verbatim — it's the ground truth for this run:
-   - `OK   <N> edges resolved (code-callers/callees live)`
-   - `WARN dream ran but this source's schema pack does not extract code symbols
-     — switch to a code-aware pack (\`gbrain schema use <pack>\`)`
-   - `WARN dream ran but the embed phase failed (missing embedding key)`
-   - `WARN dream ran but resolved 0 edges (no code symbols matched yet)`
-2. **Otherwise** fall back to the `CYCLE` value from Step 3.5, with honest wording
-   (a completed cycle proves a cycle ran, NOT that edges exist):
-   - `completed` → `OK   cycle complete — code-callers/callees live IF this source's pack extracts code symbols`
-   - `never` → `WARN call graph not built — run /sync-gbrain --dream`
-   - `unknown` → `WARN could not probe call graph (doctor unavailable) — run /sync-gbrain --dream if code-callers returns 0`
+1. If the call-graph stage ran this invocation (`--dream`, or `--full`), mirror its
+   row verbatim:
+   - OK only for the requested source with `status=ready` and `ready=true`.
+   - WARN for `not_built`, `unknown`, or `indexing` with no progress.
+   - ERR for timeout, malformed/wrong-source evidence, child-process failure,
+     or contradictory readiness.
+2. Otherwise use `GRAPH_STATUS` and `GRAPH_READY` from Step 3.5:
+   - `ready` + `true` → `OK   source ready; empty caller/callee results are trustworthy`
+   - `indexing` + `false` → `WARN call graph still indexing — run /sync-gbrain --dream`
+   - `not_built` + `false` → `WARN call graph not built — run /sync-gbrain --full`
+   - `unknown` or any inconsistent pair → `WARN readiness unavailable; no success claimed`
 
-Any `WARN` Call graph row flips the verdict to YELLOW.
-
-If any row is YELLOW or RED, the verdict line says so and the failing rows
-surface a one-line "next action" (e.g., `Capability ...... ERR  capability
-check failed; CLAUDE.md guidance block REMOVED — run /setup-gbrain to repair`).
-A `never`/`unknown` Call graph row flips the verdict to YELLOW.
+Any WARN Call graph row flips the verdict to YELLOW. Any ERR flips it to RED.
 
 ---
 

--- a/sync-gbrain/SKILL.md.tmpl
+++ b/sync-gbrain/SKILL.md.tmpl
@@ -34,9 +34,11 @@ refreshed against this repo's current state, and refreshes the agent-side
 guidance in CLAUDE.md so the coding agent knows when to prefer `gbrain`
 search over Grep.
 
-**Architecture (post-codex review):** This skill uses gbrain v0.20.0+'s
-**native code surfaces** (`gbrain sources add`, `gbrain sync --strategy code`,
-`gbrain reindex-code`, `gbrain code-def/code-refs/code-callers/code-callees`).
+**Architecture (post-codex review):** This skill requires gbrain v0.42.14+.
+It uses the **native code surfaces** (`gbrain sources add`,
+`gbrain sync --strategy code`, `gbrain reindex-code`,
+`gbrain code-def/code-refs/code-callers/code-callees`) plus the public
+source-scoped call-graph readiness envelope added in that release.
 It does NOT use `gbrain import` (that path is for markdown directories).
 It does NOT touch `~/.gstack/` indexing (the existing `gstack-gbrain-source-wireup`
 owns that — never double-store).

--- a/test/gbrain-detect-install.test.ts
+++ b/test/gbrain-detect-install.test.ts
@@ -34,7 +34,7 @@ const INSTALL = path.join(ROOT, 'bin', 'gstack-gbrain-install');
 // symlink to bun and nothing else.
 const BUN_ONLY_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'bun-only-'));
 fs.symlinkSync(process.execPath, path.join(BUN_ONLY_DIR, 'bun'));
-const SAFE_PATH = `/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin:${BUN_ONLY_DIR}`;
+const SAFE_PATH = `/usr/bin:/bin:/usr/sbin:/sbin:${BUN_ONLY_DIR}`;
 
 let tmpHome: string;
 let tmpHomeReal: string;
@@ -213,15 +213,15 @@ describe('gstack-gbrain-install D19 PATH-shadow validation', () => {
   }
 
   test('passes when install-dir version matches `gbrain --version` on PATH', () => {
-    // Version must be >= MIN_GBRAIN_VERSION (0.20.0) floor (#1744).
-    const installDir = seedInstallDir('0.41.29');
-    const fakeBin = seedFakeGbrainBinary('0.41.29');
+    // Version must be >= the source-scoped readiness floor (0.42.14).
+    const installDir = seedInstallDir('0.42.14');
+    const fakeBin = seedFakeGbrainBinary('0.42.14');
     try {
       const r = run(INSTALL, ['--validate-only', '--install-dir', installDir], {
         env: { PATH: `${fakeBin}:${SAFE_PATH}` },
       });
       expect(r.status).toBe(0);
-      expect(r.stdout).toContain('installed gbrain 0.41.29');
+      expect(r.stdout).toContain('installed gbrain 0.42.14');
     } finally {
       fs.rmSync(installDir, { recursive: true, force: true });
       fs.rmSync(fakeBin, { recursive: true, force: true });
@@ -229,8 +229,8 @@ describe('gstack-gbrain-install D19 PATH-shadow validation', () => {
   });
 
   test('hard-fails (exit 3) when the installed gbrain is below the version floor (#1744)', () => {
-    const installDir = seedInstallDir('0.18.2');
-    const fakeBin = seedFakeGbrainBinary('0.18.2');
+    const installDir = seedInstallDir('0.42.13');
+    const fakeBin = seedFakeGbrainBinary('0.42.13');
     try {
       const r = run(INSTALL, ['--validate-only', '--install-dir', installDir], {
         env: { PATH: `${fakeBin}:${SAFE_PATH}` },
@@ -244,8 +244,8 @@ describe('gstack-gbrain-install D19 PATH-shadow validation', () => {
   });
 
   test('tolerates a leading "v" in `gbrain --version` output', () => {
-    const installDir = seedInstallDir('0.41.29');
-    const fakeBin = seedFakeGbrainBinary('v0.41.29');
+    const installDir = seedInstallDir('0.42.14');
+    const fakeBin = seedFakeGbrainBinary('v0.42.14');
     try {
       const r = run(INSTALL, ['--validate-only', '--install-dir', installDir], {
         env: { PATH: `${fakeBin}:${SAFE_PATH}` },

--- a/test/gbrain-dream-stage.test.ts
+++ b/test/gbrain-dream-stage.test.ts
@@ -205,6 +205,16 @@ describe("CLI gate wiring (dry-run subprocess — never spawns a real dream)", (
 });
 
 describe("skill readiness source custody", () => {
+  it("passes the portable state root from the skill to the orchestrator writer", () => {
+    const template = readFileSync(join(import.meta.dir, "..", "sync-gbrain", "SKILL.md.tmpl"), "utf-8");
+    const runStep = template.slice(
+      template.indexOf("## Step 2: Run the orchestrator"),
+      template.indexOf("## Step 3: Code-index health check"),
+    );
+    expect(runStep).toContain('eval "$(~/.claude/skills/gstack/bin/gstack-paths)"');
+    expect(runStep).toContain('GSTACK_STATE_ROOT="$GSTACK_STATE_ROOT"');
+  });
+
   it("resolves code-index state through the portable root for this repository", () => {
     const template = readFileSync(join(import.meta.dir, "..", "sync-gbrain", "SKILL.md.tmpl"), "utf-8");
     const healthCheck = template.slice(

--- a/test/gbrain-dream-stage.test.ts
+++ b/test/gbrain-dream-stage.test.ts
@@ -117,6 +117,7 @@ describe("runDream — dry-run preview", () => {
 
 describe("dream marker — concurrency guard", () => {
   const saved = process.env.GSTACK_HOME;
+  const savedStateRoot = process.env.GSTACK_STATE_ROOT;
   const savedHome = process.env.HOME;
   const sourceA = "gstack-code-acme-a-11111111";
   const sourceB = "gstack-code-acme-b-22222222";
@@ -126,6 +127,8 @@ describe("dream marker — concurrency guard", () => {
     if (tmp) rmSync(tmp, { recursive: true, force: true });
     if (saved === undefined) delete process.env.GSTACK_HOME;
     else process.env.GSTACK_HOME = saved;
+    if (savedStateRoot === undefined) delete process.env.GSTACK_STATE_ROOT;
+    else process.env.GSTACK_STATE_ROOT = savedStateRoot;
     if (savedHome === undefined) delete process.env.HOME;
     else process.env.HOME = savedHome;
   });
@@ -133,6 +136,7 @@ describe("dream marker — concurrency guard", () => {
   function redirectHome(): void {
     tmp = mkdtempSync(join(tmpdir(), "gbrain-dream-marker-"));
     process.env.GSTACK_HOME = tmp;
+    process.env.GSTACK_STATE_ROOT = join(tmp, "portable-metadata");
     process.env.HOME = tmp;
   }
 
@@ -140,6 +144,8 @@ describe("dream marker — concurrency guard", () => {
     redirectHome();
     expect(acquireDreamMarker(sourceA)).toBe(true);
     expect(existsSync(dreamMarkerPath(sourceA))).toBe(true);
+    expect(dreamMarkerPath(sourceA).startsWith(process.env.GSTACK_HOME!)).toBe(true);
+    expect(dreamMarkerPath(sourceA).startsWith(process.env.GSTACK_STATE_ROOT!)).toBe(false);
     // Fresh marker present → a concurrent worktree must NOT launch a duplicate.
     expect(acquireDreamMarker(sourceA)).toBe(false);
   });

--- a/test/gbrain-dream-stage.test.ts
+++ b/test/gbrain-dream-stage.test.ts
@@ -97,6 +97,8 @@ describe("runDream — dry-run preview", () => {
 
 describe("dream marker — concurrency guard", () => {
   const saved = process.env.GSTACK_HOME;
+  const sourceA = "gstack-code-acme-a-11111111";
+  const sourceB = "gstack-code-acme-b-22222222";
   let tmp: string;
 
   afterEach(() => {
@@ -112,27 +114,34 @@ describe("dream marker — concurrency guard", () => {
 
   it("acquire creates the marker; a second acquire on a fresh marker fails", () => {
     redirectHome();
-    expect(acquireDreamMarker()).toBe(true);
-    expect(existsSync(dreamMarkerPath())).toBe(true);
+    expect(acquireDreamMarker(sourceA)).toBe(true);
+    expect(existsSync(dreamMarkerPath(sourceA))).toBe(true);
     // Fresh marker present → a concurrent worktree must NOT launch a duplicate.
-    expect(acquireDreamMarker()).toBe(false);
+    expect(acquireDreamMarker(sourceA)).toBe(false);
+  });
+
+  it("does not suppress a concurrent backfill for a different source", () => {
+    redirectHome();
+    expect(acquireDreamMarker(sourceA)).toBe(true);
+    expect(acquireDreamMarker(sourceB)).toBe(true);
+    expect(dreamMarkerPath(sourceA)).not.toBe(dreamMarkerPath(sourceB));
   });
 
   it("release removes the marker (same pid)", () => {
     redirectHome();
-    expect(acquireDreamMarker()).toBe(true);
-    releaseDreamMarker();
-    expect(existsSync(dreamMarkerPath())).toBe(false);
+    expect(acquireDreamMarker(sourceA)).toBe(true);
+    releaseDreamMarker(sourceA);
+    expect(existsSync(dreamMarkerPath(sourceA))).toBe(false);
   });
 
   it("a stale marker (older than TTL) is taken over", () => {
     redirectHome();
     // Plant a marker with an mtime ~46 min in the past (TTL is 45 min).
-    const path = dreamMarkerPath();
+    const path = dreamMarkerPath(sourceA);
     writeFileSync(path, JSON.stringify({ pid: 999999, started_at: "old" }));
     const old = new Date(Date.now() - 46 * 60 * 1000);
     utimesSync(path, old, old);
-    expect(acquireDreamMarker()).toBe(true); // takeover
+    expect(acquireDreamMarker(sourceA)).toBe(true); // takeover
     expect(existsSync(path)).toBe(true);
   });
 });

--- a/test/gbrain-dream-stage.test.ts
+++ b/test/gbrain-dream-stage.test.ts
@@ -205,6 +205,18 @@ describe("CLI gate wiring (dry-run subprocess — never spawns a real dream)", (
 });
 
 describe("skill readiness source custody", () => {
+  it("resolves code-index state through the portable root for this repository", () => {
+    const template = readFileSync(join(import.meta.dir, "..", "sync-gbrain", "SKILL.md.tmpl"), "utf-8");
+    const healthCheck = template.slice(
+      template.indexOf("## Step 3: Code-index health check"),
+      template.indexOf("## Step 3.5: Call-graph health check"),
+    );
+    expect(healthCheck).toContain('eval "$(~/.claude/skills/gstack/bin/gstack-paths)"');
+    expect(healthCheck).toContain('.name=="code" and .detail.source_path==$path');
+    expect(healthCheck).toContain('"$GSTACK_STATE_ROOT/.gbrain-sync-state.json"');
+    expect(healthCheck).not.toContain("~/.gstack/.gbrain-sync-state.json");
+  });
+
   it("uses the persisted path-validated dream/code source, never a raw cwd pin", () => {
     const template = readFileSync(join(import.meta.dir, "..", "sync-gbrain", "SKILL.md.tmpl"), "utf-8");
     const healthCheck = template.slice(
@@ -214,7 +226,9 @@ describe("skill readiness source custody", () => {
     expect(healthCheck).toContain('.name=="dream" and .detail.source_path==$path');
     expect(healthCheck).toContain('.name=="code" and .detail.source_path==$path');
     expect(healthCheck).toContain('.detail.source_path==$path');
-    expect(healthCheck).toContain('${GSTACK_HOME:-$HOME/.gstack}');
+    expect(healthCheck).toContain('eval "$(~/.claude/skills/gstack/bin/gstack-paths)"');
+    expect(healthCheck).toContain('"$GSTACK_STATE_ROOT/.gbrain-sync-state.json"');
+    expect(healthCheck).not.toContain('${GSTACK_HOME:-$HOME/.gstack}');
     expect(healthCheck).not.toContain("cat .gbrain-source");
   });
 });

--- a/test/gbrain-dream-stage.test.ts
+++ b/test/gbrain-dream-stage.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, existsSync, writeFileSync, utimesSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, writeFileSync, utimesSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { spawnSync } from "child_process";
@@ -201,6 +201,19 @@ describe("CLI gate wiring (dry-run subprocess — never spawns a real dream)", (
 
   it("plain --dry-run (incremental) omits the dream row", () => {
     expect(run([])).not.toContain("would: gbrain edges-backfill");
+  });
+});
+
+describe("skill readiness source custody", () => {
+  it("uses the persisted path-validated dream/code source, never a raw cwd pin", () => {
+    const template = readFileSync(join(import.meta.dir, "..", "sync-gbrain", "SKILL.md.tmpl"), "utf-8");
+    const healthCheck = template.slice(
+      template.indexOf("## Step 3.5: Call-graph health check"),
+      template.indexOf("## Step 4: Refresh"),
+    );
+    expect(healthCheck).toContain('select(.name=="dream")');
+    expect(healthCheck).toContain('select(.name=="code")');
+    expect(healthCheck).not.toContain("cat .gbrain-source");
   });
 });
 

--- a/test/gbrain-dream-stage.test.ts
+++ b/test/gbrain-dream-stage.test.ts
@@ -1,12 +1,12 @@
 /**
  * Tests for the dream (call-graph build) stage of bin/gstack-gbrain-sync.ts.
  *
- * We deliberately do NOT exercise the real `gbrain dream` spawn here — that's a
- * ~35-min brain-global job and must never run in CI. Instead we cover:
+ * We deliberately do NOT exercise a real GBrain backfill in CI. Instead we cover:
  *   1. shouldRunDream() — the pure gate matrix (issues 1/2/4). Highest-risk logic.
  *   2. runDream() dry-run — returns a preview before any engine probe / spawn.
  *   3. Dream marker (acquire/release/stale-takeover) — the concurrency guard.
- *   4. CLI gate wiring via --dry-run subprocess (safe: dry-run never spawns dream).
+ *   4. Exact-source output parsing and bounded-pass continuation decisions.
+ *   5. CLI gate wiring via --dry-run subprocess (safe: dry-run never backfills).
  *
  * The live spawn + lock-free ordering + serialization are covered by the manual
  * E2E verification in the plan (running the orchestrator against a real brain),
@@ -25,10 +25,13 @@ import {
   acquireDreamMarker,
   releaseDreamMarker,
   dreamMarkerPath,
-  classifyDreamOutcome,
-  parseResolvedEdges,
+  parseEdgeBackfillSummary,
+  parseCallGraphReadiness,
+  nextCallGraphPass,
   formatStage,
   type CliArgs,
+  type EdgeBackfillSummary,
+  type CallGraphReadiness,
 } from "../bin/gstack-gbrain-sync";
 
 const SCRIPT = join(import.meta.dir, "..", "bin", "gstack-gbrain-sync.ts");
@@ -61,11 +64,11 @@ describe("shouldRunDream — gate matrix", () => {
     expect(shouldRunDream(args({ dream: true, noCode: true }), null)).toBe(true);
   });
 
-  it("--full auto-runs ONLY when the cycle was never built", () => {
+  it("--full always backfills after reindex regardless of old cycle freshness", () => {
     expect(shouldRunDream(args({ mode: "full" }), "never")).toBe(true);
-    expect(shouldRunDream(args({ mode: "full" }), "completed")).toBe(false);
-    expect(shouldRunDream(args({ mode: "full" }), "unknown")).toBe(false);
-    expect(shouldRunDream(args({ mode: "full" }), null)).toBe(false);
+    expect(shouldRunDream(args({ mode: "full" }), "completed")).toBe(true);
+    expect(shouldRunDream(args({ mode: "full" }), "unknown")).toBe(true);
+    expect(shouldRunDream(args({ mode: "full" }), null)).toBe(true);
   });
 
   it("--full + --no-dream never auto-runs", () => {
@@ -88,7 +91,7 @@ describe("runDream — dry-run preview", () => {
     expect(r.name).toBe("dream");
     expect(r.ran).toBe(false);
     expect(r.ok).toBe(true);
-    expect(r.summary).toContain("would: gbrain dream");
+    expect(r.summary).toContain("would: gbrain edges-backfill");
   });
 });
 
@@ -148,113 +151,112 @@ describe("CLI gate wiring (dry-run subprocess — never spawns a real dream)", (
     return (r.stdout || "") + (r.stderr || "");
   }
 
-  it("--dry-run --dream shows the dream preview row", () => {
-    expect(run(["--dream"])).toContain("would: gbrain dream");
+  it("--dry-run --dream shows the source-scoped backfill preview row", () => {
+    expect(run(["--dream"])).toContain("would: gbrain edges-backfill");
   });
 
   it("plain --dry-run (incremental) omits the dream row", () => {
-    expect(run([])).not.toContain("would: gbrain dream");
+    expect(run([])).not.toContain("would: gbrain edges-backfill");
   });
 });
 
-// Canned `gbrain dream` cycle logs (verbatim shapes observed against a real
-// 0.41.x brain). These let us test the post-flight guard WITHOUT a real cycle.
-const LOG = {
-  // #2341: the DEFAULT base packs legitimately skip the CONTENT phases
-  // (extract_atoms, synthesize_concepts) while resolve_symbol_edges still runs
-  // — gbrain's only emitters of "does not declare this phase" are those
-  // content phases, so the bare-phrase match fired on EVERY base-pack brain
-  // and told users to churn schema packs for nothing. This shape (content
-  // phase undeclared, resolver ran, resolved 0) must classify as the 0-edge
-  // outcome, not the pack-capability one.
-  basePackZeroEdges:
-    "[cycle.extract] done\n" +
-    "  - extract_atoms  extract_atoms: active pack does not declare this phase\n" +
-    "[cycle.resolve_symbol_edges] start\n" +
-    "[cycle.resolve_symbol_edges] done\n" +
-    "  ✓ resolve_symbol_edges  3864 chunk(s) walked; resolved 0, ambiguous 0, unmatched 0\n" +
-    "  totals: extracted=0 embedded=1\n",
-  // #2341 headline shape: base pack skips content phases AND the graph built
-  // fine — a healthy run that used to WARN.
-  basePackBuiltEdges:
-    "  - extract_atoms  extract_atoms: active pack does not declare this phase\n" +
-    "  ✓ resolve_symbol_edges  6001 chunk(s) walked; resolved 42, ambiguous 0, unmatched 0\n" +
-    "  - synthesize_concepts  synthesize_concepts: active pack does not declare this phase\n",
-  // The GRAPH phase itself is undeclared: the one shape where the
-  // pack-capability WARN is the right diagnosis.
-  graphPhaseUndeclared:
-    "  - resolve_symbol_edges  resolve_symbol_edges: active pack does not declare this phase\n" +
-    "  totals: extracted=0 embedded=1\n",
-  // Embed phase failed for a missing key (isolated: no pack-capability line).
-  embedFailed:
-    "[cycle.embed] start\n" +
-    "[cycle.embed] done\n" +
-    "  ✗ embed       embed phase failed\n" +
-    '      [LLMError/UNKNOWN] Embedding model "openai:text-embedding-3-large" requires OPENAI_API_KEY.\n' +
-    "  totals: extracted=0 embedded=0\n",
-  // Cycle ran clean but matched zero edges (no other failure signal).
-  zeroEdges:
-    "  ✓ resolve_symbol_edges  120 chunk(s) walked; resolved 0, ambiguous 0, unmatched 0\n",
-  // Happy path: edges resolved.
-  builtEdges:
-    "  ✓ resolve_symbol_edges  500 chunk(s) walked; resolved 42, ambiguous 3, unmatched 1\n",
-  // Old gbrain / different pack: no resolve_symbol_edges summary line at all.
-  noEdgeLine: "[cycle.lint] done\n[cycle.sync] done\n  totals: lint=53\n",
-};
+const SOURCE_ID = "gstack-code-candor-eda9672b";
 
-describe("parseResolvedEdges", () => {
-  it("reads the resolved count from the ✓ summary line", () => {
-    expect(parseResolvedEdges(LOG.builtEdges)).toBe(42);
-    expect(parseResolvedEdges(LOG.zeroEdges)).toBe(0);
+function backfill(overrides: Partial<EdgeBackfillSummary> = {}): EdgeBackfillSummary {
+  return {
+    source_id: SOURCE_ID,
+    chunks_walked: 2000,
+    edges_resolved: 42,
+    edges_ambiguous: 3,
+    edges_unmatched: 7,
+    batches: 10,
+    ms: 500,
+    ...overrides,
+  };
+}
+
+function readiness(overrides: Partial<CallGraphReadiness> = {}): CallGraphReadiness {
+  return {
+    source_id: SOURCE_ID,
+    scope: "single",
+    count: 0,
+    status: "ready",
+    ready: true,
+    ...overrides,
+  };
+}
+
+describe("parseEdgeBackfillSummary — exact-source custody", () => {
+  it("accepts the one row for the requested source", () => {
+    const out = JSON.stringify({ schema_version: 1, summary: [backfill()] });
+    expect(parseEdgeBackfillSummary(out, SOURCE_ID)).toEqual(backfill());
   });
-  it("returns null when there is no resolve_symbol_edges summary", () => {
-    expect(parseResolvedEdges(LOG.noEdgeLine)).toBeNull();
-  });
-  it("does not match the bracketed [cycle.resolve_symbol_edges] marker lines", () => {
-    // Markers have no 'resolved N' on the same line, so they must not match.
-    const markersOnly = "[cycle.resolve_symbol_edges] start\n[cycle.resolve_symbol_edges] done\n";
-    expect(parseResolvedEdges(markersOnly)).toBeNull();
+
+  it("rejects another source, multiple rows, malformed JSON, and invalid counters", () => {
+    expect(parseEdgeBackfillSummary(JSON.stringify({
+      summary: [backfill({ source_id: "other-source" })],
+    }), SOURCE_ID)).toBeNull();
+    expect(parseEdgeBackfillSummary(JSON.stringify({
+      summary: [backfill(), backfill({ source_id: "other-source" })],
+    }), SOURCE_ID)).toBeNull();
+    expect(parseEdgeBackfillSummary("not-json", SOURCE_ID)).toBeNull();
+    expect(parseEdgeBackfillSummary(JSON.stringify({
+      summary: [backfill({ chunks_walked: -1 })],
+    }), SOURCE_ID)).toBeNull();
   });
 });
 
-describe("classifyDreamOutcome — post-flight truth guard", () => {
-  it("base-pack content-phase skips classify as 0-edge, NOT pack-capability (#2341)", () => {
-    const w = classifyDreamOutcome(LOG.basePackZeroEdges);
-    expect(w).not.toBeNull();
-    expect(w).toContain("resolved 0");
-    expect(w).not.toContain("code-aware");
+describe("parseCallGraphReadiness — exact-source public signal", () => {
+  it("accepts a zero-result sentinel envelope that says the source is ready", () => {
+    expect(parseCallGraphReadiness(JSON.stringify(readiness()), SOURCE_ID)).toEqual(readiness());
   });
 
-  it("a healthy base-pack run with a built graph is clean (#2341 headline)", () => {
-    expect(classifyDreamOutcome(LOG.basePackBuiltEdges)).toBeNull();
+  it("rejects global, wrong-source, colliding-sentinel, and malformed evidence", () => {
+    expect(parseCallGraphReadiness(JSON.stringify({
+      ...readiness(),
+      scope: "all",
+    }), SOURCE_ID)).toBeNull();
+    expect(parseCallGraphReadiness(JSON.stringify({
+      ...readiness(),
+      source_id: "other-source",
+    }), SOURCE_ID)).toBeNull();
+    expect(parseCallGraphReadiness(JSON.stringify({
+      ...readiness(),
+      count: 1,
+    }), SOURCE_ID)).toBeNull();
+    expect(parseCallGraphReadiness("not-json", SOURCE_ID)).toBeNull();
+  });
+});
+
+describe("nextCallGraphPass — bounded official batching", () => {
+  it("stops only on source-scoped ready=true", () => {
+    expect(nextCallGraphPass(backfill(), readiness())).toBe("ready");
   });
 
-  it("flags pack capability only when the GRAPH phase itself is undeclared", () => {
-    const w = classifyDreamOutcome(LOG.graphPhaseUndeclared);
-    expect(w).not.toBeNull();
-    expect(w).toContain("schema pack");
-    expect(w).toContain("code-aware");
+  it("continues indexing only when the official batch made progress", () => {
+    expect(nextCallGraphPass(
+      backfill({ chunks_walked: 2000 }),
+      readiness({ status: "indexing", ready: false }),
+    )).toBe("continue");
+    expect(nextCallGraphPass(
+      backfill({ chunks_walked: 0 }),
+      readiness({ status: "indexing", ready: false }),
+    )).toBe("stalled");
   });
 
-  it("flags a failed embed phase / missing embedding key", () => {
-    const w = classifyDreamOutcome(LOG.embedFailed);
-    expect(w).not.toBeNull();
-    expect(w).toContain("embed");
-    expect(w!.toLowerCase()).toContain("key");
-  });
-
-  it("flags a clean cycle that resolved 0 edges", () => {
-    const w = classifyDreamOutcome(LOG.zeroEdges);
-    expect(w).not.toBeNull();
-    expect(w).toContain("0 call-graph edges");
-  });
-
-  it("returns null on the happy path (edges resolved)", () => {
-    expect(classifyDreamOutcome(LOG.builtEdges)).toBeNull();
-  });
-
-  it("returns null when no recognizable signal is present (degrade to success)", () => {
-    expect(classifyDreamOutcome(LOG.noEdgeLine)).toBeNull();
+  it("fails closed on not-built, unknown, and contradictory readiness", () => {
+    expect(nextCallGraphPass(
+      backfill({ chunks_walked: 0 }),
+      readiness({ status: "not_built", ready: false }),
+    )).toBe("not_built");
+    expect(nextCallGraphPass(
+      backfill({ chunks_walked: 0 }),
+      readiness({ status: "unknown", ready: false }),
+    )).toBe("unknown");
+    expect(nextCallGraphPass(
+      backfill(),
+      readiness({ status: "indexing", ready: true }),
+    )).toBe("invalid");
   });
 });
 

--- a/test/gbrain-dream-stage.test.ts
+++ b/test/gbrain-dream-stage.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect, afterEach } from "bun:test";
-import { mkdtempSync, existsSync, writeFileSync, utimesSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, existsSync, writeFileSync, utimesSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { spawnSync } from "child_process";
@@ -117,6 +117,7 @@ describe("runDream — dry-run preview", () => {
 
 describe("dream marker — concurrency guard", () => {
   const saved = process.env.GSTACK_HOME;
+  const savedHome = process.env.HOME;
   const sourceA = "gstack-code-acme-a-11111111";
   const sourceB = "gstack-code-acme-b-22222222";
   let tmp: string;
@@ -125,11 +126,14 @@ describe("dream marker — concurrency guard", () => {
     if (tmp) rmSync(tmp, { recursive: true, force: true });
     if (saved === undefined) delete process.env.GSTACK_HOME;
     else process.env.GSTACK_HOME = saved;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
   });
 
   function redirectHome(): void {
     tmp = mkdtempSync(join(tmpdir(), "gbrain-dream-marker-"));
     process.env.GSTACK_HOME = tmp;
+    process.env.HOME = tmp;
   }
 
   it("acquire creates the marker; a second acquire on a fresh marker fails", () => {
@@ -140,8 +144,19 @@ describe("dream marker — concurrency guard", () => {
     expect(acquireDreamMarker(sourceA)).toBe(false);
   });
 
-  it("does not suppress a concurrent backfill for a different source", () => {
+  it("serializes different sources on one PGLite engine", () => {
     redirectHome();
+    mkdirSync(join(tmp, ".gbrain"), { recursive: true });
+    writeFileSync(join(tmp, ".gbrain", "config.json"), JSON.stringify({ engine: "pglite" }));
+    expect(acquireDreamMarker(sourceA)).toBe(true);
+    expect(acquireDreamMarker(sourceB)).toBe(false);
+    expect(dreamMarkerPath(sourceA)).toBe(dreamMarkerPath(sourceB));
+  });
+
+  it("allows different sources to backfill concurrently on Postgres", () => {
+    redirectHome();
+    mkdirSync(join(tmp, ".gbrain"), { recursive: true });
+    writeFileSync(join(tmp, ".gbrain", "config.json"), JSON.stringify({ engine: "postgres" }));
     expect(acquireDreamMarker(sourceA)).toBe(true);
     expect(acquireDreamMarker(sourceB)).toBe(true);
     expect(dreamMarkerPath(sourceA)).not.toBe(dreamMarkerPath(sourceB));

--- a/test/gbrain-dream-stage.test.ts
+++ b/test/gbrain-dream-stage.test.ts
@@ -28,6 +28,8 @@ import {
   parseEdgeBackfillSummary,
   parseCallGraphReadiness,
   nextCallGraphPass,
+  isGbrainCallGraphVersionSupported,
+  MIN_GBRAIN_CALL_GRAPH_VERSION,
   formatStage,
   type CliArgs,
   type EdgeBackfillSummary,
@@ -82,6 +84,24 @@ describe("shouldRunDream — gate matrix", () => {
   it("plain incremental never runs (no flag, no full)", () => {
     expect(shouldRunDream(args(), "never")).toBe(false);
     expect(shouldRunDream(args(), null)).toBe(false);
+  });
+});
+
+describe("GBrain call-graph version floor", () => {
+  it("accepts the readiness release and newer 3/4-part stable versions", () => {
+    expect(MIN_GBRAIN_CALL_GRAPH_VERSION).toBe("0.42.14");
+    expect(isGbrainCallGraphVersionSupported("gbrain 0.42.14.0")).toBe(true);
+    expect(isGbrainCallGraphVersionSupported("v0.42.14")).toBe(true);
+    expect(isGbrainCallGraphVersionSupported("gbrain0.46.24.0")).toBe(true);
+    expect(isGbrainCallGraphVersionSupported("1.0.0")).toBe(true);
+  });
+
+  it("rejects older, prerelease, malformed, and missing versions", () => {
+    expect(isGbrainCallGraphVersionSupported("gbrain 0.42.13.9")).toBe(false);
+    expect(isGbrainCallGraphVersionSupported("0.41.99")).toBe(false);
+    expect(isGbrainCallGraphVersionSupported("0.42.14-alpha")).toBe(false);
+    expect(isGbrainCallGraphVersionSupported("unknown")).toBe(false);
+    expect(isGbrainCallGraphVersionSupported("")).toBe(false);
   });
 });
 

--- a/test/gbrain-dream-stage.test.ts
+++ b/test/gbrain-dream-stage.test.ts
@@ -211,8 +211,10 @@ describe("skill readiness source custody", () => {
       template.indexOf("## Step 3.5: Call-graph health check"),
       template.indexOf("## Step 4: Refresh"),
     );
-    expect(healthCheck).toContain('select(.name=="dream")');
-    expect(healthCheck).toContain('select(.name=="code")');
+    expect(healthCheck).toContain('.name=="dream" and .detail.source_path==$path');
+    expect(healthCheck).toContain('.name=="code" and .detail.source_path==$path');
+    expect(healthCheck).toContain('.detail.source_path==$path');
+    expect(healthCheck).toContain('${GSTACK_HOME:-$HOME/.gstack}');
     expect(healthCheck).not.toContain("cat .gbrain-source");
   });
 });

--- a/test/gbrain-repo-policy.test.ts
+++ b/test/gbrain-repo-policy.test.ts
@@ -121,6 +121,24 @@ describe('set + get', () => {
     expect(run(['get', 'https://github.com/c/c']).stdout).toBe('deny');
   });
 
+  test('peek interprets a legacy allow tier without migrating the store', () => {
+    const legacy = JSON.stringify({ 'github.com/foo/bar': 'allow' });
+    fs.writeFileSync(policyFile(), legacy);
+    const r = run(['peek', 'https://github.com/foo/bar.git']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('read-write');
+    expect(fs.readFileSync(policyFile(), 'utf-8')).toBe(legacy);
+  });
+
+  test('peek fails closed on corrupt JSON without quarantine or replacement', () => {
+    const corrupt = '{broken';
+    fs.writeFileSync(policyFile(), corrupt);
+    const r = run(['peek', 'https://github.com/foo/bar.git']);
+    expect(r.status).toBe(2);
+    expect(fs.readFileSync(policyFile(), 'utf-8')).toBe(corrupt);
+    expect(fs.readdirSync(tmpHome).filter((name) => name.includes('.corrupt-'))).toEqual([]);
+  });
+
   test('invalid tier rejected with non-zero exit', () => {
     const r = run(['set', 'https://github.com/foo/bar', 'allow']);
     expect(r.status).not.toBe(0);
@@ -392,6 +410,19 @@ describe('gstack-gbrain-sync code stage honors the repo policy (#2140 sync path)
     } finally {
       fs.rmSync(binDir, { recursive: true, force: true });
     }
+  });
+
+  test('dream dry-run reads legacy policy without migrating it', () => {
+    makeRepo();
+    const legacy = JSON.stringify({ 'github.com/acme/widget': 'deny' });
+    fs.writeFileSync(policyFile(), legacy);
+    const r = runSync([
+      '--dry-run', '--dream', '--no-code', '--no-memory', '--no-brain-sync', '--quiet',
+    ]);
+    // Preview reports the refusal but remains a successful no-write preview.
+    expect(r.status).toBe(0);
+    expect(r.text).toContain('no GBrain interaction is allowed');
+    expect(fs.readFileSync(policyFile(), 'utf-8')).toBe(legacy);
   });
 
   test('store exists but unreadable → fail-closed refusal, never bypassed', () => {

--- a/test/gbrain-repo-policy.test.ts
+++ b/test/gbrain-repo-policy.test.ts
@@ -363,6 +363,13 @@ describe('gstack-gbrain-sync code stage honors the repo policy (#2140 sync path)
 
     try {
       expect(run(['set', REPO_URL, 'deny']).status).toBe(0);
+      const deniedPreview = runSync([
+        '--dry-run', '--dream', '--no-code', '--no-memory', '--no-brain-sync', '--quiet',
+      ], env);
+      expect(deniedPreview.text).toContain('no GBrain interaction is allowed');
+      expect(deniedPreview.text).not.toContain('would: gbrain edges-backfill');
+      expect(fs.existsSync(commandLog)).toBe(false);
+
       const denied = runSync(dreamArgs, env);
       expect(denied.status).toBe(1);
       expect(denied.stages.find((s: any) => s.name === 'dream')?.summary)
@@ -370,6 +377,13 @@ describe('gstack-gbrain-sync code stage honors the repo policy (#2140 sync path)
       expect(fs.existsSync(commandLog)).toBe(false);
 
       expect(run(['set', REPO_URL, 'read-only']).status).toBe(0);
+      const readOnlyPreview = runSync([
+        '--dry-run', '--dream', '--no-code', '--no-memory', '--no-brain-sync', '--quiet',
+      ], env);
+      expect(readOnlyPreview.text).toContain('call-graph backfill writes metadata');
+      expect(readOnlyPreview.text).not.toContain('would: gbrain edges-backfill');
+      expect(fs.existsSync(commandLog)).toBe(false);
+
       const readOnly = runSync(dreamArgs, env);
       expect(readOnly.status).toBe(0);
       expect(readOnly.stages.find((s: any) => s.name === 'dream')?.summary)

--- a/test/gbrain-repo-policy.test.ts
+++ b/test/gbrain-repo-policy.test.ts
@@ -295,13 +295,16 @@ describe('gstack-gbrain-sync code stage honors the repo policy (#2140 sync path)
     git('-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'fixture');
   }
 
-  function runSync(): { status: number; text: string; stages: any[] } {
-    const res = spawnSync('bun', [SYNC, '--code-only', '--incremental'], {
+  function runSync(
+    args: string[] = ['--code-only', '--incremental'],
+    extraEnv: Record<string, string> = {},
+  ): { status: number; text: string; stages: any[] } {
+    const res = spawnSync('bun', [SYNC, ...args], {
       cwd: repoDir,
       encoding: 'utf-8',
       timeout: 60_000,
       // HOME also redirected so engine detection can't find a real ~/.gbrain.
-      env: { ...process.env, GSTACK_HOME: tmpHome, HOME: tmpHome },
+      env: { ...process.env, GSTACK_HOME: tmpHome, HOME: tmpHome, ...extraEnv },
     });
     let stages: any[] = [];
     try {
@@ -341,6 +344,40 @@ describe('gstack-gbrain-sync code stage honors the repo policy (#2140 sync path)
     expect(r.text).toContain('read-only');
     const code = r.stages.find((s: any) => s.name === 'code');
     expect(code?.detail?.status).toBe('skipped-policy-read-only');
+  });
+
+  test('deny/read-only also block explicit call-graph backfill before any GBrain command', () => {
+    makeRepo();
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gbrain-policy-fake-bin-'));
+    const commandLog = path.join(tmpHome, 'gbrain-commands.log');
+    fs.writeFileSync(
+      path.join(binDir, 'gbrain'),
+      '#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$GSTACK_TEST_GBRAIN_LOG"\nexit 99\n',
+      { mode: 0o755 },
+    );
+    const dreamArgs = ['--dream', '--no-code', '--no-memory', '--no-brain-sync', '--quiet'];
+    const env = {
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+      GSTACK_TEST_GBRAIN_LOG: commandLog,
+    };
+
+    try {
+      expect(run(['set', REPO_URL, 'deny']).status).toBe(0);
+      const denied = runSync(dreamArgs, env);
+      expect(denied.status).toBe(1);
+      expect(denied.stages.find((s: any) => s.name === 'dream')?.summary)
+        .toContain('no GBrain interaction is allowed');
+      expect(fs.existsSync(commandLog)).toBe(false);
+
+      expect(run(['set', REPO_URL, 'read-only']).status).toBe(0);
+      const readOnly = runSync(dreamArgs, env);
+      expect(readOnly.status).toBe(0);
+      expect(readOnly.stages.find((s: any) => s.name === 'dream')?.summary)
+        .toContain('call-graph backfill writes metadata');
+      expect(fs.existsSync(commandLog)).toBe(false);
+    } finally {
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
   });
 
   test('store exists but unreadable → fail-closed refusal, never bypassed', () => {

--- a/test/gbrain-sync-skip.test.ts
+++ b/test/gbrain-sync-skip.test.ts
@@ -44,6 +44,8 @@ function makeEnv(opts: {
   withGbrain: boolean;
   gbrainBehavior?: "ok" | "broken-db" | "broken-config" | "engine-locked" | "slow";
   withConfig: boolean;
+  thinClient?: boolean;
+  version?: string;
 }): FakeEnv {
   const tmp = mkdtempSync(join(tmpdir(), "gbrain-sync-skip-"));
   const bindir = join(tmp, "bin");
@@ -59,7 +61,9 @@ function makeEnv(opts: {
   if (opts.withConfig) {
     writeFileSync(
       join(gbrainDir, "config.json"),
-      JSON.stringify({ engine: "pglite", database_url: "pglite:///fake" }),
+      JSON.stringify(opts.thinClient
+        ? { remote_mcp: { url: "https://brain.example.test/mcp" } }
+        : { engine: "pglite", database_url: "pglite:///fake" }),
     );
   }
 
@@ -85,7 +89,7 @@ function makeEnv(opts: {
             }
   exit 1`;
     const fake = `#!/bin/sh
-if [ "$1" = "--version" ]; then echo "gbrain 0.42.14.0"; exit 0; fi
+if [ "$1" = "--version" ]; then echo "${opts.version || "gbrain 0.42.14.0"}"; exit 0; fi
 if [ "$1 $2" = "sources list" ]; then
 ${sourcesBlock}
 fi
@@ -195,6 +199,25 @@ describe("gstack-gbrain-sync — split-engine SKIP (plan D12)", () => {
       // Crucial: NOT the legacy "source registration failed" error path that
       // existed before this fix (codex #2 STOP-vs-SKIP consistency).
       expect(r.stdout + r.stderr).not.toContain("source registration failed");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  it("does not apply the local call-graph version floor to a thin client", () => {
+    const env = makeEnv({
+      withGbrain: true,
+      gbrainBehavior: "broken-db",
+      withConfig: true,
+      thinClient: true,
+      version: "gbrain 0.41.0.0",
+    });
+    try {
+      const r = runOrchestrator(env, ["--full", "--no-memory", "--no-brain-sync"]);
+      const out = r.stdout + r.stderr;
+      expect(r.exitCode).toBe(0);
+      expect(out).toContain("local engine thin-client");
+      expect(out).not.toContain("call-graph backfill requires gbrain");
     } finally {
       env.cleanup();
     }

--- a/test/gbrain-sync-skip.test.ts
+++ b/test/gbrain-sync-skip.test.ts
@@ -85,7 +85,7 @@ function makeEnv(opts: {
             }
   exit 1`;
     const fake = `#!/bin/sh
-if [ "$1" = "--version" ]; then echo "gbrain 0.33.1.0"; exit 0; fi
+if [ "$1" = "--version" ]; then echo "gbrain 0.42.14.0"; exit 0; fi
 if [ "$1 $2" = "sources list" ]; then
 ${sourcesBlock}
 fi

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -242,6 +242,54 @@ esac
     rmSync(home, { recursive: true, force: true });
   });
 
+  it("rejects an old GBrain before explicit backfill can start", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    const bindir = mkdtempSync(join(tmpdir(), "gstack-old-gbrain-bin-"));
+    const repo = mkdtempSync(join(tmpdir(), "gstack-old-gbrain-repo-"));
+    const commandLog = join(home, "gbrain-commands.log");
+    mkdirSync(gstackHome, { recursive: true });
+    spawnSync("git", ["init", "--quiet", "-b", "main"], { cwd: repo });
+    spawnSync("git", ["remote", "add", "origin", "https://github.com/acme/old-gbrain.git"], { cwd: repo });
+    writeFileSync(join(bindir, "gbrain"), `#!/bin/sh
+printf '%s\n' "$*" >> "$GSTACK_TEST_GBRAIN_LOG"
+case "$*" in
+  --version) echo 'gbrain 0.42.13.9'; exit 0 ;;
+  *) exit 99 ;;
+esac
+`);
+    chmodSync(join(bindir, "gbrain"), 0o755);
+
+    const r = spawnSync("bun", [
+      SCRIPT,
+      "--dream",
+      "--no-code",
+      "--no-memory",
+      "--no-brain-sync",
+    ], {
+      encoding: "utf-8",
+      timeout: 60000,
+      cwd: repo,
+      env: {
+        ...process.env,
+        HOME: home,
+        GSTACK_HOME: gstackHome,
+        GSTACK_TEST_GBRAIN_LOG: commandLog,
+        PATH: `${bindir}:${process.env.PATH || ""}`,
+      },
+    });
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("requires gbrain >= 0.42.14");
+    expect(r.stderr).toContain("Run /setup-gbrain to upgrade before syncing");
+    const commands = readFileSync(commandLog, "utf-8").trim().split("\n");
+    expect(commands.length).toBeGreaterThan(0);
+    expect(commands.every((command) => command === "--version")).toBe(true);
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(bindir, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  });
+
   it("falls back to a derived source when .gbrain-source cannot be read", () => {
     const home = makeTestHome();
     const gstackHome = join(home, ".gstack");

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -76,6 +76,7 @@ describe("gstack-gbrain-sync CLI", () => {
 
     expect(source).toContain('const LEGACY_GSTACK_HOME = process.env.GSTACK_HOME || join(HOME, ".gstack")');
     expect(source).toContain("const GSTACK_STATE_ROOT = process.env.GSTACK_STATE_ROOT || LEGACY_GSTACK_HOME");
+    expect(source).toContain('const LOCK_PATH = join(LEGACY_GSTACK_HOME, ".sync-gbrain.lock")');
     expect(source).toContain("decideResume(gstackHome: string = LEGACY_GSTACK_HOME)");
     expect(source).not.toContain("childEnv.GSTACK_HOME =");
     expect(source).not.toContain("const childEnv = { ...process.env, GSTACK_HOME }");

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../bin/gstack-gbrain-sync";
 
 const SCRIPT = join(import.meta.dir, "..", "bin", "gstack-gbrain-sync.ts");
+const GSTACK_PATHS = join(import.meta.dir, "..", "bin", "gstack-paths");
 
 function makeTestHome(): string {
   return mkdtempSync(join(tmpdir(), "gstack-gbrain-sync-"));
@@ -588,6 +589,36 @@ esac
     expect(Array.isArray(state.last_stages)).toBe(true);
     // With all stages disabled, last_stages is empty
     expect(state.last_stages.length).toBe(0);
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("writes to the same portable plugin state root consumed by post-sync readers", () => {
+    const home = makeTestHome();
+    const pluginData = join(home, "plugin-data");
+    const env = {
+      ...process.env,
+      HOME: home,
+      CLAUDE_PLUGIN_DATA: pluginData,
+      CLAUDE_PLUGIN_ROOT: join(home, "gstack-plugin"),
+    };
+    delete env.GSTACK_HOME;
+    delete env.GSTACK_STATE_ROOT;
+
+    const r = spawnSync(
+      "bash",
+      [
+        "-c",
+        'eval "$(bash "$1")"; GSTACK_STATE_ROOT="$GSTACK_STATE_ROOT" bun "$2" --incremental --no-code --no-memory --no-brain-sync --quiet',
+        "gstack-sync-test",
+        GSTACK_PATHS,
+        SCRIPT,
+      ],
+      { encoding: "utf-8", timeout: 60000, env },
+    );
+
+    expect(r.status).toBe(0);
+    expect(existsSync(join(pluginData, ".gbrain-sync-state.json"))).toBe(true);
+    expect(existsSync(join(home, ".gstack", ".gbrain-sync-state.json"))).toBe(false);
     rmSync(home, { recursive: true, force: true });
   });
 

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -249,12 +249,18 @@ esac
     const repo = mkdtempSync(join(tmpdir(), "gstack-old-gbrain-repo-"));
     const commandLog = join(home, "gbrain-commands.log");
     mkdirSync(gstackHome, { recursive: true });
+    mkdirSync(join(home, ".gbrain"), { recursive: true });
+    writeFileSync(
+      join(home, ".gbrain", "config.json"),
+      JSON.stringify({ engine: "pglite", database_url: "pglite:///fake" }),
+    );
     spawnSync("git", ["init", "--quiet", "-b", "main"], { cwd: repo });
     spawnSync("git", ["remote", "add", "origin", "https://github.com/acme/old-gbrain.git"], { cwd: repo });
     writeFileSync(join(bindir, "gbrain"), `#!/bin/sh
 printf '%s\n' "$*" >> "$GSTACK_TEST_GBRAIN_LOG"
 case "$*" in
   --version) echo 'gbrain 0.42.13.9'; exit 0 ;;
+  'sources list --json') echo '{"sources":[]}'; exit 0 ;;
   *) exit 99 ;;
 esac
 `);
@@ -284,7 +290,10 @@ esac
     expect(r.stderr).toContain("Run /setup-gbrain to upgrade before syncing");
     const commands = readFileSync(commandLog, "utf-8").trim().split("\n");
     expect(commands.length).toBeGreaterThan(0);
-    expect(commands.every((command) => command === "--version")).toBe(true);
+    expect(commands.every((command) =>
+      command === "--version" || command === "sources list --json"
+    )).toBe(true);
+    expect(commands.some((command) => command.startsWith("edges-backfill"))).toBe(false);
     rmSync(repo, { recursive: true, force: true });
     rmSync(bindir, { recursive: true, force: true });
     rmSync(home, { recursive: true, force: true });

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -71,12 +71,14 @@ describe("gstack-gbrain-sync CLI", () => {
     expect(source).toContain('spawnGbrain(["edges-backfill", "--source", sourceId, "--json"]');
   });
 
-  it("threads the selected portable root into legacy child writers", () => {
+  it("keeps portable sync metadata separate from canonical child data stores", () => {
     const source = readFileSync(SCRIPT, "utf-8");
 
-    expect(source).toContain("childEnv.GSTACK_HOME = GSTACK_HOME");
-    expect(source).toContain("const childEnv = { ...process.env, GSTACK_HOME }");
-    expect(source).toContain("env: childEnv");
+    expect(source).toContain('const LEGACY_GSTACK_HOME = process.env.GSTACK_HOME || join(HOME, ".gstack")');
+    expect(source).toContain("const GSTACK_STATE_ROOT = process.env.GSTACK_STATE_ROOT || LEGACY_GSTACK_HOME");
+    expect(source).toContain("decideResume(gstackHome: string = LEGACY_GSTACK_HOME)");
+    expect(source).not.toContain("childEnv.GSTACK_HOME =");
+    expect(source).not.toContain("const childEnv = { ...process.env, GSTACK_HOME }");
   });
 
   it("--dry-run with --code-only reports the code import preview only", () => {

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -71,6 +71,14 @@ describe("gstack-gbrain-sync CLI", () => {
     expect(source).toContain('spawnGbrain(["edges-backfill", "--source", sourceId, "--json"]');
   });
 
+  it("threads the selected portable root into legacy child writers", () => {
+    const source = readFileSync(SCRIPT, "utf-8");
+
+    expect(source).toContain("childEnv.GSTACK_HOME = GSTACK_HOME");
+    expect(source).toContain("const childEnv = { ...process.env, GSTACK_HOME }");
+    expect(source).toContain("env: childEnv");
+  });
+
   it("--dry-run with --code-only reports the code import preview only", () => {
     const home = makeTestHome();
     const gstackHome = join(home, ".gstack");

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -62,12 +62,12 @@ describe("gstack-gbrain-sync CLI", () => {
     expect(source).toContain("localEngineStatus");
   });
 
-  it("uses GBrain's config environment when resolving dream sources", () => {
+  it("uses GBrain's config environment when resolving call-graph sources", () => {
     const source = readFileSync(SCRIPT, "utf-8");
 
     expect(source).not.toContain("resolveCodeSourceId(root, process.env)");
     expect(source).toContain("resolveCodeSourceId(root, gbrainEnv)");
-    expect(source).toContain("cycleCompleted(resolveCodeSourceId(root, gbrainEnv), gbrainEnv)");
+    expect(source).toContain('spawnGbrain(["edges-backfill", "--source", sourceId, "--json"]');
   });
 
   it("--dry-run with --code-only reports the code import preview only", () => {
@@ -236,7 +236,7 @@ esac
     });
 
     expect(r.status).toBe(0);
-    expect(r.stdout).toContain("gbrain dream --source client-acme-app");
+    expect(r.stdout).toContain("gbrain edges-backfill --source client-acme-app --json");
     rmSync(repo, { recursive: true, force: true });
     rmSync(bindir, { recursive: true, force: true });
     rmSync(home, { recursive: true, force: true });

--- a/test/setup-gbrain-bin-invocation-paths.test.ts
+++ b/test/setup-gbrain-bin-invocation-paths.test.ts
@@ -69,6 +69,14 @@ describe('setup-gbrain/SKILL.md.tmpl — bin invocation paths', () => {
     );
   });
 
+  test('every setup writer and reader shares the portable sync-state root', () => {
+    expect(tmpl).toContain('eval "$(~/.claude/skills/gstack/bin/gstack-paths)"');
+    expect(tmpl).toContain('GSTACK_STATE_ROOT="$GSTACK_STATE_ROOT" \\\n  bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --full --no-brain-sync');
+    expect(tmpl).toContain('GSTACK_STATE_ROOT="$GSTACK_STATE_ROOT" bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --incremental --quiet');
+    expect(tmpl).toContain('"$GSTACK_STATE_ROOT/.gbrain-sync-state.json"');
+    expect(tmpl).not.toContain('[ -f ~/.gstack/.gbrain-sync-state.json ]');
+  });
+
   test('the preamble-hook incremental-sync mention uses bun run + .ts (R4)', () => {
     expect(tmpl).toContain(
       'bun run ~/.claude/skills/gstack/bin/gstack-gbrain-sync.ts --incremental --quiet'


### PR DESCRIPTION
## Summary

- replace implicit `gbrain dream --source` cycle-log classification with the official source-scoped `edges-backfill` operation
- certify readiness only through an exact-source `code-callers` envelope (`scope=single`, `status=ready`, `ready=true`)
- fail closed for old GBrain versions, thin clients, policy denial, malformed/wrong-source evidence, timeouts, and concurrent PGLite writers
- keep portable orchestrator metadata separate from canonical policy, artifact, transcript, staging, and coordination-lock data
- update `/sync-gbrain` and `/setup-gbrain` to read and write the same portable sync-state file

## Root cause

Named-source implicit dream cycles do not provide a reliable source-owned call-graph readiness signal. GStack was also classifying unrelated dream-phase log text as a schema-pack limitation, which produced the false guidance reported in #2341 and could hide the real graph state.

## Verification

- `bun test test/gbrain-dream-stage.test.ts test/gstack-gbrain-sync.test.ts test/setup-gbrain-bin-invocation-paths.test.ts test/gstack-paths.test.ts` — 104 pass, 0 fail
- `bun test test/gen-skill-docs.test.ts` — 414 pass, 0 fail
- `bun build --target=bun bin/gstack-gbrain-sync.ts --outfile=/dev/null`
- `git diff --check`
- live GBrain 0.46.24 proof on an exact Candor source: bounded backfill completed ready, and `code-callers generateBusinessPlanBrief --source gstack-code-candor-eda9672b` returned its real caller

Paid eval suites were not run; this change made no model/vendor calls for product evaluation.

Addresses #2341.