### PR TITLE
feat(codex): surface cached/reasoning token breakdown in Challenge and Consult modes

### DIFF
--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -1410,8 +1410,19 @@ for line in sys.stdin:
         elif t == 'turn.completed':
             turn_completed_count += 1
             usage = obj.get('usage',{})
-            tokens = usage.get('input_tokens',0) + usage.get('output_tokens',0)
-            if tokens: print(f'\ntokens used: {tokens}', flush=True)
+            in_tok = usage.get('input_tokens',0)
+            cached_tok = usage.get('cached_input_tokens',0)
+            cache_write_tok = usage.get('cache_write_input_tokens',0)
+            out_tok = usage.get('output_tokens',0)
+            reasoning_tok = usage.get('reasoning_output_tokens',0)
+            tokens = in_tok + out_tok
+            if tokens:
+                print(f'\ntokens used: {tokens}', flush=True)
+                # Machine-parseable breakdown alongside the human-readable line above.
+                # codex's --json usage object splits cache reads from cache writes and
+                # reasoning from output; the plain 'tokens used' total collapses all of
+                # that, which is fine to read but not enough to price a call correctly.
+                print(f'CODEX_USAGE: input={in_tok} cached_input={cached_tok} cache_write={cache_write_tok} output={out_tok} reasoning_output={reasoning_tok}', flush=True)
     except: pass
 # Fix 2: completeness check — warn if no turn.completed received
 if turn_completed_count == 0:
@@ -1569,8 +1580,15 @@ for line in sys.stdin:
                 if cmd: print(f'[codex ran] {cmd}', flush=True)
         elif t == 'turn.completed':
             usage = obj.get('usage',{})
-            tokens = usage.get('input_tokens',0) + usage.get('output_tokens',0)
-            if tokens: print(f'\ntokens used: {tokens}', flush=True)
+            in_tok = usage.get('input_tokens',0)
+            cached_tok = usage.get('cached_input_tokens',0)
+            cache_write_tok = usage.get('cache_write_input_tokens',0)
+            out_tok = usage.get('output_tokens',0)
+            reasoning_tok = usage.get('reasoning_output_tokens',0)
+            tokens = in_tok + out_tok
+            if tokens:
+                print(f'\ntokens used: {tokens}', flush=True)
+                print(f'CODEX_USAGE: input={in_tok} cached_input={cached_tok} cache_write={cache_write_tok} output={out_tok} reasoning_output={reasoning_tok}', flush=True)
     except: pass
 "
 # Fix 1: hang detection for Consult new-session (mirrors Challenge + resume)
@@ -1707,6 +1725,23 @@ Parse token count from stderr. Codex prints `tokens used\nN` to stderr.
 Display as: `Tokens: N`
 
 If token count is not available, display: `Tokens: unknown`
+
+**Challenge and Consult modes** (both run `codex exec --json`) additionally emit a
+machine-parseable breakdown line alongside the human-readable one, once per
+`turn.completed` event:
+
+```
+CODEX_USAGE: input=21294 cached_input=6912 cache_write=0 output=5 reasoning_output=0
+```
+
+`input`/`output` are the same totals folded into `tokens used\nN`; `cached_input` and
+`cache_write` split the input side into what was served from cache versus written to
+it, and `reasoning_output` is the portion of the output spent on reasoning rather than
+the visible response — codex's `--json` `usage` object reports all five separately,
+this just stops discarding four of them. Consumers that only need the total keep
+reading `tokens used`; anything that wants a real per-call cost breakdown reads
+`CODEX_USAGE` instead. Native `codex review` (the default Review-mode path, which does
+not use `--json`) has no equivalent — it never emits more than the plain stderr total.
 
 ---
 

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -451,8 +451,19 @@ for line in sys.stdin:
         elif t == 'turn.completed':
             turn_completed_count += 1
             usage = obj.get('usage',{})
