### PR TITLE
fix: make squash a merge-method default

### DIFF
--- a/land-and-deploy/sections/merge-and-deploy.md
+++ b/land-and-deploy/sections/merge-and-deploy.md
@@ -5,10 +5,32 @@
 Record the start timestamp for timing data. Also record which merge path is taken
 (auto-merge vs direct) for the deploy report.
 
-Try auto-merge first (respects repo merge settings and merge queues):
+Resolve one merge method before constructing the command:
+
+1. Identify any explicit method chosen by the user in the current conversation, plus any
+   hard constraint or preferred method in the project's documented policy.
+2. Check the repository's structured capabilities with
+   `gh repo view --json mergeCommitAllowed,rebaseMergeAllowed,squashMergeAllowed`.
+   The response must contain a boolean for each method. Intersect the enabled methods with
+   any project hard constraint. If the query fails, its shape is invalid, or the intersection
+   is empty, stop and report the unresolved constraint.
+3. If an explicit choice is in that allowed set, use it. If it is outside the set, stop and
+   report the conflict; do not silently replace it.
+4. Otherwise, use the project's preferred method when it is in the allowed set. If that
+   preference is unavailable, report it and continue resolving from the allowed set.
+5. Otherwise, recommend and default to squash when squash is in the allowed set. If exactly
+   one other method remains, use it and report the constraint. If multiple alternatives
+   remain, ask the user to choose.
+
+Interpret user and project prose in full context; do not classify merge intent with
+keyword, regex, or string-containment rules. The selected method must resolve to exactly
+one of the closed CLI flags `--merge`, `--rebase`, or `--squash`.
+
+Try auto-merge first (respects repo merge settings and merge queues). The default command
+is below; replace `--squash` with the resolved `--merge` or `--rebase` flag when applicable:
 
 ```bash
-gh pr merge --squash --auto --delete-branch
+gh pr merge <resolved-pr> --squash --auto --delete-branch
 ```
 
 If `--auto` succeeds: record `MERGE_PATH=auto`. This means the repo has auto-merge enabled
@@ -29,8 +51,11 @@ the flow is unaffected — but do not report the second one as "auto-merge is di
    before this step runs.
 
 ```bash
-gh pr merge --squash --delete-branch
+gh pr merge <resolved-pr> --squash --delete-branch
 ```
+
+Merge-method flags belong only to `gh pr merge`. Keep branch upload as an ordinary
+`git push`; PR merge policy does not make squash an option or requirement for push.
 
 If direct merge succeeds: record `MERGE_PATH=direct`. Tell the user: "PR merged successfully. The branch has been cleaned up."
 

--- a/land-and-deploy/sections/merge-and-deploy.md.tmpl
+++ b/land-and-deploy/sections/merge-and-deploy.md.tmpl
@@ -3,10 +3,32 @@
 Record the start timestamp for timing data. Also record which merge path is taken
 (auto-merge vs direct) for the deploy report.
 
-Try auto-merge first (respects repo merge settings and merge queues):
+Resolve one merge method before constructing the command:
+
+1. Identify any explicit method chosen by the user in the current conversation, plus any
+   hard constraint or preferred method in the project's documented policy.
+2. Check the repository's structured capabilities with
+   `gh repo view --json mergeCommitAllowed,rebaseMergeAllowed,squashMergeAllowed`.
+   The response must contain a boolean for each method. Intersect the enabled methods with
+   any project hard constraint. If the query fails, its shape is invalid, or the intersection
+   is empty, stop and report the unresolved constraint.
+3. If an explicit choice is in that allowed set, use it. If it is outside the set, stop and
+   report the conflict; do not silently replace it.
+4. Otherwise, use the project's preferred method when it is in the allowed set. If that
+   preference is unavailable, report it and continue resolving from the allowed set.
+5. Otherwise, recommend and default to squash when squash is in the allowed set. If exactly
+   one other method remains, use it and report the constraint. If multiple alternatives
+   remain, ask the user to choose.
+
+Interpret user and project prose in full context; do not classify merge intent with
+keyword, regex, or string-containment rules. The selected method must resolve to exactly
+one of the closed CLI flags `--merge`, `--rebase`, or `--squash`.
+
+Try auto-merge first (respects repo merge settings and merge queues). The default command
+is below; replace `--squash` with the resolved `--merge` or `--rebase` flag when applicable:
 
 ```bash
-gh pr merge --squash --auto --delete-branch
+gh pr merge <resolved-pr> --squash --auto --delete-branch
 ```
 
 If `--auto` succeeds: record `MERGE_PATH=auto`. This means the repo has auto-merge enabled
