### PR TITLE
fix: bin writers drop data on paths containing apostrophes; --derive fails on MSYS-form GSTACK_HOME

### DIFF
--- a/bin/gstack-developer-profile
+++ b/bin/gstack-developer-profile
@@ -30,6 +30,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # GSTACK_STATE_ROOT takes precedence over GSTACK_HOME (test isolation per D16).
 GSTACK_HOME="${GSTACK_STATE_ROOT:-${GSTACK_HOME:-$HOME/.gstack}}"
+# Windows git-bash: GSTACK_HOME resolves to an MSYS path (/c/Users/...), which
+# Bun on Windows cannot open as a filesystem path (bites --derive). Normalize
+# once, here, before PROFILE_FILE/LEGACY_FILE are derived from it below —
+# doing it after would leave those two on the stale MSYS form.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) command -v cygpath >/dev/null 2>&1 && GSTACK_HOME="$(cygpath -m "$GSTACK_HOME")" ;;
+esac
 PROFILE_FILE="$GSTACK_HOME/developer-profile.json"
 LEGACY_FILE="$GSTACK_HOME/builder-profile.jsonl"
 eval "$("$SCRIPT_DIR/gstack-slug" 2>/dev/null || true)"
@@ -115,7 +122,7 @@ do_migrate() {
   mv "$LEGACY_FILE" "$LEGACY_FILE.migrated-$TS"
 
   local COUNT
-  COUNT=$(bun -e "console.log(JSON.parse(require('fs').readFileSync('$PROFILE_FILE','utf-8')).sessions.length)" 2>/dev/null || echo "?")
+  COUNT=$(PROFILE_FILE_PATH="$PROFILE_FILE" bun -e "console.log(JSON.parse(require('fs').readFileSync(process.env.PROFILE_FILE_PATH,'utf-8')).sessions.length)" 2>/dev/null || echo "?")
   echo "MIGRATE: ok — migrated $COUNT sessions from builder-profile.jsonl"
 }
 

--- a/bin/gstack-learnings-log
+++ b/bin/gstack-learnings-log
@@ -25,8 +25,8 @@ INPUT="$1"
 TMPERR=$(mktemp)
 trap 'rm -f "$TMPERR"' EXIT
 set +e
