### PR TITLE
fix: shared preamble telemetry lost across separate tool-call boundaries

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -546,7 +546,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/SKILL.md
+++ b/SKILL.md
@@ -69,8 +69,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -529,6 +534,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/SKILL.md
+++ b/SKILL.md
@@ -69,13 +69,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -534,22 +530,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -79,13 +79,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -811,22 +807,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -79,8 +79,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -806,6 +811,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -823,7 +823,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -73,13 +73,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -538,22 +534,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -73,8 +73,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -533,6 +538,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/benchmark-models/SKILL.md
+++ b/benchmark-models/SKILL.md
@@ -550,7 +550,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -73,13 +73,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -538,22 +534,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -73,8 +73,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -533,6 +538,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -550,7 +550,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -71,8 +71,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -531,6 +536,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -71,13 +71,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -536,22 +532,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -548,7 +548,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -71,13 +71,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -785,22 +781,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -71,8 +71,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -780,6 +785,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -797,7 +797,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -74,8 +74,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -801,6 +806,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -818,7 +818,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -74,13 +74,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -806,22 +802,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -801,7 +801,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -75,13 +75,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -789,22 +785,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -75,8 +75,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -784,6 +789,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -74,8 +74,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -783,6 +788,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -74,13 +74,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -788,22 +784,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -800,7 +800,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -77,13 +77,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -791,22 +787,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -77,8 +77,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -786,6 +791,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -803,7 +803,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -841,7 +841,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -97,8 +97,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -824,6 +829,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -97,13 +97,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -829,22 +825,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -78,13 +78,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -792,22 +788,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -78,8 +78,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -787,6 +792,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/design-html/SKILL.md
+++ b/design-html/SKILL.md
@@ -804,7 +804,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -75,13 +75,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -807,22 +803,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -819,7 +819,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -75,8 +75,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -802,6 +807,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -92,8 +92,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -801,6 +806,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -92,13 +92,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -806,22 +802,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/design-shotgun/SKILL.md
+++ b/design-shotgun/SKILL.md
@@ -818,7 +818,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -77,13 +77,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -809,22 +805,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -77,8 +77,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -804,6 +809,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -821,7 +821,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/diagram/SKILL.md
+++ b/diagram/SKILL.md
@@ -72,13 +72,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -537,22 +533,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/diagram/SKILL.md
+++ b/diagram/SKILL.md
@@ -549,7 +549,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/diagram/SKILL.md
+++ b/diagram/SKILL.md
@@ -72,8 +72,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -532,6 +537,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/document-generate/SKILL.md
+++ b/document-generate/SKILL.md
@@ -77,13 +77,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -791,22 +787,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/document-generate/SKILL.md
+++ b/document-generate/SKILL.md
@@ -77,8 +77,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -786,6 +791,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/document-generate/SKILL.md
+++ b/document-generate/SKILL.md
@@ -803,7 +803,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -801,7 +801,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -75,13 +75,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -789,22 +785,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/document-release/SKILL.md
+++ b/document-release/SKILL.md
@@ -75,8 +75,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -784,6 +789,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -73,8 +73,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -782,6 +787,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -799,7 +799,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -73,13 +73,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -787,22 +783,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -112,8 +112,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -821,6 +826,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -112,13 +112,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -826,22 +822,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -838,7 +838,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/ios-clean/SKILL.md
+++ b/ios-clean/SKILL.md
@@ -75,13 +75,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -807,22 +803,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/ios-clean/SKILL.md
+++ b/ios-clean/SKILL.md
@@ -819,7 +819,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/ios-clean/SKILL.md
+++ b/ios-clean/SKILL.md
@@ -75,8 +75,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -802,6 +807,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/ios-design-review/SKILL.md
+++ b/ios-design-review/SKILL.md
@@ -77,13 +77,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -809,22 +805,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/ios-design-review/SKILL.md
+++ b/ios-design-review/SKILL.md
@@ -77,8 +77,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -804,6 +809,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/ios-design-review/SKILL.md
+++ b/ios-design-review/SKILL.md
@@ -821,7 +821,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/ios-fix/SKILL.md
+++ b/ios-fix/SKILL.md
@@ -78,13 +78,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -810,22 +806,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/ios-fix/SKILL.md
+++ b/ios-fix/SKILL.md
@@ -78,8 +78,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -805,6 +810,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/ios-fix/SKILL.md
+++ b/ios-fix/SKILL.md
@@ -822,7 +822,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/ios-qa/SKILL.md
+++ b/ios-qa/SKILL.md
@@ -81,13 +81,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -813,22 +809,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/ios-qa/SKILL.md
+++ b/ios-qa/SKILL.md
@@ -81,8 +81,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -808,6 +813,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/ios-qa/SKILL.md
+++ b/ios-qa/SKILL.md
@@ -825,7 +825,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/ios-sync/SKILL.md
+++ b/ios-sync/SKILL.md
@@ -75,13 +75,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -807,22 +803,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/ios-sync/SKILL.md
+++ b/ios-sync/SKILL.md
@@ -819,7 +819,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/ios-sync/SKILL.md
+++ b/ios-sync/SKILL.md
@@ -75,8 +75,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -802,6 +807,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -70,13 +70,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -802,22 +798,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -814,7 +814,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -70,8 +70,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -797,6 +802,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -72,13 +72,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -786,22 +782,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -798,7 +798,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/landing-report/SKILL.md
+++ b/landing-report/SKILL.md
@@ -72,8 +72,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -781,6 +786,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -73,8 +73,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -782,6 +787,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -799,7 +799,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/learn/SKILL.md
+++ b/learn/SKILL.md
@@ -73,13 +73,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -787,22 +783,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -585,7 +585,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -72,8 +72,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -568,6 +573,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/make-pdf/SKILL.md
+++ b/make-pdf/SKILL.md
@@ -72,13 +72,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -573,22 +569,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -108,8 +108,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -835,6 +840,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -852,7 +852,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -108,13 +108,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -840,22 +836,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -71,8 +71,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -531,6 +536,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -71,13 +71,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -536,22 +532,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -548,7 +548,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -74,8 +74,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -783,6 +788,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -74,13 +74,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -788,22 +784,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -800,7 +800,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -102,13 +102,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -834,22 +830,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -846,7 +846,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -102,8 +102,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -829,6 +834,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -74,8 +74,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -801,6 +806,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -818,7 +818,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/plan-design-review/SKILL.md
+++ b/plan-design-review/SKILL.md
@@ -74,13 +74,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -806,22 +802,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -80,8 +80,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -807,6 +812,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -80,13 +80,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -812,22 +808,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -824,7 +824,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -78,13 +78,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -810,22 +806,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -78,8 +78,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -805,6 +810,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -822,7 +822,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -809,7 +809,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -83,13 +83,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -797,22 +793,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/plan-tune/SKILL.md
+++ b/plan-tune/SKILL.md
@@ -83,8 +83,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -792,6 +797,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -73,8 +73,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -800,6 +805,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -73,13 +73,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -805,22 +801,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -817,7 +817,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -79,13 +79,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -811,22 +807,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -79,8 +79,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -806,6 +811,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -823,7 +823,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -819,7 +819,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -93,13 +93,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -807,22 +803,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -93,8 +93,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -802,6 +807,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -75,13 +75,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -807,22 +803,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -819,7 +819,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -75,8 +75,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -802,6 +807,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/scrape/SKILL.md
+++ b/scrape/SKILL.md
@@ -72,13 +72,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -537,22 +533,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/scrape/SKILL.md
+++ b/scrape/SKILL.md
@@ -549,7 +549,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/scrape/SKILL.md
+++ b/scrape/SKILL.md
@@ -72,8 +72,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -532,6 +537,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/scripts/resolvers/preamble/generate-completion-status.ts
+++ b/scripts/resolvers/preamble/generate-completion-status.ts
@@ -67,6 +67,20 @@ Run this bash:
 
 \`\`\`bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/scripts/resolvers/preamble/generate-completion-status.ts
+++ b/scripts/resolvers/preamble/generate-completion-status.ts
@@ -67,22 +67,19 @@ Run this bash:
 
 \`\`\`bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=\${_TEL_START:-$_M_START}
+  _SESSION_ID=\${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=\${_TEL_START:-$_TEL_END}
+_SESSION_ID=\${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="\${GSTACK_STATE_ROOT:-\${GSTACK_HOME:-\${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=\${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/scripts/resolvers/preamble/generate-completion-status.ts
+++ b/scripts/resolvers/preamble/generate-completion-status.ts
@@ -79,7 +79,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="\${GSTACK_STATE_ROOT:-\${GSTACK_HOME:-\${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/scripts/resolvers/preamble/generate-preamble-bash.ts
+++ b/scripts/resolvers/preamble/generate-preamble-bash.ts
@@ -59,13 +59,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(${ctx.paths.binDir}/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: \${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(${ctx.paths.binDir}/gstack-config get explain_level 2>/dev/null || echo "default")

--- a/scripts/resolvers/preamble/generate-preamble-bash.ts
+++ b/scripts/resolvers/preamble/generate-preamble-bash.ts
@@ -59,8 +59,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(${ctx.paths.binDir}/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: \${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(${ctx.paths.binDir}/gstack-config get explain_level 2>/dev/null || echo "default")

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -67,8 +67,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -527,6 +532,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -544,7 +544,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/setup-browser-cookies/SKILL.md
+++ b/setup-browser-cookies/SKILL.md
@@ -67,13 +67,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -532,22 +528,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -74,8 +74,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -783,6 +788,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -74,13 +74,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -788,22 +784,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -800,7 +800,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -73,8 +73,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -782,6 +787,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -799,7 +799,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/setup-gbrain/SKILL.md
+++ b/setup-gbrain/SKILL.md
@@ -73,13 +73,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -787,22 +783,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -75,13 +75,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -807,22 +803,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -819,7 +819,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -75,8 +75,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -802,6 +807,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/skillify/SKILL.md
+++ b/skillify/SKILL.md
@@ -72,13 +72,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -786,22 +782,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/skillify/SKILL.md
+++ b/skillify/SKILL.md
@@ -798,7 +798,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/skillify/SKILL.md
+++ b/skillify/SKILL.md
@@ -72,8 +72,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -781,6 +786,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -73,8 +73,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -800,6 +805,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -73,13 +73,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -805,22 +801,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -817,7 +817,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -74,8 +74,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -783,6 +788,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -74,13 +74,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -788,22 +784,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/sync-gbrain/SKILL.md
+++ b/sync-gbrain/SKILL.md
@@ -800,7 +800,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -75,13 +75,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -807,22 +803,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -819,7 +819,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -75,8 +75,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$(~/.claude/skills/gstack/bin/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -802,6 +807,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$(~/.claude/skills/gstack/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -827,7 +827,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$($GSTACK_ROOT/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -61,8 +61,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$($GSTACK_BIN/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$($GSTACK_BIN/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -810,6 +815,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$($GSTACK_ROOT/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -61,13 +61,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$($GSTACK_BIN/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$($GSTACK_BIN/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -815,22 +811,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -63,13 +63,9 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$($GSTACK_BIN/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
-else
-  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
-fi
+_TEL_START=$(date +%s)
 _SESSION_ID="$PPID-$_TEL_START"
+printf '%s %s\n' "$_TEL_START" "$_SESSION_ID" > ~/.gstack/sessions/"$PPID" 2>/dev/null || true
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$($GSTACK_BIN/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -795,22 +791,19 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
-_SESS_MARKER=~/.gstack/sessions/"$PPID"
-if [ -z "$_TEL_START" ]; then
-  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  else
-    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
-  fi
+if [ -z "$_TEL_START" ] || [ -z "$_SESSION_ID" ]; then
+  read -r _M_START _M_SESSION < ~/.gstack/sessions/"$PPID" 2>/dev/null
+  _TEL_START=${_TEL_START:-$_M_START}
+  _SESSION_ID=${_SESSION_ID:-$_M_SESSION}
 fi
-if [ -z "$_SESSION_ID" ]; then
-  _SESSION_ID="$PPID-$_TEL_START"
-fi
+_TEL_START=${_TEL_START:-$_TEL_END}
+_SESSION_ID=${_SESSION_ID:-$PPID-$_TEL_START}
 if [ -z "$_TEL" ]; then
   _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
   _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
   [ -z "$_TEL" ] && _TEL="off"
 fi
+_TEL=${_TEL:-off}
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -63,8 +63,13 @@ _LAKE_SEEN=$([ -f ~/.gstack/.completeness-intro-seen ] && echo "yes" || echo "no
 echo "LAKE_INTRO: $_LAKE_SEEN"
 _TEL=$($GSTACK_BIN/gstack-config get telemetry 2>/dev/null || true)
 _TEL_PROMPTED=$([ -f ~/.gstack/.telemetry-prompted ] && echo "yes" || echo "no")
-_TEL_START=$(date +%s)
-_SESSION_ID="$$-$(date +%s)"
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+  _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || date +%s)
+else
+  _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || date +%s)
+fi
+_SESSION_ID="$PPID-$_TEL_START"
 echo "TELEMETRY: ${_TEL:-off}"
 echo "TEL_PROMPTED: $_TEL_PROMPTED"
 _EXPLAIN_LEVEL=$($GSTACK_BIN/gstack-config get explain_level 2>/dev/null || echo "default")
@@ -790,6 +795,20 @@ Run this bash:
 
 ```bash
 _TEL_END=$(date +%s)
