### PR TITLE
fix(config): reject malformed cross_project_learnings at set

### DIFF
--- a/bin/gstack-config
+++ b/bin/gstack-config
@@ -391,6 +391,14 @@ case "${1:-}" in
       echo "Error: codex_reviews '$VALUE' not recognized. Valid values: enabled, disabled. Existing value left unchanged." >&2
       exit 1
     fi
+    # cross_project_learnings: empty get is the first-run prompt sentinel.
+    # Skills enable only on the literal "true". A typo must not persist — that
+    # keeps the feature off and suppresses the prompt. Reject, like
+    # codex_reviews; do not coerce (a stored default still kills the sentinel).
+    if [ "$KEY" = "cross_project_learnings" ] && [ "$VALUE" != "true" ] && [ "$VALUE" != "false" ]; then
+      echo "Error: cross_project_learnings '$VALUE' not recognized. Valid values: true, false. Existing value left unchanged." >&2
+      exit 1
+    fi
     mkdir -p "$STATE_DIR"
     # Write annotated header on first creation
     if [ ! -f "$CONFIG_FILE" ]; then

--- a/test/gstack-config-cross-project.test.ts
+++ b/test/gstack-config-cross-project.test.ts
@@ -1,0 +1,67 @@
+/**
+ * #2673: gstack-config set must reject malformed cross_project_learnings.
+ *
+ * Empty get is the first-run prompt sentinel (pinned in
+ * gstack-config-defaults.test.ts). Skills only enable on the literal "true".
+ * A typo used to store verbatim and exit 0, so the feature stayed off and
+ * the prompt never returned. Unlike pair_agent / redact_prepush_hook, do
+ * not coerce to a default — that would still persist a value and still
+ * kill the sentinel. Follow codex_reviews: reject, leave existing.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const CONFIG = path.resolve(import.meta.dir, "..", "bin", "gstack-config");
+let stateRoot: string;
+
+function cfg(args: string[]): { code: number; out: string; err: string } {
+  const r = spawnSync(CONFIG, args, {
+    encoding: "utf8",
+    env: { ...process.env, GSTACK_STATE_ROOT: stateRoot },
+  });
+  return { code: r.status ?? 0, out: r.stdout ?? "", err: r.stderr ?? "" };
+}
+
+beforeEach(() => {
+  stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gstack-config-xproj-"));
+});
+
+afterEach(() => {
+  fs.rmSync(stateRoot, { recursive: true, force: true });
+});
+
+describe("cross_project_learnings set domain (#2673)", () => {
+  test("empty get is still the first-run sentinel", () => {
+    const r = cfg(["get", "cross_project_learnings"]);
+    expect(r.code).toBe(0);
+    expect(r.out).toBe("");
+  });
+
+  test("true and false round-trip", () => {
+    expect(cfg(["set", "cross_project_learnings", "true"]).code).toBe(0);
+    expect(cfg(["get", "cross_project_learnings"]).out).toBe("true");
+    expect(cfg(["set", "cross_project_learnings", "false"]).code).toBe(0);
+    expect(cfg(["get", "cross_project_learnings"]).out).toBe("false");
+  });
+
+  test("typo is rejected and does not write", () => {
+    const r = cfg(["set", "cross_project_learnings", "ture"]);
+    expect(r.code).toBe(1);
+    expect(r.err).toContain("not recognized");
+    expect(r.err).toContain("cross_project_learnings");
+    const got = cfg(["get", "cross_project_learnings"]);
+    expect(got.code).toBe(0);
+    expect(got.out).toBe("");
+  });
+
+  test("typo leaves an existing valid value unchanged", () => {
+    expect(cfg(["set", "cross_project_learnings", "true"]).code).toBe(0);
+    const r = cfg(["set", "cross_project_learnings", "yes"]);
+    expect(r.code).toBe(1);
+    expect(r.err).toContain("Existing value left unchanged");
+    expect(cfg(["get", "cross_project_learnings"]).out).toBe("true");
+  });
+});


### PR DESCRIPTION
## Why (in your own words)

`gstack-config set cross_project_learnings ture` exited 0 and stored the typo. Skills only enable on the literal `true`, and a non-empty value suppresses the first-run prompt, so the feature stayed off and the question never came back. The official AskUserQuestion path only writes `true` / `false`. A hand-typed typo was the hole.

Reject the bad write, same as `codex_reviews`. Do not coerce to `false` — a stored default still kills the empty-get sentinel.

**Fixes #2673.** Same class as #2488 (durable bad write). Not #1726 / #1723 (those are `parseInt` on one-shot flags; #1726 is already on main, #1723 has #1724). Did not add an `unset` token or a new subcommand.

### Why this shape

Issue author named `bin/gstack-config` `set` and the closed-domain block. CONTRIBUTING's wave rule: if two PRs fix the same thing, keep the smaller one. This is 2 files, on current `main`. Fine to absorb into a wave.

Did not follow the issue's "Expected" `pair_agent` warn-and-default. That would persist a value and still suppress the prompt.

### What it does

- `set cross_project_learnings` accepts only `true` and `false`.
- Anything else exits 1, prints `not recognized`, leaves the file unchanged.
- Empty `get` (first-run sentinel) is unchanged.

### What it deliberately does not do

- Accept literal `unset` (author snippet; optional undo, not the typo bug)
- Add `gstack-config unset`
- Heal an already-stored `ture` on `get`
- Whitelist `skill_prefix` / `telemetry` / other unvalidated keys
- Extract `validate_key()` (TODOS P3 leftover)
- `VERSION` / `CHANGELOG` / README / ETHOS
- `/ship` (wave stamps version)

AI was used for assistance.

## Live evidence

Temp `GSTACK_HOME` only — not `~/.gstack/config.yaml`. Same isolated dir, real `bin/gstack-config`.

**Before** (`upstream/main` @ `85fd9db`):

```
$ bin/gstack-config set cross_project_learnings ture
$ echo $?
0

$ bin/gstack-config get cross_project_learnings
ture
```

**After** (this branch):

```
$ bin/gstack-config set cross_project_learnings ture
Error: cross_project_learnings 'ture' not recognized. Valid values: true, false. Existing value left unchanged.
$ echo $?
1

$ bin/gstack-config get cross_project_learnings

$ echo $?
0

$ bin/gstack-config set cross_project_learnings true
$ bin/gstack-config get cross_project_learnings
true

$ bin/gstack-config set cross_project_learnings ture
Error: cross_project_learnings 'ture' not recognized. Valid values: true, false. Existing value left unchanged.
$ bin/gstack-config get cross_project_learnings
true
```

## Scope

- **Changed:** `bin/gstack-config` (`set` only), `test/gstack-config-cross-project.test.ts`
- **Verified live by:** the transcripts above, plus `bun test test/gstack-config-cross-project.test.ts test/gstack-config-defaults.test.ts test/gstack-config-redact-keys.test.ts test/gstack-config-key-locale.test.ts` (18 pass). The two reject cases were red on tip (`Expected: 1, Received: 0`) before the arm existed. Full `bun run test` green (7 shards). `bun run slop:diff`: no new findings in 2 files.
- **Did NOT test:** Tier 2/3 evals. A real `~/.gstack/config.yaml`. Healing a `ture` already on disk (out of scope).

## Liveness proof (required)

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
<img width="343" height="37" alt="image" src="https://github.com/user-attachments/assets/00131d08-5df3-4e77-8a45-e8e2a5191c74" />

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source, not a generated SKILL.md)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A)
- [x] Linked issue or reproduction: #2673

## Test plan

- [x] `bun test test/gstack-config-cross-project.test.ts` → 4 pass (2 were red on tip)
- [x] Live: `set ture` → exit 1, `get` empty
- [x] Live: `set true` then `set ture` → still `true`
- [x] Empty `get` sentinel still exit 0
- [x] Existing defaults / redact / locale config tests still pass

Fork PRs do not get eval secrets; the free file above is the gate.