### PR TITLE
fix(open-gstack-browser): pre-flight cleanup never killed the stale daemon

### DIFF
--- a/open-gstack-browser/SKILL.md
+++ b/open-gstack-browser/SKILL.md
@@ -204,7 +204,7 @@ positives and Chromium profile lock conflicts.
 ```bash
 # Kill any existing browse server
 if [ -f "$(git rev-parse --show-toplevel 2>/dev/null)/.gstack/browse.json" ]; then
-  _OLD_PID=$(cat "$(git rev-parse --show-toplevel)/.gstack/browse.json" 2>/dev/null | grep -o '"pid":[0-9]*' | grep -o '[0-9]*')
+  _OLD_PID=$(cat "$(git rev-parse --show-toplevel)/.gstack/browse.json" 2>/dev/null | grep -o '"pid":[[:space:]]*[0-9]*' | grep -o '[0-9]*')
   [ -n "$_OLD_PID" ] && kill "$_OLD_PID" 2>/dev/null || true
   sleep 1
   [ -n "$_OLD_PID" ] && kill -9 "$_OLD_PID" 2>/dev/null || true
@@ -249,7 +249,7 @@ $B status
 Confirm the output shows `Mode: headed`. Read the port from the state file:
 
 ```bash
-cat "$(git rev-parse --show-toplevel 2>/dev/null)/.gstack/browse.json" 2>/dev/null | grep -o '"port":[0-9]*' | grep -o '[0-9]*'
+cat "$(git rev-parse --show-toplevel 2>/dev/null)/.gstack/browse.json" 2>/dev/null | grep -o '"port":[[:space:]]*[0-9]*' | grep -o '[0-9]*'
 ```
 
 The port should be **34567**. If it's different, note it — the user may need it

--- a/open-gstack-browser/SKILL.md.tmpl
+++ b/open-gstack-browser/SKILL.md.tmpl
@@ -39,7 +39,7 @@ positives and Chromium profile lock conflicts.
 ```bash
 # Kill any existing browse server
 if [ -f "$(git rev-parse --show-toplevel 2>/dev/null)/.gstack/browse.json" ]; then
-  _OLD_PID=$(cat "$(git rev-parse --show-toplevel)/.gstack/browse.json" 2>/dev/null | grep -o '"pid":[0-9]*' | grep -o '[0-9]*')
+  _OLD_PID=$(cat "$(git rev-parse --show-toplevel)/.gstack/browse.json" 2>/dev/null | grep -o '"pid":[[:space:]]*[0-9]*' | grep -o '[0-9]*')
   [ -n "$_OLD_PID" ] && kill "$_OLD_PID" 2>/dev/null || true
   sleep 1
   [ -n "$_OLD_PID" ] && kill -9 "$_OLD_PID" 2>/dev/null || true
@@ -84,7 +84,7 @@ $B status
 Confirm the output shows `Mode: headed`. Read the port from the state file:
 
 ```bash
-cat "$(git rev-parse --show-toplevel 2>/dev/null)/.gstack/browse.json" 2>/dev/null | grep -o '"port":[0-9]*' | grep -o '[0-9]*'
+cat "$(git rev-parse --show-toplevel 2>/dev/null)/.gstack/browse.json" 2>/dev/null | grep -o '"port":[[:space:]]*[0-9]*' | grep -o '[0-9]*'
 ```
 
 The port should be **34567**. If it's different, note it — the user may need it

