### PR TITLE
Add host configs for Grok Build, Pi, and Antigravity CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ bin/gstack-global-discover*
 .openclaw/
 .hermes/
 .gbrain/
+.grok/
+.pi/
+.agy/
 .gbrain-source
 .context/
 extension/.auth.json

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Or target a specific agent with `./setup --host <name>`:
 | Slate | `--host slate` | `~/.slate/skills/gstack-*/` |
 | Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |
 | Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |
+| Grok Build | `--host grok` | `~/.grok/skills/gstack-*/` |
+| Pi | `--host pi` | `~/.pi/agent/skills/gstack-*/` |
+| Antigravity CLI | `--host agy` | `~/.gemini/config/skills/gstack-*/` |
 | GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |
 
 For Codex, setup reads the top-level `model` from
@@ -398,6 +401,9 @@ rm -rf ~/.kiro/skills/gstack* 2>/dev/null
 rm -rf ~/.openclaw/skills/gstack* 2>/dev/null
 rm -rf ~/.cursor/skills/gstack* 2>/dev/null
 rm -rf ~/.config/opencode/skills/gstack* 2>/dev/null
+rm -rf ~/.grok/skills/gstack* 2>/dev/null
+rm -rf ~/.pi/agent/skills/gstack* 2>/dev/null
+rm -rf ~/.gemini/config/skills/gstack* 2>/dev/null
 
 # 6. Remove temp files
 rm -f /tmp/gstack-* 2>/dev/null

--- a/hosts/agy.ts
+++ b/hosts/agy.ts
@@ -1,0 +1,43 @@
+import { defineHost, CROSS_MODEL_RESOLVERS, GBRAIN_RESOLVERS } from './define-host';
+
+const agy = defineHost({
+  name: 'agy',
+  displayName: 'Antigravity CLI',
+  cliAliases: ['antigravity'],
+
+  // Antigravity resolves user skills from `~/.gemini/config/skills/<name>/`
+  // (global) or `<workspace>/.agents/skills/<name>/` (repo-local). The
+  // repo-local path is the same one Codex uses, so hostSubdir stays '.agy' to
+  // keep generation output from colliding with codex's '.agents' tree, and the
+  // rewrites are written out explicitly rather than derived.
+  globalRoot: '.gemini/config/skills/gstack',
+  localSkillRoot: '.agents/skills/gstack',
+  hostSubdir: '.agy',
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.gemini/config/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.agents/skills/gstack' },
+    { from: '.claude/skills', to: '.agents/skills' },
+    { from: 'CLAUDE.md', to: 'AGENTS.md' },
+  ],
+
+  // Antigravity's tool surface. Note it has no todo tool — `manage_task`
+  // manages background processes, so task tracking is a markdown task
+  // artifact written with write_to_file, and no rewrite should point at it.
+  toolRewrites: {
+    'use the Bash tool': 'use the run_command tool',
+    'use the Write tool': 'use the write_to_file tool',
+    'use the Read tool': 'use the view_file tool',
+    'use the Edit tool': 'use the replace_file_content tool',
+    'use the Agent tool': 'use invoke_subagent',
+    'use the Grep tool': 'search the codebase for',
+    'use the Glob tool': 'find files matching',
+    'the Bash tool': 'the run_command tool',
+    'the Read tool': 'the view_file tool',
+    'the Write tool': 'the write_to_file tool',
+    'the Edit tool': 'the replace_file_content tool',
+  },
+
+  suppressedResolvers: [...CROSS_MODEL_RESOLVERS, ...GBRAIN_RESOLVERS],
+});
+
+export default agy;

--- a/hosts/grok.ts
+++ b/hosts/grok.ts
@@ -1,0 +1,36 @@
+import { defineHost, CROSS_MODEL_RESOLVERS, GBRAIN_RESOLVERS } from './define-host';
+
+const grok = defineHost({
+  name: 'grok',
+  displayName: 'Grok Build',
+
+  // The derived defaults are already correct: Grok reads global skills from
+  // ~/.grok/skills, so globalRoot/.grok/skills/gstack and the standard
+  // `.claude/skills` → `.grok/skills` rewrite both land in the right place.
+
+  extraPathRewrites: [
+    { from: 'CLAUDE.md', to: 'AGENTS.md' },
+  ],
+
+  // Grok's built-in tool names (README "Built-in Tools" table). Note there is
+  // no separate create-file tool — search_replace covers both writes and
+  // edits, and list_dir is the closest thing to a glob.
+  toolRewrites: {
+    'use the Bash tool': 'use the bash tool',
+    'use the Write tool': 'use the search_replace tool',
+    'use the Read tool': 'use the read_file tool',
+    'use the Edit tool': 'use the search_replace tool',
+    'use the Agent tool': 'use the task tool',
+    'use the Grep tool': 'use the grep_search tool',
+    'use the Glob tool': 'use the list_dir tool',
+    'the Bash tool': 'the bash tool',
+    'the Read tool': 'the read_file tool',
+    'the Write tool': 'the search_replace tool',
+    'the Edit tool': 'the search_replace tool',
+  },
+
+  // Grok cannot shell out to Codex, so the cross-model resolvers never apply.
+  suppressedResolvers: [...CROSS_MODEL_RESOLVERS, ...GBRAIN_RESOLVERS],
+});
+
+export default grok;

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -16,9 +16,12 @@ import cursor from './cursor';
 import openclaw from './openclaw';
 import hermes from './hermes';
 import gbrain from './gbrain';
+import grok from './grok';
+import pi from './pi';
+import agy from './agy';
 
 /** All registered host configs. Add new hosts here. */
