### PR TITLE
fix: support current Codex session JSONL schema

### DIFF
--- a/bin/gstack-global-discover.ts
+++ b/bin/gstack-global-discover.ts
@@ -19,13 +19,34 @@ import { homedir } from "os";
 interface Session {
   tool: "claude_code" | "codex" | "gemini";
   cwd: string;
+  codex_kind?: "root" | "subagent";
 }
 
 interface Repo {
   name: string;
   remote: string;
   paths: string[];
-  sessions: { claude_code: number; codex: number; gemini: number };
+  sessions: {
+    claude_code: number;
+    codex: number;
+    codex_root: number;
+    codex_subagent: number;
+    gemini: number;
+  };
+}
+
+interface CodexDiagnostics {
+  files_considered: number;
+  files_without_session_meta: number;
+  malformed_records: number;
+  truncated_prefixes: number;
+  read_errors: number;
+  unknown_record_types: Record<string, number>;
+}
+
+interface CodexScanResult {
+  sessions: Session[];
+  diagnostics: CodexDiagnostics;
 }
 
 interface DiscoveryResult {
@@ -34,9 +55,15 @@ interface DiscoveryResult {
   repos: Repo[];
   tools: {
     claude_code: { total_sessions: number; repos: number };
-    codex: { total_sessions: number; repos: number };
+    codex: {
+      total_sessions: number;
+      root_sessions: number;
+      subagent_sessions: number;
+      repos: number;
+    };
     gemini: { total_sessions: number; repos: number };
   };
+  diagnostics: { codex: CodexDiagnostics };
   total_sessions: number;
   total_repos: number;
 }
@@ -95,12 +122,11 @@ function parseArgs(): { since: string; format: "json" | "summary" } {
   return { since, format };
 }
 
-function windowToDate(window: string): Date {
+export function windowToDate(window: string, now = new Date()): Date {
   const match = window.match(/^(\d+)(d|h|w)$/);
   if (!match) throw new Error(`Invalid window: ${window}`);
   const [, numStr, unit] = match;
   const num = parseInt(numStr, 10);
-  const now = new Date();
 
   if (unit === "h") {
     return new Date(now.getTime() - num * 60 * 60 * 1000);
@@ -117,6 +143,13 @@ function windowToDate(window: string): Date {
     d.setHours(0, 0, 0, 0);
     return d;
   }
+}
+
+export function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 // ── URL normalization ──────────────────────────────────────────────────────
@@ -304,9 +337,110 @@ export function extractCwdFromJsonl(filePath: string): string | null {
   return null;
 }
 
-function scanCodex(since: Date): Session[] {
-  const sessionsDir = process.env.CODEX_SESSIONS_DIR || join(homedir(), ".codex", "sessions");
-  if (!existsSync(sessionsDir)) return [];
+const CODEX_JSONL_PREFIX_BYTES = 1024 * 1024;
+const KNOWN_CODEX_RECORD_TYPES = new Set([
+  "event_msg",
+  "response_item",
+  "compacted",
+  "turn_context",
+  "world_state",
+  "inter_agent_communication_metadata",
+]);
+
+interface CodexSessionParseResult {
+  session: { cwd: string; kind: "root" | "subagent" } | null;
+  malformed_records: number;
+  prefix_truncated: boolean;
+  unknown_record_types: string[];
+}
+
+function codexSessionKind(payload: Record<string, unknown>): "root" | "subagent" {
+  const source = payload.source;
+  return source && typeof source === "object" && "subagent" in source
+    ? "subagent"
+    : "root";
+}
+
+export function parseCodexJsonlPrefix(
+  text: string,
+  prefixTruncated = false
+): CodexSessionParseResult {
+  const lines = text.split("\n");
+  if (prefixTruncated && !text.endsWith("\n")) lines.pop();
+
+  let malformedRecords = 0;
+  let session: CodexSessionParseResult["session"] = null;
+  const unknownRecordTypes = new Set<string>();
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+
+    let record: Record<string, unknown>;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      malformedRecords++;
+      continue;
+    }
+
+    const type = typeof record.type === "string" ? record.type : "<missing>";
+    if (type === "session_meta") {
+      const payload = record.payload;
+      if (!payload || typeof payload !== "object") {
+        malformedRecords++;
+        continue;
+      }
+      const cwd = (payload as Record<string, unknown>).cwd;
+      if (typeof cwd !== "string" || !cwd) {
+        malformedRecords++;
+        continue;
+      }
+      if (!session) {
+        session = {
+          cwd,
+          kind: codexSessionKind(payload as Record<string, unknown>),
+        };
+      }
+      continue;
+    }
+
+    if (!KNOWN_CODEX_RECORD_TYPES.has(type)) unknownRecordTypes.add(type);
+  }
+
+  return {
+    session,
+    malformed_records: malformedRecords,
+    prefix_truncated: prefixTruncated,
+    unknown_record_types: [...unknownRecordTypes].sort(),
+  };
+}
+
+function parseCodexSessionFile(filePath: string): CodexSessionParseResult {
+  const fd = openSync(filePath, "r");
+  try {
+    const buf = Buffer.alloc(CODEX_JSONL_PREFIX_BYTES);
+    const bytesRead = readSync(fd, buf, 0, CODEX_JSONL_PREFIX_BYTES, 0);
+    return parseCodexJsonlPrefix(
+      buf.toString("utf-8", 0, bytesRead),
+      statSync(filePath).size > bytesRead
+    );
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function scanCodex(since: Date): CodexScanResult {
+  const sessionsDir =
+    process.env.CODEX_SESSIONS_DIR || join(homedir(), ".codex", "sessions");
+  const diagnostics: CodexDiagnostics = {
+    files_considered: 0,
+    files_without_session_meta: 0,
+    malformed_records: 0,
+    truncated_prefixes: 0,
+    read_errors: 0,
+    unknown_record_types: {},
+  };
+  if (!existsSync(sessionsDir)) return { sessions: [], diagnostics };
 
   const sessions: Session[] = [];
 
@@ -340,23 +474,30 @@ function scanCodex(since: Date): Session[] {
               continue;
             }
 
-            // Codex session_meta lines embed the full system prompt in
-            // base_instructions (~15KB as of CLI v0.117+). A 4KB buffer
-            // truncates the line and JSON.parse fails. 128KB covers current
-            // sizes with room for growth.
+            diagnostics.files_considered++;
             try {
-              const fd = openSync(filePath, "r");
-              const buf = Buffer.alloc(131072);
-              const bytesRead = readSync(fd, buf, 0, 131072, 0);
-              closeSync(fd);
-              const firstLine = buf.toString("utf-8", 0, bytesRead).split("\n")[0];
-              if (!firstLine) continue;
-              const meta = JSON.parse(firstLine);
-              if (meta.type === "session_meta" && meta.payload?.cwd) {
-                sessions.push({ tool: "codex", cwd: meta.payload.cwd });
+              const parsed = parseCodexSessionFile(filePath);
+              diagnostics.malformed_records += parsed.malformed_records;
+              if (parsed.prefix_truncated && !parsed.session) diagnostics.truncated_prefixes++;
+              for (const type of parsed.unknown_record_types) {
+                diagnostics.unknown_record_types[type] =
+                  (diagnostics.unknown_record_types[type] || 0) + 1;
+              }
+              if (parsed.session) {
+                sessions.push({
+                  tool: "codex",
+                  cwd: parsed.session.cwd,
+                  codex_kind: parsed.session.kind,
+                });
+              } else {
+                diagnostics.files_without_session_meta++;
+                console.error(
+                  `Warning: no usable session_meta in Codex session ${filePath}`
+                );
               }
             } catch {
-              console.error(`Warning: could not parse Codex session ${filePath}`);
+              diagnostics.read_errors++;
+              console.error(`Warning: could not read Codex session ${filePath}`);
             }
           }
         }
@@ -366,7 +507,7 @@ function scanCodex(since: Date): Session[] {
     // Directory read error
   }
 
-  return sessions;
+  return { sessions, diagnostics };
 }
 
 function scanGemini(since: Date): Session[] {
@@ -514,9 +655,19 @@ async function resolveAndDeduplicate(sessions: Session[]): Promise<Repo[]> {
       }
     }
 
-    const sessionCounts = { claude_code: 0, codex: 0, gemini: 0 };
+    const sessionCounts = {
+      claude_code: 0,
+      codex: 0,
+      codex_root: 0,
+      codex_subagent: 0,
+      gemini: 0,
+    };
     for (const s of data.sessions) {
       sessionCounts[s.tool]++;
+      if (s.tool === "codex") {
+        if (s.codex_kind === "subagent") sessionCounts.codex_subagent++;
+        else sessionCounts.codex_root++;
+      }
     }
 
     repos.push({
@@ -542,11 +693,12 @@ async function resolveAndDeduplicate(sessions: Session[]): Promise<Repo[]> {
 async function main() {
   const { since, format } = parseArgs();
   const sinceDate = windowToDate(since);
-  const startDate = sinceDate.toISOString().split("T")[0];
+  const startDate = formatLocalDate(sinceDate);
 
   // Run all scanners
   const ccSessions = scanClaudeCode(sinceDate);
-  const codexSessions = scanCodex(sinceDate);
+  const codexScan = scanCodex(sinceDate);
+  const codexSessions = codexScan.sessions;
   const geminiSessions = scanGemini(sinceDate);
 
   const allSessions = [...ccSessions, ...codexSessions, ...geminiSessions];
@@ -555,6 +707,15 @@ async function main() {
   console.error(
     `Discovered: ${ccSessions.length} CC sessions, ${codexSessions.length} Codex sessions, ${geminiSessions.length} Gemini sessions`
   );
+  const rootCodexSessions = codexSessions.filter((s) => s.codex_kind !== "subagent").length;
+  const subagentCodexSessions = codexSessions.length - rootCodexSessions;
+  if (
+    codexScan.diagnostics.malformed_records > 0 ||
+    codexScan.diagnostics.files_without_session_meta > 0 ||
+    Object.keys(codexScan.diagnostics.unknown_record_types).length > 0
+  ) {
+    console.error(`Codex diagnostics: ${JSON.stringify(codexScan.diagnostics)}`);
+  }
 
   // Deduplicate
   const repos = await resolveAndDeduplicate(allSessions);
@@ -572,9 +733,15 @@ async function main() {
     repos,
     tools: {
       claude_code: { total_sessions: ccSessions.length, repos: ccRepos },
-      codex: { total_sessions: codexSessions.length, repos: codexRepos },
+      codex: {
+        total_sessions: codexSessions.length,
+        root_sessions: rootCodexSessions,
+        subagent_sessions: subagentCodexSessions,
+        repos: codexRepos,
+      },
       gemini: { total_sessions: geminiSessions.length, repos: geminiRepos },
     },
+    diagnostics: { codex: codexScan.diagnostics },
     total_sessions: allSessions.length,
     total_repos: repos.length,
   };
@@ -584,7 +751,7 @@ async function main() {
   } else {
     // Summary format
     console.log(`Window: ${since} (since ${startDate})`);
-    console.log(`Sessions: ${allSessions.length} total (CC: ${ccSessions.length}, Codex: ${codexSessions.length}, Gemini: ${geminiSessions.length})`);
+    console.log(`Sessions: ${allSessions.length} total (CC: ${ccSessions.length}, Codex: ${codexSessions.length} [root: ${rootCodexSessions}, subagent: ${subagentCodexSessions}], Gemini: ${geminiSessions.length})`);
     console.log(`Repos: ${repos.length} unique`);
     console.log("");
     for (const repo of repos) {

--- a/test/fixtures/global-discover/codex-current.jsonl
+++ b/test/fixtures/global-discover/codex-current.jsonl
@@ -1,0 +1,4 @@
+{"type":"session_meta","payload":{"cwd":"/synthetic/current","source":"exec","base_instructions":"synthetic instructions"}}
+{"type":"event_msg","payload":{"type":"synthetic_task_started"}}
+{"type":"response_item","payload":{"type":"synthetic_message"}}
+{"type":"compacted","payload":{"replacement_history":[]}}

--- a/test/fixtures/global-discover/codex-legacy.jsonl
+++ b/test/fixtures/global-discover/codex-legacy.jsonl
@@ -1,0 +1,1 @@
+{"type":"session_meta","payload":{"cwd":"/synthetic/legacy","source":"cli"}}

--- a/test/fixtures/global-discover/codex-subagent.jsonl
+++ b/test/fixtures/global-discover/codex-subagent.jsonl
@@ -1,0 +1,1 @@
+{"type":"session_meta","payload":{"cwd":"/synthetic/subagent","source":{"subagent":{"thread_spawn":{"depth":1,"agent_path":"/root/synthetic"}}}}}

--- a/test/fixtures/global-discover/codex-unknown.jsonl
+++ b/test/fixtures/global-discover/codex-unknown.jsonl
@@ -1,0 +1,2 @@
+{"type":"future_event","payload":{}}
+{"type":"session_meta","payload":{"cwd":"/synthetic/unknown","source":"exec"}}

--- a/test/global-discover.test.ts
+++ b/test/global-discover.test.ts
@@ -1,12 +1,30 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { spawnSync } from "child_process";
+import {
+  formatLocalDate,
+  parseCodexJsonlPrefix,
+  windowToDate,
+} from "../bin/gstack-global-discover.ts";
 
 // Import normalizeRemoteUrl for unit testing
 // We test the script end-to-end via CLI and normalizeRemoteUrl via import
 const scriptPath = join(import.meta.dir, "..", "bin", "gstack-global-discover.ts");
+const fixtureDir = join(import.meta.dir, "fixtures", "global-discover");
+const bunExecutable = process.execPath;
+
+function fixture(name: string): string {
+  return readFileSync(join(fixtureDir, name), "utf-8");
+}
 
 describe("gstack-global-discover", () => {
   describe("normalizeRemoteUrl", () => {
@@ -65,7 +83,7 @@ describe("gstack-global-discover", () => {
 
   describe("CLI", () => {
     test("--help exits 0 and prints usage", () => {
-      const result = spawnSync("bun", ["run", scriptPath, "--help"], {
+      const result = spawnSync(bunExecutable, ["run", scriptPath, "--help"], {
         encoding: "utf-8",
         timeout: 10000,
       });
@@ -74,7 +92,7 @@ describe("gstack-global-discover", () => {
     });
 
     test("no args exits 1 with error", () => {
-      const result = spawnSync("bun", ["run", scriptPath], {
+      const result = spawnSync(bunExecutable, ["run", scriptPath], {
         encoding: "utf-8",
         timeout: 10000,
       });
@@ -83,7 +101,7 @@ describe("gstack-global-discover", () => {
     });
 
     test("invalid window format exits 1", () => {
-      const result = spawnSync("bun", ["run", scriptPath, "--since", "abc"], {
+      const result = spawnSync(bunExecutable, ["run", scriptPath, "--since", "abc"], {
         encoding: "utf-8",
         timeout: 10000,
       });
@@ -93,7 +111,7 @@ describe("gstack-global-discover", () => {
 
     test("--since 7d produces valid JSON", () => {
       const result = spawnSync(
-        "bun",
+        bunExecutable,
         ["run", scriptPath, "--since", "7d", "--format", "json"],
         { encoding: "utf-8", timeout: 30000 }
       );
@@ -109,7 +127,7 @@ describe("gstack-global-discover", () => {
 
     test("--since 7d --format summary produces readable output", () => {
       const result = spawnSync(
-        "bun",
+        bunExecutable,
         ["run", scriptPath, "--since", "7d", "--format", "summary"],
         { encoding: "utf-8", timeout: 30000 }
       );
@@ -121,7 +139,7 @@ describe("gstack-global-discover", () => {
 
     test("--since 1h returns results (may be empty)", () => {
       const result = spawnSync(
-        "bun",
+        bunExecutable,
         ["run", scriptPath, "--since", "1h", "--format", "json"],
         { encoding: "utf-8", timeout: 30000 }
       );
@@ -191,7 +209,7 @@ describe("gstack-global-discover", () => {
 
       // Run discovery with CODEX_SESSIONS_DIR override
       const result = spawnSync(
-        "bun",
+        bunExecutable,
         ["run", scriptPath, "--since", "1h", "--format", "json"],
         {
           encoding: "utf-8",
@@ -251,10 +269,7 @@ describe("gstack-global-discover", () => {
       expect(meta.payload.cwd).toBe("/tmp/test-repo");
     });
 
-    test("regression: session_meta beyond 128KB still needs streaming parse", () => {
-      // This test documents the current limitation: 128KB buffer is a heuristic.
-      // If Codex ever embeds >128KB in session_meta, this test will fail,
-      // signaling that the buffer needs to increase or be replaced with streaming.
+    test("parses session_meta beyond the former 128KB cap", () => {
       const padding = "x".repeat(140000); // ~140KB payload
       const sessionMeta = JSON.stringify({
         timestamp: new Date().toISOString(),
@@ -273,27 +288,15 @@ describe("gstack-global-discover", () => {
 
       expect(sessionMeta.length).toBeGreaterThan(131072);
 
-      const filePath = join(codexDir, "large-test.jsonl");
-      writeFileSync(filePath, sessionMeta + "\n");
-
-      // 128KB buffer: JSON.parse FAILS for >128KB lines (current limitation)
-      const { openSync, readSync, closeSync } = require("fs");
-      const fd = openSync(filePath, "r");
-      const buf = Buffer.alloc(131072);
-      readSync(fd, buf, 0, 131072, 0);
-      closeSync(fd);
-      expect(() =>
-        JSON.parse(buf.toString("utf-8").split("\n")[0])
-      ).toThrow();
-      // When this test starts passing (e.g., after implementing streaming parse),
-      // update it to verify correct parsing instead of documenting the limitation.
+      const result = parseCodexJsonlPrefix(`${sessionMeta}\n`);
+      expect(result.session).toEqual({ cwd: "/tmp/large-test", kind: "root" });
     });
   });
 
   describe("discovery output structure", () => {
     test("repos have required fields", () => {
       const result = spawnSync(
-        "bun",
+        bunExecutable,
         ["run", scriptPath, "--since", "30d", "--format", "json"],
         { encoding: "utf-8", timeout: 30000 }
       );
@@ -315,7 +318,7 @@ describe("gstack-global-discover", () => {
 
     test("tools summary matches repo data", () => {
       const result = spawnSync(
-        "bun",
+        bunExecutable,
         ["run", scriptPath, "--since", "30d", "--format", "json"],
         { encoding: "utf-8", timeout: 30000 }
       );
@@ -331,7 +334,7 @@ describe("gstack-global-discover", () => {
 
     test("deduplicates Conductor workspaces by remote", () => {
       const result = spawnSync(
-        "bun",
+        bunExecutable,
         ["run", scriptPath, "--since", "30d", "--format", "json"],
         { encoding: "utf-8", timeout: 30000 }
       );
@@ -429,6 +432,65 @@ describe("gstack-global-discover", () => {
       const good = JSON.stringify({ cwd: "/tmp/repo-skip-bad" });
       writeFileSync(filePath, "{ not valid json\n" + good + "\n");
       expect(extractCwdFromJsonl(filePath)).toBe("/tmp/repo-skip-bad");
+    });
+  });
+
+  describe("Codex JSONL schema", () => {
+    test("parses session_meta records larger than the old 4KB limit", () => {
+      const records = fixture("codex-current.jsonl")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      const metadata = records.find((record) => record.type === "session_meta");
+      metadata.payload.base_instructions = "x".repeat(20_000);
+      const text = records.map((record) => JSON.stringify(record)).join("\n");
+      const result = parseCodexJsonlPrefix(`${text}\n`);
+      expect(result.session).toEqual({ cwd: "/synthetic/current", kind: "root" });
+      expect(result.malformed_records).toBe(0);
+    });
+
+    test("ignores known envelopes and compaction without creating extra sessions", () => {
+      const text = `${fixture("codex-current.jsonl")}${fixture("codex-legacy.jsonl")}`;
+      const result = parseCodexJsonlPrefix(text);
+      expect(result.session).toEqual({ cwd: "/synthetic/current", kind: "root" });
+      expect(result.unknown_record_types).toEqual([]);
+    });
+
+    test("preserves explicit subagent classification", () => {
+      const result = parseCodexJsonlPrefix(fixture("codex-subagent.jsonl"));
+      expect(result.session).toEqual({
+        cwd: "/synthetic/subagent",
+        kind: "subagent",
+      });
+    });
+
+    test("surfaces malformed and unknown records before valid metadata", () => {
+      const result = parseCodexJsonlPrefix(
+        `{not-json}\n${fixture("codex-unknown.jsonl")}`
+      );
+      expect(result.session).toEqual({ cwd: "/synthetic/unknown", kind: "root" });
+      expect(result.malformed_records).toBe(1);
+      expect(result.unknown_record_types).toEqual(["future_event"]);
+    });
+
+    test("drops an incomplete record when the bounded prefix is exhausted", () => {
+      const result = parseCodexJsonlPrefix('{"type":"session_meta"', true);
+      expect(result.session).toBeNull();
+      expect(result.prefix_truncated).toBe(true);
+    });
+
+    test("uses deterministic hour and local-midnight window boundaries", () => {
+      const now = new Date(2026, 7, 31, 14, 30, 0, 0);
+      expect(windowToDate("24h", now).getTime()).toBe(
+        now.getTime() - 24 * 60 * 60 * 1000
+      );
+      const dayStart = windowToDate("1d", now);
+      expect(dayStart.getFullYear()).toBe(2026);
+      expect(dayStart.getMonth()).toBe(7);
+      expect(dayStart.getDate()).toBe(30);
+      expect(dayStart.getHours()).toBe(0);
+      expect(dayStart.getMinutes()).toBe(0);
+      expect(formatLocalDate(dayStart)).toBe("2026-08-30");
     });
   });
 });


### PR DESCRIPTION
## Summary

- replace the first-line/128 KiB Codex heuristic with a bounded 1 MiB JSONL record parser
- recognize current event_msg, response_item, compacted, and related envelopes while emitting at most one session per file
- report root/subagent counts plus explicit malformed, unknown, missing-metadata, truncated-prefix, and read-error diagnostics
- use local-calendar boundaries for day/week audit windows
- add synthetic current, legacy, subagent, unknown, >128 KiB metadata, truncation, and time-boundary fixtures
- preserve the existing CODEX_SESSIONS_DIR test override and the current untracked-build-binary policy

## Why

Current Codex session_meta records on the audited machine are 18–29 KiB, and the session stream now contains multiple typed envelopes. While main now covers the original 4 KiB truncation with a 128 KiB first-line read, that remains a heuristic and does not provide schema diagnostics or root/subagent accounting. This change makes the global retro audit repeatable against the current JSONL schema.

## Verification

- CI-pinned Bun 1.3.10 (Linux container): 31 focused tests passed
- local Bun 1.2.19 with `bun` absent from PATH: 31 focused tests passed
- live 15-day scan at head 082ddba: 211 Codex sessions (155 root, 56 subagent), 10 repos, zero parse diagnostics
- deterministic start date: 2026-08-16
- git diff --check

Linear: https://linear.app/viltrumempire/issue/VIL-512