-            tokens = usage.get('input_tokens',0) + usage.get('output_tokens',0)
-            if tokens: print(f'\ntokens used: {tokens}', flush=True)
+            in_tok = usage.get('input_tokens',0)
+            cached_tok = usage.get('cached_input_tokens',0)
+            cache_write_tok = usage.get('cache_write_input_tokens',0)
+            out_tok = usage.get('output_tokens',0)
+            reasoning_tok = usage.get('reasoning_output_tokens',0)
+            tokens = in_tok + out_tok
+            if tokens:
+                print(f'\ntokens used: {tokens}', flush=True)
+                # Machine-parseable breakdown alongside the human-readable line above.
+                # codex's --json usage object splits cache reads from cache writes and
+                # reasoning from output; the plain 'tokens used' total collapses all of
+                # that, which is fine to read but not enough to price a call correctly.
+                print(f'CODEX_USAGE: input={in_tok} cached_input={cached_tok} cache_write={cache_write_tok} output={out_tok} reasoning_output={reasoning_tok}', flush=True)
     except: pass
 # Fix 2: completeness check — warn if no turn.completed received
 if turn_completed_count == 0:
@@ -610,8 +621,15 @@ for line in sys.stdin:
                 if cmd: print(f'[codex ran] {cmd}', flush=True)
         elif t == 'turn.completed':
             usage = obj.get('usage',{})
-            tokens = usage.get('input_tokens',0) + usage.get('output_tokens',0)
-            if tokens: print(f'\ntokens used: {tokens}', flush=True)
+            in_tok = usage.get('input_tokens',0)
+            cached_tok = usage.get('cached_input_tokens',0)
+            cache_write_tok = usage.get('cache_write_input_tokens',0)
+            out_tok = usage.get('output_tokens',0)
+            reasoning_tok = usage.get('reasoning_output_tokens',0)
+            tokens = in_tok + out_tok
+            if tokens:
+                print(f'\ntokens used: {tokens}', flush=True)
+                print(f'CODEX_USAGE: input={in_tok} cached_input={cached_tok} cache_write={cache_write_tok} output={out_tok} reasoning_output={reasoning_tok}', flush=True)
     except: pass
 "
 # Fix 1: hang detection for Consult new-session (mirrors Challenge + resume)
@@ -748,6 +766,23 @@ Parse token count from stderr. Codex prints `tokens used\nN` to stderr.
 Display as: `Tokens: N`
 
 If token count is not available, display: `Tokens: unknown`
+
+**Challenge and Consult modes** (both run `codex exec --json`) additionally emit a
+machine-parseable breakdown line alongside the human-readable one, once per
+`turn.completed` event:
+
+```
+CODEX_USAGE: input=21294 cached_input=6912 cache_write=0 output=5 reasoning_output=0
+```
+
+`input`/`output` are the same totals folded into `tokens used\nN`; `cached_input` and
+`cache_write` split the input side into what was served from cache versus written to
+it, and `reasoning_output` is the portion of the output spent on reasoning rather than
+the visible response — codex's `--json` `usage` object reports all five separately,
+this just stops discarding four of them. Consumers that only need the total keep
+reading `tokens used`; anything that wants a real per-call cost breakdown reads
+`CODEX_USAGE` instead. Native `codex review` (the default Review-mode path, which does
+not use `--json`) has no equivalent — it never emits more than the plain stderr total.
 
 ---
 


### PR DESCRIPTION
<!--
gstack is AI-coded and proud of it. The bar is EVIDENCE OF REAL USE, not lines
of code. A PR with no proof behind it gets closed, no matter how clean it looks.
Fill every section below. See CONTRIBUTING.md → "The evidence bar".
-->

## Why (in your own words)

`codex exec --json`'s `turn.completed` event already reports a five-field usage
breakdown — `input_tokens`, `cached_input_tokens`, `cache_write_input_tokens`,
`output_tokens`, `reasoning_output_tokens` — but the Challenge and Consult mode
parsers in `/codex` only read `input_tokens + output_tokens` into a single
`tokens used: N` line and silently drop the other three. Anything downstream that
wants to actually price a codex call (cache hit rate, reasoning spend vs response
spend) has nothing to read. This adds a second, machine-parseable line
(`CODEX_USAGE: input=... cached_input=... cache_write=... output=... reasoning_output=...`)
printed right alongside the existing one, so the human-readable output is
byte-for-byte unchanged and any downstream tooling can key off the new line.