-export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain];
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, grok, pi, agy];
 
 /** Map from host name to config. */
 export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
@@ -65,4 +68,4 @@ export function getExternalHosts(): HostConfig[] {
 }
 
 // Re-export individual configs for direct import
-export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain };
+export { claude, codex, factory, kiro, opencode, slate, cursor, openclaw, hermes, gbrain, grok, pi, agy };

--- a/hosts/pi.ts
+++ b/hosts/pi.ts
@@ -1,0 +1,40 @@
+import { defineHost, CROSS_MODEL_RESOLVERS, GBRAIN_RESOLVERS } from './define-host';
+
+const pi = defineHost({
+  name: 'pi',
+  displayName: 'Pi',
+
+  // Pi nests its agent state one level deeper than the host name: skills live
+  // in ~/.pi/agent/skills, not ~/.pi/skills. The derived trio would point at
+  // the wrong directory, so the rewrites are spelled out. hostSubdir stays
+  // '.pi' purely as the (gitignored) generation output directory.
+  globalRoot: '.pi/agent/skills/gstack',
+  localSkillRoot: '.pi/agent/skills/gstack',
+  pathRewrites: [
+    { from: '~/.claude/skills/gstack', to: '~/.pi/agent/skills/gstack' },
+    { from: '.claude/skills/gstack', to: '.pi/agent/skills/gstack' },
+    { from: '.claude/skills', to: '.pi/agent/skills' },
+    { from: 'CLAUDE.md', to: 'AGENTS.md' },
+  ],
+
+  // Pi ships read/bash/edit/write as its core tools. It has no first-party
+  // subagent or todo tool: `subagent` comes from the optional pi-subagents
+  // package, and task tracking falls back to plan files or TODO.md.
+  toolRewrites: {
+    'use the Bash tool': 'use the bash tool',
+    'use the Write tool': 'use the write tool',
+    'use the Read tool': 'use the read tool',
+    'use the Edit tool': 'use the edit tool',
+    'use the Agent tool': 'use the subagent tool (requires pi-subagents)',
+    'use the Grep tool': 'search for',
+    'use the Glob tool': 'find files matching',
+    'the Bash tool': 'the bash tool',
+    'the Read tool': 'the read tool',
+    'the Write tool': 'the write tool',
+    'the Edit tool': 'the edit tool',
+  },
+
+  suppressedResolvers: [...CROSS_MODEL_RESOLVERS, ...GBRAIN_RESOLVERS],
+});
+
+export default pi;

--- a/test/host-config.test.ts
+++ b/test/host-config.test.ts
@@ -32,8 +32,8 @@ const RESOLVER_NAMES = new Set(Object.keys(RESOLVERS));
 // ─── hosts/index.ts ─────────────────────────────────────────
 
 describe('hosts/index.ts', () => {
-  test('ALL_HOST_CONFIGS has 10 hosts', () => {
-    expect(ALL_HOST_CONFIGS.length).toBe(10);
+  test('ALL_HOST_CONFIGS has 13 hosts', () => {
+    expect(ALL_HOST_CONFIGS.length).toBe(13);
   });
 
   test('ALL_HOST_NAMES matches config names', () => {


### PR DESCRIPTION
Adds three host configs so gstack generates correctly-worded skills for
Grok Build, Pi, and the Antigravity CLI (`agy`). Today their users get
Claude-flavored text — instructions naming Bash/Read/Edit tools they don't
have, and `~/.claude/skills/gstack` paths that don't exist for them.

Follows `docs/ADDING_A_HOST.md`: one file each, registered in the index. No
generator, setup, or tooling changes.

## Tool names

Taken from each vendor's own docs, not guessed:

| Host | Source | Notable |
|---|---|---|
| grok | Grok Build README, "Built-in Tools" | `read_file`, `search_replace`, `grep_search`, `list_dir`, `bash`, `task`. No separate create-file tool, so Write and Edit both map to `search_replace`. |
| pi | `pi --help` | `read`, `bash`, `edit`, `write`. No first-party subagent or todo tool — `subagent` ships in the optional `pi-subagents` package, which the Agent rewrite notes. |
| agy | Antigravity builtin skills | `run_command`, `view_file`, `write_to_file`, `replace_file_content`, `invoke_subagent`. No todo tool: `manage_task` drives background processes, so nothing is rewritten onto it. |

## Two non-default paths

Both needed explicit `pathRewrites` instead of the derived trio:

- **Pi** nests agent state a level deeper: `~/.pi/agent/skills`, not `~/.pi/skills`.
- **Antigravity** resolves user skills from `~/.gemini/config/skills` (global) or
  `<workspace>/.agents/skills` (repo-local). That repo-local path is the one
  `codex` already claims as its `hostSubdir`, so `agy` uses `hostSubdir: '.agy'`
  to keep generation output from colliding with codex's tree.

All three suppress `CROSS_MODEL_RESOLVERS` (none can shell out to Codex) plus
the default GBrain pair.

## Testing

The two suites named in `ADDING_A_HOST.md`, on a clean checkout:

```
bun test test/gen-skill-docs.test.ts    430 pass, 0 fail
bun test test/host-config.test.ts        76 pass, 0 fail
```

The parameterized smoke tests pick up all three hosts automatically and confirm
output exists, frontmatter is valid, the codex skill is excluded, and there's no
`.claude/skills` leakage. The only test change is the hardcoded
`ALL_HOST_CONFIGS` length, 10 → 13.

README gains the three rows in the `--host` table and matching uninstall lines;
`.gitignore` gains the three generated dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)