-VALIDATED=$(printf '%s' "$INPUT" | bun -e "
-import { hasInjection } from '$SCRIPT_DIR/../lib/jsonl-store.ts';
+VALIDATED=$(cd "$SCRIPT_DIR/.." && printf '%s' "$INPUT" | bun -e "
+import { hasInjection } from './lib/jsonl-store.ts';
 const raw = await Bun.stdin.text();
 let j;
 try { j = JSON.parse(raw); } catch { process.stderr.write('gstack-learnings-log: invalid JSON, skipping\n'); process.exit(1); }

--- a/bin/gstack-question-log
+++ b/bin/gstack-question-log
@@ -44,8 +44,8 @@ INPUT="$1"
 TMPERR=$(mktemp)
 trap 'rm -f "$TMPERR"' EXIT
 set +e
-VALIDATED=$(printf '%s' "$INPUT" | bun -e "
-import { hasInjection } from '$SCRIPT_DIR/../lib/jsonl-store.ts';
+VALIDATED=$(cd "$SCRIPT_DIR/.." && printf '%s' "$INPUT" | bun -e "
+import { hasInjection } from './lib/jsonl-store.ts';
 const path = require('path');
 const raw = await Bun.stdin.text();
 let j;

--- a/bin/gstack-telemetry-log
+++ b/bin/gstack-telemetry-log
@@ -192,8 +192,8 @@ ERR_FIELD="null"
 # look like a JSON string, the whole message becomes null — never raw.
 ERR_MSG_FIELD="null"
 if [ -n "$ERROR_MESSAGE" ]; then
-  ERR_MSG_FIELD="$(printf '%s' "$ERROR_MESSAGE" | bun -e "
-import { redactFindingSpans } from '$SCRIPT_DIR/../lib/redact-engine.ts';
+  ERR_MSG_FIELD="$(cd "$SCRIPT_DIR/.." && printf '%s' "$ERROR_MESSAGE" | bun -e "
+import { redactFindingSpans } from './lib/redact-engine.ts';
 const input = await Bun.stdin.text();
 const out = redactFindingSpans(input, { repoVisibility: 'private' });
 if (out === null) process.exit(1);

--- a/test/hostile-path-writers.test.ts
+++ b/test/hostile-path-writers.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { spawnSync } from 'child_process';
+
+/**
+ * Regression tests for the two Windows path bugs in the bin writers:
+ *
+ * 1. A checkout path containing an apostrophe used to terminate the JS
+ *    single-quoted string literal that `bun -e` programs interpolated
+ *    SCRIPT_DIR into (gstack-learnings-log, gstack-question-log,
+ *    gstack-telemetry-log, gstack-developer-profile). The scripts exited 1
+ *    but callers invoke them with 2>/dev/null, so every learning and every
+ *    plan-tune question event was dropped with no visible error.
+ *
+ * 2. gstack-developer-profile passed an MSYS-form GSTACK_HOME (/c/Users/...)
+ *    to Bun, which cannot open it — --derive always failed ENOENT on
+ *    Windows git-bash.
+ *
+ * The apostrophe repro is OS-independent: SCRIPT_DIR derives from the
+ *  script's own location, so running the bins from a copied checkout under a
+ * hostile directory name reproduces bug 1 on Linux/macOS CI too.
+ *
+ * These tests assert rows are ACTUALLY WRITTEN, not merely that the exit
+ * code is 0 — exit-code-only assertions are exactly what masked bug 1.
+ */
+
+const HOSTILE = path.join(os.tmpdir(), "gstack o'brien test");
+const STATE = path.join(HOSTILE, 'state');
+const REPO = path.resolve(import.meta.dir, '..');
+
+function runBin(bin: string, args: string[], env: Record<string, string> = {}) {
+  // Invoke through bash explicitly: the bins are shell scripts, and Windows
+  // cannot exec a shebang script directly (spawn would fail before the code
+  // under test ever ran).
+  const r = spawnSync('bash', [path.join(HOSTILE, 'bin', bin), ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, GSTACK_HOME: STATE, GSTACK_STATE_ROOT: '', ...env },
+    shell: false,
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+beforeAll(() => {
+  fs.rmSync(HOSTILE, { recursive: true, force: true });
+  fs.mkdirSync(STATE, { recursive: true });
+  // The bins resolve SCRIPT_DIR from their own location and import ../lib and
+  // ../scripts relative to it, so copy all three alongside each other.
+  for (const dir of ['bin', 'lib', 'scripts']) {
+    fs.cpSync(path.join(REPO, dir), path.join(HOSTILE, dir), { recursive: true });
+  }
+});
+
+afterAll(() => {
+  fs.rmSync(HOSTILE, { recursive: true, force: true });
+});
+
+describe('bin writers under a path containing an apostrophe', () => {
+  test('gstack-learnings-log appends a row (not just exit 0)', () => {
+    const r = runBin('gstack-learnings-log', [
+      JSON.stringify({
+        skill: 't', type: 'tool', key: 'hostile-path-probe',
+        insight: 'row must land even under a hostile checkout path',
+        confidence: 5, source: 'observed',
+      }),
+    ]);
+    expect(r.status).toBe(0);
+    expect(r.stderr ?? '').not.toContain('Expected ";"');
+
+    const projects = path.join(STATE, 'projects');
+    const rows: string[] = [];
+    for (const slug of fs.readdirSync(projects)) {
+      const f = path.join(projects, slug, 'learnings.jsonl');
+      if (fs.existsSync(f)) rows.push(...fs.readFileSync(f, 'utf-8').trim().split('\n'));
+    }
+    const parsed = rows.map((l) => JSON.parse(l));
+    expect(parsed.some((j) => j.key === 'hostile-path-probe')).toBe(true);
+  });
+
+  test('gstack-question-log gets past module resolution to its own validation', () => {
+    // An intentionally incomplete event: reaching the field-validation error
+    // proves the bun -e program parsed and ran, which is the regression under
+    // test. (A full happy-path event would couple this test to the question
+    // registry's required fields.)
+    const r = runBin('gstack-question-log', [
+      JSON.stringify({ skill: 't', question_id: 'hostile-path-probe', user_choice: 'a' }),
+    ]);
+    expect(r.stderr ?? '').not.toContain('Expected ";"');
+    expect(r.stderr ?? '').not.toContain('Cannot find module');
+  });
+
+  test('gstack-developer-profile --derive resolves GSTACK_HOME for Bun', () => {
+    const r = runBin('gstack-developer-profile', ['--derive']);
+    expect(r.stdout + r.stderr).not.toContain('ENOENT');
+    expect(r.stdout).toContain('DERIVE: ok');
+  });
+});


### PR DESCRIPTION
Two independent Windows path bugs in the bin writers. Found on a real Windows 11
/ git-bash install (gstack 1.69.0.0, Bun 1.3.13) where the user folder contains
an apostrophe — think `C:\Users\O'Brien`. Fixes verified against v1.72.0.0.

The practical impact on that machine: **every AI-logged learning and every
plan-tune question event was dropped with no visible error, since install.**
`question-log.jsonl` had never been written a single time, so `/plan-tune` had
no events to derive from and the developer profile stayed at its defaults
indefinitely.

### Bug 1 — an apostrophe in the checkout path breaks the `bun -e` writers

Four scripts interpolate a shell path into a JS **single-quoted** string
literal inside a `bun -e` program:

```bash
VALIDATED=$(printf '%s' "$INPUT" | bun -e "
import { hasInjection } from '$SCRIPT_DIR/../lib/jsonl-store.ts';
```

With an apostrophe anywhere in the path, the emitted JS string literal
terminates early and Bun dies at parse time:

```
error: Expected ";" but found "..."
```

| site | severity when it fires |
| --- | --- |
| `bin/gstack-learnings-log:29` | **data loss** — every learning write no-ops |
| `bin/gstack-question-log:48` | **data loss** — every plan-tune event no-ops |
| `bin/gstack-telemetry-log:196` | degraded — the fail-closed redaction path kicks in, telemetry error messages always become `null` |
| `bin/gstack-developer-profile:118` | cosmetic — success path of a completed migration; only the printed session count degrades to `?` |

The scripts themselves behave correctly (exit 1, error on stderr). The failure
is invisible in practice because callers invoke these bins with `2>/dev/null`
and don't check the exit status — which may be worth a separate look, since it
would have surfaced this months earlier.

Not OS-specific and no user account needed to reproduce — `SCRIPT_DIR` derives
from the script's own location:

```bash
mkdir -p "/tmp/o'brien" && cp -r bin lib scripts "/tmp/o'brien/"
"/tmp/o'brien/bin/gstack-learnings-log" \
  '{"skill":"t","type":"tool","key":"probe","insight":"x","confidence":5,"source":"observed"}'
# error: Expected ";" but found "brien"   (exit 1, nothing written)
```

Why the #1950 fix didn't cover this: all three `SCRIPT_DIR` sites already run
`SCRIPT_DIR` through `cygpath -m` for #1950, but that converts `/c/Users/X` to
`C:/Users/X` — it doesn't remove an apostrophe, so this survived it untouched.

**Fix:** stop interpolating the path into the program at all.

- The three import sites now `cd "$SCRIPT_DIR/.."` inside the command
  substitution and import `./lib/...` relatively — immune to apostrophes,
  spaces, backslashes, and MSYS forms, and it removes the need for the
  `cygpath` dance on those lines.
- The one data-path site (`developer-profile:118`, a `readFileSync`, not an
  import) passes the path through the environment instead — the same pattern
  `do_log_session` in the same file already uses.

### Bug 2 — `--derive` hands an MSYS-form path to Bun

```
$ gstack-developer-profile --derive
DERIVE: ENOENT: no such file or directory, open '/c/Users/.../.gstack/developer-profile.json'
```

`GSTACK_HOME` defaults to `$HOME/.gstack`, which under git-bash is
`/c/Users/...`, and Bun on Windows can't open that form. Not
apostrophe-specific: this should affect **every** Windows git-bash install,
meaning the inferred half of the plan-tune profile never updates on Windows.

`gstack-developer-profile` is the one writer with no `cygpath` guard, and the
one that passes filesystem paths to Bun most often.

**Fix:** normalize `GSTACK_HOME` once, with the same guard the other writers
use — placed **before** `PROFILE_FILE` / `LEGACY_FILE` are derived from it, so
they inherit the normalized form.

### Regression test

`test/hostile-path-writers.test.ts` (bun test, matching the existing harness):
copies `bin/`, `lib/`, `scripts/` into a temp directory containing an
apostrophe and asserts that

- `gstack-learnings-log` **actually appends a row** — not merely exit 0, since
  exit-code-only checks are exactly what masked Bug 1;
- `gstack-question-log` gets past module resolution to its own field
  validation;
- `--derive` completes without `ENOENT`.

Verified in both directions: 3/3 pass with the fix, 2/3 fail against stock
(the apostrophe repro is OS-independent, so this guards on Linux CI too). One
honest limitation: the `--derive` case is a smoke check — Bug 2's true trigger
is a real git-bash MSYS `$HOME`, which can't be cleanly simulated inside `bun
test` on CI.

### Validation on the affected machine

- All four writers execute past the failure point under the apostrophe path.
- `gstack-learnings-log` appended its first successfully persisted row on that
  machine.
- `--derive` returns `DERIVE: ok` instead of `ENOENT`.

---

This fix was developed with AI assistance (Claude); the diagnosis, the diff,
and the test were human-reviewed and verified end to end before filing.
