### PR TITLE
fix(land-and-deploy): check fork branches in head repo

### DIFF
--- a/land-and-deploy/sections/merge-and-deploy.md
+++ b/land-and-deploy/sections/merge-and-deploy.md
@@ -78,14 +78,22 @@ Identify candidates: a worktree is stale if (a) it is checked out on the base br
 Remote-branch reconciliation — the failed `gh pr merge` carried `--delete-branch`, and this recovery path must not silently drop that half. The success path above says "The branch has been cleaned up"; this path states the branch outcome explicitly instead of staying silent:
 
 ```bash
-BRANCH=$(gh pr view --json headRefName -q .headRefName)
-git ls-remote --heads origin "$BRANCH"
+gh pr view --json headRepository,headRefName \
+  --jq '[.headRepository.nameWithOwner, .headRefName] | @tsv'
+git ls-remote --heads "https://github.com/<head-repository>.git" "<head-branch>"
 ```
+
+Record the first field as `<head-repository>` (`owner/name`) and the second as
+`<head-branch>`, then substitute both into `git ls-remote`. The PR head repository is
+the authoritative branch location: for same-repository PRs it is the base repository;
+for fork PRs it is the fork. Do not substitute the checkout's `origin`. If the metadata
+lookup fails or either field is empty, treat the branch state as unknown and do not run
+the deletion path.
 
 Three outcomes — never read a failed check as a clean branch:
 
 - **Exit 0, empty output** — the remote branch is already gone (GitHub's post-merge deletion or a concurrent actor got there). Tell the user: "The remote branch has already been cleaned up." This makes re-runs of the recovery idempotent.
-- **Exit 0, one ref line** — the branch survived: the failed merge command never reached its `--delete-branch` half. OFFER deletion, confirm-first (matching the worktree-cleanup posture above): "The remote branch `<BRANCH>` still exists — the failed merge never ran its --delete-branch half. Delete it?" Only on confirmation: `git push origin --delete "$BRANCH"`. If a local branch of the same name exists, offer `git branch -d "$BRANCH"` alongside (`-d`, never `-D` — a non-fast-forwarded local branch is the user's call).
+- **Exit 0, one ref line** — the branch survived: the failed merge command never reached its `--delete-branch` half. OFFER deletion, confirm-first (matching the worktree-cleanup posture above): "The remote branch `<head-branch>` still exists in `<head-repository>` — the failed merge never ran its --delete-branch half. Delete it?" Only on confirmation: `git push "https://github.com/<head-repository>.git" --delete "<head-branch>"`. If a local branch of the same name exists, offer `git branch -d "<head-branch>"` alongside (`-d`, never `-D` — a non-fast-forwarded local branch is the user's call).
 - **Non-zero exit** — the check ITSELF failed (network, auth). Tell the user: "Couldn't verify remote branch state — leaving it alone." and skip the deletion offer entirely; a failed check is unknown state, not a clean branch.
 
 Record `MERGE_PATH=direct`, then continue to §4a (CI auto-deploy detection).

--- a/land-and-deploy/sections/merge-and-deploy.md.tmpl
+++ b/land-and-deploy/sections/merge-and-deploy.md.tmpl
@@ -76,14 +76,22 @@ Identify candidates: a worktree is stale if (a) it is checked out on the base br
 Remote-branch reconciliation — the failed `gh pr merge` carried `--delete-branch`, and this recovery path must not silently drop that half. The success path above says "The branch has been cleaned up"; this path states the branch outcome explicitly instead of staying silent:
 
 ```bash
-BRANCH=$(gh pr view --json headRefName -q .headRefName)
-git ls-remote --heads origin "$BRANCH"
+gh pr view --json headRepository,headRefName \
+  --jq '[.headRepository.nameWithOwner, .headRefName] | @tsv'
+git ls-remote --heads "https://github.com/<head-repository>.git" "<head-branch>"
 ```
+
+Record the first field as `<head-repository>` (`owner/name`) and the second as
+`<head-branch>`, then substitute both into `git ls-remote`. The PR head repository is
+the authoritative branch location: for same-repository PRs it is the base repository;
+for fork PRs it is the fork. Do not substitute the checkout's `origin`. If the metadata
+lookup fails or either field is empty, treat the branch state as unknown and do not run
+the deletion path.
 
 Three outcomes — never read a failed check as a clean branch:
 
 - **Exit 0, empty output** — the remote branch is already gone (GitHub's post-merge deletion or a concurrent actor got there). Tell the user: "The remote branch has already been cleaned up." This makes re-runs of the recovery idempotent.
-- **Exit 0, one ref line** — the branch survived: the failed merge command never reached its `--delete-branch` half. OFFER deletion, confirm-first (matching the worktree-cleanup posture above): "The remote branch `<BRANCH>` still exists — the failed merge never ran its --delete-branch half. Delete it?" Only on confirmation: `git push origin --delete "$BRANCH"`. If a local branch of the same name exists, offer `git branch -d "$BRANCH"` alongside (`-d`, never `-D` — a non-fast-forwarded local branch is the user's call).
+- **Exit 0, one ref line** — the branch survived: the failed merge command never reached its `--delete-branch` half. OFFER deletion, confirm-first (matching the worktree-cleanup posture above): "The remote branch `<head-branch>` still exists in `<head-repository>` — the failed merge never ran its --delete-branch half. Delete it?" Only on confirmation: `git push "https://github.com/<head-repository>.git" --delete "<head-branch>"`. If a local branch of the same name exists, offer `git branch -d "<head-branch>"` alongside (`-d`, never `-D` — a non-fast-forwarded local branch is the user's call).
 - **Non-zero exit** — the check ITSELF failed (network, auth). Tell the user: "Couldn't verify remote branch state — leaving it alone." and skip the deletion offer entirely; a failed check is unknown state, not a clean branch.
 
 Record `MERGE_PATH=direct`, then continue to §4a (CI auto-deploy detection).

--- a/test/land-and-deploy-postfail.test.ts
+++ b/test/land-and-deploy-postfail.test.ts
@@ -92,11 +92,16 @@ describe("PR #1620 §4a-postfail in land-and-deploy template", () => {
 
   // #2656: the failed merge carried --delete-branch; the recovery path must
   // reconcile the remote branch instead of silently dropping that half.
-  test("MERGED branch reconciles the remote branch (ls-remote, confirm-first delete)", () => {
+  // #2696: that reconciliation must target the PR head repository, not the
+  // base checkout's origin, because fork branches do not exist in origin.
+  test("MERGED branch reconciles the PR head repository (ls-remote, confirm-first delete)", () => {
     const body = readTmpl();
-    expect(body).toMatch(/git ls-remote --heads origin "\$BRANCH"/);
-    expect(body).toMatch(/gh pr view --json headRefName -q \.headRefName/);
-    expect(body).toMatch(/git push origin --delete "\$BRANCH"/);
+    expect(body).toMatch(/gh pr view --json headRepository,headRefName/);
+    expect(body).toMatch(/\.headRepository\.nameWithOwner/);
+    expect(body).toMatch(/git ls-remote --heads "https:\/\/github\.com\/<head-repository>\.git" "<head-branch>"/);
+    expect(body).toMatch(/git push "https:\/\/github\.com\/<head-repository>\.git" --delete "<head-branch>"/);
+    expect(body).not.toMatch(/git ls-remote --heads origin/);
+    expect(body).not.toMatch(/git push origin --delete/);
     // Confirm-first: deletion is offered, never unilateral.
     expect(body).toMatch(/Delete it\?/);
   });
@@ -130,5 +135,7 @@ describe("PR #1620 §4a-postfail in land-and-deploy template", () => {
     const md = readMd();
     expect(md).toMatch(/### 4a-postfail: Post-failure PR-state check/);
     expect(md).toMatch(/state == "MERGED"/);
+    expect(md).toMatch(/\.headRepository\.nameWithOwner/);
+    expect(md).not.toMatch(/git ls-remote --heads origin/);
   });
 });


### PR DESCRIPTION
## Why (in your own words)

When a merge succeeds remotely but local cleanup fails, `land-and-deploy` reconciles the PR branch before offering deletion. That check always queried the checkout's `origin`, so a branch from a fork produced an empty result and was incorrectly reported as already cleaned up. This change resolves the PR's actual head repository and uses it consistently for the check and the confirm-first deletion path, while preserving same-repository behavior and failing closed when metadata is unavailable.

## Live evidence

```text
$ gh pr view 2723 --repo garrytan/gstack --json headRepository,headRefName --jq '[.headRepository.nameWithOwner, .headRefName] | @tsv'
yansigit/gstack codex/minimal-codex-plugin

$ git ls-remote --heads https://github.com/garrytan/gstack.git codex/minimal-codex-plugin
# no output (the old origin-based check would classify this as cleaned up)

$ git ls-remote --heads https://github.com/yansigit/gstack.git codex/minimal-codex-plugin
bf78df00... refs/heads/codex/minimal-codex-plugin

$ gh pr view 2722 --repo garrytan/gstack --json headRepository,headRefName --jq '[.headRepository.nameWithOwner, .headRefName] | @tsv'
garrytan/gstack ponytail-inspiration-review

$ git ls-remote --heads https://github.com/garrytan/gstack.git ponytail-inspiration-review
74549cee... refs/heads/ponytail-inspiration-review

$ bun test test/land-and-deploy-postfail.test.ts
14 pass
0 fail
36 expect() calls
```

## Scope

- **Changed:** The §4a-postfail branch reconciliation now reads `headRepository.nameWithOwner` with `headRefName`, queries that repository directly, and uses the same target for any confirmed deletion. Added regression coverage and regenerated the section output.
- **Verified live by:** Comparing a current fork PR (#2723) against both the base repository and its actual head repository; checking a same-repository PR (#2722); running the focused 14-test suite, generated-doc freshness check, `git diff --check`, and the full build.
- **Did NOT test:** An actual post-merge branch deletion, because that would be destructive. Paid Anthropic E2E/LLM evals were not run. The Windows-curated free suite also contains unrelated host-environment failures where symlink creation is denied, `jq` is unavailable, or MSYS path handling differs.

## Liveness proof (required)

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/dac4fb6c-4b1b-4068-8718-11b17999c2a2" />

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A)
- [x] Linked issue or reproduction: #2696