### PR TITLE
fix(brain-sync): fail loud when artifacts source has zero pages

### DIFF
--- a/bin/gstack-brain-sync
+++ b/bin/gstack-brain-sync
@@ -71,6 +71,213 @@ remote_auth_hint() {
   esac
 }
 
+# Derive the artifacts source id without creating, advancing, or re-registering
+# anything. The explicit override is the same one used by
+# gstack-gbrain-source-wireup; otherwise the artifacts remote basename is the
+# canonical source id.
+artifacts_source_id() {
+  if [ -n "${GSTACK_BRAIN_SOURCE_ID:-}" ]; then
+    printf '%s\n' "$GSTACK_BRAIN_SOURCE_ID"
+    return 0
+  fi
+
+  local remote_url=""
+  remote_url=$(git -C "$GSTACK_HOME" remote get-url origin 2>/dev/null) || true
+  if [ -z "$remote_url" ]; then
+    local remote_file
+    if [ -f "$HOME/.gstack-artifacts-remote.txt" ]; then
+      remote_file="$HOME/.gstack-artifacts-remote.txt"
+    else
+      remote_file="$HOME/.gstack-brain-remote.txt"
+    fi
+    [ -f "$remote_file" ] && remote_url=$(head -1 "$remote_file" 2>/dev/null | tr -d '[:space:]')
+  fi
+  [ -z "$remote_url" ] && return 1
+
+  basename "$remote_url" .git \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr -c 'a-z0-9-' '-' \
+    | sed 's/--*/-/g; s/^-//; s/-$//' \
+    | cut -c1-32
+}
+
+# Recursively signal a process tree when process-group signalling is unavailable.
+# pgrep is present on macOS/Linux; Windows uses taskkill /T below. This fallback
+# still terminates the root when neither helper exists.
+signal_probe_tree() {
+  local signal="$1"
+  local root_pid="$2"
+  local child_pid
+  if command -v pgrep >/dev/null 2>&1; then
+    while IFS= read -r child_pid; do
+      case "$child_pid" in
+        ''|*[!0-9]*) continue ;;
+      esac
+      signal_probe_tree "$signal" "$child_pid"
+    done < <(pgrep -P "$root_pid" 2>/dev/null || true)
+  fi
+  kill -s "$signal" "$root_pid" 2>/dev/null || true
+}
+
+# The probe is launched in its own process group. Terminate that whole group so
+# a shim which spawns bun/node cannot leave the single-writer database wedged.
+# taskkill /T is the native Windows process-tree fallback; recursive pgrep is
+# the POSIX fallback if group signalling is unavailable.
+terminate_probe_tree() {
+  local probe_pid="$1"
+  local uname_s
+  uname_s=$(uname -s 2>/dev/null || printf 'unknown')
+  case "$uname_s" in
+    MINGW*|MSYS*|CYGWIN*)
+      if command -v taskkill.exe >/dev/null 2>&1; then
+        # Git Bash/MSYS otherwise rewrites /PID, /T, and /F as filesystem
+        # paths before taskkill receives them.
+        if MSYS_NO_PATHCONV=1 taskkill.exe /PID "$probe_pid" /T /F >/dev/null 2>&1; then
+          return 0
+        fi
+      fi
+      ;;
+  esac
+
+  if kill -TERM -- "-$probe_pid" 2>/dev/null; then
+    # A descendant may ignore TERM even after its launcher exits. Always send
+    # KILL to the dedicated group after a short grace period.
+    sleep 0.2
+    kill -KILL -- "-$probe_pid" 2>/dev/null || true
+  else
+    signal_probe_tree TERM "$probe_pid"
+    sleep 0.2
+    signal_probe_tree KILL "$probe_pid"
+  fi
+}
+
+# Read-only, bounded verification of the artifacts source's current page count.
+# Output is a tab-separated classifier consumed by write_index_aware_status:
+#   pages <id> <count> | zero <id> 0 | absent <id> | unverified <id> <reason>
+#
+# This deliberately does NOT call `gbrain sync`: --once runs at every skill
+# boundary, while indexing can be expensive and owns a single-writer database.
+# A git push is therefore reported as git-only. The one provable bad state — a
+# source this installation maintains reporting zero pages — fails loud.
+probe_artifacts_index() {
+  local source_id
+  source_id=$(artifacts_source_id 2>/dev/null) || {
+    printf 'unverified\tunknown\tartifacts source id unavailable\n'
+    return 0
+  }
+
+  # Do not probe a random local gbrain merely because the CLI is on PATH. An
+  # explicit id or the managed artifacts worktree is the evidence that this
+  # installation believes it maintains the source. Presence-only: never call
+  # ensure_worktree here (that lifecycle is owned by source-wireup).
+  if [ -z "${GSTACK_BRAIN_SOURCE_ID:-}" ] \
+      && [ ! -e "${GSTACK_BRAIN_WORKTREE:-$HOME/.gstack-brain-worktree}" ]; then
+    printf 'unverified\t%s\tartifacts source is not managed on this machine\n' "$source_id"
+    return 0
+  fi
+
+  local gbrain_bin
+  gbrain_bin=$(command -v gbrain 2>/dev/null) || {
+    printf 'unverified\t%s\tgbrain CLI unavailable\n' "$source_id"
+    return 0
+  }
+
+  # Launch through Bash so Git Bash can resolve gbrain's .cmd/shebang launcher
+  # on Windows. Job control gives the probe a dedicated process group, and a
+  # small watchdog bounds a wedged single-writer database (stock macOS has no
+  # timeout(1)).
+  local probe_file probe_pid probe_ticks=0 probe_rc=0
+  probe_file=$(mktemp /tmp/gstack-index-probe.XXXXXX) || {
+    printf 'unverified\t%s\tpage-count probe tempfile failed\n' "$source_id"
+    return 0
+  }
+  set -m
+  bash -c 'exec "$1" sources list --json' _ "$gbrain_bin" >"$probe_file" 2>/dev/null &
+  probe_pid=$!
+  set +m
+  while kill -0 "$probe_pid" 2>/dev/null; do
+    if [ "$probe_ticks" -ge 50 ]; then
+      terminate_probe_tree "$probe_pid"
+      wait "$probe_pid" 2>/dev/null || true
+      rm -f "$probe_file"
+      printf 'unverified\t%s\tpage-count probe timed out\n' "$source_id"
+      return 0
+    fi
+    sleep 0.1
+    probe_ticks=$(( probe_ticks + 1 ))
+  done
+  wait "$probe_pid" 2>/dev/null || probe_rc=$?
+  if [ "$probe_rc" -ne 0 ]; then
+    rm -f "$probe_file"
+    printf 'unverified\t%s\tpage-count probe exited %s\n' "$source_id" "$probe_rc"
+    return 0
+  fi
+
+  local parsed
+  parsed=$(python3 - "$probe_file" "$source_id" <<'PYEOF' 2>/dev/null
+import json
+import sys
+
+path, source_id = sys.argv[1:3]
+try:
+    with open(path) as f:
+        raw = json.load(f)
+except (OSError, TypeError, json.JSONDecodeError):
+    print(f"unverified\t{source_id}\tpage-count probe returned invalid JSON")
+    raise SystemExit(0)
+
+sources = raw if isinstance(raw, list) else raw.get("sources", []) if isinstance(raw, dict) else []
+match = next((row for row in sources if isinstance(row, dict) and row.get("id") == source_id), None)
+if match is None:
+    print(f"absent\t{source_id}\t")
+    raise SystemExit(0)
+
+count = match.get("page_count")
+if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+    print(f"unverified\t{source_id}\tpage_count missing or invalid")
+elif count == 0:
+    print(f"zero\t{source_id}\t0")
+else:
+    print(f"pages\t{source_id}\t{count}")
+PYEOF
+) || parsed=$(printf 'unverified\t%s\tpage-count probe parse failed' "$source_id")
+  rm -f "$probe_file"
+  printf '%s\n' "$parsed"
+}
+
+# Preserve the git outcome while making the indexing boundary explicit. Returns
+# non-zero only for the verified zero-page false-green; callers convert that to
+# a command failure after completing any safe git/queue finalization already in
+# progress.
+write_index_aware_status() {
+  local code="$1"
+  local message="$2"
+  local probe kind source_id detail
+  probe=$(probe_artifacts_index)
+  IFS=$'\t' read -r kind source_id detail <<EOF
+$probe
+EOF
+
+  case "$kind" in
+    zero)
+      message="$message; git sync does not index gbrain; artifacts source $source_id reports 0 pages"
+      write_status "index_failed" "$message"
+      echo "BRAIN_SYNC: error: artifacts source $source_id reports 0 pages; git sync completed but gbrain indexing did not. Run gstack-gbrain-source-wireup --strict, then verify gbrain sources list." >&2
+      return 1
+      ;;
+    pages)
+      write_status "$code" "$message; git sync does not index gbrain; artifacts source $source_id reports $detail pages (freshness not verified)"
+      ;;
+    absent)
+      write_status "$code" "$message; git sync does not index gbrain; artifacts source $source_id is not registered"
+      ;;
+    *)
+      write_status "$code" "$message; git sync does not index gbrain; indexing not verified (${detail:-unknown reason})"
+      ;;
+  esac
+  return 0
+}
+
 write_status() {
   # args: status_code message [extra_json_blob]
   local code="$1"
@@ -641,7 +848,7 @@ subcmd_once() {
   # the queue is empty.) The lock-release trap installed at acquisition
   # covers this exit.
   if ! spool_has_records && [ ! -s "$QUEUE" ] && [ ! -s "$QUEUE.migrating" ]; then
-    write_status "idle" "queue empty"
+    write_index_aware_status "idle" "queue empty" || exit 1
     exit 0
   fi
 
@@ -668,7 +875,7 @@ subcmd_once() {
     finalize_queue "$snapshot_file" "$class_file" "$paths_file"
     local summary
     summary=$(queue_summary "$class_file")
-    write_status "idle" "no stageable changes${summary:+ ($summary)}"
+    write_index_aware_status "idle" "no stageable changes${summary:+ ($summary)}" || exit 1
     exit 0
   fi
 
@@ -718,7 +925,7 @@ subcmd_once() {
       # Nothing to commit (e.g. all files already committed). The drained
       # records leave the spool; retained + post-snapshot records survive.
       finalize_queue "$snapshot_file" "$class_file" "$paths_file"
-      write_status "idle" "queue drained but no new changes to commit"
+      write_index_aware_status "idle" "queue drained but no new changes to commit" || exit 1
       exit 0
     }
 
@@ -750,7 +957,7 @@ subcmd_once() {
             bash -c 'git -C "$1" push origin HEAD 2>/dev/null' _ "$GSTACK_HOME"; then
           finalize_queue "$snapshot_file" "$class_file" "$paths_file"
           date -u +%Y-%m-%dT%H:%M:%SZ > "$LAST_PUSH_FILE"
-          write_status "ok" "pushed $n file(s) after rebase"
+          write_index_aware_status "ok" "pushed $n file(s) after rebase" || exit 1
           exit 0
         fi
       fi
@@ -764,7 +971,7 @@ subcmd_once() {
   # Success: drained records leave the spool (retained + post-snapshot survive).
   finalize_queue "$snapshot_file" "$class_file" "$paths_file"
   date -u +%Y-%m-%dT%H:%M:%SZ > "$LAST_PUSH_FILE"
-  write_status "ok" "pushed $n file(s)"
+  write_index_aware_status "ok" "pushed $n file(s)" || exit 1
   exit 0
 }
 

--- a/bin/gstack-gbrain-sync.ts
+++ b/bin/gstack-gbrain-sync.ts
@@ -1342,7 +1342,13 @@ function runBrainSyncPush(args: CliArgs): StageResult {
     ran: true,
     ok: result.status === 0,
     duration_ms: Date.now() - t0,
-    summary: result.status === 0 ? "curated artifacts pushed" : `gstack-brain-sync exited ${result.status}`,
+    // Exit 0 means the git-sync command completed; it does NOT mean gbrain
+    // indexed the artifacts. gstack-brain-sync records the exact git outcome
+    // and its bounded page-count verification in --status, and exits nonzero
+    // for a maintained source that reports zero pages.
+    summary: result.status === 0
+      ? "artifact git-sync command finished; gbrain indexing is not performed by this stage (see gstack-brain-sync --status)"
+      : `gstack-brain-sync exited ${result.status}`,
   };
 }
 

--- a/test/brain-sync-windows-paths.test.ts
+++ b/test/brain-sync-windows-paths.test.ts
@@ -27,6 +27,10 @@ import * as path from 'path';
 //   5. the skip-list must be normalized to the same separator form as `rel`,
 //      or a backslash entry in .brain-skip.txt stops matching and a file the
 //      user explicitly skipped gets synced.
+//   6. the index probe must launch through Bash so Git Bash can resolve a
+//      gbrain .cmd/shebang shim.
+//   7. timeout cleanup must use taskkill /T on Windows so a shim's bun/node
+//      child cannot outlive the launcher and keep the database wedged.
 const ROOT = path.resolve(import.meta.dir, '..');
 const SRC = fs.readFileSync(path.join(ROOT, 'bin', 'gstack-brain-sync'), 'utf-8');
 
@@ -66,5 +70,13 @@ describe('gstack-brain-sync — Windows path/exec invariants', () => {
     // commit, syncing a file the user explicitly skipped.
     const NORM = 's.replace(os.sep, "/") for s in load_lines(skip_path)';
     expect(SRC.split(NORM).length - 1).toBeGreaterThanOrEqual(2);
+  });
+
+  test('page-count probe launches the gbrain shim through Bash', () => {
+    expect(SRC).toContain("bash -c 'exec \"$1\" sources list --json'");
+  });
+
+  test('page-count timeout kills the full Windows process tree', () => {
+    expect(SRC).toContain('MSYS_NO_PATHCONV=1 taskkill.exe /PID "$probe_pid" /T /F');
   });
 });

--- a/test/brain-sync.test.ts
+++ b/test/brain-sync.test.ts
@@ -291,6 +291,182 @@ describe('init + sync + restore round-trip', () => {
     expect(log.stdout).toMatch(/sync: 1 file/);
   });
 
+  test('registered artifacts source with zero pages fails loud instead of reporting git sync as indexing', () => {
+    run(['gstack-artifacts-init', '--remote', bareRemote]);
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
+    fs.mkdirSync(path.join(tmpHome, 'projects/p'), { recursive: true });
+    fs.writeFileSync(path.join(tmpHome, 'projects/p/learnings.jsonl'),
+      '{"skill":"x","insight":"zero-page guard","ts":"2026-08-22T10:00:00Z"}\n');
+    run(['gstack-brain-enqueue', 'projects/p/learnings.jsonl']);
+
+    const fakeBin = path.join(tmpHome, 'fake-bin');
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, 'gbrain'), `#!/bin/sh
+case "$*" in
+  "sources list --json")
+    printf '%s\\n' '{"sources":[{"id":"fixture-artifacts","page_count":0}]}'
+    ;;
+  *) exit 1 ;;
+esac
+`);
+    fs.chmodSync(path.join(fakeBin, 'gbrain'), 0o755);
+
+    const r = run(['gstack-brain-sync', '--once'], {
+      env: {
+        GSTACK_BRAIN_SOURCE_ID: 'fixture-artifacts',
+        PATH: `${fakeBin}:${process.env.PATH || ''}`,
+      },
+    });
+
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain('fixture-artifacts reports 0 pages');
+    const log = spawnSync('git', ['--git-dir=' + bareRemote, 'log', '--oneline'], { encoding: 'utf-8' });
+    expect(log.stdout).toMatch(/sync: 1 file/);
+    const status = JSON.parse(fs.readFileSync(path.join(tmpHome, '.brain-sync-status.json'), 'utf-8'));
+    expect(status.status).toBe('index_failed');
+    expect(status.message).toContain('git sync does not index gbrain');
+  });
+
+  test('nonzero artifacts page count stays green but does not claim index freshness', () => {
+    run(['gstack-artifacts-init', '--remote', bareRemote]);
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
+
+    const fakeBin = path.join(tmpHome, 'fake-bin');
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, 'gbrain'), `#!/bin/sh
+case "$*" in
+  "sources list --json")
+    printf '%s\\n' '{"sources":[{"id":"fixture-artifacts","page_count":3}]}'
+    ;;
+  *) exit 1 ;;
+esac
+`);
+    fs.chmodSync(path.join(fakeBin, 'gbrain'), 0o755);
+
+    const r = run(['gstack-brain-sync', '--once'], {
+      env: {
+        GSTACK_BRAIN_SOURCE_ID: 'fixture-artifacts',
+        PATH: `${fakeBin}:${process.env.PATH || ''}`,
+      },
+    });
+
+    expect(r.status).toBe(0);
+    const status = JSON.parse(fs.readFileSync(path.join(tmpHome, '.brain-sync-status.json'), 'utf-8'));
+    expect(status.status).toBe('idle');
+    expect(status.message).toContain('reports 3 pages (freshness not verified)');
+  });
+
+  test('timed-out page-count probe kills its launcher and stubborn child process', () => {
+    run(['gstack-artifacts-init', '--remote', bareRemote]);
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
+
+    const fakeBin = path.join(tmpHome, 'fake-bin');
+    const childPidFile = path.join(tmpHome, 'probe-child.pid');
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, 'gbrain'), `#!/bin/sh
+sh -c '
+  trap "" TERM
+  printf "%s\\n" "$$" > "$GSTACK_PROBE_CHILD_PID_FILE"
+  while :; do sleep 1; done
+' &
+wait
+`);
+    fs.chmodSync(path.join(fakeBin, 'gbrain'), 0o755);
+
+    const r = run(['gstack-brain-sync', '--once'], {
+      env: {
+        GSTACK_BRAIN_SOURCE_ID: 'fixture-artifacts',
+        GSTACK_PROBE_CHILD_PID_FILE: childPidFile,
+        PATH: `${fakeBin}:${process.env.PATH || ''}`,
+      },
+    });
+
+    expect(r.status).toBe(0);
+    const status = JSON.parse(fs.readFileSync(path.join(tmpHome, '.brain-sync-status.json'), 'utf-8'));
+    expect(status.message).toContain('page-count probe timed out');
+    const childPid = Number(fs.readFileSync(childPidFile, 'utf-8').trim());
+    expect(childPid).toBeGreaterThan(0);
+    if (process.platform !== 'win32') {
+      expect(() => process.kill(childPid, 0)).toThrow();
+    }
+  }, 15_000);
+
+  test('MINGW timeout passes literal taskkill tree flags and skips the POSIX fallback', () => {
+    run(['gstack-artifacts-init', '--remote', bareRemote]);
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
+
+    const fakeBin = path.join(tmpHome, 'fake-bin');
+    const taskkillArgsFile = path.join(tmpHome, 'taskkill-args.txt');
+    const pgrepCalledFile = path.join(tmpHome, 'pgrep-called');
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, 'uname'), '#!/bin/sh\nprintf "%s\\n" "MINGW64_NT-10.0"\n');
+    fs.writeFileSync(path.join(fakeBin, 'gbrain'), '#!/bin/sh\nexec sleep 30\n');
+    fs.writeFileSync(path.join(fakeBin, 'pgrep'), `#!/bin/sh
+: > "$GSTACK_PGREP_CALLED_FILE"
+exit 1
+`);
+    fs.writeFileSync(path.join(fakeBin, 'taskkill.exe'), `#!/bin/sh
+printf '%s\\t%s\\n' "\${MSYS_NO_PATHCONV:-}" "$*" > "$GSTACK_TASKKILL_ARGS_FILE"
+pid="$2"
+kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+sleep 0.1
+kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+exit 0
+`);
+    for (const name of ['uname', 'gbrain', 'pgrep', 'taskkill.exe']) {
+      fs.chmodSync(path.join(fakeBin, name), 0o755);
+    }
+
+    const r = run(['gstack-brain-sync', '--once'], {
+      env: {
+        GSTACK_BRAIN_SOURCE_ID: 'fixture-artifacts',
+        GSTACK_TASKKILL_ARGS_FILE: taskkillArgsFile,
+        GSTACK_PGREP_CALLED_FILE: pgrepCalledFile,
+        PATH: `${fakeBin}:${process.env.PATH || ''}`,
+      },
+    });
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(taskkillArgsFile, 'utf-8').trim()).toMatch(/^1\t\/PID \d+ \/T \/F$/);
+    expect(fs.existsSync(pgrepCalledFile)).toBe(false);
+    const status = JSON.parse(fs.readFileSync(path.join(tmpHome, '.brain-sync-status.json'), 'utf-8'));
+    expect(status.message).toContain('page-count probe timed out');
+  }, 15_000);
+
+  test('page-count probe distinguishes absent, invalid-JSON, and nonzero-exit results', () => {
+    run(['gstack-artifacts-init', '--remote', bareRemote]);
+    run(['gstack-config', 'set', 'artifacts_sync_mode', 'full']);
+
+    const fakeBin = path.join(tmpHome, 'fake-bin');
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, 'gbrain'), `#!/bin/sh
+case "$GSTACK_PROBE_FIXTURE" in
+  absent) printf '%s\\n' '{"sources":[{"id":"other","page_count":4}]}' ;;
+  invalid) printf '%s\\n' 'not-json' ;;
+  nonzero) exit 7 ;;
+esac
+`);
+    fs.chmodSync(path.join(fakeBin, 'gbrain'), 0o755);
+
+    const cases = [
+      ['absent', 'is not registered'],
+      ['invalid', 'page-count probe returned invalid JSON'],
+      ['nonzero', 'page-count probe exited 7'],
+    ] as const;
+    for (const [fixture, message] of cases) {
+      const r = run(['gstack-brain-sync', '--once'], {
+        env: {
+          GSTACK_BRAIN_SOURCE_ID: 'fixture-artifacts',
+          GSTACK_PROBE_FIXTURE: fixture,
+          PATH: `${fakeBin}:${process.env.PATH || ''}`,
+        },
+      });
+      expect(r.status).toBe(0);
+      const status = JSON.parse(fs.readFileSync(path.join(tmpHome, '.brain-sync-status.json'), 'utf-8'));
+      expect(status.message).toContain(message);
+    }
+  });
+
   test('restore round-trip: writes on machine A visible on machine B', () => {
     // Machine A.
     run(['gstack-artifacts-init', '--remote', bareRemote]);

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -556,6 +556,51 @@ esac
     rmSync(home, { recursive: true, force: true });
   });
 