+_SESS_MARKER=~/.gstack/sessions/"$PPID"
+if [ -z "$_TEL_START" ]; then
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    _TEL_START=$(stat -f %m "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  else
+    _TEL_START=$(date -r "$_SESS_MARKER" +%s 2>/dev/null || stat -c %Y "$_SESS_MARKER" 2>/dev/null || echo "$_TEL_END")
+  fi
+fi
+if [ -z "$_SESSION_ID" ]; then
+  _SESSION_ID="$PPID-$_TEL_START"
+fi
+if [ -z "$_TEL" ]; then
+  _TEL=$($GSTACK_ROOT/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true
 # Session timeline: record skill completion (local-only, never sent anywhere)

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -807,7 +807,9 @@ if [ -z "$_SESSION_ID" ]; then
   _SESSION_ID="$PPID-$_TEL_START"
 fi
 if [ -z "$_TEL" ]; then
-  _TEL=$($GSTACK_ROOT/bin/gstack-config get telemetry 2>/dev/null || echo "off")
+  _TEL_CFG="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-${GSTACK_STATE_DIR:-$HOME/.gstack}}}/config.yaml"
+  _TEL=$(grep -E '^telemetry:' "$_TEL_CFG" 2>/dev/null | tail -1 | sed -E 's/^telemetry:[[:space:]]*//; s/[[:space:]]+$//')
+  [ -z "$_TEL" ] && _TEL="off"
 fi
 _TEL_DUR=$(( _TEL_END - _TEL_START ))
 rm -f ~/.gstack/analytics/.pending-"$_SESSION_ID" 2>/dev/null || true

--- a/test/helpers/carve-guards.ts
+++ b/test/helpers/carve-guards.ts
@@ -126,7 +126,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     },
     behavioral: 'external',
     externalTest: 'test/skill-e2e-ship-section-loading.test.ts',
-    maxSkeletonBytes: 92_600, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 92,043
+    maxSkeletonBytes: 92_200, // cross-call telemetry recovery fix (marker-content duration/session-id + live-config _TEL re-read, ~340B/skill); measured 91,954
     minUnionBytes: 120_000,
     mustContain: ['VERSION', 'CHANGELOG', 'review', 'merge', 'PR'],
     // v1.58.5.0: pre-push-guard install (#2077) stacks on the shared first-run-guidance preamble.
@@ -157,7 +157,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // v1.65 merge: provisional larger-of-both-waves budget; re-measured below.
         // Fork port wave 2 (#703): the repo-doc-preference block in the design
     // check grew every plan-review skeleton ~0.7KB. Measured values noted.
-    maxSkeletonBytes: 94_900, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 94,327
+    maxSkeletonBytes: 94_400, // cross-call telemetry recovery fix (marker-content duration/session-id + live-config _TEL re-read, ~340B/skill); measured 94,238
     minUnionBytes: 80_000,
     mustContain: ['SCOPE EXPANSION', 'SELECTIVE EXPANSION', 'HOLD SCOPE', 'SCOPE REDUCTION'],
     // Default-on Codex outside-voice (codexPreflight block + CODEX_MODE branch
@@ -183,7 +183,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // check grew every plan-review skeleton ~0.7KB. Measured values noted.
     // #2499 project-scope MCP jq in the brain-sync block grew every tier-2+
     // skeleton ~1.5KB (entry resolution emitted once per SKILL.md).
-    maxSkeletonBytes: 72_800, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 72,210
+    maxSkeletonBytes: 72_300, // cross-call telemetry recovery fix (marker-content duration/session-id + live-config _TEL re-read, ~340B/skill); measured 72,121
     minUnionBytes: 70_000,
     mustContain: ['Architecture', 'Code Quality', 'Test', 'Performance'],
     // Cross-cutting preamble growth (v1.57.2.0 AUQ-failure prose fallback + the
@@ -216,7 +216,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // tier-2+ skeleton (measured 89,184). Main's v1.64.0.0 adds ~340 B more
     // (telemetry --error-message/--failed-step preamble prose, PR #769).
     // Budget covers the sum of both waves.
-    maxSkeletonBytes: 92_700, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 92,158
+    maxSkeletonBytes: 92_100, // cross-call telemetry recovery fix (marker-content duration/session-id + live-config _TEL re-read, ~340B/skill); measured 92,069
     minUnionBytes: 70_000,
     mustContain: ['design', 'visual'],
     maxSizeRatio: 1.12, // D1 1.104 + main's ~0.008
@@ -240,7 +240,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // check grew every plan-review skeleton ~0.7KB. Measured values noted.
     // #2499 project-scope MCP jq in the brain-sync block grew every tier-2+
     // skeleton ~1.5KB (entry resolution emitted once per SKILL.md).
-    maxSkeletonBytes: 84_500, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 83,923
+    maxSkeletonBytes: 84_000, // cross-call telemetry recovery fix (marker-content duration/session-id + live-config _TEL re-read, ~340B/skill); measured 83,834
     minUnionBytes: 70_000,
     mustContain: ['developer experience', 'Getting Started'],
     // Default-on Codex outside-voice (codexPreflight block + CODEX_MODE branch
@@ -270,7 +270,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // the #538 opt-out + D1 evidence directive — ratio 1.104 measured.
     // #2499 project-scope MCP jq in the brain-sync block grew every tier-2+
     // skeleton ~1.5KB (entry resolution emitted once per SKILL.md).
-    maxSkeletonBytes: 103_800, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 103,202
+    maxSkeletonBytes: 103_300, // cross-call telemetry recovery fix (marker-content duration/session-id + live-config _TEL re-read, ~340B/skill); measured 103,113
     minUnionBytes: 70_000,
     mustContain: ['design doc', 'problem statement'],
     maxSizeRatio: 1.12,
@@ -291,7 +291,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // +Conductor AUQ-default-prose rule + one-way/continuation safety in the
     // always-loaded AskUserQuestion Format section.
     // v1.2.0 activation lift: first-run-guidance section in the shared preamble.
-    maxSkeletonBytes: 58_900, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 58,367
+    maxSkeletonBytes: 58_400, // cross-call telemetry recovery fix (marker-content duration/session-id + live-config _TEL re-read, ~340B/skill); measured 58,278
     minUnionBytes: 55_000,
     mustContain: ['CHANGELOG', 'Diataxis', 'coverage'],
     // Two intentional additions stack on this small skill: the AUQ-failure prose
@@ -322,7 +322,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // v1.65 merge: provisional larger-of-both-waves budget; re-measured below.
     // v1.64.1.0: shared-preamble prose from the two parallel v1.64 waves lands
     // the skeleton at 69,022 B; +~1 KB headroom.
-    maxSkeletonBytes: 72_300, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 71,797
+    maxSkeletonBytes: 71_900, // cross-call telemetry recovery fix (marker-content duration/session-id + live-config _TEL re-read, ~340B/skill); measured 71,708
     minUnionBytes: 72_000,
     mustContain: ['Typography', 'Color', 'Aesthetic Direction'],
     // Cross-cutting preamble growth (v1.57.2.0 AUQ-failure prose fallback ~2KB +
@@ -362,7 +362,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // +Conductor AUQ-default-prose rule + one-way/continuation safety in the
     // always-loaded AskUserQuestion Format section.
     // v1.2.0 activation lift: first-run-guidance section in the shared preamble.
-    maxSkeletonBytes: 78_200, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 77,687
+    maxSkeletonBytes: 77_700, // cross-call telemetry recovery fix (marker-content duration/session-id + live-config _TEL re-read, ~340B/skill); measured 77,598
     minUnionBytes: 72_000,
     mustContain: ['OWASP', 'STRIDE', 'daily', 'comprehensive', 'verif'],
     // cso keeps its mode-dispatch + FP-filtering phases always-loaded, so the

--- a/test/helpers/carve-guards.ts
+++ b/test/helpers/carve-guards.ts
@@ -126,7 +126,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     },
     behavioral: 'external',
     externalTest: 'test/skill-e2e-ship-section-loading.test.ts',
