### PR TITLE
fix(ship): point design-checklist at installed gstack/review path

### DIFF
--- a/scripts/resolvers/design.ts
+++ b/scripts/resolvers/design.ts
@@ -44,7 +44,7 @@ source <(${ctx.paths.binDir}/gstack-diff-scope <base> 2>/dev/null)
 
 1. **Check for DESIGN.md.** If \`DESIGN.md\` or \`design-system.md\` exists in the repo root, read it. All design findings are calibrated against it — patterns blessed in DESIGN.md are not flagged. If not found, use universal design principles.
 
-2. **Read \`.claude/skills/review/design-checklist.md\`.** If the file cannot be read, skip design review with a note: "Design checklist not found — skipping design review."
+2. **Read \`~/.claude/skills/gstack/review/design-checklist.md\`.** If the file cannot be read, skip design review with a note: "Design checklist not found — skipping design review."
 
 3. **Read each changed frontend file** (full file, not just diff hunks). Frontend files are identified by the patterns listed in the checklist.
 

--- a/ship/sections/review-army.md
+++ b/ship/sections/review-army.md
@@ -88,7 +88,7 @@ source <(~/.claude/skills/gstack/bin/gstack-diff-scope <base> 2>/dev/null)
 
 1. **Check for DESIGN.md.** If `DESIGN.md` or `design-system.md` exists in the repo root, read it. All design findings are calibrated against it — patterns blessed in DESIGN.md are not flagged. If not found, use universal design principles.
 
-2. **Read `.claude/skills/review/design-checklist.md`.** If the file cannot be read, skip design review with a note: "Design checklist not found — skipping design review."
+2. **Read `~/.claude/skills/gstack/review/design-checklist.md`.** If the file cannot be read, skip design review with a note: "Design checklist not found — skipping design review."
 
 3. **Read each changed frontend file** (full file, not just diff hunks). Frontend files are identified by the patterns listed in the checklist.
 

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -1700,7 +1700,7 @@ source <($GSTACK_BIN/gstack-diff-scope <base> 2>/dev/null)
 
 1. **Check for DESIGN.md.** If `DESIGN.md` or `design-system.md` exists in the repo root, read it. All design findings are calibrated against it — patterns blessed in DESIGN.md are not flagged. If not found, use universal design principles.
 
-2. **Read `.agents/skills/gstack/review/design-checklist.md`.** If the file cannot be read, skip design review with a note: "Design checklist not found — skipping design review."
+2. **Read `$GSTACK_ROOT/review/design-checklist.md`.** If the file cannot be read, skip design review with a note: "Design checklist not found — skipping design review."
 
 3. **Read each changed frontend file** (full file, not just diff hunks). Frontend files are identified by the patterns listed in the checklist.
 

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -1707,7 +1707,7 @@ source <($GSTACK_BIN/gstack-diff-scope <base> 2>/dev/null)
 
 1. **Check for DESIGN.md.** If `DESIGN.md` or `design-system.md` exists in the repo root, read it. All design findings are calibrated against it — patterns blessed in DESIGN.md are not flagged. If not found, use universal design principles.
 
-2. **Read `.factory/skills/gstack/review/design-checklist.md`.** If the file cannot be read, skip design review with a note: "Design checklist not found — skipping design review."
+2. **Read `$GSTACK_ROOT/review/design-checklist.md`.** If the file cannot be read, skip design review with a note: "Design checklist not found — skipping design review."
 
 3. **Read each changed frontend file** (full file, not just diff hunks). Frontend files are identified by the patterns listed in the checklist.
 

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1778,6 +1778,16 @@ describe('DESIGN_REVIEW_LITE extended with Codex', () => {
     expect(content).toContain('SCOPE_FRONTEND');
   });
 
+  test('design-checklist path uses installed gstack/review root (#2694)', () => {
+    // #2694: generateDesignReviewLite used to emit
+    // `.claude/skills/review/design-checklist.md` (missing the gstack/ segment).
+    // After install the file lives at ~/.claude/skills/gstack/review/design-checklist.md.
+    // The bad relative form must not appear — the good path does not contain it
+    // as a substring because `gstack/` sits between `skills/` and `review/`.
+    expect(content).toContain('~/.claude/skills/gstack/review/design-checklist.md');
+    expect(content).not.toContain('.claude/skills/review/design-checklist.md');
+  });
+
 });
 
 // ─── Codex Generation Tests ─────────────────────────────────


### PR DESCRIPTION
## Why

The `design-review-army` resolver emits the design-checklist path without the `gstack/` namespace segment:

- `scripts/resolvers/design.ts:47` emits `~/.claude/skills/review/design-checklist.md`, but the file is installed at `~/.claude/skills/gstack/review/design-checklist.md`.
- The same resolver already uses the correct namespaced form elsewhere in the file (the `~/.claude/skills/gstack/review/...` shape), so this is an inconsistency within one resolver.
- #2661 fixed the sibling `checklist.md` path in this section but missed `design-checklist.md`, so the broken path survives on current `main` (verified at `394db32`, v1.71.0.0: generated `ship/sections/review-army.md:91` still carries the broken path, while line 185 of the same generated file shows the correct form).

## What changed

- `scripts/resolvers/design.ts` — one line: point the design-checklist path at `~/.claude/skills/gstack/review/design-checklist.md`.
- `ship/sections/review-army.md` — regenerated (the only shipped artifact that references this resolver output).
- `test/gen-skill-docs.test.ts` — new regression assertion locking the corrected path.
- `test/fixtures/golden/codex-ship-SKILL.md`, `test/fixtures/golden/factory-ship-SKILL.md` — regenerated. After the fix, the codex/factory path rewrites render the checklist as `$GSTACK_ROOT/review/design-checklist.md`, which is the canonical form already used by the existing golden line (matches the `pathRewrites` in `hosts/codex.ts` / `hosts/factory.ts`).

## Live evidence

- On `main` (`394db32`): generated `ship/sections/review-army.md:91` contains `.claude/skills/review/design-checklist.md` (broken; missing the `gstack/` segment). Line 185 of the same file shows the correct form.
- After the fix + `bun run gen:skill-docs`: line 91 renders `~/.claude/skills/gstack/review/design-checklist.md`, byte-identical to the canonical form used at line 185.
- Mutation check: reverting the source line (reintroducing the broken path) fails the new regression assertion; restoring it goes back to green — the guard actually bites.
- `bun run gen-skill-docs --host all` regenerates a clean tree: `--dry-run` reports FRESH, no diff.
- `bun test test/gen-skill-docs.test.ts` → 416 pass / 0 fail (includes the new assertion and the updated goldens).
- `bun test test/host-config.test.ts` → 76 pass / 0 fail.
- Same fix shape as #2661 (correct the resolver path, regenerate), which landed in v1.68.0.0.

## Scope

- No runtime code touched; this is a resolver output fix plus regeneration and test coverage.
- Not addressed here (separate residue noted in #2661 discussion): the `TODOS-format.md` reference in `ship/SKILL.md.tmpl` — deliberately left out to keep this diff minimal.

## Did NOT test

- End-to-end inside a live `gstack ship` session (the fix is verified at the generator/output/golden level; the skill content itself is unchanged prose).

Fixes #2694
