### PR TITLE
test(gbrain-sync): stub pgrep so the pin case is hermetic

### DIFF
--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -192,6 +192,13 @@ case "$*" in
 esac
 `);
     chmodSync(join(bindir, "gbrain"), 0o755);
+    // #2685: this case is a real (non-dry-run) --code-only child, so it hits
+    // detectAutopilot's PATH-resolved `pgrep -f "gbrain autopilot"`. A live
+    // host autopilot is a correct #1734 refuse — the test cannot inject
+    // processRunning. Stub pgrep to "no match" so the pin is about the
+    // symlink, not the operator's daemon. Do not add a production env hatch.
+    writeFileSync(join(bindir, "pgrep"), "#!/bin/sh\nexit 1\n");
+    chmodSync(join(bindir, "pgrep"), 0o755);
 
     const r = spawnSync("bun", [SCRIPT, "--code-only", "--quiet"], {
       encoding: "utf-8",

--- a/test/gstack-gbrain-sync.test.ts
+++ b/test/gstack-gbrain-sync.test.ts
@@ -196,7 +196,9 @@ esac
     // detectAutopilot's PATH-resolved `pgrep -f "gbrain autopilot"`. A live
     // host autopilot is a correct #1734 refuse — the test cannot inject
     // processRunning. Stub pgrep to "no match" so the pin is about the
-    // symlink, not the operator's daemon. Do not add a production env hatch.
+    // symlink, not the operator's daemon. Blank GBRAIN_HOME so an inherited
+    // lock under $GBRAIN_HOME/.gbrain cannot refuse before pgrep. Do not add
+    // a production env hatch.
     writeFileSync(join(bindir, "pgrep"), "#!/bin/sh\nexit 1\n");
     chmodSync(join(bindir, "pgrep"), 0o755);
 
@@ -208,6 +210,7 @@ esac
         ...process.env,
         HOME: home,
         GSTACK_HOME: gstackHome,
+        GBRAIN_HOME: "",
         GSTACK_TEST_GBRAIN_LOG: commandLog,
         PATH: `${bindir}:${process.env.PATH || ""}`,
       },


### PR DESCRIPTION
## Why (in your own words)

`keeps a symlink-equivalent pinned source registered as-is` is supposed to pin the symlink path, not the operator's daemon. It is the only non-`--dry-run` `--code-only` child in `test/gstack-gbrain-sync.test.ts`, so it hits `#1734`'s `detectAutopilot()` → `pgrep -f "gbrain autopilot"`. If autopilot is up, the child correctly exits 1: `refused: gbrain autopilot active (process:gbrain autopilot)`. The test only asserts `r.status === 0`, so it looks like a symlink/pin failure. CI is green because CI has no daemon. The refuse is correct. The test never neutralized the probe.

The fixture already prepends `bindir` to `PATH` and stubs `gbrain`. `defaultProcessRunning` invokes bare `pgrep`, which is PATH-resolved. Drop a `pgrep` that exits 1 into that same `bindir`. Blank `GBRAIN_HOME` so an inherited lock under `$GBRAIN_HOME/.gbrain` cannot refuse before pgrep. The child cannot inject `processRunning` the way `test/gbrain-guards.test.ts` does.

This is a test-isolation fix, not a product fix. Real `/sync-gbrain` still refuses while autopilot is live.

**Fixes #2685.**

### Why this shape

Author offered the stub *or* an env hatch. Stub is the smaller blast radius. An env override on `detectAutopilot` would weaken a data-loss guard. Skip-if-autopilot would hide the pin case on the machines that follow the documented setup. Did not edit `lib/gbrain-guards.ts`.

### What it does

- That one `it` writes an executable `pgrep` stub (`exit 1`) next to the existing `gbrain` stub, and blanks `GBRAIN_HOME` on the child.

### What it deliberately does not do

- Env hatch / skip-if-autopilot on `detectAutopilot`
- Production guard changes
- Stub `pgrep` in other tests in this file (they are `--dry-run` or `--no-code`)
- Stub `pgrep` in `test/gbrain-sync-skip.test.ts` (sibling `--code-only` file; those cases do not assert `exitCode === 0`, so they false-pass on a refuse instead of going red)
- `VERSION` / `CHANGELOG` / `/ship`

AI was used for assistance.

## Live evidence

Temp `HOME` / `GSTACK_HOME` only. Never `rm`'d real `~/.gbrain`. Did **not** start real `gbrain autopilot` (that daemon can race a destructive walk). Recreated the author's process signal with a dummy whose argv contains `gbrain autopilot`. Host `/usr/bin/pgrep -f "gbrain autopilot"` went to exit 0. Then the same named `it`:

**Tip (`ad84005`, no stub), dummy up — the issue:**

```
expect(r.status).toBe(0)
Expected: 0
Received: 1

(fail) gstack-gbrain-sync CLI > keeps a symlink-equivalent pinned source registered as-is [593.11ms]
  0 pass  1 fail
```

Same fixture without `--quiet`:

```
status=1
ERR   code  refused: gbrain autopilot active (process:gbrain autopilot). Stop autopilot, then re-run /sync-gbrain.
  0 ok, 1 error, 0 skipped
```

**This branch, dummy still up — the fix:**

```
(pass) gstack-gbrain-sync CLI > keeps a symlink-equivalent pinned source registered as-is [836.46ms]
  1 pass  0 fail
```

Quiet machine (no dummy, `pgrep` exit 1, `GBRAIN_HOME` unset): tip is already green. That is why this laptop looked fine until we planted the signal. Author's red is machine-specific; CI has no daemon. After the dummy was killed, host `pgrep` was exit 1 again.

On this Bun, child `os.homedir()` honors `HOME`, so operator `~/.gbrain/autopilot.lock` is not visible to the child. The remaining lock residual was inherited `GBRAIN_HOME`; the child now blanks it.

## Scope

- **Changed:** `test/gstack-gbrain-sync.test.ts` (one `it`)
- **Verified live by:** dummy-process recreation above (tip red / branch green, same host `pgrep` match); `bun test test/gstack-gbrain-sync.test.ts` (42 pass).
- **Did NOT test:** real `gbrain autopilot --install`. A live lock under an operator `GBRAIN_HOME` (child now blanks it). Paid evals. Full `bun run test`.

## Liveness proof (required)

`GSTACK PR` typed live into the browser address bar:

<img width="343" height="37" alt="GSTACK PR typed live" src="https://github.com/user-attachments/assets/00131d08-5df3-4e77-8a45-e8e2a5191c74" />

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source, not a generated SKILL.md)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A)
- [x] Linked issue or reproduction: #2685

## Test plan

- [x] Quiet machine, tip, no stub → named `it` passes (no signal)
- [x] Dummy argv `gbrain autopilot`, tip, no stub → named `it` fails, status 1
- [x] Same dummy still up, this branch → named `it` passes
- [x] `bun test test/gstack-gbrain-sync.test.ts` → 42 pass
- [x] Dummy killed; host `pgrep` exit 1 again

Fork PRs do not get eval secrets; the free file above is the gate.