-    maxSkeletonBytes: 91_600, // v1.68 fix wave: unconditional learnings capture (#2402, ~450B/skill); measured 91,061
+    maxSkeletonBytes: 92_600, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 92,043
     minUnionBytes: 120_000,
     mustContain: ['VERSION', 'CHANGELOG', 'review', 'merge', 'PR'],
     // v1.58.5.0: pre-push-guard install (#2077) stacks on the shared first-run-guidance preamble.
@@ -157,7 +157,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // v1.65 merge: provisional larger-of-both-waves budget; re-measured below.
         // Fork port wave 2 (#703): the repo-doc-preference block in the design
     // check grew every plan-review skeleton ~0.7KB. Measured values noted.
-    maxSkeletonBytes: 93_900, // v1.68 fix wave: #2402 learnings capture + spool queue-depth lines; measured 93,345
+    maxSkeletonBytes: 94_900, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 94,327
     minUnionBytes: 80_000,
     mustContain: ['SCOPE EXPANSION', 'SELECTIVE EXPANSION', 'HOLD SCOPE', 'SCOPE REDUCTION'],
     // Default-on Codex outside-voice (codexPreflight block + CODEX_MODE branch
@@ -183,7 +183,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // check grew every plan-review skeleton ~0.7KB. Measured values noted.
     // #2499 project-scope MCP jq in the brain-sync block grew every tier-2+
     // skeleton ~1.5KB (entry resolution emitted once per SKILL.md).
