### PR TITLE
fix(browse): honour CHROMIUM_PROFILE in cli profile-lock cleanup

### DIFF
--- a/browse/src/cli.ts
+++ b/browse/src/cli.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import { spawn as nodeSpawn } from 'child_process';
 import { safeUnlink, safeUnlinkQuiet, safeKill, isProcessAlive } from './error-handling';
 import { writeSecureFile, mkdirSecure } from './file-permissions';
-import { resolveConfig, ensureStateDir, readVersionHash, isPairAgentEnabled } from './config';
+import { resolveConfig, ensureStateDir, readVersionHash, isPairAgentEnabled, resolveChromiumProfile } from './config';
 import { parseProxyConfig, computeConfigHash, ProxyConfigError } from './proxy-config';
 import { redactProxyUrl } from './proxy-redact';
 import { spawnTerminalAgent } from './terminal-agent-control';
@@ -257,9 +257,12 @@ function cleanupLegacyState(): void {
 }
 
 // ─── Chromium profile lock helpers (#1781) ─────────────────────
-/** Profile dir used by headed/connect Chromium sessions. */
+/** Profile dir used by headed/connect Chromium sessions. Must resolve exactly
+ * as browser-manager does (config.resolveChromiumProfile), or the lock cleanup
+ * and orphan kill below target a different profile than the one being launched
+ * and evict an unrelated browser. */
 function chromiumProfileDir(): string {
-  return path.join(process.env.HOME || '/tmp', '.gstack', 'chromium-profile');
+  return resolveChromiumProfile();
 }
 
 /** Remove Chromium SingletonLock/Socket/Cookie so a relaunch can acquire the


### PR DESCRIPTION
Starting a `browse` instance with a custom `CHROMIUM_PROFILE` kills an unrelated browser running on the default profile. This makes it impossible to run two headed instances side by side, which is what multi-agent setups need.

## Cause

`browser-manager` launches `config.resolveChromiumProfile()`, which honours `CHROMIUM_PROFILE` (and `GSTACK_HOME`):

```ts
// browse/src/config.ts
export function resolveChromiumProfile(explicit?: string): string {
  if (explicit && explicit.length > 0) return explicit;
  const env = process.env.CHROMIUM_PROFILE;
  if (env && env.length > 0) return env;
  return path.join(resolveGstackHome(), "chromium-profile");
}
```

But `cli.ts` resolved it independently, with the env var ignored:

```ts
// browse/src/cli.ts (before)
function chromiumProfileDir(): string {
  return path.join(process.env.HOME || "/tmp", ".gstack", "chromium-profile");
}
```

`killOrphanChromium()` and `cleanChromiumProfileLocks()` are invoked with no argument (three call sites), so they defaulted to that hardcoded path. With `CHROMIUM_PROFILE` set, the launch path and the cleanup path disagreed: the cleanup removed `SingletonLock`/`SingletonSocket`/`SingletonCookie` from, and killed Chromium on, the **default** profile, while the browser was launched on the custom one.

## Reproduction

Before this change, using the shipped binary:

```
default-profile  browse --headed goto wikipedia.org   -> https://www.wikipedia.org/
custom-profile   browse --headed goto example.com     -> https://example.com/
default-profile  browse --headed url                  -> 127.0.0.1:PORT/welcome   # evicted
```

After, with a locally compiled binary carrying this patch:

```
default-profile  browse --headed url                  -> https://www.wikipedia.org/   # survives
```

Two headed instances then coexist: each renavigates without disturbing the other, and `stop` on one leaves the other running.

## The change

`chromiumProfileDir()` now delegates to `resolveChromiumProfile()`, so cleanup targets whatever profile is actually being launched.

Two incidental corrections come with it, both making cli.ts consistent with browser-manager: `GSTACK_HOME` is now respected, and `os.homedir()` replaces `process.env.HOME`, which matters on Windows where `HOME` is frequently unset. The `|| "/tmp"` fallback is dropped as unreachable, since `os.homedir()` always returns a path.

## Notes

- Behaviour is unchanged for anyone not setting `CHROMIUM_PROFILE` or `GSTACK_HOME`.
- No test currently references `CHROMIUM_PROFILE`, `chromiumProfileDir` or `SingletonLock`, so this path is uncovered. Happy to add a regression test asserting the launch and cleanup paths resolve identically if you would like one in this PR.
- Verified with `bun build --compile browse/src/cli.ts`.