### PR TITLE
fix(codex): a CLI that cannot execute no longer reports CODEX_MODE: ready

### DIFF
--- a/bin/gstack-codex-probe
+++ b/bin/gstack-codex-probe
@@ -53,6 +53,10 @@ _gstack_codex_model_probe() {
   #     section, forever. Editing config.toml (the fix) changes the cache
   #     signature and re-probes immediately; the short TTL covers server-side
   #     entitlement recovery the signature can't see.
+  #   MODEL_UNUSABLE_INSTALL (exit 2) — the CLI cannot execute at all (spawn
+  #     ENOENT, non-executable binary, missing vendor payload). Deterministic,
+  #     so fail-open is wrong: retrying never helps. Never cached — a reinstall
+  #     fixes it and must be picked up on the very next probe (#2742).
   #   MODEL_PROBE_INCONCLUSIVE (exit 0) — timeout/transient; FAIL-OPEN so a
   #     slow network never wedges codex mode (the per-invocation Error
   #     Handling entry still covers a later 400). Never cached.
@@ -114,6 +118,18 @@ _gstack_codex_model_probe() {
     _gstack_codex_log_event "codex_model_unusable" 2>/dev/null || true
     return 1
   fi
+  # A CLI that cannot execute is deterministic, not transient: the fail-open
+  # below exists for network luck, and swallowing this here is what let a
+  # missing vendor binary report CODEX_MODE: ready while every Codex pass was
+  # silently skipped (#2742). 126 = found but not executable, 127 = not found.
+  if [ "$_code" -eq 126 ] || [ "$_code" -eq 127 ] || printf '%s' "$_out" | grep -qiE 'ENOENT|ENOEXEC|EACCES|no such file or directory|cannot execute binary file|not executable|permission denied'; then
+    echo "MODEL_UNUSABLE_INSTALL"
+    printf '%s\n' "$_out" | grep -iE 'ENOENT|ENOEXEC|EACCES|no such file or directory|cannot execute|permission denied' | head -3
+    echo "HINT: the Codex CLI is on PATH but cannot run — its binary or vendor payload is missing."
+    echo "HINT: reinstall with: npm install -g @openai/codex"
+    _gstack_codex_log_event "codex_broken_install" 2>/dev/null || true
+    return 2
+  fi
   # Timeout (124) or transient failure: fail-open with a warning. The probe
   # exists to catch the deterministic model 400, not to gate on network luck.
   echo "MODEL_PROBE_INCONCLUSIVE (exit $_code) — proceeding; if invocations fail with a model 400, see the codex skill's Error Handling entry."
@@ -127,8 +143,23 @@ _gstack_codex_version_check() {
   # positives like 0.120.10 or 0.120.20 from matching. 0.120.2-beta still
   # matches the bad release and gets warned (it IS buggy).
   # Update this list when a new Codex CLI version regresses.
-  local _ver
-  _ver=$(codex --version 2>/dev/null | head -1)
+  local _ver _vcode
+  # Capture the code from codex, not from `head` — a pipeline reports the LAST
+  # command's status, which is why a CLI that only ever printed a spawn error
+  # still read as healthy here (#2742). Keep stderr: it carries the diagnosis.
+  _ver=$(codex --version 2>&1)
+  _vcode=$?
+  _ver=$(printf '%s' "$_ver" | head -1)
+  # Only a NON-ZERO exit is evidence of a broken CLI. Empty-but-successful
+  # output stays silent by design (a CLI may legitimately print nothing), which
+  # the "empty output → OK" case in this file's suite pins.
+  if [ "$_vcode" -ne 0 ]; then
+    echo "WARN: \`codex --version\` failed (exit $_vcode) — the CLI is on PATH but may not be runnable."
+    [ -n "$_ver" ] && echo "WARN: it said: $_ver"
+    echo "WARN: if Codex passes are being skipped, reinstall with: npm install -g @openai/codex"
+    _gstack_codex_log_event "codex_version_unreadable" 2>/dev/null || true
+    return 0
+  fi
   [ -z "$_ver" ] && return 0
   if echo "$_ver" | grep -Eq '(^|[^0-9.])0\.120\.(0|1|2)([^0-9.]|$)'; then
     echo "WARN: Codex CLI $_ver has known stdin deadlock bugs. Run: npm install -g @openai/codex@latest"

--- a/document-release/sections/release-body.md
+++ b/document-release/sections/release-body.md
@@ -447,10 +447,17 @@ elif ! command -v codex >/dev/null 2>&1; then
   _CODEX_MODE="not_installed"; _gstack_codex_log_event "codex_cli_missing" 2>/dev/null || true
 elif ! _gstack_codex_auth_probe >/dev/null 2>&1; then
   _CODEX_MODE="not_authed"; _gstack_codex_log_event "codex_auth_failed" 2>/dev/null || true
-elif ! _gstack_codex_model_probe; then
-  _CODEX_MODE="model_unusable"
 else
-  _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  # Capture the probe's code: 2 means the CLI cannot execute at all, which is a
+  # different problem (and a different fix) from a model the account can't use.
+  _gstack_codex_model_probe; _CODEX_MP=$?
+  if [ "$_CODEX_MP" -eq 2 ]; then
+    _CODEX_MODE="broken_install"
+  elif [ "$_CODEX_MP" -ne 0 ]; then
+    _CODEX_MODE="model_unusable"
+  else
+    _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  fi
 fi
 echo "CODEX_MODE: $_CODEX_MODE"
 ```
@@ -460,6 +467,7 @@ Branch on the echoed `CODEX_MODE`:
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`under_codex`** — this session is already running INSIDE a Codex host, so spawning codex again is the same model reviewing itself at multiplied token cost (#2519). Print exactly one line: "[running under Codex — nested codex passes skipped; set GSTACK_FORCE_CODEX_REVIEW=1 to force]" and skip the codex invocations below; run the section's free in-host pass instead if it defines one.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
+- **`broken_install`** — the CLI is on PATH but cannot execute (spawn ENOENT, non-executable binary, missing vendor payload). Print: "Codex is installed but its binary cannot run — Codex passes skipped. Reinstall: `npm install -g @openai/codex`." Relay the probe's HINT lines and fall back to the Claude subagent path. This state exists because a missing binary used to land in the model probe's fail-open bucket and report `ready`, so every Codex pass was skipped silently (#2742).
 - **`model_unusable`** — authed but the account cannot use its configured model (#2477: HTTP 400 on every call, usually a stale `model =` pin in `~/.codex/config.toml`). Relay the probe's HINT lines, tell the user the one-line fix (update the pin; `[notice.model_migrations]` names the replacement), and fall back to the Claude subagent path. The ~10s round trip is cached for 1h; timeouts fail open to `ready`.
 - **`ready`** — run the Codex pass below.
 

--- a/plan-ceo-review/sections/review-sections.md
+++ b/plan-ceo-review/sections/review-sections.md
@@ -282,10 +282,17 @@ elif ! command -v codex >/dev/null 2>&1; then
   _CODEX_MODE="not_installed"; _gstack_codex_log_event "codex_cli_missing" 2>/dev/null || true
 elif ! _gstack_codex_auth_probe >/dev/null 2>&1; then
   _CODEX_MODE="not_authed"; _gstack_codex_log_event "codex_auth_failed" 2>/dev/null || true
-elif ! _gstack_codex_model_probe; then
-  _CODEX_MODE="model_unusable"
 else
-  _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  # Capture the probe's code: 2 means the CLI cannot execute at all, which is a
+  # different problem (and a different fix) from a model the account can't use.
+  _gstack_codex_model_probe; _CODEX_MP=$?
+  if [ "$_CODEX_MP" -eq 2 ]; then
+    _CODEX_MODE="broken_install"
+  elif [ "$_CODEX_MP" -ne 0 ]; then
+    _CODEX_MODE="model_unusable"
+  else
+    _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  fi
 fi
 echo "CODEX_MODE: $_CODEX_MODE"
 ```
@@ -295,6 +302,7 @@ Branch on the echoed `CODEX_MODE`:
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`under_codex`** — this session is already running INSIDE a Codex host, so spawning codex again is the same model reviewing itself at multiplied token cost (#2519). Print exactly one line: "[running under Codex — nested codex passes skipped; set GSTACK_FORCE_CODEX_REVIEW=1 to force]" and skip the codex invocations below; run the section's free in-host pass instead if it defines one.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
+- **`broken_install`** — the CLI is on PATH but cannot execute (spawn ENOENT, non-executable binary, missing vendor payload). Print: "Codex is installed but its binary cannot run — Codex passes skipped. Reinstall: `npm install -g @openai/codex`." Relay the probe's HINT lines and fall back to the Claude subagent path. This state exists because a missing binary used to land in the model probe's fail-open bucket and report `ready`, so every Codex pass was skipped silently (#2742).
 - **`model_unusable`** — authed but the account cannot use its configured model (#2477: HTTP 400 on every call, usually a stale `model =` pin in `~/.codex/config.toml`). Relay the probe's HINT lines, tell the user the one-line fix (update the pin; `[notice.model_migrations]` names the replacement), and fall back to the Claude subagent path. The ~10s round trip is cached for 1h; timeouts fail open to `ready`.
 - **`ready`** — run the Codex pass below.
 

--- a/plan-devex-review/sections/review-sections.md
+++ b/plan-devex-review/sections/review-sections.md
@@ -268,10 +268,17 @@ elif ! command -v codex >/dev/null 2>&1; then
   _CODEX_MODE="not_installed"; _gstack_codex_log_event "codex_cli_missing" 2>/dev/null || true
 elif ! _gstack_codex_auth_probe >/dev/null 2>&1; then
   _CODEX_MODE="not_authed"; _gstack_codex_log_event "codex_auth_failed" 2>/dev/null || true
-elif ! _gstack_codex_model_probe; then
-  _CODEX_MODE="model_unusable"
 else
-  _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  # Capture the probe's code: 2 means the CLI cannot execute at all, which is a
+  # different problem (and a different fix) from a model the account can't use.
+  _gstack_codex_model_probe; _CODEX_MP=$?
+  if [ "$_CODEX_MP" -eq 2 ]; then
+    _CODEX_MODE="broken_install"
+  elif [ "$_CODEX_MP" -ne 0 ]; then
+    _CODEX_MODE="model_unusable"
+  else
+    _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  fi
 fi
 echo "CODEX_MODE: $_CODEX_MODE"
 ```
@@ -281,6 +288,7 @@ Branch on the echoed `CODEX_MODE`:
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`under_codex`** — this session is already running INSIDE a Codex host, so spawning codex again is the same model reviewing itself at multiplied token cost (#2519). Print exactly one line: "[running under Codex — nested codex passes skipped; set GSTACK_FORCE_CODEX_REVIEW=1 to force]" and skip the codex invocations below; run the section's free in-host pass instead if it defines one.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
+- **`broken_install`** — the CLI is on PATH but cannot execute (spawn ENOENT, non-executable binary, missing vendor payload). Print: "Codex is installed but its binary cannot run — Codex passes skipped. Reinstall: `npm install -g @openai/codex`." Relay the probe's HINT lines and fall back to the Claude subagent path. This state exists because a missing binary used to land in the model probe's fail-open bucket and report `ready`, so every Codex pass was skipped silently (#2742).
 - **`model_unusable`** — authed but the account cannot use its configured model (#2477: HTTP 400 on every call, usually a stale `model =` pin in `~/.codex/config.toml`). Relay the probe's HINT lines, tell the user the one-line fix (update the pin; `[notice.model_migrations]` names the replacement), and fall back to the Claude subagent path. The ~10s round trip is cached for 1h; timeouts fail open to `ready`.
 - **`ready`** — run the Codex pass below.
 

--- a/plan-eng-review/sections/review-sections.md
+++ b/plan-eng-review/sections/review-sections.md
@@ -363,10 +363,17 @@ elif ! command -v codex >/dev/null 2>&1; then
   _CODEX_MODE="not_installed"; _gstack_codex_log_event "codex_cli_missing" 2>/dev/null || true
 elif ! _gstack_codex_auth_probe >/dev/null 2>&1; then
   _CODEX_MODE="not_authed"; _gstack_codex_log_event "codex_auth_failed" 2>/dev/null || true
-elif ! _gstack_codex_model_probe; then
-  _CODEX_MODE="model_unusable"
 else
-  _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  # Capture the probe's code: 2 means the CLI cannot execute at all, which is a
+  # different problem (and a different fix) from a model the account can't use.
+  _gstack_codex_model_probe; _CODEX_MP=$?
+  if [ "$_CODEX_MP" -eq 2 ]; then
+    _CODEX_MODE="broken_install"
+  elif [ "$_CODEX_MP" -ne 0 ]; then
+    _CODEX_MODE="model_unusable"
+  else
+    _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  fi
 fi
 echo "CODEX_MODE: $_CODEX_MODE"
 ```
@@ -376,6 +383,7 @@ Branch on the echoed `CODEX_MODE`:
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`under_codex`** — this session is already running INSIDE a Codex host, so spawning codex again is the same model reviewing itself at multiplied token cost (#2519). Print exactly one line: "[running under Codex — nested codex passes skipped; set GSTACK_FORCE_CODEX_REVIEW=1 to force]" and skip the codex invocations below; run the section's free in-host pass instead if it defines one.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
+- **`broken_install`** — the CLI is on PATH but cannot execute (spawn ENOENT, non-executable binary, missing vendor payload). Print: "Codex is installed but its binary cannot run — Codex passes skipped. Reinstall: `npm install -g @openai/codex`." Relay the probe's HINT lines and fall back to the Claude subagent path. This state exists because a missing binary used to land in the model probe's fail-open bucket and report `ready`, so every Codex pass was skipped silently (#2742).
 - **`model_unusable`** — authed but the account cannot use its configured model (#2477: HTTP 400 on every call, usually a stale `model =` pin in `~/.codex/config.toml`). Relay the probe's HINT lines, tell the user the one-line fix (update the pin; `[notice.model_migrations]` names the replacement), and fall back to the Claude subagent path. The ~10s round trip is cached for 1h; timeouts fail open to `ready`.
 - **`ready`** — run the Codex pass below.
 

--- a/review/sections/adversarial.md
+++ b/review/sections/adversarial.md
@@ -35,10 +35,17 @@ elif ! command -v codex >/dev/null 2>&1; then
   _CODEX_MODE="not_installed"; _gstack_codex_log_event "codex_cli_missing" 2>/dev/null || true
 elif ! _gstack_codex_auth_probe >/dev/null 2>&1; then
   _CODEX_MODE="not_authed"; _gstack_codex_log_event "codex_auth_failed" 2>/dev/null || true
-elif ! _gstack_codex_model_probe; then
-  _CODEX_MODE="model_unusable"
 else
-  _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  # Capture the probe's code: 2 means the CLI cannot execute at all, which is a
+  # different problem (and a different fix) from a model the account can't use.
+  _gstack_codex_model_probe; _CODEX_MP=$?
+  if [ "$_CODEX_MP" -eq 2 ]; then
+    _CODEX_MODE="broken_install"
+  elif [ "$_CODEX_MP" -ne 0 ]; then
+    _CODEX_MODE="model_unusable"
+  else
+    _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  fi
 fi
 echo "CODEX_MODE: $_CODEX_MODE"
 ```
@@ -48,6 +55,7 @@ Branch on the echoed `CODEX_MODE`:
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`under_codex`** — this session is already running INSIDE a Codex host, so spawning codex again is the same model reviewing itself at multiplied token cost (#2519). Print exactly one line: "[running under Codex — nested codex passes skipped; set GSTACK_FORCE_CODEX_REVIEW=1 to force]" and skip the codex invocations below; run the section's free in-host pass instead if it defines one.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
+- **`broken_install`** — the CLI is on PATH but cannot execute (spawn ENOENT, non-executable binary, missing vendor payload). Print: "Codex is installed but its binary cannot run — Codex passes skipped. Reinstall: `npm install -g @openai/codex`." Relay the probe's HINT lines and fall back to the Claude subagent path. This state exists because a missing binary used to land in the model probe's fail-open bucket and report `ready`, so every Codex pass was skipped silently (#2742).
 - **`model_unusable`** — authed but the account cannot use its configured model (#2477: HTTP 400 on every call, usually a stale `model =` pin in `~/.codex/config.toml`). Relay the probe's HINT lines, tell the user the one-line fix (update the pin; `[notice.model_migrations]` names the replacement), and fall back to the Claude subagent path. The ~10s round trip is cached for 1h; timeouts fail open to `ready`.
 - **`ready`** — run the Codex pass below.
 

--- a/scripts/resolvers/constants.ts
+++ b/scripts/resolvers/constants.ts
@@ -130,10 +130,17 @@ elif ! command -v codex >/dev/null 2>&1; then
   ${m}="not_installed"; _gstack_codex_log_event "codex_cli_missing" 2>/dev/null || true
 elif ! _gstack_codex_auth_probe >/dev/null 2>&1; then
   ${m}="not_authed"; _gstack_codex_log_event "codex_auth_failed" 2>/dev/null || true
-elif ! _gstack_codex_model_probe; then
-  ${m}="model_unusable"
 else
-  ${m}="ready"; _gstack_codex_version_check 2>/dev/null || true
+  # Capture the probe's code: 2 means the CLI cannot execute at all, which is a
+  # different problem (and a different fix) from a model the account can't use.
+  _gstack_codex_model_probe; _CODEX_MP=$?
+  if [ "$_CODEX_MP" -eq 2 ]; then
+    ${m}="broken_install"
+  elif [ "$_CODEX_MP" -ne 0 ]; then
+    ${m}="model_unusable"
+  else
+    ${m}="ready"; _gstack_codex_version_check 2>/dev/null || true
+  fi
 fi
 echo "CODEX_MODE: $${m}"
 \`\`\`
@@ -143,6 +150,7 @@ Branch on the echoed \`CODEX_MODE\`:
 - **\`not_installed\`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: \`npm install -g @openai/codex\`." Fall back to the Claude subagent path.
 - **\`under_codex\`** — this session is already running INSIDE a Codex host, so spawning codex again is the same model reviewing itself at multiplied token cost (#2519). Print exactly one line: "[running under Codex — nested codex passes skipped; set GSTACK_FORCE_CODEX_REVIEW=1 to force]" and skip the codex invocations below; run the section's free in-host pass instead if it defines one.
 - **\`not_authed\`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run \`codex login\` or set \`$CODEX_API_KEY\`." Fall back to the Claude subagent path.
+- **\`broken_install\`** — the CLI is on PATH but cannot execute (spawn ENOENT, non-executable binary, missing vendor payload). Print: "Codex is installed but its binary cannot run — Codex passes skipped. Reinstall: \`npm install -g @openai/codex\`." Relay the probe's HINT lines and fall back to the Claude subagent path. This state exists because a missing binary used to land in the model probe's fail-open bucket and report \`ready\`, so every Codex pass was skipped silently (#2742).
 - **\`model_unusable\`** — authed but the account cannot use its configured model (#2477: HTTP 400 on every call, usually a stale \`model =\` pin in \`~/.codex/config.toml\`). Relay the probe's HINT lines, tell the user the one-line fix (update the pin; \`[notice.model_migrations]\` names the replacement), and fall back to the Claude subagent path. The ~10s round trip is cached for 1h; timeouts fail open to \`ready\`.
 - **\`ready\`** — run the Codex pass below.`;
 }

--- a/ship/sections/adversarial.md
+++ b/ship/sections/adversarial.md
@@ -35,10 +35,17 @@ elif ! command -v codex >/dev/null 2>&1; then
   _CODEX_MODE="not_installed"; _gstack_codex_log_event "codex_cli_missing" 2>/dev/null || true
 elif ! _gstack_codex_auth_probe >/dev/null 2>&1; then
   _CODEX_MODE="not_authed"; _gstack_codex_log_event "codex_auth_failed" 2>/dev/null || true
-elif ! _gstack_codex_model_probe; then
-  _CODEX_MODE="model_unusable"
 else
-  _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  # Capture the probe's code: 2 means the CLI cannot execute at all, which is a
+  # different problem (and a different fix) from a model the account can't use.
+  _gstack_codex_model_probe; _CODEX_MP=$?
+  if [ "$_CODEX_MP" -eq 2 ]; then
+    _CODEX_MODE="broken_install"
+  elif [ "$_CODEX_MP" -ne 0 ]; then
+    _CODEX_MODE="model_unusable"
+  else
+    _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  fi
 fi
 echo "CODEX_MODE: $_CODEX_MODE"
 ```
@@ -48,6 +55,7 @@ Branch on the echoed `CODEX_MODE`:
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`under_codex`** — this session is already running INSIDE a Codex host, so spawning codex again is the same model reviewing itself at multiplied token cost (#2519). Print exactly one line: "[running under Codex — nested codex passes skipped; set GSTACK_FORCE_CODEX_REVIEW=1 to force]" and skip the codex invocations below; run the section's free in-host pass instead if it defines one.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
+- **`broken_install`** — the CLI is on PATH but cannot execute (spawn ENOENT, non-executable binary, missing vendor payload). Print: "Codex is installed but its binary cannot run — Codex passes skipped. Reinstall: `npm install -g @openai/codex`." Relay the probe's HINT lines and fall back to the Claude subagent path. This state exists because a missing binary used to land in the model probe's fail-open bucket and report `ready`, so every Codex pass was skipped silently (#2742).
 - **`model_unusable`** — authed but the account cannot use its configured model (#2477: HTTP 400 on every call, usually a stale `model =` pin in `~/.codex/config.toml`). Relay the probe's HINT lines, tell the user the one-line fix (update the pin; `[notice.model_migrations]` names the replacement), and fall back to the Claude subagent path. The ~10s round trip is cached for 1h; timeouts fail open to `ready`.
 - **`ready`** — run the Codex pass below.
 

--- a/test/codex-hardening.test.ts
+++ b/test/codex-hardening.test.ts
@@ -599,3 +599,135 @@ describe('codex skeleton+sections union: review sandbox + fail-closed gate + tim
     });
   }
 });
+
+// #2742: a Codex CLI that is on PATH but cannot execute (spawn ENOENT, missing
+// vendor payload, non-executable binary) used to land in the model probe's
+// fail-open bucket and resolve to CODEX_MODE: ready — so every Codex pass was
+// skipped in silence. These pin the classification, the exit-code contract, and
+// the fact that the fail-open path still exists for genuine transients.
+describe('codex broken-install detection (#2742)', () => {
+  // A fake `codex` on PATH that reproduces the real failure: node's spawn dump
+  // on stderr, non-zero exit. `mode` picks which failure shape to emit.
+  function shimHome(mode: 'enoent' | 'notexec' | 'timeout' | 'model400') {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-codex-shim-'));
+    const bin = path.join(home, 'bin');
+    fs.mkdirSync(bin, { recursive: true });
+    // auth.json so the auth probe passes and we reach the model probe.
+    fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.codex/auth.json'), '{}');
+    const bodies: Record<string, string> = {
+      enoent:
+        `echo "Error: spawn /x/vendor/aarch64-apple-darwin/codex/codex ENOENT" >&2\n` +
+        `echo "  errno: -2, code: 'ENOENT'" >&2\nexit 1\n`,
+      notexec: `echo "bash: codex: cannot execute binary file" >&2\nexit 126\n`,
+      timeout: `echo "network hiccup" >&2\nexit 124\n`,
+      model400: `echo "The 'gpt-x' model is not supported when using Codex with a ChatGPT account" >&2\nexit 1\n`,
+    };
+    fs.writeFileSync(path.join(bin, 'codex'), `#!/usr/bin/env bash\n${bodies[mode]}`, { mode: 0o755 });
+    return { home, bin };
+  }
+
+  const cases: Array<[string, 'enoent' | 'notexec', string]> = [
+    ['spawn ENOENT', 'enoent', 'ENOENT'],
+    ['non-executable binary (exit 126)', 'notexec', 'cannot execute binary file'],
+  ];
+
+  for (const [label, mode, needle] of cases) {
+    test(`${label} is classified as a broken install, not a transient`, () => {
+      const { home, bin } = shimHome(mode);
+      try {
+        const r = runProbe({
+          snippet: '_gstack_codex_model_probe; echo "EXIT:$?"',
+          home,
+          env: { PATH: `${bin}:${process.env.PATH ?? ''}`, GSTACK_HOME: home },
+        });
+        expect(r.stdout).toContain('MODEL_UNUSABLE_INSTALL');
+        // Exit 2 is what lets the preflight tell this apart from a model 400.
+        expect(r.stdout).toContain('EXIT:2');
+        // It must NOT fail open — that was the whole defect.
+        expect(r.stdout).not.toContain('MODEL_PROBE_INCONCLUSIVE');
+        // The remedy names the install, not the model pin.
+        expect(r.stdout).toContain('npm install -g @openai/codex');
+        expect(r.stdout.toLowerCase()).toContain(needle.toLowerCase());
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    });
+  }
+
+  test('a broken install is never cached — a reinstall is picked up next probe', () => {
+    const { home, bin } = shimHome('enoent');
+    try {
+      runProbe({
+        snippet: '_gstack_codex_model_probe >/dev/null 2>&1',
+        home,
+        env: { PATH: `${bin}:${process.env.PATH ?? ''}`, GSTACK_HOME: home },
+      });
+      const cache = path.join(home, '.codex-model-probe');
+      if (fs.existsSync(cache)) {
+        expect(fs.readFileSync(cache, 'utf8')).not.toContain('MODEL_OK');
+      }
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('a genuine transient (exit 124) still fails open', () => {
+    const { home, bin } = shimHome('timeout');
+    try {
+      const r = runProbe({
+        snippet: '_gstack_codex_model_probe; echo "EXIT:$?"',
+        home,
+        env: { PATH: `${bin}:${process.env.PATH ?? ''}`, GSTACK_HOME: home },
+      });
+      expect(r.stdout).toContain('MODEL_PROBE_INCONCLUSIVE');
+      expect(r.stdout).toContain('EXIT:0');
+      expect(r.stdout).not.toContain('MODEL_UNUSABLE_INSTALL');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('the model 400 still classifies as MODEL_UNUSABLE, not a broken install', () => {
+    const { home, bin } = shimHome('model400');
+    try {
+      const r = runProbe({
+        snippet: '_gstack_codex_model_probe; echo "EXIT:$?"',
+        home,
+        env: { PATH: `${bin}:${process.env.PATH ?? ''}`, GSTACK_HOME: home },
+      });
+      expect(r.stdout).toContain('MODEL_UNUSABLE');
+      expect(r.stdout).not.toContain('MODEL_UNUSABLE_INSTALL');
+      expect(r.stdout).toContain('EXIT:1');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('version check warns instead of returning silently when codex cannot report a version', () => {
+    const { home, bin } = shimHome('enoent');
+    try {
+      const r = runProbe({
+        snippet: '_gstack_codex_version_check; echo "EXIT:$?"',
+        home,
+        env: { PATH: `${bin}:${process.env.PATH ?? ''}`, GSTACK_HOME: home },
+      });
+      // Previously this printed nothing: `codex --version 2>/dev/null | head -1`
+      // captured head's status, so a CLI that only ever errored read as healthy.
+      expect(r.stdout).toContain('WARN');
+      expect(r.stdout).toContain('npm install -g @openai/codex');
+      // Still non-fatal — the version check has never gated anything.
+      expect(r.stdout).toContain('EXIT:0');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('the preflight resolver routes exit 2 to broken_install', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'scripts/resolvers/constants.ts'), 'utf8');
+    expect(src).toContain('broken_install');
+    // The chain must capture the probe's code; `elif ! _gstack_codex_model_probe`
+    // collapses 1 and 2 into one branch and loses the distinction.
+    expect(src).toContain('_CODEX_MP=$?');
+  });
+});

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -2148,10 +2148,17 @@ elif ! command -v codex >/dev/null 2>&1; then
   _CODEX_MODE="not_installed"; _gstack_codex_log_event "codex_cli_missing" 2>/dev/null || true
 elif ! _gstack_codex_auth_probe >/dev/null 2>&1; then
   _CODEX_MODE="not_authed"; _gstack_codex_log_event "codex_auth_failed" 2>/dev/null || true
-elif ! _gstack_codex_model_probe; then
-  _CODEX_MODE="model_unusable"
 else
-  _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  # Capture the probe's code: 2 means the CLI cannot execute at all, which is a
+  # different problem (and a different fix) from a model the account can't use.
+  _gstack_codex_model_probe; _CODEX_MP=$?
+  if [ "$_CODEX_MP" -eq 2 ]; then
+    _CODEX_MODE="broken_install"
+  elif [ "$_CODEX_MP" -ne 0 ]; then
+    _CODEX_MODE="model_unusable"
+  else
+    _CODEX_MODE="ready"; _gstack_codex_version_check 2>/dev/null || true
+  fi
 fi
 echo "CODEX_MODE: $_CODEX_MODE"
 ```
@@ -2161,6 +2168,7 @@ Branch on the echoed `CODEX_MODE`:
 - **`not_installed`** — Codex CLI absent. Print: "Codex not installed — using Claude subagent. Install for cross-model coverage: `npm install -g @openai/codex`." Fall back to the Claude subagent path.
 - **`under_codex`** — this session is already running INSIDE a Codex host, so spawning codex again is the same model reviewing itself at multiplied token cost (#2519). Print exactly one line: "[running under Codex — nested codex passes skipped; set GSTACK_FORCE_CODEX_REVIEW=1 to force]" and skip the codex invocations below; run the section's free in-host pass instead if it defines one.
 - **`not_authed`** — installed but no credentials. Print: "Codex installed but not authenticated — using Claude subagent. Run `codex login` or set `$CODEX_API_KEY`." Fall back to the Claude subagent path.
+- **`broken_install`** — the CLI is on PATH but cannot execute (spawn ENOENT, non-executable binary, missing vendor payload). Print: "Codex is installed but its binary cannot run — Codex passes skipped. Reinstall: `npm install -g @openai/codex`." Relay the probe's HINT lines and fall back to the Claude subagent path. This state exists because a missing binary used to land in the model probe's fail-open bucket and report `ready`, so every Codex pass was skipped silently (#2742).
 - **`model_unusable`** — authed but the account cannot use its configured model (#2477: HTTP 400 on every call, usually a stale `model =` pin in `~/.codex/config.toml`). Relay the probe's HINT lines, tell the user the one-line fix (update the pin; `[notice.model_migrations]` names the replacement), and fall back to the Claude subagent path. The ~10s round trip is cached for 1h; timeouts fail open to `ready`.
 - **`ready`** — run the Codex pass below.
 


### PR DESCRIPTION
Fixes #2742.

## Why (in your own words)

Codex passes can be skipped for months without anyone noticing. `@openai/codex` was installed and on my `PATH`, but `node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/` was an **empty directory** — the binary had been removed some time after install while its sibling `vendor/.../path/rg` stayed intact. Every invocation died with `spawn ... ENOENT`, and gstack reported `CODEX_MODE: ready` throughout. `/ship`, `/review` and `/autoplan` skipped their Codex passes silently and reported themselves complete. Reviews I believed were cross-model were single-model for two months.

The cause of the deletion was local and isn't the point. The detection gap is: #2477 added `_gstack_codex_model_probe` precisely so "auth exists" would stop being mistaken for "Codex works", and it does a real round trip — but its final branch is the `else` of a "model 400" grep. A spawn ENOENT has neither a 400 nor the word "model", so it landed in the bucket whose comment reads *"Timeout (124) or transient failure: fail-open... not to gate on network luck."* That reasoning is right for a timeout. A missing binary is deterministic: retrying never helps.

This adds a `broken_install` state, keeps fail-open for genuine transients, and stops the version check reading a broken CLI as healthy.

## Live evidence

**Before — unmodified `main` (253d1df), with a `codex` on PATH that cannot execute:**

```
$ bash /tmp/codex-evidence.sh <main's bin/gstack-codex-probe>
MODEL_PROBE_INCONCLUSIVE (exit 1) — proceeding; if invocations fail with a model 400, see the codex skill's Error Handling entry.
CODEX_MODE: ready
```

A CLI that cannot run resolves to `ready`, and the one hint printed points the user at their *model configuration*.

**After — this branch, same shim, same chain:**

```
$ bash /tmp/codex-evidence.sh <this branch's bin/gstack-codex-probe>
MODEL_UNUSABLE_INSTALL
Error: spawn /opt/.../vendor/aarch64-apple-darwin/codex/codex ENOENT
  errno: -2, code: 'ENOENT'
HINT: the Codex CLI is on PATH but cannot run — its binary or vendor payload is missing.
HINT: reinstall with: npm install -g @openai/codex
CODEX_MODE: broken_install
```

The shim reproduces the real failure exactly (node's spawn dump on stderr, non-zero exit) and the chain is the one from `scripts/resolvers/constants.ts`, run verbatim.

**All three original probes passed on the broken install** — this is what the issue reproduces, and why nothing caught it:

```
AUTH_OK                             auth: 0
MODEL_PROBE_INCONCLUSIVE (exit 1)   model: 0   ← fails open
(silent)                            version: 0
```

**Tests — the suites that cover the changed files:**

```
$ bun test test/codex-model-probe.test.ts test/codex-hardening.test.ts \
    test/codex-web-search-flag.test.ts test/codex-under-codex-detection.test.ts \
    test/setup-codex-model.test.ts test/gen-skill-docs.test.ts \
    test/skill-validation.test.ts test/skill-cross-model-recommendation-emit.test.ts
 845 pass
 0 fail
 8051 expect() calls

$ bun test test/host-config.test.ts        # golden fixtures
 76 pass
 0 fail
```

**The fix caught its own regression.** My first version of the version-check warned whenever `$_ver` was empty, which broke the existing `empty output → OK (silent, no crash)` case — that behavior is deliberate, so the condition is now narrowed to a non-zero exit only. The real broken CLI exits non-zero, so the detection is unaffected.

## Scope

- **Changed:**
  - `bin/gstack-codex-probe` — `_gstack_codex_model_probe` classifies deterministic install failures (exit 126/127, or stderr matching `ENOENT|ENOEXEC|EACCES|cannot execute binary file|no such file or directory|permission denied`) as `MODEL_UNUSABLE_INSTALL`, **exit 2**, never cached so a reinstall is picked up on the next probe. Exit 124 and genuine transients still fail open. `_gstack_codex_version_check` captures codex's own exit code instead of `head`'s (`codex --version 2>/dev/null | head -1` reported the pipeline's last status) and warns on non-zero; `2>/dev/null` also discarded the only diagnostic, so stderr is kept.
  - `scripts/resolvers/constants.ts` — the chain captures the probe's code rather than testing truthiness, so exit 2 routes to a new **`broken_install`** mode whose remedy is `npm install -g @openai/codex`, not "check your model pin". Regenerated the six section files and the factory ship golden.
  - `test/codex-hardening.test.ts` — 6 tests using the existing `runProbe` harness.
- **Verified live by:** reproducing the failure with a PATH shim and running the real preflight chain before/after; running every suite that touches the changed files; and by the original incident on my own machine (two months of silently skipped Codex passes, found only when a doc-sync subagent reported it couldn't reach Codex).
- **Did NOT test:** a real partially-deleted npm install (simulated via PATH shim instead — the shim reproduces the observed stderr and exit code); Windows and Linux paths; whether `broken_install` should also be surfaced by `/autoplan`'s own preflight copy, if it has one.

**On the full suite — the measurement, and two wrong explanations I gave before it.**

Full-suite numbers on this machine:

| | pass | fail | tests | time |
| --- | --- | --- | --- | --- |
| unmodified `main` (253d1df) | 8474 | 6 | 8944 | 622s |
| this branch | 8360 | 115 | 8939 | 1200s |

Every one of the 115 is a `browse` test. I twice guessed at a mechanism and was wrong both times — first "two suites running concurrently", disproved when a non-concurrent run failed the same way; then "orphaned browse daemons holding the lock", disproved when I reaped every one of them (`pgrep -f <clone> → 0`) and a clean run still failed 115. I am not offering a third guess.

Here is the controlled comparison instead. Same browse suite, both clones, back to back, daemons killed between runs:

```
$ cd gstack-base && bun test browse/test/commands.test.ts     # unmodified main
 242 pass
 2 fail
Ran 244 tests across 1 file. [30.62s]

$ cd gstack-pr && bun test browse/test/commands.test.ts       # this branch
 242 pass
 2 fail
Ran 244 tests across 1 file. [30.65s]
```

Identical, to the test and to a third of a second. The same two fail on both — `Path traversal prevention > eval rejects path traversal with ..` and `> cookie-import rejects path traversal` — so they are pre-existing on `main`, not from this change.

So: `browse` behaves the same with and without this diff when measured in isolation. The full-suite difference is variance in how this machine runs all 592 files together; whatever drives it, it is not this change, and I would rather show you the isolation comparison than assert a cause I have not proven. Worth noting the suite is already known to be non-deterministic here (#2536, #2597).

What the diff can actually reach is green. It is 10 files — `bin/gstack-codex-probe`, 6 generated section `.md`s, `scripts/resolvers/constants.ts`, `test/codex-hardening.test.ts`, and the factory golden — nothing in `browse` imports any of them, and every suite that covers them passes:

```
845 pass / 0 fail   the 8 suites touching the changed files
 76 pass / 0 fail   test/host-config.test.ts (golden fixtures)
 52 pass / 0 fail   test/codex-hardening.test.ts (incl. the 6 new)
```

The one non-`browse` failure across all my runs, `setup: ensure_emoji_font ... (color=False)`, passes in isolation on both this branch and `main`.

I am flagging the corrections rather than quietly editing them, since a maintainer may have read the earlier versions.

## Liveness proof (required)

⚠️ **Not yet attached — the repo owner will add it before this leaves draft.**

This PR was prepared with an AI coding agent on the author's machine. The liveness screenshot exists to confirm a human opened the PR, so it would defeat its own purpose for the agent to produce one; it is deliberately left for the human author rather than faked. Marked as a draft until then.

## Checklist

- [ ] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited `bin/gstack-codex-probe` + `scripts/resolvers/constants.ts` and ran `bun run gen:skill-docs`)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A) — N/A, no new command or service
- [x] Linked issue or reproduction: #2742


