### PR TITLE
fix(gbrain-detect): classify gbrain >= 0.43 held-lock refusal as engine-locked, not broken-config

### DIFF
--- a/lib/gbrain-local-status.ts
+++ b/lib/gbrain-local-status.ts
@@ -464,6 +464,17 @@ function freshClassify(env?: NodeJS.ProcessEnv): LocalEngineStatus {
         return configuredEngine(env) === "pglite" ? "engine-locked" : "broken-db";
       }
 
+      // gbrain >= 0.43 refuses the same held-lock case with exit 1 and its
+      // own message: "GBrain's local database is already open through `gbrain
+      // serve` (MCP, PID N). This brain uses PGLite, ...". That string matches
+      // none of the branches above, so without this check it falls through to
+      // the defensive broken-config default — whose remediation tells the user
+      // to move a perfectly healthy config.json aside and re-init the engine
+      // (#2194 follow-up).
+      if (stderr.includes("already open through")) {
+        return configuredEngine(env) === "pglite" ? "engine-locked" : "broken-db";
+      }
+
       // Probe killed by the timeout with no recognized error: the engine is
       // most likely healthy but slow (cold pooler connections measured at
       // 6.9-10.7s in #1964). Don't tell the user their config is malformed.

--- a/test/gbrain-local-status.test.ts
+++ b/test/gbrain-local-status.test.ts
@@ -62,7 +62,7 @@ interface FakeEnv {
  */
 function makeEnv(opts: {
   withGbrain?: boolean;
-  gbrainBehavior?: "ok" | "broken-db" | "broken-config" | "engine-locked" | "throws" | "slow" | "thin-refusal";
+  gbrainBehavior?: "ok" | "broken-db" | "broken-config" | "engine-locked" | "engine-locked-v43" | "throws" | "slow" | "thin-refusal";
   withConfig?: boolean;
   /** #2051: config carries gbrain's remote_mcp thin-client marker. */
   thinClientConfig?: boolean;
@@ -116,7 +116,7 @@ function makeEnv(opts: {
 }
 
 function makeFakeGbrainScript(
-  behavior: "ok" | "broken-db" | "broken-config" | "engine-locked" | "throws" | "slow" | "thin-refusal",
+  behavior: "ok" | "broken-db" | "broken-config" | "engine-locked" | "engine-locked-v43" | "throws" | "slow" | "thin-refusal",
 ): string {
   // "slow": healthy engine on a cold pooler connection (#1964) — sleeps past
   // the (test-lowered) probe timeout, then would answer fine.
@@ -141,6 +141,8 @@ exit 0
         ? 'echo "Error: malformed config.json at ~/.gbrain/config.json" >&2'
         : behavior === "engine-locked"
           ? 'echo "gbrain sources: connect timed out (default 10000ms; pass --timeout=Ns to override)." >&2'
+        : behavior === "engine-locked-v43"
+          ? "echo \"GBrains local database is already open through gbrain serve (MCP, PID 12345). This brain uses PGLite, so a separate CLI process cannot open it at the same time. Stop gbrain serve, then retry this CLI command.\" >&2"
         : behavior === "throws"
           ? 'echo "unexpected gbrain failure" >&2'
           : behavior === "thin-refusal"
@@ -247,6 +249,19 @@ describe("lib/gbrain-local-status — status classification", () => {
     env = makeEnv({ withGbrain: true, gbrainBehavior: "engine-locked", withConfig: true });
     restoreEnv = applyEnv(env);
     expect(localEngineStatus({ noCache: true })).toBe("engine-locked");
+  });
+
+  it("returns 'engine-locked' when gbrain >= 0.43 refuses with 'already open through' and exit 1", () => {
+    env = makeEnv({ withGbrain: true, gbrainBehavior: "engine-locked-v43", withConfig: true });
+    restoreEnv = applyEnv(env);
+    expect(localEngineStatus({ noCache: true })).toBe("engine-locked");
+  });
+
+  it("classifies the >= 0.43 held-lock refusal on a non-PGLite engine as broken-db", () => {
+    env = makeEnv({ withGbrain: true, gbrainBehavior: "engine-locked-v43", withConfig: true });
+    restoreEnv = applyEnv(env);
+    writeFileSync(env.configPath, JSON.stringify({ engine: "postgres", database_url: "postgres://fake" }));
+    expect(localEngineStatus({ noCache: true })).toBe("broken-db");
   });
 
   it("classifies a non-PGLite connect timeout as unreachable DB, not malformed config", () => {


### PR DESCRIPTION
## What

`lib/gbrain-local-status.ts` recognizes a held PGLite lock only by the pre-0.43 signature: stderr containing `connect timed out` or exit code 124 (#2194). Since gbrain 0.43.0.0 the CLI refuses the same case with **exit 1** and its own message:

> GBrain's local database is already open through `gbrain serve` (MCP, PID N). This brain uses PGLite, so a separate CLI process cannot open it at the same time. Stop `gbrain serve`, then retry this CLI command.

That string matches none of the classifier branches, so it falls through to the defensive `broken-config` default.

## Why it matters

`broken-config` is not cosmetic: Step 1.5 of `/setup-gbrain` and `/sync-gbrain` STOP on it and offer remediation that moves a perfectly healthy `~/.gbrain/config.json` aside and re-inits the engine. A user who follows that advice wipes a working setup because an MCP serve happened to hold the lock — which is the *normal* state whenever a Claude Code session with the gbrain MCP is open.

Reproduced live on gbrain 0.43.0.0, 0.44.0.0 and 0.46.30.0: with a serve running, `gstack-gbrain-detect` reports `gbrain_local_status=broken-config`; kill the serve and the same untouched config reports `ok`. Verified the message contains neither `config.json` nor `Cannot connect to database` nor `connect timed out`, so no existing branch can catch it.

## Fix

One branch next to the existing #2194 case, matching the stable substring `already open through`, with identical semantics: `engine-locked` for pglite, `broken-db` otherwise.

## Tests

Added a fake-gbrain behavior for the 0.43+ refusal (exit 1 + message) and two cases: pglite → `engine-locked`, postgres → `broken-db`. Without the lib change both fail on the `broken-config` fall-through.

```
bun test test/gbrain-local-status.test.ts
46 pass, 0 fail
```

Kind regards from Peter's agent, who never sleeps... ツ

🤖 Generated with [Claude Code](https://claude.com/claude-code)