### PR TITLE
fix(browse): reset profile crash markers so headed launch stops showing the profile-error bubble

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -21,7 +21,7 @@ import { addConsoleEntry, addNetworkEntry, addDialogEntry, networkBuffer, type D
 import { emitActivity } from './activity';
 import { validateNavigationUrl } from './url-validation';
 import { TabSession, type RefEntry } from './tab-session';
-import { resolveChromiumProfile, cleanSingletonLocks } from './config';
+import { resolveChromiumProfile, cleanSingletonLocks, resetProfileExitState } from './config';
 import { launchWithXProtectHeal } from './xprotect-heal';
 import { withCdpSession } from './cdp-bridge';
 import type { MemorySnapshot, MemoryStructureStats, MemoryTabSnapshot, MemoryProcess } from './memory-snapshot';
@@ -600,6 +600,10 @@ export class BrowserManager {
     // too. Safe under external coordination: gbd.lock for gbrowser,
     // single-instance CLI check for gstack.
     cleanSingletonLocks(userDataDir);
+    // Same crash, other half: a SIGKILLed shutdown leaves the profile marked
+    // "Crashed", which paints the "Something went wrong opening your profile"
+    // bubble over the page on the next headed launch.
+    resetProfileExitState(userDataDir);
 
     // Support custom Chromium binary via GSTACK_CHROMIUM_PATH env var.
     // Used by GStack Browser.app to point at the bundled Chromium.
@@ -1726,6 +1730,7 @@ export class BrowserManager {
       const userDataDir = resolveChromiumProfile();
       fs.mkdirSync(userDataDir, { recursive: true });
       cleanSingletonLocks(userDataDir);
+      resetProfileExitState(userDataDir);
 
       // Self-heal probe (#2242): handoff always launches the Playwright-cache
       // bundle (this launchPersistentContext call passes no executablePath),

--- a/browse/src/config.ts
+++ b/browse/src/config.ts
@@ -296,10 +296,10 @@ export function resolveChromiumProfile(explicit?: string): string {
  * peer is using this profile (gbd.lock for gbrowser; single-instance CLI
  * check for gstack).
  */
-export function cleanSingletonLocks(userDataDir: string): void {
+function resolveRecognizedProfileDir(userDataDir: string, caller: string): string | null {
   if (!path.isAbsolute(userDataDir)) {
-    console.warn(`[browse] cleanSingletonLocks: refusing relative path: ${userDataDir}`);
-    return;
+    console.warn(`[browse] ${caller}: refusing relative path: ${userDataDir}`);
+    return null;
   }
   const resolved = path.resolve(userDataDir);
   const basename = path.basename(resolved);
@@ -309,10 +309,57 @@ export function cleanSingletonLocks(userDataDir: string): void {
     : null;
   const isSafe = basename === 'chromium-profile' || (explicitAbs !== null && resolved === explicitAbs);
   if (!isSafe) {
-    console.warn(`[browse] cleanSingletonLocks: refusing to clean unrecognized profile dir: ${resolved}`);
-    return;
+    console.warn(`[browse] ${caller}: refusing to clean unrecognized profile dir: ${resolved}`);
+    return null;
   }
+  return resolved;
+}
+
+export function cleanSingletonLocks(userDataDir: string): void {
+  const resolved = resolveRecognizedProfileDir(userDataDir, 'cleanSingletonLocks');
+  if (resolved === null) return;
   for (const lockFile of ['SingletonLock', 'SingletonSocket', 'SingletonCookie']) {
     safeUnlinkQuiet(path.join(resolved, lockFile));
+  }
+}
+
+/**
+ * Reset the profile's crash markers before launch.
+ *
+ * cleanSingletonLocks() clears the lockfiles that stop Chromium starting at
+ * all. This clears the *other* half of the same problem: close() falls back to
+ * SIGKILL when a graceful shutdown overruns closeRaceMs, so Default/Preferences
+ * is left with `exit_type: "Crashed"`. On the next headed launch Chromium shows
+ * the "Something went wrong when opening your profile" bubble over the page,
+ * which lands in screenshots and swallows clicks near the top of the viewport.
+ *
+ * --hide-crash-restore-bubble does not cover this one. That flag suppresses the
+ * session-restore ("Restore pages?") bubble; the profile-error bubble is driven
+ * by the profile's own stored exit state, so it has to be reset on disk.
+ *
+ * Same directory guard as cleanSingletonLocks, and the same caller contract:
+ * external coordination must already guarantee no live peer holds the profile.
+ */
+export function resetProfileExitState(userDataDir: string): void {
+  const resolved = resolveRecognizedProfileDir(userDataDir, 'resetProfileExitState');
+  if (resolved === null) return;
+  const prefsPath = path.join(resolved, 'Default', 'Preferences');
+  let prefs: Record<string, unknown>;
+  try {
+    prefs = JSON.parse(fs.readFileSync(prefsPath, 'utf8'));
+  } catch {
+    return; // no profile yet, or unreadable/corrupt — launch handles both
+  }
+  if (typeof prefs !== 'object' || prefs === null || Array.isArray(prefs)) return;
+  const profile = prefs.profile;
+  if (typeof profile !== 'object' || profile === null || Array.isArray(profile)) return;
+  const p = profile as Record<string, unknown>;
+  if (p.exit_type === 'Normal' && p.exited_cleanly === true) return; // already clean
+  p.exit_type = 'Normal';
+  p.exited_cleanly = true;
+  try {
+    fs.writeFileSync(prefsPath, JSON.stringify(prefs));
+  } catch {
+    // Best effort: a profile we cannot rewrite still launches, just with the bubble.
   }
 }

--- a/browse/test/config.test.ts
+++ b/browse/test/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { resolveConfig, ensureStateDir, readVersionHash, getGitRoot, getRemoteSlug, resolveGstackHome, resolveChromiumProfile, cleanSingletonLocks } from '../src/config';
+import { resolveConfig, ensureStateDir, readVersionHash, getGitRoot, getRemoteSlug, resolveGstackHome, resolveChromiumProfile, cleanSingletonLocks, resetProfileExitState } from '../src/config';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -509,5 +509,106 @@ describe('cleanSingletonLocks', () => {
     expect(() => cleanSingletonLocks(tmpDir)).not.toThrow();
     expect(() => cleanSingletonLocks(tmpDir)).not.toThrow();
     fs.rmSync(path.dirname(tmpDir), { recursive: true, force: true });
+  });
+});
+
+describe('resetProfileExitState', () => {
+  const mkProfile = (name: string, prefs: unknown): string => {
+    const dir = path.join(os.tmpdir(), `${name}-${Date.now()}`, 'chromium-profile');
+    fs.mkdirSync(path.join(dir, 'Default'), { recursive: true });
+    if (prefs !== undefined) {
+      fs.writeFileSync(path.join(dir, 'Default', 'Preferences'), JSON.stringify(prefs));
+    }
+    return dir;
+  };
+  const readPrefs = (dir: string) =>
+    JSON.parse(fs.readFileSync(path.join(dir, 'Default', 'Preferences'), 'utf8'));
+
+  test('rewrites Crashed exit state to Normal', () => {
+    const dir = mkProfile('crashed', { profile: { exit_type: 'Crashed', exited_cleanly: false } });
+    resetProfileExitState(dir);
+    const prefs = readPrefs(dir);
+    expect(prefs.profile.exit_type).toBe('Normal');
+    expect(prefs.profile.exited_cleanly).toBe(true);
+    fs.rmSync(path.dirname(dir), { recursive: true, force: true });
+  });
+
+  test('preserves unrelated preference keys', () => {
+    const dir = mkProfile('preserve', {
+      profile: { exit_type: 'Crashed', exited_cleanly: false, name: 'Person 1' },
+      browser: { window_placement: { top: 10 } },
+    });
+    resetProfileExitState(dir);
+    const prefs = readPrefs(dir);
+    expect(prefs.profile.name).toBe('Person 1');
+    expect(prefs.browser.window_placement.top).toBe(10);
+    fs.rmSync(path.dirname(dir), { recursive: true, force: true });
+  });
+
+  test('leaves an already-clean profile byte-identical', () => {
+    const dir = mkProfile('clean', { profile: { exit_type: 'Normal', exited_cleanly: true } });
+    const before = fs.readFileSync(path.join(dir, 'Default', 'Preferences'), 'utf8');
+    resetProfileExitState(dir);
+    expect(fs.readFileSync(path.join(dir, 'Default', 'Preferences'), 'utf8')).toBe(before);
+    fs.rmSync(path.dirname(dir), { recursive: true, force: true });
+  });
+
+  test('no Preferences file is a no-op, not a throw', () => {
+    const dir = mkProfile('missing', undefined);
+    expect(() => resetProfileExitState(dir)).not.toThrow();
+    expect(fs.existsSync(path.join(dir, 'Default', 'Preferences'))).toBe(false);
+    fs.rmSync(path.dirname(dir), { recursive: true, force: true });
+  });
+
+  test('corrupt Preferences is left untouched', () => {
+    const dir = mkProfile('corrupt', undefined);
+    const prefsPath = path.join(dir, 'Default', 'Preferences');
+    fs.writeFileSync(prefsPath, '{not json');
+    expect(() => resetProfileExitState(dir)).not.toThrow();
+    expect(fs.readFileSync(prefsPath, 'utf8')).toBe('{not json');
+    fs.rmSync(path.dirname(dir), { recursive: true, force: true });
+  });
+
+  test('refuses unrecognized profile dir basename', () => {
+    const dir = path.join(os.tmpdir(), `unrelated-prefs-${Date.now()}`);
+    fs.mkdirSync(path.join(dir, 'Default'), { recursive: true });
+    const prefsPath = path.join(dir, 'Default', 'Preferences');
+    fs.writeFileSync(prefsPath, JSON.stringify({ profile: { exit_type: 'Crashed' } }));
+    const origWarn = console.warn;
+    let warned = '';
+    console.warn = (msg: string) => { warned = msg; };
+    try {
+      resetProfileExitState(dir);
+      expect(warned).toContain('refusing to clean unrecognized profile dir');
+      expect(JSON.parse(fs.readFileSync(prefsPath, 'utf8')).profile.exit_type).toBe('Crashed');
+    } finally {
+      console.warn = origWarn;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('respects explicit CHROMIUM_PROFILE env with non-standard basename', () => {
+    const dir = path.join(os.tmpdir(), `custom-prefs-${Date.now()}`);
+    fs.mkdirSync(path.join(dir, 'Default'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'Default', 'Preferences'),
+      JSON.stringify({ profile: { exit_type: 'Crashed', exited_cleanly: false } }));
+    const orig = process.env.CHROMIUM_PROFILE;
+    process.env.CHROMIUM_PROFILE = dir;
+    try {
+      resetProfileExitState(dir);
+      const prefs = JSON.parse(fs.readFileSync(path.join(dir, 'Default', 'Preferences'), 'utf8'));
+      expect(prefs.profile.exit_type).toBe('Normal');
+    } finally {
+      if (orig === undefined) delete process.env.CHROMIUM_PROFILE;
+      else process.env.CHROMIUM_PROFILE = orig;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('missing or non-object profile key is a no-op', () => {
+    const dir = mkProfile('noprofile', { browser: { window_placement: {} } });
+    expect(() => resetProfileExitState(dir)).not.toThrow();
+    expect(readPrefs(dir).profile).toBeUndefined();
+    fs.rmSync(path.dirname(dir), { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
Headed Chromium shows "Something went wrong when opening your profile. Some features may be unavailable." over the page on most launches. It lands in screenshots and swallows clicks near the top of the viewport, so `/browse --headed` QA has to dismiss it first.

Cause: `close()` falls back to `SIGKILL` when a graceful shutdown overruns `closeRaceMs` (browser-manager.ts), so `Default/Preferences` keeps `exit_type: "Crashed"`. Chromium reports the unclean profile on the next launch.

`cleanSingletonLocks()` already handles the half of this that blocks launch outright. This adds `resetProfileExitState()` beside it in config.ts, sharing the same directory guard via an extracted `resolveRecognizedProfileDir()`, and calls it from both `launchPersistentContext` paths (`launchHeaded` and the handoff path).

`--hide-crash-restore-bubble` (browser-manager.ts:547, :1711) does not cover this one. That flag suppresses the session-restore bubble; the profile-error bubble reads the profile's own stored exit state, so it has to be reset on disk. Confirmed by testing the flag against a Crashed profile.

Notes:
- Parses and rewrites the Preferences JSON rather than regexing it, so unrelated keys survive.
- No-ops on a missing, corrupt, or already-clean profile; never throws.
- Respects `$CHROMIUM_PROFILE`, so gbrowser per-workspace profiles are covered.
- 8 tests added to browse/test/config.test.ts. Full `bun run scripts/test-free-shards.ts` is green apart from 3 pre-existing brain-cache-roundtrip failures that import nothing in this diff.

Related but not the same: #2311 (SingletonLock in handoff), #2492 (per-project headed profile). Should merge cleanly with either.