-    maxSkeletonBytes: 71_800, // v1.68 fix wave (#2402); measured 71,228
+    maxSkeletonBytes: 72_800, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 72,210
     minUnionBytes: 70_000,
     mustContain: ['Architecture', 'Code Quality', 'Test', 'Performance'],
     // Cross-cutting preamble growth (v1.57.2.0 AUQ-failure prose fallback + the
@@ -216,7 +216,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // tier-2+ skeleton (measured 89,184). Main's v1.64.0.0 adds ~340 B more
     // (telemetry --error-message/--failed-step preamble prose, PR #769).
     // Budget covers the sum of both waves.
-    maxSkeletonBytes: 91_700, // v1.68 fix wave (#2402); measured 91,176
+    maxSkeletonBytes: 92_700, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 92,158
     minUnionBytes: 70_000,
     mustContain: ['design', 'visual'],
     maxSizeRatio: 1.12, // D1 1.104 + main's ~0.008
@@ -240,7 +240,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // check grew every plan-review skeleton ~0.7KB. Measured values noted.
     // #2499 project-scope MCP jq in the brain-sync block grew every tier-2+
     // skeleton ~1.5KB (entry resolution emitted once per SKILL.md).
-    maxSkeletonBytes: 83_500, // v1.68 fix wave (#2402); measured 82,941
+    maxSkeletonBytes: 84_500, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 83,923
     minUnionBytes: 70_000,
     mustContain: ['developer experience', 'Getting Started'],
     // Default-on Codex outside-voice (codexPreflight block + CODEX_MODE branch
@@ -270,7 +270,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // the #538 opt-out + D1 evidence directive — ratio 1.104 measured.
     // #2499 project-scope MCP jq in the brain-sync block grew every tier-2+
     // skeleton ~1.5KB (entry resolution emitted once per SKILL.md).
-    maxSkeletonBytes: 102_800, // v1.68 fix wave (#2402); measured 102,220
+    maxSkeletonBytes: 103_800, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 103,202
     minUnionBytes: 70_000,
     mustContain: ['design doc', 'problem statement'],
     maxSizeRatio: 1.12,
@@ -291,7 +291,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // +Conductor AUQ-default-prose rule + one-way/continuation safety in the
     // always-loaded AskUserQuestion Format section.
     // v1.2.0 activation lift: first-run-guidance section in the shared preamble.
-    maxSkeletonBytes: 57_900, // v1.68 fix wave (#2402); measured 57,385
+    maxSkeletonBytes: 58_900, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 58,367
     minUnionBytes: 55_000,
     mustContain: ['CHANGELOG', 'Diataxis', 'coverage'],
     // Two intentional additions stack on this small skill: the AUQ-failure prose
