### PR TITLE
feat(redact): add Groq, Tavily and Notion API key patterns

### DIFF
--- a/lib/redact-patterns.ts
+++ b/lib/redact-patterns.ts
@@ -439,6 +439,33 @@ export const PATTERNS: RedactPattern[] = [
     regex: /\b(gl(?:pat|ptt|dt)-[A-Za-z0-9_-]{20,})\b/,
   },
   {
+    id: "groq.key",
+    tier: "HIGH",
+    category: "secret",
+    description: "Groq API key",
+    regex: /\b(gsk_[A-Za-z0-9]{20,})\b/,
+  },
+  {
+    id: "tavily.key",
+    tier: "HIGH",
+    category: "secret",
+    description: "Tavily API key (incl. tvly-dev-/tvly-prod-)",
+    // Explicit environment infixes rather than a globally-optional segment,
+    // which would also match separator-less tvly-devabc… (same reasoning as
+    // openai.key above).
+    regex: /\b(tvly-(?:dev-|prod-)?[A-Za-z0-9]{16,})\b/,
+  },
+  {
+    id: "notion.token",
+    tier: "HIGH",
+    category: "secret",
+    description: "Notion integration token (ntn_ current, secret_ legacy)",
+    // Two explicit shapes. The legacy `secret_` form keeps a high {40,} floor
+    // because the prefix is an ordinary English word — the length is what makes
+    // it a credential rather than prose.
+    regex: /\b(ntn_[A-Za-z0-9]{40,}|secret_[A-Za-z0-9]{40,})\b/,
+  },
+  {
     id: "huggingface.token",
     tier: "HIGH",
     category: "secret",

--- a/test/redact-engine.test.ts
+++ b/test/redact-engine.test.ts
@@ -48,6 +48,11 @@ describe("HIGH credential patterns", () => {
     ["gitlab.token", "remote: glpat-" + "Ab12Cd34Ef56Gh78Ij90"],
     ["gitlab.token", "trigger glptt-" + "a1b2c3d4e5f6a7b8c9d0e1f2"],
     ["gitlab.token", "deploy gldt-" + "Zy98Xw76Vu54Ts32Rq10"],
+    ["groq.key", "gsk_" + "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGhIjKlMn"],
+    ["tavily.key", "tvly-" + "AbCdEfGhIjKlMnOpQrStUvWx"],
+    ["tavily.key", "tvly-dev-" + "AbCdEfGhIjKlMnOpQrStUvWx"],
+    ["notion.token", "ntn_" + "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGh"],
+    ["notion.token", "secret_" + "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGh"],
     ["huggingface.token", "hf_" + "AbCdEfGhIjKlMnOpQrStUvWxYz012345"],
     ["npm.token", "npm_" + "a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8"],
     ["digitalocean.token", "dop_v1_" + "0123456789abcdef".repeat(4)],
@@ -261,6 +266,11 @@ describe("#1946 pattern negatives (placeholders never fire)", () => {
   test("short or placeholder shapes don't trip the new HIGH patterns", () => {
     expect(ids("glpat-xxxx")).not.toContain("gitlab.token");
     expect(ids("hf_token")).not.toContain("huggingface.token");
+    expect(ids("gsk_key")).not.toContain("groq.key");
+    expect(ids("tvly-key")).not.toContain("tavily.key");
+    expect(ids("ntn_token")).not.toContain("notion.token");
+    // `secret_` is an ordinary word; only the length makes it a credential.
+    expect(ids("secret_value")).not.toContain("notion.token");
     expect(ids("npm_install")).not.toContain("npm.token");
     expect(ids("dop_v1_short")).not.toContain("digitalocean.token");
     // pem header WITHOUT the GCP JSON shape stays pem.private_key only.


### PR DESCRIPTION
## The gap

Three provider key shapes have no pattern, so a **bare** key — one not written as `NAME=value` — is not detected at all.

Measured against `b5a951e` with `bin/gstack-redact --from-file`, one shape per file:

| input | finding |
|---|---|
| `gsk_…` on its own | **none** |
| `tvly-dev-…` on its own | **none** |
| `ntn_…` on its own | **none** |
| `GROQ_API_KEY=gsk_…` | MEDIUM `env.kv` |
| `NOTION_TOKEN=ntn_…` | MEDIUM `env.kv` |

`env.kv` covers the assignment form, which is the common case in a `.env` — but it keys on the *variable name*, so a key in a comment, a URL, a JSON blob or a test fixture is invisible. That is the shape a key most often escapes in, and it is why the prefixed provider patterns (`openai.key`, `anthropic.key`, `huggingface.token`, `npm.token`, …) exist alongside `env.kv` rather than instead of it.

## The change

Three patterns, in the shape of the existing provider entries:

```ts
{ id: "groq.key",     tier: "HIGH", regex: /\b(gsk_[A-Za-z0-9]{20,})\b/ },
{ id: "tavily.key",   tier: "HIGH", regex: /\b(tvly-(?:dev-|prod-)?[A-Za-z0-9]{16,})\b/ },
{ id: "notion.token", tier: "HIGH", regex: /\b(ntn_[A-Za-z0-9]{40,}|secret_[A-Za-z0-9]{40,})\b/ },
```

**HIGH** follows the taxonomy's own calibration rather than my preference: every provider-prefixed secret credential in the file is HIGH (`openai.key`, `anthropic.key`, `github.pat`, `sendgrid.key`, `slack.token`, `huggingface.token`, `npm.token`, `digitalocean.token`, `twilio.auth_token`), and the two MEDIUM exceptions are there for stated reasons that do not apply here — `stripe.publishable` is public by design, `google.api_key` is context-variable. These three are single-purpose secret tokens with distinctive prefixes; a `gsk_`-prefixed 40-character token is not context-variable.

Notes on the specific regexes:

- **Tavily** spells its environment infixes out (`(?:dev-|prod-)?`) rather than using a globally-optional segment, for the same reason `openai.key` does — an optional segment would also match separator-less `tvly-devabc…`.
- **Notion** carries two explicit shapes: `ntn_` (current) and `secret_` (legacy, still in circulation). The legacy prefix is an ordinary English word, so the `{40,}` floor is what makes it a credential rather than prose — `secret_value` does not match, and there is a negative test for exactly that.
- No nested unbounded quantifiers; `test/redact-pattern-lint.test.ts` passes.

## Tests

Positive cases added to the `redact-engine` table, negatives to the `#1946 pattern negatives` block (`gsk_key`, `tvly-key`, `ntn_token`, `secret_value` must not fire).

```
bun test test/redact-engine.test.ts test/redact-pattern-lint.test.ts \
         test/redact-engine-autoredact.test.ts test/gstack-redact-cli.test.ts \
         test/redact-prepush-hook.test.ts test/redact-doc-resolver.test.ts
→ 201 pass, 0 fail

bun test test/document-skills-redaction.test.ts test/ship-template-redaction.test.ts \
         test/gstack-config-redact-keys.test.ts
→ 20 pass, 0 fail
```

The generated docs pick the descriptions up from the taxonomy, so nothing was hand-edited.

## Context

Found while auditing a sixteen-repo fleet where every one of these three is a live key. Not related to #2358 (chained `pre-push.local` stdin) — that is a separate wrapper bug with its own PR, and this change is independent of it.

I have no way to verify Groq/Tavily/Notion key lengths beyond published formats and live keys I hold, so the floors are deliberately conservative: they are false-positive guards, and the prefix carries the signal. Happy to tighten them to exact lengths if you would rather pin them.
