### PR TITLE
fix(redact): install-prepush-hook never refreshes a stale managed hook, so shipped wrapper fixes never reach an existing install

### DIFF
--- a/bin/gstack-redact
+++ b/bin/gstack-redact
@@ -62,19 +62,6 @@ function installPrepushHook(): void {
   const hookPath = path.join(dir, "pre-push");
   const prepushBin = path.join(import.meta.dir, "gstack-redact-prepush");
 
-  // If a non-managed hook exists, preserve it as pre-push.local and chain it.
-  if (fs.existsSync(hookPath)) {
-    const existing = fs.readFileSync(hookPath, "utf8");
-    if (existing.includes(MANAGED_MARKER)) {
-      process.stdout.write("gstack-redact: pre-push hook already installed.\n");
-      return;
-    }
-    const localPath = path.join(dir, "pre-push.local");
-    fs.renameSync(hookPath, localPath);
-    fs.chmodSync(localPath, 0o755);
-    process.stdout.write("gstack-redact: preserved existing hook as pre-push.local (chained).\n");
-  }
-
   // stdin is single-consume: capture it once, feed both the chained hook and ours.
   // The `printf x` sentinel preserves the trailing newline that `$(cat)` strips.
   // Without it, a chained shell pre-push.local built on `while read` silently
@@ -91,6 +78,39 @@ if [ -x "$_local" ]; then
 fi
 printf '%s' "$_input" | bun "${prepushBin}" "$@"
 `;
+
+  // If a non-managed hook exists, preserve it as pre-push.local and chain it.
+  if (fs.existsSync(hookPath)) {
+    const existing = fs.readFileSync(hookPath, "utf8");
+    if (existing.includes(MANAGED_MARKER)) {
+      // A hook we already own. Returning here unconditionally froze every
+      // existing install on whatever wrapper it first received: the `printf x`
+      // fail-open fix landed in v1.64.0.0 and still had not reached a single
+      // repo that got the hook before it, because the only writer is gated on
+      // this branch. A wrapper naming a gstack that has since been moved or
+      // removed stays pointed at that dead path for the same reason.
+      //
+      // Rewrite when the body has drifted from what this version generates;
+      // stay a no-op when it has not, so the command is still idempotent. The
+      // chained pre-push.local is never touched on either path — it is the
+      // user's, not ours.
+      if (existing === wrapper) {
+        process.stdout.write("gstack-redact: pre-push hook already installed.\n");
+        return;
+      }
+      fs.writeFileSync(hookPath, wrapper, { mode: 0o755 });
+      fs.chmodSync(hookPath, 0o755);
+      process.stdout.write(
+        `gstack-redact: refreshed stale managed pre-push hook at ${hookPath}\n`,
+      );
+      return;
+    }
+    const localPath = path.join(dir, "pre-push.local");
+    fs.renameSync(hookPath, localPath);
+    fs.chmodSync(localPath, 0o755);
+    process.stdout.write("gstack-redact: preserved existing hook as pre-push.local (chained).\n");
+  }
+
   fs.writeFileSync(hookPath, wrapper, { mode: 0o755 });
   fs.chmodSync(hookPath, 0o755);
   process.stdout.write(`gstack-redact: installed pre-push hook at ${hookPath}\n`);

--- a/test/redact-prepush-hook.test.ts
+++ b/test/redact-prepush-hook.test.ts
@@ -378,6 +378,87 @@ describe("install / chaining", () => {
     expect(r.status).toBe(1);
   });
 
+  // Regression: install returned early on ANY hook carrying the managed marker,
+  // so the only writer was unreachable once a hook existed. Every fix to the
+  // wrapper — including the `printf x` fail-open fix of v1.64.0.0 — stopped at
+  // repos that had never had the hook. The pre-existing newline test above
+  // cannot catch this: it installs into a repo with no prior managed hook, which
+  // is the one case that was never broken.
+  test("a stale managed hook is rewritten, and the refresh delivers the newline fix", () => {
+    const hookDir = path.join(repo, ".git", "hooks");
+    fs.mkdirSync(hookDir, { recursive: true });
+    const hook = path.join(hookDir, "pre-push");
+
+    // The v1.63-era wrapper, verbatim: same marker, `$(cat)` with no sentinel.
+    fs.writeFileSync(
+      hook,
+      [
+        "#!/usr/bin/env bash",
+        "# gstack-redact pre-push (managed)",
+        "set -euo pipefail",
+        '_input="$(cat)"',
+        '_local="$(git rev-parse --git-path hooks/pre-push.local)"',
+        'if [ -x "$_local" ]; then',
+        `  printf '%s' "$_input" | "$_local" "$@" || exit $?`,
+        "fi",
+        `printf '%s' "$_input" | bun ${JSON.stringify(PREPUSH)} "$@"`,
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    // A chained local hook of the shape the old wrapper starved: a bare
+    // `while read`, which never enters its body without a trailing newline.
+    const seen = path.join(repo, "seen.txt");
+    fs.writeFileSync(
+      path.join(hookDir, "pre-push.local"),
+      `#!/usr/bin/env bash\nwhile read -r a _b _c _d; do echo "$a" >> ${JSON.stringify(seen)}; done\nexit 0\n`,
+      { mode: 0o755 },
+    );
+
+    const r = spawnSync("bun", [REDACT, "install-prepush-hook"], {
+      cwd: repo,
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("refreshed stale managed pre-push hook");
+    expect(fs.readFileSync(hook, "utf8")).toContain("printf x");
+
+    // The chained hook is the user's; a refresh must not rename or rewrite it.
+    expect(fs.readFileSync(path.join(hookDir, "pre-push.local"), "utf8")).toContain("while read");
+
+    // Behavioural half: the refreshed wrapper actually feeds the final ref line.
+    const sha = "c".repeat(40);
+    const run = spawnSync("bash", [hook], {
+      cwd: repo,
+      input: Buffer.from(`refs/heads/main ${sha} refs/heads/main ${ZERO}\n`),
+      encoding: "utf8",
+      env: { ...process.env, GSTACK_REDACT_PREPUSH: "skip" },
+    });
+    expect(run.status).toBe(0);
+    expect(fs.readFileSync(seen, "utf8").trim()).toBe("refs/heads/main");
+  });
+
+  test("install stays idempotent: an up-to-date managed hook is not rewritten", () => {
+    const hookDir = path.join(repo, ".git", "hooks");
+    fs.mkdirSync(hookDir, { recursive: true });
+    const hook = path.join(hookDir, "pre-push");
+
+    spawnSync("bun", [REDACT, "install-prepush-hook"], { cwd: repo });
+    const first = fs.readFileSync(hook, "utf8");
+    const stamp = fs.statSync(hook).mtimeMs;
+
+    const again = spawnSync("bun", [REDACT, "install-prepush-hook"], {
+      cwd: repo,
+      encoding: "utf8",
+    });
+    expect(again.status).toBe(0);
+    expect(again.stdout).toContain("already installed");
+    expect(again.stdout).not.toContain("refreshed");
+    expect(fs.readFileSync(hook, "utf8")).toBe(first);
+    expect(fs.statSync(hook).mtimeMs).toBe(stamp);
+  });
+
   test("uninstall restores the chained original", () => {
     const hookDir = path.join(repo, ".git", "hooks");
     fs.mkdirSync(hookDir, { recursive: true });


### PR DESCRIPTION
## The bug

`installPrepushHook` returns before the only `writeFileSync` whenever the existing hook carries the managed marker:

```ts
if (existing.includes(MANAGED_MARKER)) {
  process.stdout.write("gstack-redact: pre-push hook already installed.\n");
  return;          // ← the only writer is below this line
}
```

There is no version stamp in the marker and no comparison against what the current version generates, so **the wrapper a repo receives on its first install is the wrapper it keeps forever**. No migration touches `pre-push` either (all 12 under `gstack-upgrade/migrations/` checked), and `./setup` does not call the command.

That has already cost one shipped security fix. `_input="$(cat; printf x)"` — the sentinel that stops a chained `pre-push.local` from silently failing open — landed in **v1.64.0.0**. Sixteen repos here got the hook before that and were still running `_input="$(cat)"` after upgrading v1.60.1.0 → v1.72.0.0. Eight versions, zero delivery. Measured, one shape per column, with a chained `.local` built on a bare `while read`:

| installed wrapper | refs the chained `.local` sees |
|---|---|
| `$(cat)` (pre-v1.64) | **0** |
| `$(cat; printf x)` (v1.64+) | 1 |

Zero refs, exit 0 — the guard reports success having scanned nothing, which is precisely the failure `printf x` was added to close. `bin/gstack-redact-prepush` itself is unaffected (it reads stdin as `readFileSync(0).split("\n")`, so a missing trailing newline costs it no line), so this only bites the chained-hook seam.

The same freeze hits a second, non-security case: `prepushBin` is baked in as an absolute path. Move or reinstall gstack elsewhere and the stale wrapper keeps naming a `bun` script that is no longer there, with no way to repair it short of `uninstall` + `install` — and `uninstall` renames `pre-push.local` back over `pre-push`, so that route eats the user's chained hook.

This is the same shape as #2444 (`link_codex_skill_dirs` skipping already-installed skill dirs, "reports ready but never refreshes"), also filed against 1.60.1.0.

## The fix

Hoist the `wrapper` construction above the existence check, then compare bodies:

- `existing === wrapper` → `already installed`, no write, **no mtime change** (idempotent, as before).
- marker present but body drifted → rewrite, print `refreshed stale managed pre-push hook at <path>`.
- no marker → unchanged: preserve as `pre-push.local` and chain it.

`pre-push.local` is never read, renamed, or written on any of the three paths — it is the user's, not gstack's.

Content equality rather than a version stamp keeps the marker format untouched and means a wrapper is judged by what it actually is, not by what it claims. The trade-off, stated plainly: a hand-edited hook still carrying the managed marker is overwritten. That seems right — the marker is gstack's ownership claim and `pre-push.local` is the documented seam for user code — but the refresh says so on stdout rather than doing it silently, and I'll take a different policy if you prefer one.

One consequence worth naming: with both a global and a vendored gstack installed, whichever one runs the command last now owns the `prepushBin` path, where before it was frozen at whichever installed first. Last-writer-wins is the lesser evil against frozen-at-a-dead-path, but it is a behaviour change.

## Tests

Two added to `test/redact-prepush-hook.test.ts`:

- **`a stale managed hook is rewritten, and the refresh delivers the newline fix`** — plants the verbatim v1.63-era wrapper plus a bare-`while read` `.local`, runs install, and asserts the body gains `printf x`, the `.local` survives untouched, and — the half that matters — the refreshed wrapper actually delivers the final ref line to that `.local`.
- **`install stays idempotent: an up-to-date managed hook is not rewritten`** — second run prints `already installed`, never `refreshed`, with byte-identical content and unchanged mtime.

Receipts, per the standard in the v1.69 notes — the first test fails on a scratch worktree of `b5a951e` for the right reason:

```
✗ install / chaining > a stale managed hook is rewritten, and the refresh delivers the newline fix
  Expected to contain: "refreshed stale managed pre-push hook"
  Received: "gstack-redact: pre-push hook already installed.\n"
  27 pass, 1 fail
```

With the fix: `28 pass, 0 fail` in that file, and `200 pass, 0 fail` across `redact-prepush-hook`, `fs-utils`, `gstack-redact-cli`, `redact-engine`, `redact-engine-autoredact`, `redact-pattern-lint`, `redact-doc-resolver`.

`bun run test:free` is **not clean on this machine at `b5a951e` itself** — I ran it on a pristine worktree of upstream HEAD to get a baseline before reading my own run. Baseline fails 22 tests (`bun-polyfill` spawn/serve, `gstack-developer-profile --migrate`, `bump:`/DRIFT-REPAIR, a browser-skills E2E); my branch fails a subset of the same set. The one name appearing on my side and not on the baseline's is `codex-hardening`'s bash-native watchdog deadline test, which fails 1-in-3 on a pristine `b5a951e` and 1-in-3 on this branch, and contains zero references to redact. No test fails on this branch that does not also fail upstream.

Happy to add a CHANGELOG entry / VERSION bump if you'd rather this land as its own release than be absorbed into a wave.