--- a/test/skill-browse-state-extraction.test.ts
+++ b/test/skill-browse-state-extraction.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+// Tripwire for the pid/port extraction snippets in /open-gstack-browser.
+//
+// Step 0 (pre-flight cleanup) reads the stale daemon's pid out of
+// .gstack/browse.json to kill it; Step 2 reads the port back to tell the user
+// which one the Side Panel needs. Both used `grep -o '"pid":[0-9]*'`, which
+// cannot match: every writer of that file in browse/src/server.ts serializes
+// with `JSON.stringify(state, null, 2)`, so the real bytes are `"pid": 12060`
+// — colon, SPACE, digits.
+//
+// The failure was silent in the worst way. `_OLD_PID` came back empty, the
+// `kill` never ran, browse.json was deleted anyway, and the next `connect`
+// died with "existing daemon has different config (proxy/headed mismatch)"
+// — an error that points at proxy/headed flags, not at the cleanup that
+// no-opped. Observed 2026-08-28 against a daemon left over from a reboot.
+//
+// So this test does not match strings; it RUNS the snippets the skill tells
+// the agent to run, against a state file written exactly the way the server
+// writes one, and asserts the values come back out.
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const SKILL = path.join(ROOT, 'open-gstack-browser', 'SKILL.md');
+const TMPL = path.join(ROOT, 'open-gstack-browser', 'SKILL.md.tmpl');
+
+/** The exact shape browse/src/server.ts writes (JSON.stringify(state, null, 2)). */
+function writeStateFile(dir: string, pid: number, port: number): string {
+  const file = path.join(dir, 'browse.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify({ pid, port, token: 'not-a-real-token', mode: 'headed' }, null, 2),
+  );
+  return file;
+}
+
+/** Pull the grep pipeline for `field` out of the skill prose and run it. */
+function extractViaSkill(source: string, field: 'pid' | 'port', stateFile: string): string {
+  const line = source
+    .split('\n')
+    .find((l) => l.includes(`grep -o '"${field}":`));
+  expect(line, `no ${field} extraction line found in the skill`).toBeDefined();
+
+  // Keep only the pipeline itself: everything from the first `grep` on, so the
+  // surrounding shell (cat of a git-root path, variable assignment) does not
+  // have to be reproduced here.
+  const pipeline = line!.slice(line!.indexOf('grep -o'));
+  const script = `cat ${JSON.stringify(stateFile)} | ${pipeline.replace(/\)$/, '')}`;
+  return execFileSync('bash', ['-c', script], { encoding: 'utf-8' }).trim();
+}
+
+describe('/open-gstack-browser state-file extraction', () => {
+  for (const [label, file] of [['generated', SKILL], ['template', TMPL]] as const) {
+    test(`${label}: pid and port survive the pretty-printed state file`, () => {
+      const source = fs.readFileSync(file, 'utf-8');
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'browse-state-'));
+      try {
+        const stateFile = writeStateFile(dir, 12060, 34567);
+        expect(extractViaSkill(source, 'pid', stateFile)).toBe('12060');
+        expect(extractViaSkill(source, 'port', stateFile)).toBe('34567');
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  }
+
+  test('server.ts still writes the state file pretty-printed', () => {
+    // If a refactor ever switches to compact JSON, the snippets above keep
+    // working (the pattern tolerates zero spaces too) — but the reason this
+    // test exists changes, so make the coupling visible instead of implicit.
+    const server = fs.readFileSync(path.join(ROOT, 'browse', 'src', 'server.ts'), 'utf-8');
+    expect(server).toContain('JSON.stringify(state, null, 2)');
+  });
+});


### PR DESCRIPTION
## The bug

Step 0 of `/open-gstack-browser` reads the stale daemon's pid out of
`.gstack/browse.json` so it can kill it, and Step 2 reads the port back to tell
the user which one the Side Panel needs. Both use:

```bash
grep -o '"pid":[0-9]*'
```

That pattern cannot match. Every writer of the state file in
`browse/src/server.ts` serializes with `JSON.stringify(state, null, 2)`, so the
bytes on disk are `"pid": 12060`, with a space after the colon.

## Why it is worth fixing

The failure is silent and it misdirects. `_OLD_PID` comes back empty, the
`kill` never runs, `browse.json` is deleted anyway, and the next `connect`
fails with:

```
[browse] existing daemon has different config (proxy/headed mismatch).
[browse] run 'browse disconnect' first to apply --proxy/--headed.
```

The operator is now looking at proxy and headed flags they never passed. The
actual problem is a cleanup step that reported success while doing nothing.

Hit twice on the same machine: once with a daemon left over from a reboot, and
again an hour later with a daemon left in headless config.

## Repro

```bash
printf '{\n  "pid": 12060\n}\n' | grep -o '"pid":[0-9]*' | grep -o '[0-9]*'
# prints nothing
printf '{\n  "pid": 12060\n}\n' | grep -o '"pid":[[:space:]]*[0-9]*' | grep -o '[0-9]*'
# prints 12060
```

## The fix

Both patterns accept optional whitespace. Template and generated SKILL.md are
regenerated together via `bun run gen:skill-docs`.

## Test

`test/skill-browse-state-extraction.test.ts` does not match strings. It pulls
the grep pipeline out of the skill prose, runs it against a state file written
exactly the way the server writes one, and asserts pid and port come back out.
A third case pins the coupling to `JSON.stringify(state, null, 2)`, so a switch
to compact JSON shows up as a failing expectation rather than as silence.

Both the template and the generated file are checked, so regenerating from a
stale template cannot quietly reintroduce the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111Mq3JGwZDcstn5wYcbhSw
