### PR TITLE
fix(redact): pii.cc flagged migration timestamps and captured a trail…

### DIFF
--- a/lib/redact-patterns.ts
+++ b/lib/redact-patterns.ts
@@ -95,6 +95,47 @@ export function luhnValid(span: string): boolean {
   return sum % 10 === 0;
 }
 
+/**
+ * A bare 14-digit `YYYYMMDDhhmmss` stamp — the shape every Supabase/Rails/Flyway
+ * migration filename uses (`20260823000001_reap_stale_notifications.sql`).
+ *
+ * Same collision class as the digit-only UUID `insideUuid` already guards: a
+ * 14-digit run passes Luhn roughly one time in ten, so a repo with a hundred
+ * migrations reliably ships a handful of "credit cards" on every branch that
+ * touches them. The noise is not incidental — it recurs on each push and trains
+ * people to wave the scanner through.
+ *
+ * NARROW BY CONSTRUCTION, in three ways that keep real cards flagged:
+ *   1. EXACTLY 14 digits. 13/15/16/19-digit cards never reach this check.
+ *   2. The digits must parse as a real date AND time — month 01-12, a day that
+ *      exists in that month, hh<24, mm<60, ss<60. Random 14-digit runs fail.
+ *   3. Year 1900-2099. So the span always begins "19" or "20", and the only
+ *      14-digit card family in circulation is Diners Club, whose IINs are
+ *      300-305, 3095, 36, 38 and 39 — every one begins "30", "36", "38" or
+ *      "39". The two sets cannot intersect.
+ *
+ * Separators are deliberately NOT stripped: a card written "1234 5678 9012 34"
+ * must not become timestamp-shaped by having its spaces removed.
+ */
+export function looksLikeDatetimeStamp(span: string): boolean {
+  if (!/^\d{14}$/.test(span)) return false;
+
+  const year = Number(span.slice(0, 4));
+  const month = Number(span.slice(4, 6));
+  const day = Number(span.slice(6, 8));
+  const hour = Number(span.slice(8, 10));
+  const minute = Number(span.slice(10, 12));
+  const second = Number(span.slice(12, 14));
+
+  if (year < 1900 || year > 2099) return false;
+  if (month < 1 || month > 12) return false;
+  if (hour > 23 || minute > 59 || second > 59) return false;
+
+  // Real day-of-month, leap years included.
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return day >= 1 && day <= daysInMonth;
+}
+
 /** Shannon entropy in bits/char. Used to gate env-style KV (skip placeholders). */
 export function shannonEntropy(s: string): number {
   if (!s.length) return 0;
@@ -693,12 +734,23 @@ export const PATTERNS: RedactPattern[] = [
     tier: "MEDIUM",
     category: "pii",
     description: "Credit-card number (Luhn-valid)",
-    regex: /\b((?:\d[ \-]?){13,19})\b/,
+    // The trailing `\d` is load-bearing. `(?:\d[ \-]?){13,19}` let the LAST
+    // digit absorb the separator after it, so the captured span came back as
+    // "4111 1111 1111 1111 " — trailing space included. That span is what the
+    // engine hands to `allow.has(span)`, to maskPreview and to the redactor,
+    // so an --allowlist entry written as the number itself could never match
+    // (the documented "exact spans" contract was unusable for this pattern),
+    // the preview was off by a character, and an auto-redaction ate the
+    // following space. Requiring a digit at the end keeps every spaced and
+    // hyphenated card matching while ending the span ON the number.
+    regex: /\b((?:\d[ \-]?){12,18}\d)\b/,
     autoRedactable: true,
     redactToken: "<REDACTED-CC>",
     // A 13-19 digit slice of a digit-only UUID passes Luhn often enough to
     // matter; the enclosing-UUID check runs first so it never reaches Luhn.
-    validate: (span, match) => !insideUuid(match) && luhnValid(span),
+    // Datetime stamps are the same collision class — see looksLikeDatetimeStamp.
+    validate: (span, match) =>
+      !insideUuid(match) && !looksLikeDatetimeStamp(span) && luhnValid(span),
   },
   {
     id: "pii.ip_public",

--- a/test/redact-migration-timestamp-false-positive.test.ts
+++ b/test/redact-migration-timestamp-false-positive.test.ts
@@ -1,0 +1,162 @@
+/**
+ * pii.cc vs 14-digit migration timestamps.
+ *
+ * `20260823000001_reap_stale_notifications.sql` — the Supabase/Rails/Flyway
+ * migration filename shape — is 14 digits, and a 14-digit run clears Luhn about
+ * one time in ten. A repo with a hundred migrations therefore ships a handful of
+ * "credit cards" on every branch that touches them, and a doc that lists the
+ * whole migration history lights up all at once. That is the same collision
+ * class the digit-only UUID `insideUuid` already guards.
+ *
+ * Both directions are pinned here. The negative controls are the point: a guard
+ * that exempted long digit runs wholesale would pass the "timestamps clean" half
+ * and quietly gut the pattern.
+ *
+ * The second describe block covers a separate defect found alongside it — the
+ * captured span used to include the separator FOLLOWING the last digit, which
+ * made the documented --allowlist "exact spans" contract impossible to satisfy.
+ */
+import { describe, test, expect } from "bun:test";
+import { scan } from "../lib/redact-engine";
+import { looksLikeDatetimeStamp } from "../lib/redact-patterns";
+
+const flagsCc = (s: string): boolean =>
+  scan(s, { repoVisibility: "private" }).findings.some((f) => f.id === "pii.cc");
+
+describe("pii.cc — real cards stay flagged", () => {
+  const REAL_CARDS: [string, string][] = [
+    ["Visa 16 bare", "card 4111111111111111"],
+    ["Visa 16 spaced", "card 4111 1111 1111 1111"],
+    ["Visa 16 hyphenated", "card 4111-1111-1111-1111"],
+    ["Mastercard 16", "card 5555555555554444"],
+    ["Amex 15", "card 378282246310005"],
+    ["Diners 14", "card 30569309025904"],
+    ["Visa 13", "card 4222222222222"],
+    ["Discover 16", "card 6011111111111117"],
+  ];
+  for (const [label, input] of REAL_CARDS) {
+    test(label, () => {
+      expect(flagsCc(input)).toBe(true);
+    });
+  }
+});
+
+describe("pii.cc — migration timestamps are not credit cards", () => {
+  test("a Luhn-passing migration stamp in prose is exempt", () => {
+    // The exact stamp that started this: Luhn-valid, and pure coincidence.
+    expect(flagsCc("Reaped rows are terminal (20260823000001); also what makes")).toBe(false);
+  });
+
+  test("a bare stamp is exempt", () => {
+    expect(flagsCc("card 20260823000001 here")).toBe(false);
+  });
+
+  test("a stamp inside a migration filename is exempt", () => {
+    expect(flagsCc("| 20260816205449_fix_publish_schedule_opens_join | ...")).toBe(false);
+  });
+});
+
+describe("pii.cc — the timestamp guard stays narrow", () => {
+  /**
+   * The load-bearing controls. The guard may only exempt something that is
+   * genuinely a 14-digit datetime; anything else must still reach Luhn.
+   */
+  /**
+   * THE load-bearing control. 20260832000000 is date-SHAPED (starts 2026-08)
+   * but day 32 does not exist, and it is genuinely Luhn-valid — so if the guard
+   * ever loosens into "starts like a year, close enough", this goes green by
+   * exemption and the pattern has a hole. It must still be flagged.
+   */
+  test("a date-shaped but impossible 14-digit run is still flagged", () => {
+    expect(looksLikeDatetimeStamp("20260832000000")).toBe(false);
+    expect(flagsCc("card 20260832000000 here")).toBe(true);
+  });
+
+  test("a month-13 run is date-shaped, Luhn-valid, and still flagged", () => {
+    expect(looksLikeDatetimeStamp("20261399000003")).toBe(false);
+    expect(flagsCc("card 20261399000003 here")).toBe(true);
+  });
+
+  test("a 14-digit Diners card is never datetime-shaped", () => {
+    expect(looksLikeDatetimeStamp("30569309025904")).toBe(false);
+  });
+
+  test("16 digits are out of scope even if they start like a date", () => {
+    expect(looksLikeDatetimeStamp("2026082300000123")).toBe(false);
+  });
+
+  test("an impossible day is rejected (Feb 30)", () => {
+    expect(looksLikeDatetimeStamp("20260230000001")).toBe(false);
+  });
+
+  test("a real leap day is accepted", () => {
+    expect(looksLikeDatetimeStamp("20240229120000")).toBe(true);
+  });
+
+  test("Feb 29 in a non-leap year is rejected", () => {
+    expect(looksLikeDatetimeStamp("20260229120000")).toBe(false);
+  });
+
+  test("out-of-range hour/minute/second are rejected", () => {
+    expect(looksLikeDatetimeStamp("20260823240000")).toBe(false);
+    expect(looksLikeDatetimeStamp("20260823006000")).toBe(false);
+    expect(looksLikeDatetimeStamp("20260823000060")).toBe(false);
+  });
+
+  test("years outside 1900-2099 are rejected", () => {
+    expect(looksLikeDatetimeStamp("18260823000001")).toBe(false);
+    expect(looksLikeDatetimeStamp("21260823000001")).toBe(false);
+  });
+
+  test("separators are not stripped to manufacture a stamp", () => {
+    // A spaced card must not become timestamp-shaped by losing its spaces.
+    expect(looksLikeDatetimeStamp("2026 0823 000001")).toBe(false);
+  });
+});
+
+describe("pii.cc — the captured span ends on the number", () => {
+  /**
+   * `(?:\d[ \-]?){13,19}` let the final digit absorb the separator after it, so
+   * the span carried a trailing space. Everything downstream takes the span
+   * verbatim — allow.has(span), maskPreview, the redactor — so the documented
+   * --allowlist contract could not be satisfied by writing the number itself.
+   */
+  const SAMPLE = "card 4111 1111 1111 1111 here";
+
+  test("the capture ends on a digit, not on the following separator", () => {
+    // Asserted against the regex directly: `preview` is masked and truncated,
+    // so it cannot show a trailing character either way. This is the shape the
+    // engine derives `span` from.
+    const shipped = /\b((?:\d[ \-]?){12,18}\d)\b/g.exec(SAMPLE)?.[1];
+    expect(shipped).toBe("4111 1111 1111 1111");
+    expect(shipped!.endsWith(" ")).toBe(false);
+  });
+
+  test("the old quantifier really did absorb the separator (regression pin)", () => {
+    // Documents the defect this file exists for. If someone reverts the
+    // pattern, the assertion above fails and this one explains why.
+    const previous = /\b((?:\d[ \-]?){13,19})\b/g.exec(SAMPLE)?.[1];
+    expect(previous).toBe("4111 1111 1111 1111 ");
+  });
+
+  test("an exact-span allowlist entry actually suppresses the finding", () => {
+    const input = "card 4111111111111111 here";
+    expect(flagsCc(input)).toBe(true);
+    expect(
+      scan(input, {
+        repoVisibility: "private",
+        allowlist: ["4111111111111111"],
+      }).findings.some((f) => f.id === "pii.cc"),
+    ).toBe(false);
+  });
+
+  test("the allowlist works for a spaced card written as it appears", () => {
+    const input = "card 4111 1111 1111 1111 here";
+    expect(
+      scan(input, {
+        repoVisibility: "private",
+        allowlist: ["4111 1111 1111 1111"],
+      }).findings.some((f) => f.id === "pii.cc"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION

<img width="1862" height="617" alt="Screenshot 2026-08-24 104409" src="https://github.com/user-attachments/assets/483799d9-bcd9-4427-903b-09843781aa69" />
…ing separator

Two defects in the same pattern. 25 new tests, both directions pinned.

1. FALSE POSITIVE — 14-digit YYYYMMDDhhmmss migration stamps.

   `20260823000001_reap_stale_notifications.sql` is the Supabase/Rails/Flyway filename shape, and a 14-digit run clears Luhn about one time in ten. A repo with ~100 migrations ships a handful of "credit cards" on every branch that touches them; a doc listing the migration history lights up all at once (14 MEDIUM findings on one real push, every one of them a timestamp). That is the collision class `insideUuid` already guards for digit-only UUIDs.

   New `looksLikeDatetimeStamp`, narrow in three ways so real cards keep flagging: exactly 14 digits (13/15/16/19 never reach it); the digits must parse as a real date and time, leap years included; and year 1900-2099, so the span always starts "19" or "20" while the only 14-digit card family, Diners Club, starts "30", "36", "38" or "39" — the sets cannot intersect. Separators are deliberately not stripped, so a spaced card cannot be reshaped into a stamp.

2. CORRECTNESS — the captured span included the separator after the last digit.

   `(?:\d[ \-]?){13,19}` let the final digit absorb its trailing separator, so the span came back as "4111 1111 1111 1111 ". The engine passes that span verbatim to `allow.has(span)`, to maskPreview and to the redactor, so: an --allowlist entry written as the number itself could NEVER match, making the documented "exact spans" contract unusable for this pattern; the preview was off by a character; and an auto-redaction consumed the following space. Now `(?:\d[ \-]?){12,18}\d` — same 13-19 digit range, span ends on a digit.

Verified: the push that prompted this goes 14 findings -> 0, and the two allowlist tests fail against the old quantifier. The load-bearing controls are the negatives — 20260832000000 (day 32) and 20261399000003 (month 13) are both date-shaped AND Luhn-valid, and both must stay flagged; if the guard ever loosens to "starts like a year", they go green and the pattern has a hole.

Pre-existing unrelated failure, unchanged by this commit and confirmed by stashing it: redact-audit-log.test.ts "file is mode 0600" fails on Windows, which does not honour chmod.

<!--
gstack is AI-coded and proud of it. The bar is EVIDENCE OF REAL USE, not lines
of code. A PR with no proof behind it gets closed, no matter how clean it looks.
Fill every section below. See CONTRIBUTING.md → "The evidence bar".
-->

## Why (in your own words)

<!-- One paragraph: what breaks for a user today, and what this change does about
it. Not a restatement of the diff. -->

## Live evidence

<!-- REQUIRED. Paste the command(s) you ran and their real output — before and
after. For a bug: the reproduction, failing then fixed. For a skill change: the
actual transcript / `claude -p` output. For anything visual: before/after
screenshots. "bun test passes" alone is not enough — show the behavior you
changed. -->

```
# what you ran + what it produced
```

## Scope

- **Changed:**
- **Verified live by:**
- **Did NOT test:**

## Liveness proof (required)

<!-- Attach a screenshot of your own machine with the text `GSTACK PR` typed LIVE
into a real surface — terminal prompt, a shell command, your browser
address/search bar, an editor buffer. It must be TYPED INTO A LIVE UI, not drawn,
overlaid, or edited onto the image. A painted-on `GSTACK PR` is an automatic
close. This confirms a human opened this PR. -->

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [ ] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [ ] New public command / external service / host adapter has an accepted issue linked (or N/A)
- [ ] Linked issue or reproduction: #
