### PR TITLE
fix(setup): serve rendered sections/, not the checkout copy (#2706)

### DIFF
--- a/bin/gstack-relink
+++ b/bin/gstack-relink
@@ -52,6 +52,51 @@ _cleanup_skill_entry() {
   fi
 }
 
+# #2706: setup links runtime assets (sections/, checklist.md, specialists/...)
+# from the CHECKOUT, while SKILL.md is served from the render dir. Where the
+# gbrain render produced a counterpart, serve that one instead — otherwise
+# `gstack-config gbrain-refresh`, which calls this script to "repoint installed
+# skills at the render", leaves every rendered section file unreachable and the
+# Save Results to Brain blocks never load.
+#
+# Overlay per FILE, not per directory: render dirs carry only the generated
+# *.md, so repointing the whole directory would drop manifest.json and other
+# checkout-only assets.
+_overlay_rendered_assets() {
+  local skill="$1"
+  local target="$2"
+  local rskill="$RENDER_DIR/$skill"
+  [ -d "$rskill" ] || return 0
+  local rasset asset_name src_asset child rchild child_name
+  for rasset in "$rskill"/*; do
+    [ -e "$rasset" ] || continue
+    asset_name="$(basename "$rasset")"
+    [ "$asset_name" = "SKILL.md" ] && continue
+    src_asset="$INSTALL_DIR/$skill/$asset_name"
+    if [ -d "$rasset" ]; then
+      # If the installed entry is still a SYMLINK it points at the checkout;
+      # linking a child through it would write into the tracked install. Drop
+      # it and rebuild as a real directory of per-file links.
+      [ -L "$target/$asset_name" ] && rm -f "$target/$asset_name"
+      mkdir -p "$target/$asset_name"
+      if [ -d "$src_asset" ]; then
+        for child in "$src_asset"/*; do
+          [ -e "$child" ] || continue
+          child_name="$(basename "$child")"
+          ln -snf "$child" "$target/$asset_name/$child_name"
+        done
+      fi
+      for rchild in "$rasset"/*; do
+        [ -e "$rchild" ] || continue
+        child_name="$(basename "$rchild")"
+        ln -snf "$rchild" "$target/$asset_name/$child_name"
+      done
+    else
+      ln -snf "$rasset" "$target/$asset_name"
+    fi
+  done
+}
+
 _link_root_skill_alias() {
   local target="$SKILLS_DIR/_gstack-command"
 
@@ -107,6 +152,7 @@ for skill_dir in "$INSTALL_DIR"/*/; do
   skill_md_src="$INSTALL_DIR/$skill/SKILL.md"
   [ -f "$RENDER_DIR/$skill/SKILL.md" ] && skill_md_src="$RENDER_DIR/$skill/SKILL.md"
   ln -snf "$skill_md_src" "$target/SKILL.md"
+  _overlay_rendered_assets "$skill" "$target"
   SKILL_COUNT=$((SKILL_COUNT + 1))
 done
 

--- a/setup
+++ b/setup
@@ -866,7 +866,13 @@ mkdir -p "$HOME/.gstack/projects"
 _link_skill_runtime_assets() {
   local src_dir="$1"
   local dst_dir="$2"
-  local asset asset_name
+  # #2706: optional gbrain render dir for this skill. link_claude_skill_dirs
+  # already prefers the rendered SKILL.md (#2569); without the same preference
+  # here, SKILL.md is served from the render dir while sections/ is served from
+  # the checkout, so the rendered "Save Results to Brain" blocks are generated
+  # and never read. Empty for hosts/skills with no render.
+  local render_dir="${3:-}"
+  local asset asset_name rsub child child_name
   for asset in "$src_dir"/*; do
     [ -e "$asset" ] || continue  # empty-glob guard
     asset_name="$(basename "$asset")"
@@ -878,7 +884,27 @@ _link_skill_runtime_assets() {
     if [ -e "$dst_dir/$asset_name" ] || [ -L "$dst_dir/$asset_name" ]; then
       rm -rf "$dst_dir/$asset_name"
     fi
-    _link_or_copy "$asset" "$dst_dir/$asset_name"
+    # Serve the rendered counterpart when the gbrain render produced one.
+    # Overlay per FILE rather than repointing the whole directory: render dirs
+    # carry only the generated *.md, so a directory-level repoint would drop
+    # manifest.json and any other checkout-only asset.
+    rsub="$render_dir/$asset_name"
+    if [ -n "$render_dir" ] && [ -d "$asset" ] && [ -d "$rsub" ]; then
+      mkdir -p "$dst_dir/$asset_name"
+      for child in "$asset"/*; do
+        [ -e "$child" ] || continue
+        child_name="$(basename "$child")"
+        if [ -e "$rsub/$child_name" ]; then
+          _link_or_copy "$rsub/$child_name" "$dst_dir/$asset_name/$child_name"
+        else
+          _link_or_copy "$child" "$dst_dir/$asset_name/$child_name"
+        fi
+      done
+    elif [ -n "$render_dir" ] && [ -f "$asset" ] && [ -f "$rsub" ]; then
+      _link_or_copy "$rsub" "$dst_dir/$asset_name"
+    else
+      _link_or_copy "$asset" "$dst_dir/$asset_name"
+    fi
     # P5: the exclusion list above filters DIRECT children only, but the
     # Windows cp -R copy sweeps NESTED gitignored build output too (concrete:
     # ios-qa/scripts/gen-accessors-tool/.build is 252MB). Prune post-copy —
@@ -932,9 +958,15 @@ link_claude_skill_dirs() {
       # #2569: prefer a rendered :user variant when present. gbrain installs
       # render brain-aware SKILL.md into ${GSTACK_HOME}/render/claude via
       # gen:skill-docs --out-dir instead of dirtying the tracked source
-      # checkout; when a render exists for this skill, serve it. The rendered
-      # file's section-base paths point into the render dir, so section reads
-      # resolve there too.
+      # checkout; when a render exists for this skill, serve it.
+      #
+      # #2706: serving the rendered SKILL.md is NOT sufficient on its own. It
+      # embeds absolute Read paths into the render dir, but the Section index
+      # and the carved-skill footer also route via RELATIVE "sections/<name>.md"
+      # refs, which resolve through this installed dir. So the runtime assets
+      # have to prefer the render too — hence the third arg below. Without it
+      # SKILL.md came from the render while sections/ came from the checkout,
+      # and the rendered Save Results to Brain blocks were never reachable.
       _skill_md_src="$gstack_dir/$dir_name/SKILL.md"
       _render_dir="${GSTACK_USER_RENDER_DIR:-${GSTACK_HOME:-$HOME/.gstack}/render/claude}"
       if [ -f "$_render_dir/$dir_name/SKILL.md" ]; then
@@ -948,7 +980,7 @@ link_claude_skill_dirs() {
       # landed and /review 404'd at "Read .claude/skills/review/checklist.md"
       # on every fresh Claude install. Routes through _link_or_copy so Windows
       # gets real copies refreshed on every ./setup.
-      _link_skill_runtime_assets "$gstack_dir/$dir_name" "$target"
+      _link_skill_runtime_assets "$gstack_dir/$dir_name" "$target" "$_render_dir/$dir_name"
       linked+=("$link_name")
     fi
   done

--- a/test/render-sections-provenance.test.ts
+++ b/test/render-sections-provenance.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The install must SERVE the rendered section files, not just generate them (#2706).
+ *
+ * #2569 made the Claude installers prefer the gbrain-rendered SKILL.md out of
+ * ~/.gstack/render/claude. Runtime assets kept coming from the checkout, so
+ * SKILL.md was served from the render dir while sections/ was served from the
+ * source tree — and the rendered "Save Results to Brain" blocks, which live
+ * ONLY in the rendered section files, were generated and never read.
+ *
+ * gen-skill-docs-out-dir.test.ts already pins the generator side (the rendered
+ * section file gains the block). These tests pin the delivery side: what the
+ * installed skill dir actually serves.
+ *
+ * Both install paths are covered — setup's _link_skill_runtime_assets and
+ * bin/gstack-relink, which `gstack-config gbrain-refresh` calls to "repoint
+ * installed skills at the render".
+ */
+import { describe, test as _bunTest, expect, beforeEach, afterEach } from 'bun:test';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const test = Object.assign(
+  ((name: any, fn: any, timeout?: number) =>
+    _bunTest(name, fn, timeout ?? 15_000)) as typeof _bunTest,
+  _bunTest,
+);
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const BIN = path.join(ROOT, 'bin');
+const SETUP_SRC = fs.readFileSync(path.join(ROOT, 'setup'), 'utf-8');
+
+/** Body of a shell function `name() { ... }`, including the closing brace. */
+function extractFn(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`);
+  const end = src.indexOf('\n}\n', start);
+  if (start < 0 || end < 0) throw new Error(`Could not locate ${name}()`);
+  return src.slice(start, end + 3);
+}
+
+const SAVE_BLOCK = '## Save Results to Brain';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-render-sections-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * Source checkout + render dir for one carved skill. The rendered section
+ * carries the brain block; the checkout copy does not. manifest.json exists
+ * ONLY in the checkout — the reason the overlay has to be per-file rather than
+ * a directory-level repoint.
+ */
+function fixture(): { src: string; render: string; dst: string } {
+  const src = path.join(tmpDir, 'install', 'ship');
+  const render = path.join(tmpDir, 'render', 'ship');
+  const dst = path.join(tmpDir, 'skills', 'ship');
+  fs.mkdirSync(path.join(src, 'sections'), { recursive: true });
+  fs.mkdirSync(path.join(render, 'sections'), { recursive: true });
+  fs.mkdirSync(dst, { recursive: true });
+
+  fs.writeFileSync(path.join(src, 'SKILL.md'), '---\nname: ship\ndescription: t\n---\n# ship');
+  fs.writeFileSync(path.join(src, 'sections', 'adversarial.md'), 'body\n');
+  fs.writeFileSync(path.join(src, 'sections', 'tests.md'), 'tests\n');
+  fs.writeFileSync(path.join(src, 'sections', 'manifest.json'), '{"x":1}\n');
+  fs.writeFileSync(path.join(render, 'SKILL.md'), '---\nname: ship\ndescription: t\n---\n# ship rendered');
+  // Only the diverging file is re-rendered with the block.
+  fs.writeFileSync(path.join(render, 'sections', 'adversarial.md'), `body\n${SAVE_BLOCK}\n`);
+  fs.writeFileSync(path.join(render, 'sections', 'tests.md'), 'tests\n');
+  return { src, render, dst };
+}
+
+describe('installed skills serve rendered sections (#2706)', () => {
+  test("setup's _link_skill_runtime_assets serves the rendered section, keeping checkout-only assets", () => {
+    const { src, render, dst } = fixture();
+    const script = [
+      'set -eu',
+      'IS_WINDOWS=0',
+      extractFn(SETUP_SRC, '_link_or_copy'),
+      extractFn(SETUP_SRC, '_link_skill_runtime_assets'),
+      `_link_skill_runtime_assets "${src}" "${dst}" "${render}"`,
+    ].join('\n');
+    execSync(script, { shell: '/bin/bash', encoding: 'utf-8' });
+
+    // The whole point: the block reaches the agent.
+    expect(fs.readFileSync(path.join(dst, 'sections', 'adversarial.md'), 'utf-8')).toContain(SAVE_BLOCK);
+    // A per-file overlay, not a directory repoint — checkout-only assets survive.
+    expect(fs.existsSync(path.join(dst, 'sections', 'manifest.json'))).toBe(true);
+    // Non-diverging files still resolve.
+    expect(fs.readFileSync(path.join(dst, 'sections', 'tests.md'), 'utf-8')).toContain('tests');
+  });
+
+  test('_link_skill_runtime_assets without a render dir is unchanged (no-gbrain installs)', () => {
+    const { src, dst } = fixture();
+    const script = [
+      'set -eu',
+      'IS_WINDOWS=0',
+      extractFn(SETUP_SRC, '_link_or_copy'),
+      extractFn(SETUP_SRC, '_link_skill_runtime_assets'),
+      `_link_skill_runtime_assets "${src}" "${dst}"`,
+    ].join('\n');
+    execSync(script, { shell: '/bin/bash', encoding: 'utf-8' });
+
+    expect(fs.readFileSync(path.join(dst, 'sections', 'adversarial.md'), 'utf-8')).not.toContain(SAVE_BLOCK);
+    expect(fs.existsSync(path.join(dst, 'sections', 'manifest.json'))).toBe(true);
+  });
+
+  test('gstack-relink repoints sections at the render (the gbrain-refresh path)', () => {
+    const { src, render, dst } = fixture();
+    const installDir = path.dirname(src);
+    const skillsDir = path.dirname(dst);
+    const renderRoot = path.dirname(render);
+
+    const mockBin = path.join(installDir, 'bin');
+    fs.mkdirSync(mockBin, { recursive: true });
+    for (const b of ['gstack-config', 'gstack-relink', 'gstack-patch-names']) {
+      fs.copyFileSync(path.join(BIN, b), path.join(mockBin, b));
+      fs.chmodSync(path.join(mockBin, b), 0o755);
+    }
+
+    // Reproduce the pre-fix install shape: sections/ is a symlink INTO the
+    // checkout. Relink must not link children through it (that would write
+    // into the tracked install) — it has to rebuild a real directory.
+    fs.symlinkSync(path.join(src, 'sections'), path.join(dst, 'sections'));
+
+    const env: Record<string, string | undefined> = {
+      ...process.env,
+      GSTACK_STATE_DIR: tmpDir,
+      GSTACK_INSTALL_DIR: installDir,
+      GSTACK_SKILLS_DIR: skillsDir,
+      GSTACK_USER_RENDER_DIR: renderRoot,
+    };
+    delete env.GSTACK_HOME;
+    execSync(path.join(mockBin, 'gstack-relink'), { env, encoding: 'utf-8', timeout: 10000 });
+
+    expect(fs.readFileSync(path.join(dst, 'sections', 'adversarial.md'), 'utf-8')).toContain(SAVE_BLOCK);
+    expect(fs.existsSync(path.join(dst, 'sections', 'manifest.json'))).toBe(true);
+    // The checkout stays pristine — nothing was written through the old symlink.
+    expect(fs.readFileSync(path.join(src, 'sections', 'adversarial.md'), 'utf-8')).not.toContain(SAVE_BLOCK);
+    expect(fs.readdirSync(path.join(src, 'sections')).sort())
+      .toEqual(['adversarial.md', 'manifest.json', 'tests.md']);
+  });
+});

--- a/test/setup-sections-linking.test.ts
+++ b/test/setup-sections-linking.test.ts
@@ -31,7 +31,13 @@ describe('setup links sections/ for cherry-pick install targets', () => {
     // routes through _link_or_copy internally (windows-safe), so the old
     // per-directory _link_or_copy assertion moved there.
     const body = fnBody(SETUP, 'link_claude_skill_dirs');
-    expect(body).toMatch(/_link_skill_runtime_assets\s+"\$gstack_dir\/\$dir_name"\s+"\$target"/);
+    // #2706: the render dir is a REQUIRED third argument. Serving SKILL.md
+    // from the render while sections/ came from the checkout is exactly the
+    // split that made rendered brain blocks unreachable, so pin the arg here
+    // rather than leaving the old two-arg shape matchable.
+    expect(body).toMatch(
+      /_link_skill_runtime_assets\s+"\$gstack_dir\/\$dir_name"\s+"\$target"\s+"\$_render_dir\/\$dir_name"/,
+    );
     const helper = fnBody(SETUP, '_link_skill_runtime_assets');
     expect(helper).toContain('_link_or_copy');
     expect(helper).not.toMatch(/\bln -s/);


### PR DESCRIPTION
Fixes #2706.

## Why (in your own words)

On a gbrain install, `/ship`, `/office-hours` and the four `plan-*-review` skills silently stopped saving anything to the brain. The blocks were being generated correctly — they just never reached the agent.

#2569 moved the brain-aware render out of the tracked checkout and made the installers prefer the rendered `SKILL.md`. Runtime assets kept coming from the checkout, so an installed skill ended up served from two different trees: `SKILL.md` from `~/.gstack/render/claude`, `sections/` from the source. The rendered section files are the only copies carrying the injected **Save Results to Brain** block, so that block was written to disk and then never read.

The comment above the call says the opposite — "the rendered file's section-base paths point into the render dir, so section reads resolve there too". That's true of the absolute `Read` directives, but the Section index and the carved-skill footer route via *relative* `sections/<name>.md` refs, and those resolve through the installed dir. So the render preference has to cover runtime assets too, not just `SKILL.md`.

`gstack-config gbrain-refresh` doesn't heal it either: it calls `gstack-relink` to "repoint installed skills at the render", and relink only ever repointed `SKILL.md`. That's the path someone hits when they install gbrain *after* gstack, and it's why re-running refresh looks successful while changing nothing.

## Live evidence

**Before — on a real v1.71.0.0 install with gbrain:** every diverging section file is served from the checkout, i.e. without its block.

```
$ for d in ~/.gstack/render/claude/*/; do s=$(basename "$d"); [ -d "$d/sections" ] || continue
    for f in "$d/sections"/*.md; do b=$(basename "$f"); src=~/.claude/skills/gstack/$s/sections/$b
      [ -f "$src" ] && ! cmp -s "$f" "$src" && { served=~/.claude/skills/$s/sections/$b
        cmp -s "$served" "$f" && echo "$s/$b serves RENDER" || echo "$s/$b serves SOURCE (block lost)"; }
    done; done

ship/adversarial.md                       serves SOURCE (block lost)
office-hours/design-and-handoff.md        serves SOURCE (block lost)
plan-ceo-review/review-sections.md        serves SOURCE (block lost)
plan-design-review/review-sections.md     serves SOURCE (block lost)
plan-devex-review/review-sections.md      serves SOURCE (block lost)
plan-eng-review/review-sections.md        serves SOURCE (block lost)
```

The content that never arrives:

```
$ diff ~/.claude/skills/gstack/ship/sections/adversarial.md \
       ~/.gstack/render/claude/ship/sections/adversarial.md
> ## Save Results to Brain
> **Skip this entire section if `gbrain` is not on PATH.**
> ... gbrain put "releases/<feature-slug>" ...
```

**Red on unpatched main** — new tests run against a clean `394db32` worktree, before the fix:

```
$ bun test test/render-sections-provenance.test.ts     # on upstream/main

(fail) installed skills serve rendered sections (#2706) > setup's _link_skill_runtime_assets
       serves the rendered section, keeping checkout-only assets
  Expected to contain: "## Save Results to Brain"
  Received: "body\n"

(fail) installed skills serve rendered sections (#2706) > gstack-relink repoints sections
       at the render (the gbrain-refresh path)
  Expected to contain: "## Save Results to Brain"
  Received: "body\n"

 1 pass
 2 fail
```

The one that passes on main is the control: the no-render path must stay byte-identical for installs without gbrain.

**Green after the fix:**

```
$ bun test test/render-sections-provenance.test.ts
 3 pass
 0 fail
 9 expect() calls
```

**No regressions in the surrounding area** — every suite that touches linking, relink, render isolation, team mode and uninstall:

```
$ bun test test/relink.test.ts test/setup-claude-skill-assets.test.ts \
    test/user-render-out-dir-install.test.ts test/setup-windows-rerun-refresh.test.ts \
    test/gbrain-refresh-install-render.test.ts test/dev-setup-render-isolation.test.ts \
    test/setup-sections-linking.test.ts test/render-sections-provenance.test.ts \
    test/team-mode.test.ts test/uninstall.test.ts

 126 pass
 0 fail
 644 expect() calls
```

**Full free suite, branch vs clean main on the same machine:** 19 failures on this branch, 22 on `upstream/main` — the failures are identical pre-existing local-environment ones (`bun-polyfill`, `findPort`, `bump`/`DRIFT REPAIR`, `gstack-gbrain-sync`, `browse` `node --check`), caused by `node` here being a Bun shim at `~/.bun/bin/node` rather than real Node. My diff touches no file any of those suites exercise.

## Scope

- **Changed:** `setup` (`_link_skill_runtime_assets` takes the render dir and overlays per file; corrected the comment whose premise caused this), `bin/gstack-relink` (same overlay, so `gbrain-refresh` actually repoints), `test/setup-sections-linking.test.ts` (its `:34` assertion matched the two-arg shape and so pinned the bug in place), plus the new `test/render-sections-provenance.test.ts`.
- **Verified live by:** the real-install sweep above on a gbrain-enabled v1.71.0.0 global-git install (macOS), red-then-green on the new tests against a clean `394db32` worktree, and the 126-test surrounding-area run.
- **Did NOT test:** Windows (`_link_or_copy`'s copy path — the overlay routes through the same helper, but I have no Windows box); the paid/eval tiers; ShellCheck (not installed locally — `bash -n` passes on both scripts, and CI gates `setup` at `--severity=error`).

## Design note

The overlay is per **file**, not per directory. Render dirs carry only the generated `*.md`, so repointing the whole `sections/` symlink at the render would drop `manifest.json` and the `*.tmpl` files that exist only in the checkout.

In relink there's one sharp edge worth flagging: on an existing install `sections/` is *already* a symlink into the checkout, so linking children through it would write into the tracked install and dirty it. The helper drops that symlink and rebuilds a real directory first; a test asserts the checkout is byte-unchanged afterwards.

Related but distinct from #2692 (which is the *absolute* refs pointing at the deleted `claude.tmp.$$` dir). On this install both routes to `ship/sections/adversarial.md` fail — 9 dead tmp refs and 9 relative refs into un-rendered content in the same file. #2692 repairs the absolute route; this repairs the relative one. They compose.

If you'd rather remove the two-tree split at the source than overlay it, the alternative in #2706 stands: have `gen-skill-docs --out-dir` emit the full `sections/` payload so the whole directory can be linked from the render dir. Happy to redo it that way.

## Liveness proof

<!-- SCREENSHOT GOES HERE — drag the image into this line in the GitHub editor. -->

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