+  it("brain-sync stage does not label a successful git command as gbrain indexing", () => {
+    const source = readFileSync(SCRIPT, "utf-8");
+
+    expect(source).not.toContain('summary: result.status === 0 ? "curated artifacts pushed"');
+    expect(source).toContain("gbrain indexing is not performed by this stage");
+  });
+
+  it("brain-sync stage is ERR when its maintained artifacts source has zero pages", () => {
+    const home = makeTestHome();
+    const gstackHome = join(home, ".gstack");
+    const fakeBin = join(home, "fake-bin");
+    mkdirSync(gstackHome, { recursive: true });
+    mkdirSync(fakeBin, { recursive: true });
+    spawnSync("git", ["init", "--quiet", "-b", "main"], { cwd: gstackHome });
+    writeFileSync(join(gstackHome, "config.yaml"), "artifacts_sync_mode: full\n");
+    writeFileSync(join(fakeBin, "gbrain"), `#!/bin/sh
+case "$*" in
+  "sources list --json")
+    printf '%s\\n' '{"sources":[{"id":"fixture-artifacts","page_count":0}]}'
+    ;;
+  *) exit 1 ;;
+esac
+`);
+    chmodSync(join(fakeBin, "gbrain"), 0o755);
+
+    const r = runScript(
+      ["--incremental", "--no-code", "--no-memory", "--quiet"],
+      {
+        HOME: home,
+        GSTACK_HOME: gstackHome,
+        GSTACK_BRAIN_SOURCE_ID: "fixture-artifacts",
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+      },
+    );
+
+    expect(r.exitCode).toBe(1);
+    const state = JSON.parse(readFileSync(join(gstackHome, ".gbrain-sync-state.json"), "utf-8"));
+    const stage = state.last_stages.find((entry: { name: string }) => entry.name === "brain-sync");
+    expect(stage.ok).toBe(false);
+    expect(stage.summary).toContain("gstack-brain-sync exited 1");
+    const status = JSON.parse(readFileSync(join(gstackHome, ".brain-sync-status.json"), "utf-8"));
+    expect(status.status).toBe("index_failed");
+    rmSync(home, { recursive: true, force: true });
+  });
+
   it("worktree-aware source ID: two worktrees of the same repo get DIFFERENT ids", () => {
     // Conductor pattern: same origin, two different absolute paths. Pre-fix the
     // ID was slug-only so both worktrees collapsed onto `gstack-code-<slug>` and


### PR DESCRIPTION
## Summary

- stop reporting a successful artifact git command as gbrain indexing
- verify the maintained artifact source page count with a read-only, five-second bounded probe
- fail loud with `index_failed` when that source reports zero pages; otherwise report the git result and explicitly mark index freshness as unverified
- terminate the full probe process tree on timeout, including Git Bash/MSYS native cleanup

This deliberately does not run `gbrain sync` at every skill boundary: that operation is expensive and owns a single-writer database. Missing, unavailable, invalid, or nonzero probe results remain truthful `indexing not verified` outcomes rather than false indexing claims.

## Verification

Red first on upstream `main`: the zero-page regression returned status 0 before this change. The final test proves a real artifact commit reaches the remote, then the command fails because the maintained source still has zero pages.

- `bun test test/brain-sync.test.ts test/gstack-gbrain-sync.test.ts test/brain-sync-windows-paths.test.ts test/gbrain-spawn-windows-shell.test.ts` — 122 pass, 0 fail
- `bash -n bin/gstack-brain-sync`
- `shellcheck --severity=error bin/gstack-brain-sync`
- `git diff --check`

The broader free suite completed every shard except one unrelated timeout-wrapper timing assertion under six-way load (`rc=143` vs `rc=124`); that assertion passes standalone on both this commit and pristine upstream `main`.