@@ -27,8 +49,11 @@ the flow is unaffected — but do not report the second one as "auto-merge is di
    before this step runs.
 
 ```bash
-gh pr merge --squash --delete-branch
+gh pr merge <resolved-pr> --squash --delete-branch
 ```
+
+Merge-method flags belong only to `gh pr merge`. Keep branch upload as an ordinary
+`git push`; PR merge policy does not make squash an option or requirement for push.
 
 If direct merge succeeds: record `MERGE_PATH=direct`. Tell the user: "PR merged successfully. The branch has been cleaned up."
 

--- a/test/helpers/carve-guards.ts
+++ b/test/helpers/carve-guards.ts
@@ -471,7 +471,7 @@ export const CARVE_GUARDS: Record<string, CarveGuard> = {
       mustPrecedeStop: ['land-deploy-confirmed'],
       mustMoveToSection: [
         'PRE-MERGE READINESS REPORT',
-        'gh pr merge --squash --auto --delete-branch',
+        'gh pr merge <resolved-pr> --squash --auto --delete-branch',
         'DEPLOY INFRASTRUCTURE VALIDATION',
       ],
       gateAfterStop: undefined, // operational skill

--- a/test/land-and-deploy-merge-method.test.ts
+++ b/test/land-and-deploy-merge-method.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const template = readFileSync(
+  join(
+    import.meta.dir,
+    '..',
+    'land-and-deploy',
+    'sections',
+    'merge-and-deploy.md.tmpl',
+  ),
+  'utf8',
+);
+
+describe('land-and-deploy merge command invariants', () => {
+  test('every non-interactive merge example binds one target and one method', () => {
+    const commands = template.match(/^gh pr merge\b.*$/gm) ?? [];
+    expect(commands.length).toBeGreaterThan(0);
+
+    for (const command of commands) {
+      const tokens = command.split(/\s+/);
+      expect(tokens[3]).toBe('<resolved-pr>');
+      const methodCount = ['--merge', '--rebase', '--squash'].filter((flag) =>
+        tokens.includes(flag),
+      ).length;
+      expect(methodCount).toBe(1);
+    }
+  });
+
+  test('push examples never receive a PR merge-method flag', () => {
+    expect(template).not.toContain('git push --squash');
+    expect(template).not.toContain('git push --merge');
+    expect(template).not.toContain('git push --rebase');
+  });
+});


### PR DESCRIPTION
## Summary
- Treat squash as the recommended default instead of a mandatory merge method.
- Honor explicit user choices and documented project constraints after intersecting them with GitHub repository capabilities.
- Bind each non-interactive merge command to an explicit PR target and exactly one resolved method.
- Keep ordinary git push behavior separate from PR merge policy.
- Update the carved-section invariant for the resolved command shape.

## Commit structure
- Source template, regression tests, and carve guard.
- Generated merge-and-deploy section in a separate commit.

## Tests
- Merge-method and carve-ordering tests: 22 passed, 0 failed.
- Generated skill freshness passes for all supported hosts.
- Full free suite was run on 13900k; unrelated environment/baseline failures reproduce on unmodified origin/main (missing node, touchfile anchor, handoff, ship-version fixtures).
- git diff --check passes.

## Behavior examples
- Repositories that allow squash default to squash.
- A repository that only allows rebase automatically uses rebase and reports the constraint.
- When squash is unavailable and multiple alternatives remain, the workflow asks instead of guessing.