@@ -322,7 +322,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // v1.65 merge: provisional larger-of-both-waves budget; re-measured below.
     // v1.64.1.0: shared-preamble prose from the two parallel v1.64 waves lands
     // the skeleton at 69,022 B; +~1 KB headroom.
-    maxSkeletonBytes: 71_400, // v1.68 fix wave (#2402); measured 70,815
+    maxSkeletonBytes: 72_300, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 71,797
     minUnionBytes: 72_000,
     mustContain: ['Typography', 'Color', 'Aesthetic Direction'],
     // Cross-cutting preamble growth (v1.57.2.0 AUQ-failure prose fallback ~2KB +
@@ -362,7 +362,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
     // +Conductor AUQ-default-prose rule + one-way/continuation safety in the
     // always-loaded AskUserQuestion Format section.
     // v1.2.0 activation lift: first-run-guidance section in the shared preamble.
-    maxSkeletonBytes: 77_300, // v1.68 fix wave (#2402); measured 76,705
+    maxSkeletonBytes: 78_200, // cross-call telemetry recovery fix (shared preamble, ~430B/skill); measured 77,687
     minUnionBytes: 72_000,
     mustContain: ['OWASP', 'STRIDE', 'daily', 'comprehensive', 'verif'],
     // cso keeps its mode-dispatch + FP-filtering phases always-loaded, so the

