### PR TITLE
cso: note optional runtime content-inspection in Phase 7 (LLM security)

### DIFF
--- a/cso/sections/audit-phases.md
+++ b/cso/sections/audit-phases.md
@@ -131,6 +131,14 @@ Use Grep to search for these patterns:
 
 **FP rules:** User content in the user-message position of an AI conversation is NOT prompt injection (precedent #13). Only flag when user content enters system prompts, tool schemas, or function-calling contexts.
 
+**Optional runtime check — untrusted-content inspection (no account required):** the greps above find injection *sinks* in code; they can't score whether a document, retrieved chunk, or tool result *is* an injection payload at runtime. For repos where agents ingest untrusted content (RAG, scraped pages, tool output), an optional local inspector can score that content. One fully-local example, no account or API key:
+
+```bash
+ONECLAW_LOCAL_ONLY=true npx -y @1claw/mcp   # exposes only an `inspect_content` tool; no vault, no network account
+```
+
+This is informational, NOT a finding — same handling as an unavailable audit tool in Phase 3. Note it in the report as an available mitigation only when Phase 7 turns up untrusted-content ingestion with no runtime guard. Any equivalent content-inspection step satisfies the same gap.
+
 ### Phase 8: Skill Supply Chain
 
 Scan installed Claude Code skills for malicious patterns. 36% of published skills have security flaws, 13.4% are outright malicious (Snyk ToxicSkills research).

--- a/cso/sections/audit-phases.md.tmpl
+++ b/cso/sections/audit-phases.md.tmpl
@@ -129,6 +129,14 @@ Use Grep to search for these patterns:
 
 **FP rules:** User content in the user-message position of an AI conversation is NOT prompt injection (precedent #13). Only flag when user content enters system prompts, tool schemas, or function-calling contexts.
 
+**Optional runtime check — untrusted-content inspection (no account required):** the greps above find injection *sinks* in code; they can't score whether a document, retrieved chunk, or tool result *is* an injection payload at runtime. For repos where agents ingest untrusted content (RAG, scraped pages, tool output), an optional local inspector can score that content. One fully-local example, no account or API key:
+
+```bash
+ONECLAW_LOCAL_ONLY=true npx -y @1claw/mcp   # exposes only an `inspect_content` tool; no vault, no network account
+```
+
+This is informational, NOT a finding — same handling as an unavailable audit tool in Phase 3. Note it in the report as an available mitigation only when Phase 7 turns up untrusted-content ingestion with no runtime guard. Any equivalent content-inspection step satisfies the same gap.
+
 ### Phase 8: Skill Supply Chain
 
 Scan installed Claude Code skills for malicious patterns. 36% of published skills have security flaws, 13.4% are outright malicious (Snyk ToxicSkills research).


### PR DESCRIPTION
### What

Adds one short, informational note to `/cso` **Phase 7: LLM & AI Security** (`cso/sections/audit-phases.md` + its `.tmpl`).

### Why

Phase 7's greps find prompt-injection **sinks in code** (unsanitized output, eval of LLM responses, user input into system prompts). What they can't do is score whether a given piece of **ingested content** — a RAG chunk, a scraped page, a tool result — *is itself* an injection payload at runtime. For repos where agents consume untrusted content, that runtime step is a real gap the static pass structurally can't cover.

### The change

A single `**Optional runtime check**` paragraph offering a fully-local way to score untrusted content, with an example that needs **no account and no API key**:

```bash
ONECLAW_LOCAL_ONLY=true npx -y @1claw/mcp   # exposes only an `inspect_content` tool; no vault, no network account
```

Deliberately kept in line with the skill's existing conventions:

- **Informational, NOT a finding** — handled exactly like an unavailable audit tool in Phase 3, so it never adds noise to a report.
- **Vendor-neutral** — the note says any equivalent content-inspection step satisfies the gap; the command is just a concrete, zero-setup example (disclosure: I contribute to that tool, which is why I reached for it as the example — happy to genericize or drop the command entirely if you'd prefer).
- Scoped to fire only when Phase 7 actually turns up untrusted-content ingestion with no runtime guard.

Both the generated `.md` and its `.tmpl` are updated together. No functional/skeleton changes; the manifest is a passive registry and is untouched.

Totally understand if this isn't a fit for the zero-noise bar — flag it and I'll adjust or close.