### PR TITLE
fix(taste-update): resolve slug via bin-context, honor GSTACK_HOME

### DIFF
--- a/bin/gstack-taste-update
+++ b/bin/gstack-taste-update
@@ -31,9 +31,13 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { resolveSlug } from '../lib/bin-context';
 
-const STATE_DIR = process.env.GSTACK_STATE_DIR || path.join(process.env.HOME || '/', '.gstack');
+const HERE = import.meta.dir;
+
+// GSTACK_HOME is the var the rest of gstack reads; GSTACK_STATE_DIR stays first
+// so anything already setting it keeps working
+const STATE_DIR = process.env.GSTACK_STATE_DIR || process.env.GSTACK_HOME || path.join(process.env.HOME || '/', '.gstack');
 const SCHEMA_VERSION = 1;
 const SESSION_CAP = 50;
 const DECAY_PER_WEEK = 0.05;
@@ -63,13 +67,10 @@ interface TasteProfile {
   sessions: SessionRecord[];
 }
 
+// the canonical slug comes from gstack-slug, never from the directory name —
+// a repo whose folder is not owner-repo would otherwise split its own profile
 function getSlug(): string {
-  try {
-    const output = execSync('git rev-parse --show-toplevel', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
-    return path.basename(output);
-  } catch {
-    return 'unknown';
-  }
+  return resolveSlug(`${HERE}/gstack-slug`);
 }
 
 function profilePath(slug: string): string {


### PR DESCRIPTION
`gstack-taste-update` does not use the shared `lib/bin-context` conventions its
sibling writers use. That shows up as two defects, fixed here together because
they are the same omission.

## 1. The slug came from the directory name

`getSlug()` returned `path.basename(git rev-parse --show-toplevel)` instead of
resolving the canonical slug. Every other writer calls `resolveSlug` —
`bin/gstack-decision-log:34`, `bin/gstack-decision-search:36` — with the
identical two-line form this patch adopts.

The result is a **split taste profile**. A repo checked out into a folder whose
name is not `owner-repo` files its rejections under the folder name while its
decisions and learnings file under the canonical slug. Neither writer errors,
and the pile silently holds two half-profiles for one project. The old
`catch { return 'unknown' }` similarly collapsed every non-git and marker-only
directory into a shared `projects/unknown/` bucket no other writer uses.

## 2. `STATE_DIR` read the wrong env var

`STATE_DIR` read only `GSTACK_STATE_DIR`, while `resolveSlug` and every other
writer read `GSTACK_HOME`. A test isolated the documented way — `GSTACK_HOME`
pointed at a temp dir — still wrote into the operator's real `~/.gstack`. This
is observed, not theoretical: a run against unpatched code leaked a real
directory into a live pile.

`GSTACK_STATE_DIR` deliberately stays first in the chain so anything already
setting it keeps working.

## Evidence

A differential harness runs five repo shapes and compares where
`gstack-taste-update` files against where `gstack-decision-log` files.
Agreement is the pass condition — the defect is a *split*, so correctness means
converging with the other writers in every shape, not merely "not crashing".

Both columns measured on `main` at `253d1df` (v1.76.0.0):

| repo shape | canonical slug | before | after |
|---|---|---|---|
| folder name ≠ slug | `acme-portfolio-site` | `wrongname` ❌ | `acme-portfolio-site` ✅ |
| folder name = slug | `acme-portfolio-site` | `acme-portfolio-site` ✅ | `acme-portfolio-site` ✅ |
| git repo, no remote | `no-remote-repo` | `no-remote-repo` ✅ | `no-remote-repo` ✅ |
| plain folder, no git | `plain-folder` | `unknown` ❌ | `plain-folder` ✅ |
| marker-only dir | `marker-only` | `unknown` ❌ | `marker-only` ✅ |

Three of five disagree before; all five agree after.

A second loop covers defect 2 directly: with `GSTACK_HOME` set to a sandbox and
`GSTACK_STATE_DIR` unset, unpatched code writes nothing to the sandbox and
leaks a directory into the real pile; patched code writes to the sandbox and
leaks nothing.

A control case is deliberately green in **both** states — the shape where the
folder name already equals the slug. It is the discriminator proving the
harness reports this specific divergence rather than failing unconditionally.

Happy to contribute the harness (6 scripts, hermetic, sub-second) as a
follow-up if you want it in `test/` — say the word and I'll shape it to the
suite's conventions rather than drop it in unasked.

## Not proven

- **Windows.** `resolveSlug` has a `NEEDS_NATIVE_SLUG_ON_WINDOWS` path that this
  machine never reaches. Untested here.
- **Whether `GSTACK_STATE_DIR` should survive at all.** Reading `GSTACK_HOME`
  only would be the cleaner fix, and the precedence order is the sole judgement
  call in this patch. Your call — say so and I'll drop it.
