### PR TITLE
fix: don't flag git SSH remotes as pii.email

### DIFF
--- a/lib/redact-engine.ts
+++ b/lib/redact-engine.ts
@@ -83,6 +83,17 @@ const DEFAULT_MAX_BYTES = 1024 * 1024; // 1 MiB
 
 const EMAIL_ALLOW_DOMAINS = [/@example\.(com|org|net)$/i, /@example\.[a-z]{2,}$/i];
 const EMAIL_ALLOW_LOCALPARTS = [/^noreply@/i, /^no-reply@/i, /^donotreply@/i];
+/**
+ * Hosts whose `git@<host>` is a git transport endpoint, never a person's
+ * mailbox. Matched EXACTLY — a domain that merely starts with "git"
+ * (gitmail.com) is a normal domain and must keep firing.
+ */
+const SSH_GIT_HOSTS = new Set([
+  "github.com",
+  "gitlab.com",
+  "bitbucket.org",
+  "ssh.dev.azure.com",
+]);
 
 // ── Normalization ─────────────────────────────────────────────────────────────
 
@@ -240,12 +251,59 @@ function hasNear(
 
 // ── Email allowlist ───────────────────────────────────────────────────────────
 
-function emailAllowed(email: string, opts: ScanOptions): boolean {
+/**
+ * True when the matched "email" is really the user@host of a git SSH remote.
+ *
+ * `pii.email` matches the `git@github.com` inside
+ * `git@github.com:org/repo.git` — a transport identity, not PII. This keys on
+ * the surrounding URL SHAPE, not on the `git` local part: allowlisting `git@`
+ * outright would also suppress a genuine address at a domain that merely
+ * begins with "git" (e.g. git@gitmail.com), turning a false positive into a
+ * false negative.
+ *
+ * Two accepted shapes:
+ *   - scp-like `<user>@<host>:<path>` where the path ends in `.git`, for any
+ *     host — this covers self-hosted remotes.
+ *   - `git@<known-host>` for the major forges, whose bare form appears in docs
+ *     and in `ssh -T git@github.com` connectivity checks with no path at all.
+ */
+function isSshGitRemote(email: string, text: string, spanStart: number): boolean {
+  const at = email.lastIndexOf("@");
+  if (at < 0) return false;
+  const local = email.slice(0, at).toLowerCase();
+  const host = email.slice(at + 1).toLowerCase();
+
+  // Major forges: `git@host`, with or without a trailing path.
+  if (local === "git" && SSH_GIT_HOSTS.has(host)) return true;
+
+  // Any host in `<user>@<host>:<path>.git` position. The path stops at
+  // whitespace or a quote so a trailing delimiter never defeats the suffix.
+  const rest = text.slice(spanStart + email.length, spanStart + email.length + 512);
+  const scp = /^:(?!\/)([^\s'"`<>]*)/.exec(rest);
+  if (scp && /\.git\/?$/.test(scp[1])) return true;
+
+  // ssh:// URL form: ssh://<user>@<host>/<path>.git
+  const before = text.slice(Math.max(0, spanStart - 16), spanStart);
+  if (/(?:git\+)?ssh:\/\/$/i.test(before)) {
+    const slash = /^\/([^\s'"`<>]*)/.exec(rest);
+    if (slash && /\.git\/?$/.test(slash[1])) return true;
+  }
+
+  return false;
+}
+
+function emailAllowed(
+  email: string,
+  opts: ScanOptions,
+  text: string,
+  spanStart: number,
+): boolean {
   const lower = email.toLowerCase();
   if (opts.selfEmail && lower === opts.selfEmail.toLowerCase()) return true;
   if (opts.repoPublicEmails?.some((e) => e.toLowerCase() === lower)) return true;
   if (EMAIL_ALLOW_DOMAINS.some((re) => re.test(email))) return true;
   if (EMAIL_ALLOW_LOCALPARTS.some((re) => re.test(email))) return true;
+  if (isSshGitRemote(email, text, spanStart)) return true;
   return false;
 }
 
@@ -322,7 +380,8 @@ export function scan(input: string, opts: ScanOptions = {}): ScanResult {
       }
 
       // Email allowlist (layered on top of the pattern).
-      if (pat.id === "pii.email" && emailAllowed(span, opts)) continue;
+      if (pat.id === "pii.email" && emailAllowed(span, opts, normalized, normOffset))
+        continue;
 
       const origOffset = map[Math.min(normOffset, map.length - 1)] ?? 0;
       const key = `${pat.id}:${origOffset}`;

--- a/test/redact-engine.test.ts
+++ b/test/redact-engine.test.ts
@@ -302,6 +302,28 @@ describe("PII patterns", () => {
       scan("bob@acme.co", { repoVisibility: "private", repoPublicEmails: ["bob@acme.co"] }).findings,
     ).toHaveLength(0);
   });
+  // A git SSH remote's `git@host` is a transport user@host, not a person's
+  // address. Suppressed by URL SHAPE rather than by allowlisting the `git`
+  // local part: a bare `git@` entry would also silently hide a real address
+  // at a domain that merely starts with "git".
+  test("ssh git remotes are not flagged as emails", () => {
+    expect(ids("set :repo_url, 'git@github.com:acme/widgets.git'")).not.toContain(
+      "pii.email",
+    );
+    expect(ids("git clone git@gitlab.com:acme/widgets.git")).not.toContain("pii.email");
+    expect(ids("git@bitbucket.org:acme/widgets.git")).not.toContain("pii.email");
+    expect(ids("git@ssh.dev.azure.com:v3/acme/widgets/widgets")).not.toContain("pii.email");
+    expect(ids("ssh -T git@github.com")).not.toContain("pii.email");
+    // General case: any host in <user>@<host>:<path>.git position.
+    expect(ids("git@git.acme-internal.net:infra/tools.git")).not.toContain("pii.email");
+    expect(ids("ssh://git@scm.acme-internal.net/infra/tools.git")).not.toContain("pii.email");
+  });
+  test("a real address is still flagged, including at a git host", () => {
+    expect(ids("ping alex@github.com about the issue")).toContain("pii.email");
+    // A domain that merely STARTS WITH "git" is not a git host — this is the
+    // case a bare `git@` local-part allowlist would have wrongly suppressed.
+    expect(ids("contact git@gitmail.com for access")).toContain("pii.email");
+  });
   test("phone E.164 flags, skips compact timestamps", () => {
     expect(ids("call +14155550123 now")).toContain("pii.phone.e164");
     expect(ids("backup stamp 20260727202423 ran late")).not.toContain("pii.phone.e164");


### PR DESCRIPTION
## Why (in your own words)

The pre-push guard warns on ordinary clone URLs. `pii.email` matches the
`git@github.com` inside `git@github.com:acme/widgets.git` — that is an SSH
transport user@host, not anybody's mailbox. So any diff that touches a clone
URL (a deploy config's repo URL, a submodule entry, a README clone line) draws
a MEDIUM "PII/internal" warning on every push.

It doesn't block, but it is the kind of routine false positive that teaches
people to skim past the guard's output — which is exactly when a real HIGH gets
waved through. Renaming a single repo URL was enough to trigger it.

The obvious fix is to allowlist the `git` local part, and that is the wrong
fix: `git@` as a prefix would also silence a real person at a domain that
merely begins with "git" (`git@gitmail.com`), turning a false positive into a
false negative. So this keys on the surrounding URL shape instead.

## Live evidence

Reproduction — a single added line from a diff that renames a clone URL:

```
$ cat added.txt
set :repo_url, 'git@github.com:acme/widgets.git'
```

BEFORE (origin/main @ 07b59e39):

```
$ bun bin/gstack-redact --repo-visibility private --from-file added.txt
gstack-redact scan — repo PRIVATE
  MEDIUM pii.email                   1:17  git@********…
  HIGH=0 MEDIUM=1 LOW=0 WARN=0
exit: 2
```

AFTER (this branch):

```
$ bun bin/gstack-redact --repo-visibility private --from-file added.txt
gstack-redact scan — repo PRIVATE
  (no findings)
  HIGH=0 MEDIUM=0 LOW=0 WARN=0
exit: 0
```

The guard still fires on real addresses — including at a git host, and at a
domain that merely starts with "git":

```
$ printf 'ping alex@github.com about the issue\ncontact git@gitmail.com for access\n' > real.txt
$ bun bin/gstack-redact --repo-visibility private --from-file real.txt
gstack-redact scan — repo PRIVATE
  MEDIUM pii.email                   1:6   alex********…
  MEDIUM pii.email                   2:9   git@********…
  HIGH=0 MEDIUM=2 LOW=0 WARN=0
exit: 2
```

New tests against the UNPATCHED engine, confirming they actually pin the bug:

```
$ bun test test/redact-engine.test.ts
(fail) PII patterns > ssh git remotes are not flagged as emails [4.75ms]
 91 pass
 1 fail
```

Same tests, patched:

```
$ bun test test/redact-engine.test.ts
 92 pass
 0 fail
```

Full redact suite (10 files):

```
$ bun test test/redact-engine.test.ts test/redact-engine-autoredact.test.ts \
    test/redact-pattern-lint.test.ts test/gstack-redact-cli.test.ts \
    test/redact-prepush-hook.test.ts test/redact-audit-log.test.ts \
    test/redact-doc-resolver.test.ts test/ship-template-redaction.test.ts \
    test/document-skills-redaction.test.ts test/gstack-config-redact-keys.test.ts
 221 pass
 0 fail
Ran 221 tests across 10 files. [5.26s]
```

## Scope

- **Changed:** `lib/redact-engine.ts` — new `isSshGitRemote()` shape check,
  consulted by `emailAllowed()`, which now also receives the normalized text
  and the span offset (it had only ever been handed the matched span, so it
  could not see context). `test/redact-engine.test.ts` — two tests.
- **Verified live by:** running `bin/gstack-redact` before and after against a
  real clone-URL diff (output above); running the new tests against the
  unpatched engine to watch them fail, then against the patched engine; and the
  full 10-file redact suite.
- **Did NOT test:** the pre-push hook end-to-end against a live remote — the
  reproduction goes through the CLI, which shares the same engine entrypoint.
  No test of Windows path handling. `ssh.dev.azure.com` is covered by the
  known-host rule and a unit test, but not against a real Azure DevOps remote.
- **Not included:** no version bump or CHANGELOG entry, since the diff touches
  neither and I'd rather leave release versioning to the maintainer. Happy to
  add one if you'd prefer it in the PR.

## Liveness proof (required)

![GSTACK PR liveness proof](https://raw.githubusercontent.com/alopes50/gstack/pr-assets/liveness/gstack-pr.png)

Drafted with agent assistance, reviewed and opened by me.

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A) — N/A, no new surface
- [x] Linked issue or reproduction: reproduction in "Live evidence" above; no existing issue found for this false positive