--- a/test/preamble-cross-process-telemetry.test.ts
+++ b/test/preamble-cross-process-telemetry.test.ts
@@ -44,16 +44,31 @@ function run(script: string, home: string) {
 }
 
 describe('preamble/completion telemetry survive separate processes', () => {
-  test('_TEL recovery does not depend on preamble-local runtime path vars (env-var hosts)', () => {
-    // Adversarial review finding: an earlier version of this fix recovered
+  test('recovery does not depend on preamble-local runtime path vars (env-var hosts)', () => {
+    // Adversarial review finding #1: an earlier version of this fix recovered
     // `_TEL` via `${ctx.paths.binDir}/gstack-config`, which resolves to
     // `$GSTACK_BIN`/`$GSTACK_ROOT` for env-var hosts (Codex, Factory, ...).
     // Those vars are themselves only set by the SAME preamble-local
     // `runtimeRoot` block this whole fix exists to work around, so recovery
     // would silently fall back to "off" for opted-in users on those hosts
-    // whenever the completion block runs in a separate process. The fix
-    // reads `~/.gstack/config.yaml` directly (host-independent state dir),
-    // matching gstack-config's own internal resolution and default.
+    // whenever the completion block runs in a separate process.
+    //
+    // Design-comparison pass: duration/session-id recovery moved to a single
+    // marker-file READ (the preamble writes real content into the
+    // already-shipped `~/.gstack/sessions/"$PPID"` file instead of just
+    // touching it) — no binary, no config path, no host-specific path at all.
+    //
+    // Adversarial review finding #2 (on the marker-content design itself):
+    // trusting the MARKER for `_TEL` specifically is fail-OPEN under a PPID
+    // mismatch (e.g. reparenting to init, confirmed to happen on real
+    // machines — `~/.gstack/sessions/1` was found to exist here): a
+    // completion process could read an unrelated/stale session's marker and
+    // inherit ITS `_TEL` value (e.g. "community") even though the CURRENT
+    // session's config is "off". So `_TEL` is deliberately NOT stored in or
+    // recovered from the marker at all — it's recovered by re-reading the
+    // live config.yaml directly (host-independent state dir), same as
+    // duration/session-id's fallback-of-last-resort, but for `_TEL`
+    // specifically this is the ONLY recovery path, never the marker.
     const envVarCtx: TemplateContext = {
       skillName: 'test-skill',
       tmplPath: 'test-skill/SKILL.md.tmpl',
@@ -62,13 +77,22 @@ describe('preamble/completion telemetry survive separate processes', () => {
       preambleTier: 2,
     };
     const completionBash = extractBashFence(generateCompletionStatus(envVarCtx), 1);
-    const telRecoveryBlock = completionBash.slice(
-      completionBash.indexOf('if [ -z "$_TEL" ]'),
-      completionBash.indexOf('_TEL_DUR=')
+    const recoveryBlock = completionBash.slice(
+      completionBash.indexOf('_TEL_END=$(date +%s)'),
+      completionBash.indexOf('rm -f ~/.gstack/analytics/.pending-')
     );
-    expect(telRecoveryBlock).not.toContain('GSTACK_BIN');
-    expect(telRecoveryBlock).not.toContain('GSTACK_ROOT');
-    expect(telRecoveryBlock).toContain('GSTACK_STATE_ROOT');
+    expect(recoveryBlock).not.toContain('GSTACK_BIN');
+    expect(recoveryBlock).not.toContain('GSTACK_ROOT');
+    expect(recoveryBlock).toContain('~/.gstack/sessions/');
+    expect(recoveryBlock).toContain('GSTACK_STATE_ROOT');
+    // The _TEL recovery clause must never read from the marker file — only
+    // from the live config. Isolate just that clause and assert it has no
+    // reference to the marker/read-from-marker variables at all.
+    const telClause = recoveryBlock.slice(recoveryBlock.indexOf('if [ -z "$_TEL" ]'));
+    expect(telClause).not.toContain('_M_START');
+    expect(telClause).not.toContain('_M_SESSION');
+    expect(telClause).not.toContain('sessions/');
+    expect(telClause).toContain('config.yaml');
   });
 
 
@@ -150,6 +174,73 @@ describe('preamble/completion telemetry survive separate processes', () => {
       // remote gstack-telemetry-log call, gated the same way) fire even
       // though the user set telemetry: off. Post-fix, _TEL must recover from
       // the real persisted config and stay "off".
+      expect(after).toBe(before);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('a foreign/stale marker cannot leak a different session\'s telemetry opt-in (opt-out survives PID reuse/reparenting)', () => {
+    // Behavioral reproduction of the adversarial review's finding #2: real
+    // machines have observed a Bash-tool subprocess reparented to init before
+    // it read $PPID (a marker literally named `1` was found in
+    // ~/.gstack/sessions/ during development of this fix). If a completion
+    // process ever ran under a $PPID that collides with an unrelated, older
+    // session's marker, and that marker's format ever carried a telemetry
+    // value (a plausible legacy/foreign format, not this fix's own write
+    // path), a design that recovered `_TEL` FROM the marker would adopt the
+    // foreign session's opt-in — leaking analytics for a user who currently
+    // has telemetry: off. This test plants exactly that adversarial marker
+    // and asserts current telemetry: off still wins.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-tel-foreign-'));
+    try {
+      fs.mkdirSync(path.join(home, '.gstack'), { recursive: true });
+      fs.writeFileSync(path.join(home, '.gstack', 'config.yaml'), 'telemetry: off\n');
+
+      // `$PPID` is read-only in bash (confirmed: `bash -c 'PPID=1'` errors
+      // "PPID: переменная только для чтения" / readonly variable) — it can't
+      // be spoofed to simulate a PID collision. Instead, discover the REAL
+      // $PPID our spawned bash children will share (same pattern as the
+      // other tests: two separate spawnSync calls from this same Node
+      // process share one parent, hence one $PPID), and plant a foreign
+      // 3-field marker AT THAT REAL PATH before the completion block runs.
+      // This exercises the identical code path a genuine collision/stale-
+      // format marker would (the completion block cannot tell "foreign
+      // content under my real PID" from "this PID belongs to someone else
+      // right now" — both are just "unexpected content already at this
+      // path"), without needing to fake process identity.
+      const ppidProbe = spawnSync('bash', ['-c', 'echo $PPID'], { encoding: 'utf-8' });
+      const realPpid = ppidProbe.stdout.trim();
+      expect(realPpid).toMatch(/^\d+$/);
+
+      fs.mkdirSync(path.join(home, '.gstack', 'sessions'), { recursive: true });
+      fs.writeFileSync(
+        path.join(home, '.gstack', 'sessions', realPpid),
+        `1700000000 ${realPpid}-1700000000 community\n`
+      );
+
+      const completionBash = extractBashFence(generateCompletionStatus(baseCtx()), 1);
+      const analyticsFile = path.join(home, '.gstack', 'analytics', 'skill-usage.jsonl');
+      const before = fs.existsSync(analyticsFile) ? fs.readFileSync(analyticsFile, 'utf-8') : '';
+
+      const completionScript = `unset _TEL_START _SESSION_ID _TEL\n${completionBash
+        .replace('SKILL_NAME', 'test-skill')
+        .replace('OUTCOME', 'success')
+        .replace(/USED_BROWSE/g, 'false')}\necho "RESULT _TEL=$_TEL"`;
+      const result = spawnSync('bash', ['-c', completionScript], {
+        env: { ...process.env, HOME: home, PATH: process.env.PATH },
+        encoding: 'utf-8',
+        timeout: 30_000,
+      });
+      expect(result.status).toBe(0);
+
+      const match = result.stdout.match(/RESULT _TEL=(\S*)/);
+      expect(match).not.toBeNull();
+      // The foreign marker's third field ("community") must NOT win, even
+      // though it exists at the exact path this $PPID resolves to.
+      expect(match![1]).toBe('off');
+
+      const after = fs.existsSync(analyticsFile) ? fs.readFileSync(analyticsFile, 'utf-8') : '';
       expect(after).toBe(before);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });

--- a/test/preamble-cross-process-telemetry.test.ts
+++ b/test/preamble-cross-process-telemetry.test.ts
@@ -44,6 +44,34 @@ function run(script: string, home: string) {
 }
 
 describe('preamble/completion telemetry survive separate processes', () => {
+  test('_TEL recovery does not depend on preamble-local runtime path vars (env-var hosts)', () => {
+    // Adversarial review finding: an earlier version of this fix recovered
+    // `_TEL` via `${ctx.paths.binDir}/gstack-config`, which resolves to
+    // `$GSTACK_BIN`/`$GSTACK_ROOT` for env-var hosts (Codex, Factory, ...).
+    // Those vars are themselves only set by the SAME preamble-local
+    // `runtimeRoot` block this whole fix exists to work around, so recovery
+    // would silently fall back to "off" for opted-in users on those hosts
+    // whenever the completion block runs in a separate process. The fix
+    // reads `~/.gstack/config.yaml` directly (host-independent state dir),
+    // matching gstack-config's own internal resolution and default.
+    const envVarCtx: TemplateContext = {
+      skillName: 'test-skill',
+      tmplPath: 'test-skill/SKILL.md.tmpl',
+      host: 'codex',
+      paths: HOST_PATHS['codex'],
+      preambleTier: 2,
+    };
+    const completionBash = extractBashFence(generateCompletionStatus(envVarCtx), 1);
+    const telRecoveryBlock = completionBash.slice(
+      completionBash.indexOf('if [ -z "$_TEL" ]'),
+      completionBash.indexOf('_TEL_DUR=')
+    );
+    expect(telRecoveryBlock).not.toContain('GSTACK_BIN');
+    expect(telRecoveryBlock).not.toContain('GSTACK_ROOT');
+    expect(telRecoveryBlock).toContain('GSTACK_STATE_ROOT');
+  });
+
+
   test('recovered _TEL_START is a real recent epoch, not the unset-as-zero bug', () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-tel-'));
     try {

--- a/test/preamble-cross-process-telemetry.test.ts
+++ b/test/preamble-cross-process-telemetry.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect } from 'bun:test';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { generatePreambleBash } from '../scripts/resolvers/preamble/generate-preamble-bash';
+import { generateCompletionStatus } from '../scripts/resolvers/preamble/generate-completion-status';
+import { HOST_PATHS } from '../scripts/resolvers/types';
+import type { TemplateContext } from '../scripts/resolvers/types';
+
+// Regression coverage for: shared `_TEL_START` / `_SESSION_ID` / `_TEL` do not
+// survive when a skill's preamble bash and its "Telemetry (run last)" bash run
+// as two SEPARATE processes sharing a common parent — exactly what happens
+// when an agent host (observed: Claude Code) executes each fenced bash block
+// in a SKILL.md as its own tool call. Prior to the fix, an empty `_TEL_START`
+// in `_TEL_DUR=$(( _TEL_END - _TEL_START ))` evaluates to `_TEL_END` (a raw
+// current epoch, not near-zero), `_SESSION_ID` mismatches between the
+// "started" and "completed" timeline events, and — the highest-severity part
+// — an empty `_TEL` makes `[ "$_TEL" != "off" ]` true even when the user
+// configured `telemetry: off`, so analytics fire anyway.
+
+function extractBashFence(markdown: string, occurrence = 0): string {
+  const fences = [...markdown.matchAll(/```bash\n([\s\S]*?)```/g)];
+  expect(fences.length).toBeGreaterThan(occurrence);
+  return fences[occurrence][1];
+}
+
+function baseCtx(): TemplateContext {
+  return {
+    skillName: 'test-skill',
+    tmplPath: 'test-skill/SKILL.md.tmpl',
+    host: 'claude',
+    paths: HOST_PATHS['claude'],
+    preambleTier: 2,
+  };
+}
+
+function run(script: string, home: string) {
+  return spawnSync('bash', ['-c', script], {
+    env: { ...process.env, HOME: home, PATH: process.env.PATH },
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+}
+
+describe('preamble/completion telemetry survive separate processes', () => {
+  test('recovered _TEL_START is a real recent epoch, not the unset-as-zero bug', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-tel-'));
+    try {
+      const preambleBash = extractBashFence(generatePreambleBash(baseCtx()));
+      const completionBash = extractBashFence(generateCompletionStatus(baseCtx()), 1); // 0 = learnings-log fence, 1 = Telemetry fence
+
+      const before = Math.floor(Date.now() / 1000);
+      const preambleResult = run(preambleBash, home);
+      expect(preambleResult.status).toBe(0);
+
+      // Completion runs in a SEPARATE process with none of the preamble's vars
+      // exported — this is the actual failure condition, not a simulation of it.
+      const completionScript = `unset _TEL_START _SESSION_ID _TEL\n${completionBash.replace(
+        'SKILL_NAME',
+        'test-skill'
+      ).replace('OUTCOME', 'success').replace(/USED_BROWSE/g, 'false')}\necho "RESULT _TEL_DUR=$_TEL_DUR _SESSION_ID=$_SESSION_ID"`;
+      const completionResult = run(completionScript, home);
+      expect(completionResult.status).toBe(0);
+
+      const match = completionResult.stdout.match(/RESULT _TEL_DUR=(-?\d+) _SESSION_ID=(\S+)/);
+      expect(match).not.toBeNull();
+      const dur = Number(match![1]);
+      const sessionId = match![2];
+
+      // Pre-fix bug: an unset _TEL_START in `$(( _TEL_END - _TEL_START ))`
+      // arithmetic evaluates to 0, so _TEL_DUR == _TEL_END (a ~1.7-billion
+      // second "duration"). Post-fix, duration must be small and non-negative.
+      expect(dur).toBeGreaterThanOrEqual(0);
+      expect(dur).toBeLessThan(60); // both processes run back-to-back in this test
+
+      // Pre-fix bug: _SESSION_ID built from "$$" in the preamble process can
+      // never be reconstructed in a different process, so recovery falls back
+      // to an empty or ad-hoc value. Post-fix it's keyed on $PPID, which is
+      // shared by both subprocesses here (same spawning test process).
+      expect(sessionId).toMatch(/^\d+-\d+$/);
+
+      // Sanity: the recovered epoch used to build _SESSION_ID/_TEL_DUR is
+      // plausible (within this test's own execution window), not a stale or
+      // garbage value.
+      const dashIdx = sessionId.indexOf('-');
+      const recoveredEpoch = Number(sessionId.slice(dashIdx + 1));
+      const now = Math.floor(Date.now() / 1000);
+      expect(recoveredEpoch).toBeGreaterThanOrEqual(before - 2);
+      expect(recoveredEpoch).toBeLessThanOrEqual(now + 2);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('telemetry: off is honored even when the completion block runs in a separate process (opt-out, not just metrics accuracy)', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-tel-off-'));
+    try {
+      fs.mkdirSync(path.join(home, '.gstack'), { recursive: true });
+      fs.writeFileSync(path.join(home, '.gstack', 'config.yaml'), 'telemetry: off\n');
+
+      const preambleBash = extractBashFence(generatePreambleBash(baseCtx()));
+      const completionBash = extractBashFence(generateCompletionStatus(baseCtx()), 1);
+
+      const preambleResult = run(preambleBash, home);
+      expect(preambleResult.status).toBe(0);
+
+      const analyticsFile = path.join(home, '.gstack', 'analytics', 'skill-usage.jsonl');
+      const before = fs.existsSync(analyticsFile) ? fs.readFileSync(analyticsFile, 'utf-8') : '';
+
+      const completionScript = `unset _TEL_START _SESSION_ID _TEL\n${completionBash
+        .replace('SKILL_NAME', 'test-skill')
+        .replace('OUTCOME', 'success')
+        .replace(/USED_BROWSE/g, 'false')}`;
+      const completionResult = run(completionScript, home);
+      expect(completionResult.status).toBe(0);
+
+      const after = fs.existsSync(analyticsFile) ? fs.readFileSync(analyticsFile, 'utf-8') : '';
+
+      // Pre-fix bug: _TEL recovers to "" in the separate completion process,
+      // and `[ "" != "off" ]` is true, so the local-analytics append (and the
+      // remote gstack-telemetry-log call, gated the same way) fire even
+      // though the user set telemetry: off. Post-fix, _TEL must recover from
+      // the real persisted config and stay "off".
+      expect(after).toBe(before);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
_Implementation: Claude Code (Sonnet 5). Independent technical review: Codex — findings from three separate review passes (initial plan, initial diff, and this revision's diff) are folded into this PR (see Live evidence). This PR was revised after a design-comparison pass explicitly asked "is the current implementation the simplest way to guarantee the required properties, or just the first one that worked" — the revision below replaced the original mtime-based recovery with something smaller and safer; details in the "Revision" section._

## Why (in your own words)

Every skill's preamble sets _TEL_START/_SESSION_ID/_TEL once, and the
"Telemetry (run last)" block reads them again at the end. On a host that runs
each fenced bash block in a SKILL.md as its own subprocess (observed: Claude
Code — only cwd persists between tool calls, not shell state), the
completion block sees none of them. Worst case: _TEL (telemetry on/off) is
lost the same way, and the completion gate is `[ "$_TEL" != "off" ]` — an
empty _TEL reads as "not off", so a user who explicitly set telemetry: off
still gets local analytics writes and a remote gstack-telemetry-log call.

## Live evidence

Before (the actual arithmetic bug, this machine):

```
$ env -u _TEL_START bash -c '_TEL_END=$(date +%s); _TEL_DUR=$(( _TEL_END - _TEL_START )); echo "TEL_START=[$_TEL_START] TEL_DUR=$_TEL_DUR"'
TEL_START=[] TEL_DUR=1787837147
```

(an unset _TEL_START is 0 in Bash arithmetic, so duration becomes the raw
current epoch, not near-zero as the symptom first suggested)

Full end-to-end live run on this machine (real telemetry: off setting),
preamble and completion run as genuinely separate processes sharing one
parent PID:

```
$ (preamble) echo "TELEMETRY=$_TEL PPID=$PPID EXPECT_SESSION_ID=$_SESSION_ID"
TELEMETRY=off PPID=3427913 EXPECT_SESSION_ID=3427913-1787849499

$ (completion, separate process, ~4s later, no inherited vars) echo "RECOVERED _TEL=$_TEL _TEL_DUR=$_TEL_DUR _SESSION_ID=$_SESSION_ID"
RECOVERED _TEL=off _TEL_DUR=17 _SESSION_ID=3427913-1787849499

analytics before=26 after=26 (must match, TELEMETRY=off)
```

(session id matches exactly across the two separate-process events; 17s
duration matches the real wall-clock gap; zero new analytics lines despite
telemetry: off being invisible to the completion process)

Regression test (test/preamble-cross-process-telemetry.test.ts) run against
this exact diff:

```
bun test v1.3.14 (0d9b296a)
 4 pass
 0 fail
 30 expect() calls
Ran 4 tests across 1 file.
```

## Revision: mtime-based recovery replaced with marker-content recovery

The first version of this PR recovered _TEL_START/_SESSION_ID by reading
`~/.gstack/sessions/"$PPID"`'s file MTIME, which needs an OS branch (GNU
`date -r` vs BSD `stat -f %m`) — exactly the kind of platform-specific
parsing this fix exists to remove. A design-comparison pass (explicitly
framed as "don't take the current implementation as given — compare
alternatives on: amount of new logic, blast radius, edge cases, host-path
dependency, per-skill byte cost, fit with upstream's architecture") found
that since the preamble already controls both the write and read side of
the marker file, there's no need to infer anything from filesystem
timestamps: write the real values as text instead of an empty `touch`, read
them back with `read -r`. This dropped the OS branch entirely from both
files and reduced the per-skill byte cost by roughly a quarter (measured
below).

One candidate considered and rejected: pushing the recovery into a `bin/`
script (matching the existing `gstack-repo-mode`/`gstack-slug`
`eval "$(...)"` pattern). Verified this doesn't work: `hosts/define-host.ts`
defaults `usesEnvVars: true` for every host except Claude, so
`${ctx.paths.binDir}` resolves to `$GSTACK_BIN` — a variable set only inside
the preamble's own `runtimeRoot` block, which doesn't survive to a separate
completion-process for 9 of 10 hosts. (This exact pre-existing bug is
already reproducible today in this repo's own `test/fixtures/golden/codex-
ship-SKILL.md`, lines 837/843-844 — the completion block's existing
timeline-log/telemetry-log calls already silently no-op on env-var hosts
for the same reason. Filed as a separate, pre-existing, out-of-scope
observation, not part of this fix.)

A second `/codex review` pass on the marker-content revision itself caught
a real fail-open risk: if `_TEL` were ALSO recovered from the marker (as
originally drafted), a completion process whose $PPID happens to collide
with an unrelated or stale session's marker (confirmed possible on this
machine — `~/.gstack/sessions/1` exists, meaning some Bash-tool subprocess
was at some point reparented to init before reading $PPID) could inherit
that foreign session's telemetry opt-IN, leaking analytics for a user who
currently has telemetry: off. Fixed by keeping `_TEL` recovery on its own,
separate path: re-reading the live `~/.gstack/config.yaml` directly (never
the marker), so a marker collision can only ever produce a wrong-but-
harmless duration/session-id, never a privacy leak. Added a behavioral test
that plants a foreign marker with an old-format telemetry-looking third
field and asserts it's ignored.

Measured impact (real generator run, not estimated):
- `ship/SKILL.md`: 91,954 B vs main's 91,267 B (delta +687) vs this PR's
  original version's 92,204 B (delta +937) — about a quarter smaller, while
  closing the fail-open gap above that the original version didn't have.
- All 9 previously-bumped `maxSkeletonBytes` budgets re-measured and
  reduced (still bumped, but by roughly half as much; exact values in each
  comment in `test/helpers/carve-guards.ts`).

A third `/codex review` pass on this final diff raised one advisory (P2,
non-blocking) finding: the `$PPID` marker is shared across concurrent or
rapidly-sequential skill invocations in one host process, so a second
invocation's preamble can overwrite a first invocation's marker before the
first's completion reads it, misattributing duration/session-id. This is
the same trade-off already disclosed in this PR's first commit (reusing the
existing shared marker rather than introducing a new per-invocation file) —
independently reconfirmed here, not a new finding, and still judged
acceptable: it degrades to wrong-but-harmless local analytics, never a
crash, never a privacy issue (that path is now hard-separated per the fix
above).

## Scope

- **Changed:** scripts/resolvers/preamble/generate-preamble-bash.ts,
  scripts/resolvers/preamble/generate-completion-status.ts (writes real
  values into the existing `~/.gstack/sessions/"$PPID"` marker instead of an
  empty touch; recovers duration/session-id via `read -r` from that marker;
  recovers `_TEL` separately and only from the live config file, never the
  marker) + regenerated all 50 preamble-tier SKILL.md files + 3 refreshed
  `ship` golden fixtures + adjusted `maxSkeletonBytes` for the 9 skills
  whose skeleton was already close to budget (same convention as the prior
  v1.68 #2402 bumps, each with its measured value in the comment)
- **Verified live by:** the commands above, run directly on this machine,
  across three review/revision cycles
- **Did NOT test:** the marker-sharing race between concurrent skills in
  one host process (documented, accepted, see "Revision" above); Windows
  (this PR's changed files aren't in the curated Windows CI subset, and the
  new regression test uses `spawn('bash', ...)`, which is excluded from
  that subset by the runner's own POSIX-only curation)

## Liveness proof (required)

<img width="1920" height="1080" alt="изображение" src="https://github.com/user-attachments/assets/a38def33-31a5-4358-ae66-bd5d90bd93b5" />

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface
- [x] This is not a generated-file-only diff (edited the two resolver .ts
      sources, regenerated)
- [x] No ETHOS.md edits, no voice/founder-perspective/YC changes
- [x] N/A — not a new public command/service/host adapter
- [x] Linked issue or reproduction: reproduction above (no existing issue found)