## Live evidence

```
$ codex exec "say hi in one word" -s read-only --skip-git-repo-check --json < /dev/null
{"type":"thread.started","thread_id":"01a0249b-250c-7e13-a32d-82b9746dd022"}
{"type":"turn.started"}
{"type":"item.completed","item":{"id":"item_0","type":"error","message":"Skill descriptions were shortened..."}}
{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"Hi"}}
{"type":"turn.completed","usage":{"input_tokens":21294,"cached_input_tokens":6912,"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0}}
```

That raw capture piped through the exact parser code now in `codex/SKILL.md.tmpl`
(Challenge-mode block):

```
$ cat codex-verify-out.jsonl | python3 -u -c "<the new parser code>"
Hi

tokens used: 21299
CODEX_USAGE: input=21294 cached_input=6912 cache_write=0 output=5 reasoning_output=0
```

`tokens used: 21299` is unchanged from before this PR (21294 + 5). `CODEX_USAGE` is
the new line, sourced from fields that were already in the JSON object and simply
weren't being read.

Note on `obj.model`: while investigating this I checked `test/helpers/providers/gpt.ts`,
which has a defensive `if (obj.model) modelUsed = obj.model;` on the same
`turn.completed` event. I could not find a `model` field anywhere in a real capture
(checked every event type: `thread.started`, `turn.started`, `item.completed`,
`turn.completed`) on codex-cli 0.146.0. Left that alone — not touching an existing
assumption I can't independently confirm, and out of scope for this PR either way.

## Scope

- **Changed:** `codex/SKILL.md.tmpl` — Challenge mode and Consult mode (new-session)
  JSONL parsers both print a `CODEX_USAGE:` line on `turn.completed`, in addition to
  the existing `tokens used: N` line. Consult mode's resumed-session path shares the
  same parser by reference ("same python streaming parser as above" in the template)
  so it picks this up without a separate edit. Documented in the `## Cost Estimation`
  section. Regenerated `codex/SKILL.md` via `bun run gen:skill-docs` (verified with
  `--dry-run` afterward — all files report `FRESH`).
- **Verified live by:** a real `codex exec --json` call (codex-cli 0.146.0, shown
  above), the extracted parser code run standalone against that capture (shown
  above), `bun test test/skill-validation.test.ts` (331 pass / 0 fail — includes the
  existing `expect(content).toContain('tokens used')` assertion, unaffected since that
  string is untouched), and the full codex test surface: `codex-e2e*.test.ts`,
  `codex-hardening.test.ts`, `codex-model-probe.test.ts`,
  `codex-resume-flag-semantics.test.ts`, `codex-under-codex-detection.test.ts`,
  `codex-web-search-flag.test.ts`, `codex-generation-model.test.ts` (76 pass / 20
  skip / 0 fail, 96 tests across 10 files).
- **Did NOT test:** Review mode is unaffected by design (native `codex review` never
  uses `--json`, so it has no `turn.completed` event to read this from at all — noted
  explicitly in the doc addition). Did not add a new automated test asserting the
  `CODEX_USAGE:` line's exact format, since the existing test suite validates rendered
  skill content/structure rather than executing the embedded Python against live
  JSONL — happy to add one if a maintainer wants a specific shape/location for that.

## Liveness proof (required)

<!-- Screenshot pending: terminal capture of `echo "GSTACK PR"` typed live, timestamp 23:43:03,
     to be attached by dragging the image into this description via the GitHub web editor
     immediately after the PR opens (local file paths don't render in PR markdown). -->

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image) — pending, see note above
<img width="1602" height="487" alt="Screenshot 2026-08-21 at 11 43 16 PM" src="https://github.com/user-attachments/assets/2c6bedfc-4683-42c2-94f7-e5c000768b71" />
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A) — N/A, no new command/service/adapter
- [ ] Linked issue or reproduction: #
