### PR TITLE
docs(openclaw): fix spawned session env guidance

### DIFF
--- a/docs/OPENCLAW.md
+++ b/docs/OPENCLAW.md
@@ -127,7 +127,14 @@ environment variable should be set. gstack detects this and adjusts:
   rendering prose to nobody
 - Focuses on task completion and prose reporting
 
-Set the env var in sessions_spawn: `env: { OPENCLAW_SESSION: "1" }`
+OpenClaw's `sessions_spawn` does not currently accept a per-spawn `env`
+argument ([openclaw/openclaw#51654](https://github.com/openclaw/openclaw/issues/51654)).
+Do not add an unsupported `env` field to the tool call. Set
+`OPENCLAW_SESSION=1` in the environment of the Claude ACP harness instead,
+typically through the executable wrapper selected by the ACP backend or the
+Gateway service environment. Keep credentials out of that wrapper and verify
+the variable from the spawned process rather than relying on the model's final
+message.
 
 ### Explicit override: GSTACK_SESSION_KIND
 

--- a/test/openclaw-native-skills.test.ts
+++ b/test/openclaw-native-skills.test.ts
@@ -32,4 +32,12 @@ describe('OpenClaw native skills', () => {
       expect((parsed.description as string).length).toBeGreaterThan(0);
     }
   });
+
+  test('integration docs do not advertise unsupported per-spawn env', () => {
+    const content = fs.readFileSync(path.join(ROOT, 'docs/OPENCLAW.md'), 'utf-8');
+
+    expect(content).not.toContain('env: { OPENCLAW_SESSION: "1" }');
+    expect(content).toContain('does not currently accept a per-spawn `env`');
+    expect(content).toContain('environment of the Claude ACP harness');
+  });
 });


### PR DESCRIPTION
## Summary

- remove unsupported per-spawn env guidance from the OpenClaw integration docs
- document setting OPENCLAW_SESSION=1 in the Claude ACP harness or Gateway service environment
- require verification from the spawned process instead of trusting the model final message
- add a regression test that prevents the unsupported sessions_spawn shape from returning

OpenClaw does not currently expose a per-spawn env parameter; see openclaw/openclaw#51654.

## Tests

- bun test test/openclaw-native-skills.test.ts (2 pass, 0 fail)
- git diff --check