### PR TITLE
fix(update-check): flag stale installs by commit clock, not VERSION string alone (#2378)

### DIFF
--- a/bin/gstack-skill-start
+++ b/bin/gstack-skill-start
@@ -359,7 +359,7 @@ if [ "$_SESSION_KIND" != "spawned" ]; then
 # Upgrade flow (gated: update-check emitted something above).
 if [ -n "$_UPD" ]; then
   _emit_block upgrade-flow <<EOI
-The update-check output above applies. If it shows \`UPGRADE_AVAILABLE <old> <new>\`: read \`$_ROOT_DIR/gstack-upgrade/SKILL.md\` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If it shows \`JUST_UPGRADED <from> <to>\`: print "Running gstack v{to} (just updated!)". If \`SPAWNED_SESSION\` is true, skip feature discovery. After upgrade prompts, continue the workflow.
+The update-check output above applies. If it shows \`UPGRADE_AVAILABLE <old> <new>\`: read \`$_ROOT_DIR/gstack-upgrade/SKILL.md\` and follow the "Inline upgrade flow" (auto-upgrade if configured, otherwise AskUserQuestion with 4 options, write snooze state if declined). If it shows \`UPGRADE_COMMITS <version> <local_sha7> <remote_sha7>\`: same flow, plus read \`$_ROOT_DIR/gstack-upgrade/COMMIT-CLOCK.md\` — the version does not change in that case, so never render it as \`<old> → <new>\`. If it shows \`JUST_UPGRADED <from> <to>\`: print "Running gstack v{to} (just updated!)". If \`SPAWNED_SESSION\` is true, skip feature discovery. After upgrade prompts, continue the workflow.
 EOI
 fi
 # Feature discovery (one prompt per session, marker-gated). These are

--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -184,9 +184,16 @@ if [ -f "$CACHE_FILE" ]; then
     if [ -e "$GSTACK_DIR/.git" ] && command -v git >/dev/null 2>&1; then
       _CURRENT_HEAD="$(git -C "$GSTACK_DIR" rev-parse HEAD 2>/dev/null | tr -d '[:space:]')"
     fi
-    if [ -n "$_CACHED_HEAD" ] && [ -n "$_CURRENT_HEAD" ] && [ "$_CACHED_HEAD" != "$_CURRENT_HEAD" ]; then
-      : # HEAD moved since the cache was written — fall through to the slow path
-    else
+    _CACHE_REPLAY=1
+    if [ -e "$GSTACK_DIR/.git" ]; then
+      if ! command -v git >/dev/null 2>&1 \
+        || ! echo "$_CACHED_HEAD" | grep -qE '^[0-9a-f]{40}$' \
+        || ! echo "$_CURRENT_HEAD" | grep -qE '^[0-9a-f]{40}$' \
+        || [ "$_CACHED_HEAD" != "$_CURRENT_HEAD" ]; then
+        _CACHE_REPLAY=0
+      fi
+    fi
+    if [ "$_CACHE_REPLAY" -eq 1 ]; then
     case "$CACHED" in
       UP_TO_DATE*)
         CACHED_VER="$(echo "$CACHED" | awk '{print $2}')"
@@ -247,27 +254,29 @@ fi
 # landed. git ls-remote always returns the live HEAD; SHA-pinned raw URLs
 # are immediately consistent.
 #
-# An explicit GSTACK_REMOTE_URL override (tests, mirrors) skips this path
-# so the override is honored verbatim. An explicit GSTACK_REMOTE_SHA
-# override (tests, mirrors) supplies the remote tip without ls-remote and
-# is honored independently of the URL override — the #2378 cross-check
-# needs a remote SHA even when the VERSION source is overridden.
+# An explicit GSTACK_REMOTE_URL override (tests, mirrors) is authoritative
+# for VERSION content. An explicit GSTACK_REMOTE_SHA override (tests,
+# mirrors) supplies the remote tip without ls-remote and is independent of
+# the URL override — the #2378 cross-check needs a remote SHA even when the
+# VERSION source is overridden.
 REMOTE=""
-_REMOTE_SHA=""
-if [ -n "${GSTACK_REMOTE_SHA:-}" ]; then
-  _REMOTE_SHA="$GSTACK_REMOTE_SHA"
-elif [ -z "${GSTACK_REMOTE_URL:-}" ]; then
-  # Disable credential prompts and apply a 5-second low-speed timeout so a
-  # flaky network or captive portal can't hang every skill preamble.
-  _REPO_HOST="${REMOTE_REPO#*://}"; _REPO_HOST="${_REPO_HOST#*@}"; _REPO_HOST="${_REPO_HOST%%[/:]*}"
-  _LSR_LINE="$(GSTACK_HOME="$STATE_DIR" _receipted_git open update-check "${_REPO_HOST:-unknown}" version-ls-remote "update_check!=false" \
-    bash -c 'GIT_TERMINAL_PROMPT=0 GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=5 \
-      git ls-remote "$1" refs/heads/main 2>/dev/null' _ "$REMOTE_REPO" || true)"
-  _REMOTE_SHA="$(echo "$_LSR_LINE" | awk '{print $1}')"
-fi
-if echo "$_REMOTE_SHA" | grep -qE '^[0-9a-f]{40}$'; then
-  _SHA_URL="https://raw.githubusercontent.com/garrytan/gstack/${_REMOTE_SHA}/VERSION"
-  REMOTE="$(_receipted_version_fetch "$_SHA_URL")"
+_REMOTE_SHA="${GSTACK_REMOTE_SHA:-}"
+if [ -n "${GSTACK_REMOTE_URL:-}" ]; then
+  REMOTE="$(_receipted_version_fetch "$REMOTE_URL")"
+else
+  if [ -z "$_REMOTE_SHA" ]; then
+    # Disable credential prompts and apply a 5-second low-speed timeout so a
+    # flaky network or captive portal can't hang every skill preamble.
+    _REPO_HOST="${REMOTE_REPO#*://}"; _REPO_HOST="${_REPO_HOST#*@}"; _REPO_HOST="${_REPO_HOST%%[/:]*}"
+    _LSR_LINE="$(GSTACK_HOME="$STATE_DIR" _receipted_git open update-check "${_REPO_HOST:-unknown}" version-ls-remote "update_check!=false" \
+      bash -c 'GIT_TERMINAL_PROMPT=0 GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=5 \
+        git ls-remote "$1" refs/heads/main 2>/dev/null' _ "$REMOTE_REPO" || true)"
+    _REMOTE_SHA="$(echo "$_LSR_LINE" | awk '{print $1}')"
+  fi
+  if echo "$_REMOTE_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+    _SHA_URL="https://raw.githubusercontent.com/garrytan/gstack/${_REMOTE_SHA}/VERSION"
+    REMOTE="$(_receipted_version_fetch "$_SHA_URL")"
+  fi
 fi
 
 # Fallback: branch-pinned URL when ls-remote is unavailable (no git, no
@@ -317,7 +326,20 @@ _update_check_sha_clock_behind() {
   # Only vouch for installs whose origin IS the repo we compare against: a
   # fork/mirror origin that merely shares VERSION strings is not this main.
   _origin_url="$(git -C "$GSTACK_DIR" remote get-url origin 2>/dev/null)" || return 1
-  _origin_slug="$(echo "$_origin_url" | sed -E 's#^[^:]+://[^/]+/##; s#^[^@]+@##; s#\.git$##; s#:#/#' | tr -d '[:space:]')"
+  _origin_url="$(printf '%s' "$_origin_url" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  case "$_origin_url" in
+    https://github.com/*|http://github.com/*|ssh://git@github.com/*)
+      _origin_slug="${_origin_url#*github.com/}"
+      ;;
+    git@github.com:*)
+      _origin_slug="${_origin_url#git@github.com:}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  _origin_slug="${_origin_slug%/}"
+  _origin_slug="${_origin_slug%.git}"
   [ "$_origin_slug" = "garrytan/gstack" ] || return 1
   if [ "$_sha_local" = "$_sha_remote" ]; then
     return 1  # already on remote main — genuinely current

--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -10,6 +10,8 @@
 #   GSTACK_DIR          — override auto-detected gstack root
 #   GSTACK_REMOTE_URL   — override remote VERSION URL (branch-pinned fallback)
 #   GSTACK_REMOTE_REPO  — override remote git URL for ls-remote SHA resolution
+#   GSTACK_REMOTE_SHA   — override the remote main tip SHA (tests, mirrors);
+#                         skips ls-remote when set
 #   GSTACK_STATE_DIR    — override ~/.gstack state directory
 set -euo pipefail
 
@@ -47,6 +49,7 @@ _receipted_version_fetch() {
   esac
 }
 CACHE_FILE="$STATE_DIR/last-update-check"
+HEAD_CACHE_FILE="$STATE_DIR/last-update-check-head"
 MARKER_FILE="$STATE_DIR/just-upgraded-from"
 SNOOZE_FILE="$STATE_DIR/update-snoozed"
 VERSION_FILE="$GSTACK_DIR/VERSION"
@@ -166,6 +169,24 @@ if [ -f "$CACHE_FILE" ]; then
 
   STALE=$(find "$CACHE_FILE" -mmin +$CACHE_TTL 2>/dev/null || true)
   if [ -z "$STALE" ] && [ "$CACHE_TTL" -gt 0 ]; then
+    # #2378: the cached verdict is only replayable if the install's HEAD is
+    # still the HEAD the verdict was computed for. The commit clock can move
+    # (upgrade, git pull) while the VERSION string stays identical, and a
+    # replayed verdict would then be stale for up to the full TTL — e.g. an
+    # UPGRADE_AVAILABLE nag that survives the user actually upgrading. A
+    # missing head cache (older install, non-git setup, pre-fix state file)
+    # falls through to the slow path, which re-evaluates and writes it.
+    _CACHED_HEAD=""
+    if [ -f "$HEAD_CACHE_FILE" ]; then
+      _CACHED_HEAD="$(cat "$HEAD_CACHE_FILE" 2>/dev/null | tr -d '[:space:]')"
+    fi
+    _CURRENT_HEAD=""
+    if [ -e "$GSTACK_DIR/.git" ] && command -v git >/dev/null 2>&1; then
+      _CURRENT_HEAD="$(git -C "$GSTACK_DIR" rev-parse HEAD 2>/dev/null | tr -d '[:space:]')"
+    fi
+    if [ -n "$_CACHED_HEAD" ] && [ -n "$_CURRENT_HEAD" ] && [ "$_CACHED_HEAD" != "$_CURRENT_HEAD" ]; then
+      : # HEAD moved since the cache was written — fall through to the slow path
+    else
     case "$CACHED" in
       UP_TO_DATE*)
         CACHED_VER="$(echo "$CACHED" | awk '{print $2}')"
@@ -185,6 +206,7 @@ if [ -f "$CACHE_FILE" ]; then
         fi
         ;;
     esac
+    fi
   fi
 fi
 
@@ -226,9 +248,15 @@ fi
 # are immediately consistent.
 #
 # An explicit GSTACK_REMOTE_URL override (tests, mirrors) skips this path
-# so the override is honored verbatim.
+# so the override is honored verbatim. An explicit GSTACK_REMOTE_SHA
+# override (tests, mirrors) supplies the remote tip without ls-remote and
+# is honored independently of the URL override — the #2378 cross-check
+# needs a remote SHA even when the VERSION source is overridden.
 REMOTE=""
-if [ -z "${GSTACK_REMOTE_URL:-}" ]; then
+_REMOTE_SHA=""
+if [ -n "${GSTACK_REMOTE_SHA:-}" ]; then
+  _REMOTE_SHA="$GSTACK_REMOTE_SHA"
+elif [ -z "${GSTACK_REMOTE_URL:-}" ]; then
   # Disable credential prompts and apply a 5-second low-speed timeout so a
   # flaky network or captive portal can't hang every skill preamble.
   _REPO_HOST="${REMOTE_REPO#*://}"; _REPO_HOST="${_REPO_HOST#*@}"; _REPO_HOST="${_REPO_HOST%%[/:]*}"
@@ -236,10 +264,10 @@ if [ -z "${GSTACK_REMOTE_URL:-}" ]; then
     bash -c 'GIT_TERMINAL_PROMPT=0 GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=5 \
       git ls-remote "$1" refs/heads/main 2>/dev/null' _ "$REMOTE_REPO" || true)"
   _REMOTE_SHA="$(echo "$_LSR_LINE" | awk '{print $1}')"
-  if echo "$_REMOTE_SHA" | grep -qE '^[0-9a-f]{40}$'; then
-    _SHA_URL="https://raw.githubusercontent.com/garrytan/gstack/${_REMOTE_SHA}/VERSION"
-    REMOTE="$(_receipted_version_fetch "$_SHA_URL")"
-  fi
+fi
+if echo "$_REMOTE_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  _SHA_URL="https://raw.githubusercontent.com/garrytan/gstack/${_REMOTE_SHA}/VERSION"
+  REMOTE="$(_receipted_version_fetch "$_SHA_URL")"
 fi
 
 # Fallback: branch-pinned URL when ls-remote is unavailable (no git, no
@@ -257,8 +285,68 @@ if ! echo "$REMOTE" | grep -qE '^[0-9]+\.[0-9.]+$'; then
   exit 0
 fi
 
+# ─── Commit-clock cross-check (#2378) ─────────────────────────
+#
+# The VERSION comparison below is one clock; /gstack-upgrade installs on
+# another (origin/main HEAD). Between releases the two legitimately agree
+# while main moves, and a merge that bypasses the VERSION bump (version-gate
+# only fires on PRs touching VERSION/CHANGELOG/package.json) makes that
+# window permanent: installs are silently behind, including security fixes.
+# Garry 2026-08-22 on #2378: "The structural mismatch identified here is
+# still real."
+#
+# _update_check_sha_clock_behind <remote_sha>
+#   0 = the install is a pristine git sync of an OLDER main (upgrade flow's
+#       git pull --ff-only is provably safe) and remote main moved past it
+#       → caller emits UPGRADE_AVAILABLE.
+#   1 = not behind, or the comparison is inconclusive (non-git install, no
+#       git binary, missing refs, fork/mirror origin, dirty HEAD state) —
+#       the caller falls back to the VERSION-string verdict unchanged.
+_update_check_sha_clock_behind() {
+  local _sha_remote="$1" _sha_local _sha_synced _origin_url _origin_slug
+  # No remote tip resolved (ls-remote failed, override unset) → inconclusive.
+  echo "$_sha_remote" | grep -qE '^[0-9a-f]{40}$' || return 1
+  [ -e "$GSTACK_DIR/.git" ] || return 1
+  command -v git >/dev/null 2>&1 || return 1
+  # Git escapes $GSTACK_DIR into commands with -C; any failure (corrupt repo,
+  # unborn HEAD) degrades to inconclusive, never to a false positive.
+  _sha_local="$(git -C "$GSTACK_DIR" rev-parse HEAD 2>/dev/null | tr -d '[:space:]')" || return 1
+  _sha_synced="$(git -C "$GSTACK_DIR" rev-parse refs/remotes/origin/main 2>/dev/null | tr -d '[:space:]')" || return 1
+  echo "$_sha_local"   | grep -qE '^[0-9a-f]{40}$' || return 1
+  echo "$_sha_synced"  | grep -qE '^[0-9a-f]{40}$' || return 1
+  # Only vouch for installs whose origin IS the repo we compare against: a
+  # fork/mirror origin that merely shares VERSION strings is not this main.
+  _origin_url="$(git -C "$GSTACK_DIR" remote get-url origin 2>/dev/null)" || return 1
+  _origin_slug="$(echo "$_origin_url" | sed -E 's#^[^:]+://[^/]+/##; s#^[^@]+@##; s#\.git$##; s#:#/#' | tr -d '[:space:]')"
+  [ "$_origin_slug" = "garrytan/gstack" ] || return 1
+  if [ "$_sha_local" = "$_sha_remote" ]; then
+    return 1  # already on remote main — genuinely current
+  fi
+  # Pristine-sync gate: HEAD must equal the install's own origin/main ref
+  # (the sync point the upgrade path moves). Anything else — an old release
+  # checkout, local commits, a dev branch — is a state this check cannot
+  # classify, and --ff-only safety is not provable. Stay silent.
+  [ "$_sha_local" = "$_sha_synced" ] || return 1
+  return 0
+}
+
 if [ "$LOCAL" = "$REMOTE" ]; then
-  echo "UP_TO_DATE $LOCAL" > "$CACHE_FILE"
+  if _update_check_sha_clock_behind "$_REMOTE_SHA"; then
+    echo "UPGRADE_AVAILABLE $LOCAL $LOCAL" > "$CACHE_FILE"
+    # Same-version flag: snooze still applies (the user may have deferred this
+    # exact state already), keyed on the version string like any other nag.
+    if check_snooze "$LOCAL"; then
+      exit 0  # snoozed — stay quiet
+    fi
+    echo "UPGRADE_AVAILABLE $LOCAL $LOCAL"
+  else
+    echo "UP_TO_DATE $LOCAL" > "$CACHE_FILE"
+  fi
+  # Record the HEAD this verdict was computed for, so the fresh-cache path
+  # can tell "replayable" from "the commit clock moved since" (#2378).
+  # Non-git installs: rev-parse fails, the file stays absent, and the cache
+  # path behaves exactly as before this change.
+  git -C "$GSTACK_DIR" rev-parse HEAD 2>/dev/null | tr -d '[:space:]' > "$HEAD_CACHE_FILE" 2>/dev/null || true
   exit 0
 fi
 
@@ -269,11 +357,13 @@ fi
 _HIGHER="$(printf '%s\n%s\n' "$LOCAL" "$REMOTE" | sort -V | tail -1)"
 if [ "$_HIGHER" != "$REMOTE" ]; then
   echo "UP_TO_DATE $LOCAL" > "$CACHE_FILE"
+  git -C "$GSTACK_DIR" rev-parse HEAD 2>/dev/null | tr -d '[:space:]' > "$HEAD_CACHE_FILE" 2>/dev/null || true
   exit 0
 fi
 
 # REMOTE is strictly newer — upgrade available
 echo "UPGRADE_AVAILABLE $LOCAL $REMOTE" > "$CACHE_FILE"
+git -C "$GSTACK_DIR" rev-parse HEAD 2>/dev/null | tr -d '[:space:]' > "$HEAD_CACHE_FILE" 2>/dev/null || true
 if check_snooze "$REMOTE"; then
   exit 0  # snoozed — stay quiet
 fi

--- a/bin/gstack-update-check
+++ b/bin/gstack-update-check
@@ -4,6 +4,13 @@
 # Output (one line, or nothing):
 #   JUST_UPGRADED <old> <new>       — marker found from recent upgrade
 #   UPGRADE_AVAILABLE <old> <new>   — remote VERSION differs from local
+#   UPGRADE_COMMITS <ver> <local_sha7> <remote_sha7>
+#                                   — VERSION strings AGREE but main moved past
+#                                     this install (#2378 commit clock). A
+#                                     separate token on purpose: consumers that
+#                                     render "<old> → <new>" have nothing to
+#                                     render here, and the CHANGELOG range
+#                                     between two equal versions is empty.
 #   (nothing)                       — up to date, snoozed, disabled, or check skipped
 #
 # Env overrides (for testing):
@@ -49,16 +56,122 @@ _receipted_version_fetch() {
   esac
 }
 CACHE_FILE="$STATE_DIR/last-update-check"
-HEAD_CACHE_FILE="$STATE_DIR/last-update-check-head"
+# Install state a cached verdict is only valid for (#2378): HEAD, the install's
+# own origin/main, and which install it is. See the replay guard in Step 3.
+STAMP_FILE="$STATE_DIR/last-update-check-stamp"
 MARKER_FILE="$STATE_DIR/just-upgraded-from"
 SNOOZE_FILE="$STATE_DIR/update-snoozed"
 VERSION_FILE="$GSTACK_DIR/VERSION"
 REMOTE_URL="${GSTACK_REMOTE_URL:-https://raw.githubusercontent.com/garrytan/gstack/main/VERSION}"
 REMOTE_REPO="${GSTACK_REMOTE_REPO:-https://github.com/garrytan/gstack.git}"
 
+# _uc_is_sha40 <string> — 40 lowercase hex chars. Pure builtin: this runs on
+# the cached fast path, which every skill preamble pays.
+_uc_is_sha40() {
+  case "${1:-}" in
+    ""|*[!0-9a-f]*) return 1 ;;
+  esac
+  [ "${#1}" -eq 40 ]
+}
+
+# _uc_github_slug <git-url> — echo "owner/repo" for a github.com remote, else
+# fail. Accepts https/http/ssh/git schemes with or without userinfo (an access
+# token, or git@) and with an explicit port, plus the scp-like
+# git@github.com:owner/repo form. The host must be EXACTLY github.com after
+# normalization, so https://evil.com/github.com/garrytan/gstack and
+# https://github.com.evil.com/garrytan/gstack are both rejected.
+_uc_github_slug() {
+  local _u _rest _host _path
+  _u="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  case "$_u" in
+    *://*) _rest="${_u#*://}"; _rest="${_rest#*@}" ;;
+    *@*:*) _rest="${_u#*@}"; _rest="${_rest/://}" ;;
+    *)     return 1 ;;
+  esac
+  case "$_rest" in
+    */*) _host="${_rest%%/*}"; _path="${_rest#*/}" ;;
+    *)   return 1 ;;
+  esac
+  [ "${_host%%:*}" = "github.com" ] || return 1
+  _path="${_path%/}"; _path="${_path%.git}"; _path="${_path%/}"
+  # Exactly owner/repo — nothing deeper, neither half empty.
+  case "$_path" in
+    */*/*|/*|*/) return 1 ;;
+    */*) printf '%s\n' "$_path" ;;
+    *)   return 1 ;;
+  esac
+}
+
+# _uc_state_stamp — echo "<HEAD> <origin/main|-> <install-path>" for a git
+# install, or nothing at all when there is no resolvable git state.
+#
+# The third field identifies WHICH install the verdict belongs to. STATE_DIR is
+# machine-global, so a path is what separates a global install from a dev clone
+# or a sibling Conductor workspace. It is a shell variable, not a git call: the
+# origin URL would be more precise about a remote being re-pointed in place,
+# but that costs a fork on the cached fast path every skill preamble pays, and
+# re-pointing an existing install's origin is bounded by the cache TTL anyway.
+#
+# Never fails and never emits a partial line. Every git call is captured with
+# `|| true` ON PURPOSE: set -E propagates the ERR trap into command
+# substitutions, so an unguarded failure here would put the CHECK_FAILED
+# sentinel into the CALLER'S VARIABLE instead of on the script's stdout — the
+# #1974 guarantee, silently swallowed. `|| true` keeps the trap out of the
+# subshell; _uc_is_sha40 then decides what is usable.
+_uc_state_stamp() {
+  local _rp _h _o _nl
+  [ -e "$GSTACK_DIR/.git" ] || return 0
+  command -v git >/dev/null 2>&1 || return 0
+  # One rev-parse for both refs. A missing origin/main makes rev-parse exit
+  # 128 after echoing the unresolvable ref name, which _uc_is_sha40 rejects.
+  _rp="$(git -C "$GSTACK_DIR" rev-parse HEAD refs/remotes/origin/main 2>/dev/null || true)"
+  _nl=$'\n'
+  case "$_rp" in
+    *"$_nl"*) _h="${_rp%%"$_nl"*}"; _o="${_rp#*"$_nl"}" ;;
+    *)        _h="$_rp"; _o="" ;;
+  esac
+  _uc_is_sha40 "$_h" || return 0
+  _uc_is_sha40 "$_o" || _o="-"
+  printf '%s %s %s\n' "$_h" "$_o" "$GSTACK_DIR"
+}
+
+# _uc_write_verdict <line> — write the cache and the stamp it was computed
+# for, together. They are one fact; splitting them is how a verdict ends up
+# replayable against install state it never saw.
+_uc_write_verdict() {
+  local _stamp
+  printf '%s\n' "$1" > "$CACHE_FILE"
+  _stamp="$(_uc_state_stamp)"
+  if [ -n "$_stamp" ]; then
+    # Temp+rename so a failed write can't destroy a good stamp, and so the
+    # reader never sees a half-written line. A 0-byte or "HEAD" stamp would
+    # fail every later comparison and pin the install to the slow path.
+    if ( printf '%s\n' "$_stamp" > "$STAMP_FILE.tmp.$$" ) 2>/dev/null; then
+      mv -f "$STAMP_FILE.tmp.$$" "$STAMP_FILE" 2>/dev/null || rm -f "$STAMP_FILE.tmp.$$"
+    fi
+  else
+    # No git state: leave no stamp. The replay guard treats "no stamp" as
+    # "this verdict never depended on git", which is exactly right here.
+    rm -f "$STAMP_FILE"
+  fi
+  return 0
+}
+
+# _uc_log_prompted — upgrade_prompted telemetry, fired on any slow-path nag
+# (both UPGRADE_AVAILABLE and UPGRADE_COMMITS), never on a cached replay.
+_uc_log_prompted() {
+  local _tel="$GSTACK_DIR/bin/gstack-telemetry-log"
+  if [ -x "$_tel" ]; then
+    "$_tel" --event-type upgrade_prompted --skill "" --duration 0 \
+      --outcome success --session-id "update-$$-$(date +%s)" 2>/dev/null &
+  fi
+  return 0
+}
+
 # ─── Force flag (busts cache + snooze for standalone /gstack-upgrade) ──
 if [ "${1:-}" = "--force" ]; then
   rm -f "$CACHE_FILE"
+  rm -f "$STAMP_FILE"
   rm -f "$SNOOZE_FILE"
 fi
 
@@ -159,60 +272,82 @@ fi
 # ─── Step 3: Check cache freshness ──────────────────────────
 # UP_TO_DATE: 60 min TTL (detect new releases quickly)
 # UPGRADE_AVAILABLE: 720 min TTL (keep nagging)
+# UPGRADE_COMMITS: 60 min TTL. Deliberately NOT the 720-min nag bucket: the
+#   VERSION strings agree in this state, so a real release can land while the
+#   verdict is cached. At 720 min that release stays invisible for up to 12
+#   hours — strictly worse than before this check existed. 60 min matches the
+#   UP_TO_DATE bucket it replaces, so the release-detection latency is
+#   unchanged and only the extra nag is new.
 if [ -f "$CACHE_FILE" ]; then
   CACHED="$(cat "$CACHE_FILE" 2>/dev/null || true)"
   case "$CACHED" in
     UP_TO_DATE*)        CACHE_TTL=60 ;;
+    UPGRADE_COMMITS*)   CACHE_TTL=60 ;;
     UPGRADE_AVAILABLE*) CACHE_TTL=720 ;;
     *)                  CACHE_TTL=0 ;;  # corrupt → force re-fetch
   esac
 
   STALE=$(find "$CACHE_FILE" -mmin +$CACHE_TTL 2>/dev/null || true)
   if [ -z "$STALE" ] && [ "$CACHE_TTL" -gt 0 ]; then
-    # #2378: the cached verdict is only replayable if the install's HEAD is
-    # still the HEAD the verdict was computed for. The commit clock can move
-    # (upgrade, git pull) while the VERSION string stays identical, and a
-    # replayed verdict would then be stale for up to the full TTL — e.g. an
-    # UPGRADE_AVAILABLE nag that survives the user actually upgrading. A
-    # missing head cache (older install, non-git setup, pre-fix state file)
-    # falls through to the slow path, which re-evaluates and writes it.
-    _CACHED_HEAD=""
-    if [ -f "$HEAD_CACHE_FILE" ]; then
-      _CACHED_HEAD="$(cat "$HEAD_CACHE_FILE" 2>/dev/null | tr -d '[:space:]')"
-    fi
-    _CURRENT_HEAD=""
-    if [ -e "$GSTACK_DIR/.git" ] && command -v git >/dev/null 2>&1; then
-      _CURRENT_HEAD="$(git -C "$GSTACK_DIR" rev-parse HEAD 2>/dev/null | tr -d '[:space:]')"
-    fi
+    # #2378: a cached verdict is replayable only while the install state it
+    # was computed FROM is unchanged. The commit clock moves (an upgrade, a
+    # git pull, a bare fetch) while the VERSION string stays identical, so a
+    # replayed verdict can be wrong for the whole TTL — e.g. a nag that
+    # survives the user actually upgrading.
+    #
+    # The stamp carries HEAD and origin/main because the commit-clock verdict
+    # reads both, plus the install path. STATE_DIR is machine-global
+    # ($HOME/.gstack), so two checkouts — a global install plus a dev clone,
+    # or sibling Conductor workspaces — would otherwise replay each other's
+    # verdict even when they legitimately disagree. A stamp mismatch means
+    # "unknown for THIS install", and one slow path is the correct price.
+    #
+    # A git install with no stamp (a cache written before this change) also
+    # takes one slow path, which writes the stamp.
+    #
+    # Non-git installs produce no stamp and replay exactly as before: their
+    # verdict never depended on git state in the first place.
     _CACHE_REPLAY=1
-    if [ -e "$GSTACK_DIR/.git" ]; then
-      if ! command -v git >/dev/null 2>&1 \
-        || ! echo "$_CACHED_HEAD" | grep -qE '^[0-9a-f]{40}$' \
-        || ! echo "$_CURRENT_HEAD" | grep -qE '^[0-9a-f]{40}$' \
-        || [ "$_CACHED_HEAD" != "$_CURRENT_HEAD" ]; then
+    _CURRENT_STAMP="$(_uc_state_stamp)"
+    if [ -n "$_CURRENT_STAMP" ]; then
+      _CACHED_STAMP=""
+      if [ -f "$STAMP_FILE" ]; then
+        IFS= read -r _CACHED_STAMP < "$STAMP_FILE" 2>/dev/null || _CACHED_STAMP=""
+      fi
+      if [ "$_CACHED_STAMP" != "$_CURRENT_STAMP" ]; then
         _CACHE_REPLAY=0
       fi
     fi
     if [ "$_CACHE_REPLAY" -eq 1 ]; then
-    case "$CACHED" in
-      UP_TO_DATE*)
-        CACHED_VER="$(echo "$CACHED" | awk '{print $2}')"
-        if [ "$CACHED_VER" = "$LOCAL" ]; then
-          exit 0
-        fi
-        ;;
-      UPGRADE_AVAILABLE*)
-        CACHED_OLD="$(echo "$CACHED" | awk '{print $2}')"
-        if [ "$CACHED_OLD" = "$LOCAL" ]; then
-          CACHED_NEW="$(echo "$CACHED" | awk '{print $3}')"
-          if check_snooze "$CACHED_NEW"; then
-            exit 0  # snoozed — stay quiet
+      case "$CACHED" in
+        UP_TO_DATE*)
+          CACHED_VER="$(echo "$CACHED" | awk '{print $2}')"
+          if [ "$CACHED_VER" = "$LOCAL" ]; then
+            exit 0
           fi
-          echo "$CACHED"
-          exit 0
-        fi
-        ;;
-    esac
+          ;;
+        UPGRADE_COMMITS*)
+          CACHED_VER="$(echo "$CACHED" | awk '{print $2}')"
+          if [ "$CACHED_VER" = "$LOCAL" ]; then
+            if check_snooze "$CACHED_VER"; then
+              exit 0  # snoozed — stay quiet
+            fi
+            echo "$CACHED"
+            exit 0
+          fi
+          ;;
+        UPGRADE_AVAILABLE*)
+          CACHED_OLD="$(echo "$CACHED" | awk '{print $2}')"
+          if [ "$CACHED_OLD" = "$LOCAL" ]; then
+            CACHED_NEW="$(echo "$CACHED" | awk '{print $3}')"
+            if check_snooze "$CACHED_NEW"; then
+              exit 0  # snoozed — stay quiet
+            fi
+            echo "$CACHED"
+            exit 0
+          fi
+          ;;
+      esac
     fi
   fi
 fi
@@ -289,8 +424,11 @@ REMOTE="$(echo "$REMOTE" | tr -d '[:space:]')"
 
 # Validate: must look like a version number (reject HTML error pages)
 if ! echo "$REMOTE" | grep -qE '^[0-9]+\.[0-9.]+$'; then
-  # Invalid or empty response — assume up to date
-  echo "UP_TO_DATE $LOCAL" > "$CACHE_FILE"
+  # Invalid or empty response — assume up to date. This is the offline /
+  # captive-portal / HTML-error-page path, and it must stamp like any other
+  # verdict: an unstamped cache is unreplayable, so every later run would pay
+  # the full ls-remote + curl slow path while still offline.
+  _uc_write_verdict "UP_TO_DATE $LOCAL"
   exit 0
 fi
 
@@ -305,70 +443,79 @@ fi
 # still real."
 #
 # _update_check_sha_clock_behind <remote_sha>
-#   0 = the install is a pristine git sync of an OLDER main (upgrade flow's
-#       git pull --ff-only is provably safe) and remote main moved past it
-#       → caller emits UPGRADE_AVAILABLE.
+#   0 = the install is a pristine git sync of an OLDER main (the upgrade
+#       flow's git pull --ff-only applies cleanly) and remote main moved past
+#       it → caller emits UPGRADE_COMMITS. Sets _UC_CLOCK_LOCAL_SHA.
 #   1 = not behind, or the comparison is inconclusive (non-git install, no
-#       git binary, missing refs, fork/mirror origin, dirty HEAD state) —
-#       the caller falls back to the VERSION-string verdict unchanged.
+#       git binary, unresolvable HEAD, missing origin/main, fork/mirror
+#       origin, local commits, a dev branch) — the caller falls back to the
+#       VERSION-string verdict unchanged.
+_UC_CLOCK_LOCAL_SHA=""
 _update_check_sha_clock_behind() {
-  local _sha_remote="$1" _sha_local _sha_synced _origin_url _origin_slug
+  local _sha_remote="$1" _stamp _rest _sha_local _sha_synced _origin_url _origin_slug _want_slug
   # No remote tip resolved (ls-remote failed, override unset) → inconclusive.
-  echo "$_sha_remote" | grep -qE '^[0-9a-f]{40}$' || return 1
-  [ -e "$GSTACK_DIR/.git" ] || return 1
-  command -v git >/dev/null 2>&1 || return 1
-  # Git escapes $GSTACK_DIR into commands with -C; any failure (corrupt repo,
-  # unborn HEAD) degrades to inconclusive, never to a false positive.
-  _sha_local="$(git -C "$GSTACK_DIR" rev-parse HEAD 2>/dev/null | tr -d '[:space:]')" || return 1
-  _sha_synced="$(git -C "$GSTACK_DIR" rev-parse refs/remotes/origin/main 2>/dev/null | tr -d '[:space:]')" || return 1
-  echo "$_sha_local"   | grep -qE '^[0-9a-f]{40}$' || return 1
-  echo "$_sha_synced"  | grep -qE '^[0-9a-f]{40}$' || return 1
-  # Only vouch for installs whose origin IS the repo we compare against: a
-  # fork/mirror origin that merely shares VERSION strings is not this main.
-  _origin_url="$(git -C "$GSTACK_DIR" remote get-url origin 2>/dev/null)" || return 1
-  _origin_url="$(printf '%s' "$_origin_url" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
-  case "$_origin_url" in
-    https://github.com/*|http://github.com/*|ssh://git@github.com/*)
-      _origin_slug="${_origin_url#*github.com/}"
-      ;;
-    git@github.com:*)
-      _origin_slug="${_origin_url#git@github.com:}"
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-  _origin_slug="${_origin_slug%/}"
-  _origin_slug="${_origin_slug%.git}"
-  [ "$_origin_slug" = "garrytan/gstack" ] || return 1
+  _uc_is_sha40 "$_sha_remote" || return 1
+  # One stamp, one read: non-git install, missing git, or an unresolvable HEAD
+  # all produce an empty stamp, which is inconclusive by construction.
+  _stamp="$(_uc_state_stamp)"
+  [ -n "$_stamp" ] || return 1
+  _sha_local="${_stamp%% *}"
+  _rest="${_stamp#* }"
+  _sha_synced="${_rest%% *}"
+  # No origin/main ref to compare the sync point against → inconclusive.
+  _uc_is_sha40 "$_sha_synced" || return 1
+  # Only vouch for installs whose origin IS the repo the remote SHA came
+  # from. Derived from REMOTE_REPO rather than hardcoded, so a
+  # GSTACK_REMOTE_REPO mirror is compared against ITS OWN slug instead of
+  # silently losing the check. Read here, not in the stamp: this is the slow
+  # path, where one more git call is free.
+  _origin_url="$(git -C "$GSTACK_DIR" config --get remote.origin.url 2>/dev/null || true)"
+  [ -n "$_origin_url" ] || return 1
+  _want_slug="$(_uc_github_slug "$REMOTE_REPO" || true)"
+  [ -n "$_want_slug" ] || return 1
+  _origin_slug="$(_uc_github_slug "$_origin_url" || true)"
+  [ -n "$_origin_slug" ] || return 1
+  [ "$_origin_slug" = "$_want_slug" ] || return 1
   if [ "$_sha_local" = "$_sha_remote" ]; then
     return 1  # already on remote main — genuinely current
   fi
-  # Pristine-sync gate: HEAD must equal the install's own origin/main ref
-  # (the sync point the upgrade path moves). Anything else — an old release
-  # checkout, local commits, a dev branch — is a state this check cannot
-  # classify, and --ff-only safety is not provable. Stay silent.
-  [ "$_sha_local" = "$_sha_synced" ] || return 1
+  # Pristine-sync gate: HEAD must be an ancestor of (or equal to) the
+  # install's own origin/main. Requiring EQUALITY was too strict — a bare
+  # `git fetch` moves origin/main ahead of HEAD without making the install
+  # any less pristine, and /gstack-upgrade runs `git fetch origin` before it
+  # pulls, so an upgrade that failed after the fetch would have silenced this
+  # check permanently: the exact silent-staleness class #2378 documents.
+  # Local commits and dev branches still fail ancestry and stay silent.
+  git -C "$GSTACK_DIR" merge-base --is-ancestor "$_sha_local" "$_sha_synced" 2>/dev/null || return 1
+  # When the remote tip is already in the local object store we can prove the
+  # direction outright: an install AHEAD of that tip, or on unrelated
+  # history, is not behind it. (In the normal "main moved" case the tip is
+  # NOT local and ancestry against it is unprovable without a fetch, which
+  # this check must not do — the origin/main ancestry above is the guarantee
+  # we rely on there.)
+  if git -C "$GSTACK_DIR" cat-file -e "${_sha_remote}^{commit}" 2>/dev/null; then
+    git -C "$GSTACK_DIR" merge-base --is-ancestor "$_sha_local" "$_sha_remote" 2>/dev/null || return 1
+  fi
+  _UC_CLOCK_LOCAL_SHA="$_sha_local"
   return 0
 }
 
 if [ "$LOCAL" = "$REMOTE" ]; then
   if _update_check_sha_clock_behind "$_REMOTE_SHA"; then
-    echo "UPGRADE_AVAILABLE $LOCAL $LOCAL" > "$CACHE_FILE"
-    # Same-version flag: snooze still applies (the user may have deferred this
-    # exact state already), keyed on the version string like any other nag.
+    _UC_L7="${_UC_CLOCK_LOCAL_SHA:0:7}"
+    _UC_R7="${_REMOTE_SHA:0:7}"
+    _uc_write_verdict "UPGRADE_COMMITS $LOCAL $_UC_L7 $_UC_R7"
+    # Snooze still applies (the user may have deferred this exact state),
+    # keyed on the version string like any other nag. The 60-minute TTL above
+    # is what stops that key from also covering a later real release.
     if check_snooze "$LOCAL"; then
       exit 0  # snoozed — stay quiet
     fi
-    echo "UPGRADE_AVAILABLE $LOCAL $LOCAL"
+    echo "UPGRADE_COMMITS $LOCAL $_UC_L7 $_UC_R7"
+    _uc_log_prompted
   else
-    echo "UP_TO_DATE $LOCAL" > "$CACHE_FILE"
+    _uc_write_verdict "UP_TO_DATE $LOCAL"
   fi
-  # Record the HEAD this verdict was computed for, so the fresh-cache path
-  # can tell "replayable" from "the commit clock moved since" (#2378).
-  # Non-git installs: rev-parse fails, the file stays absent, and the cache
-  # path behaves exactly as before this change.
-  git -C "$GSTACK_DIR" rev-parse HEAD 2>/dev/null | tr -d '[:space:]' > "$HEAD_CACHE_FILE" 2>/dev/null || true
   exit 0
 fi
 
@@ -378,23 +525,16 @@ fi
 # emit a backwards UPGRADE_AVAILABLE line.
 _HIGHER="$(printf '%s\n%s\n' "$LOCAL" "$REMOTE" | sort -V | tail -1)"
 if [ "$_HIGHER" != "$REMOTE" ]; then
-  echo "UP_TO_DATE $LOCAL" > "$CACHE_FILE"
-  git -C "$GSTACK_DIR" rev-parse HEAD 2>/dev/null | tr -d '[:space:]' > "$HEAD_CACHE_FILE" 2>/dev/null || true
+  _uc_write_verdict "UP_TO_DATE $LOCAL"
   exit 0
 fi
 
 # REMOTE is strictly newer — upgrade available
-echo "UPGRADE_AVAILABLE $LOCAL $REMOTE" > "$CACHE_FILE"
-git -C "$GSTACK_DIR" rev-parse HEAD 2>/dev/null | tr -d '[:space:]' > "$HEAD_CACHE_FILE" 2>/dev/null || true
+_uc_write_verdict "UPGRADE_AVAILABLE $LOCAL $REMOTE"
 if check_snooze "$REMOTE"; then
   exit 0  # snoozed — stay quiet
 fi
 
-# Log upgrade_prompted event (only on slow-path fetch, not cached replays)
-TEL_CMD="$GSTACK_DIR/bin/gstack-telemetry-log"
-if [ -x "$TEL_CMD" ]; then
-  "$TEL_CMD" --event-type upgrade_prompted --skill "" --duration 0 \
-    --outcome success --session-id "update-$$-$(date +%s)" 2>/dev/null &
-fi
+_uc_log_prompted
 
 echo "UPGRADE_AVAILABLE $LOCAL $REMOTE"

--- a/browse/test/gstack-update-check.test.ts
+++ b/browse/test/gstack-update-check.test.ts
@@ -6,7 +6,7 @@
  * for full isolation.
  */
 
-import { describe, test, expect, beforeEach, afterEach, beforeAll } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
 import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync, mkdirSync, symlinkSync, utimesSync } from 'fs';
 import { join } from 'path';
@@ -583,25 +583,24 @@ describe('gstack-update-check', () => {
 // — the VERSION verdict is untouched.
 describe('gstack-update-check commit-clock cross-check (#2378)', () => {
   let gitEnv: Record<string, string>;
-
-  // A local bare "upstream" plus a seed clone for the VERSION file, built
-  // once per describe. The fixture install's origin points at the garrytan
-  // slug WITHOUT fetching from it: the SHA comes from GSTACK_REMOTE_SHA and
-  // the VERSION from a file:// URL, so the whole block is hermetic.
-  const upstreamBare = join(tmpRoot, 'uc-clock-upstream.git');
-  const seedClone = join(tmpRoot, 'uc-clock-seed');
-  const plainDir = join(tmpRoot, 'uc-clock-plain');
+  let fixtureRoot: string;
+  let upstreamBare: string;
+  let seedClone: string;
+  let plainDir: string;
 
   function git(cwd: string, ...args: string[]) {
-    const r = Bun.spawnSync(['git', '-C', cwd, ...args], { stdout: 'pipe', stderr: 'pipe' });
+    const r = Bun.spawnSync(['git', '-C', cwd, ...args], { stdout: 'pipe', stderr: 'pipe', timeout: 30_000 });
     if (r.exitCode !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr.toString()}`);
     return r.stdout.toString().trim();
   }
 
-  beforeAll(() => {
-    fs.mkdirSync(tmpRoot, { recursive: true });
-    git(tmpRoot, 'init', '--bare', '-q', upstreamBare);
-    git(tmpRoot, 'clone', '-q', upstreamBare, seedClone);
+  beforeEach(() => {
+    fixtureRoot = mkdtempSync(join(tmpRoot, 'uc-clock-fixture-'));
+    upstreamBare = join(fixtureRoot, 'upstream.git');
+    seedClone = join(fixtureRoot, 'seed');
+    plainDir = join(fixtureRoot, 'plain');
+    git(fixtureRoot, 'init', '--bare', '-q', upstreamBare);
+    git(fixtureRoot, 'clone', '-q', upstreamBare, seedClone);
     git(seedClone, 'config', 'user.email', 'test@example.com');
     git(seedClone, 'config', 'user.name', 'test');
     writeFileSync(join(seedClone, 'VERSION'), '1.60.1.0\n');
@@ -613,29 +612,7 @@ describe('gstack-update-check commit-clock cross-check (#2378)', () => {
     writeFileSync(join(plainDir, 'VERSION'), '1.60.1.0\n');
     symlinkSync(join(ROOT, 'bin', 'gstack-config'), join(plainDir, 'bin', 'gstack-config'));
     symlinkSync(join(ROOT, 'bin', 'gstack-egress-lib.sh'), join(plainDir, 'bin', 'gstack-egress-lib.sh'));
-  });
 
-  // A pristine install of the CURRENT remote main: origin slug matches
-  // REMOTE_REPO, refs/remotes/origin/main exists, HEAD == origin/main.
-  function makeInstall(): string {
-    const dir = mkdtempSync(join(tmpRoot, 'uc-clock-install-'));
-    git(tmpRoot, 'clone', '-q', upstreamBare, dir);
-    git(dir, 'remote', 'set-url', 'origin', 'https://github.com/garrytan/gstack.git');
-    mkdirSync(join(dir, 'bin'), { recursive: true });
-    symlinkSync(join(ROOT, 'bin', 'gstack-config'), join(dir, 'bin', 'gstack-config'));
-    symlinkSync(join(ROOT, 'bin', 'gstack-egress-lib.sh'), join(dir, 'bin', 'gstack-egress-lib.sh'));
-    return dir;
-  }
-
-  // One local commit on the fixture upstream that does NOT bump VERSION —
-  // the #2378 scenario. Returns the new remote main SHA.
-  function advanceRemoteMain(): string {
-    git(seedClone, 'commit', '-q', '--allow-empty', '-m', 'security fix (no VERSION bump)');
-    git(seedClone, 'push', '-q', 'origin', 'HEAD:main');
-    return git(upstreamBare, 'rev-parse', 'main');
-  }
-
-  beforeEach(() => {
     gstackDir = mkdtempSync(join(tmpdir(), 'gstack-upd-test-'));
     stateDir = mkdtempSync(join(tmpdir(), 'gstack-state-test-'));
     const binDir = join(gstackDir, 'bin');
@@ -657,7 +634,27 @@ describe('gstack-update-check commit-clock cross-check (#2378)', () => {
   afterEach(() => {
     rmSync(gstackDir, { recursive: true, force: true });
     rmSync(stateDir, { recursive: true, force: true });
+    rmSync(fixtureRoot, { recursive: true, force: true });
   });
+  // A pristine install of the CURRENT remote main: origin slug matches
+  // REMOTE_REPO, refs/remotes/origin/main exists, HEAD == origin/main.
+  function makeInstall(origin = 'https://github.com/garrytan/gstack.git'): string {
+    const dir = mkdtempSync(join(tmpRoot, 'uc-clock-install-'));
+    git(fixtureRoot, 'clone', '-q', upstreamBare, dir);
+    git(dir, 'remote', 'set-url', 'origin', origin);
+    mkdirSync(join(dir, 'bin'), { recursive: true });
+    symlinkSync(join(ROOT, 'bin', 'gstack-config'), join(dir, 'bin', 'gstack-config'));
+    symlinkSync(join(ROOT, 'bin', 'gstack-egress-lib.sh'), join(dir, 'bin', 'gstack-egress-lib.sh'));
+    return dir;
+  }
+
+  // One local commit on the fixture upstream that does NOT bump VERSION —
+  // the #2378 scenario. Returns the new remote main SHA.
+  function advanceRemoteMain(): string {
+    git(seedClone, 'commit', '-q', '--allow-empty', '-m', 'security fix (no VERSION bump)');
+    git(seedClone, 'push', '-q', 'origin', 'HEAD:main');
+    return git(upstreamBare, 'rev-parse', 'main');
+  }
 
   test('THE BUG: pristine sync, main moved without a VERSION bump → flags even though versions are equal', () => {
     const install = makeInstall();
@@ -759,6 +756,63 @@ describe('gstack-update-check commit-clock cross-check (#2378)', () => {
     expect(stdout).toContain('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
   });
 
+  test('SSH origins receive the commit-clock check', () => {
+    const install = makeInstall('git@github.com:garrytan/gstack.git');
+    advanceRemoteMain();
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+  });
+
+  test('ssh:// origins receive the commit-clock check', () => {
+    const install = makeInstall('ssh://git@github.com/garrytan/gstack.git');
+    advanceRemoteMain();
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+  });
+
+  test('missing HEAD cache forces a fresh check for git installs', () => {
+    const install = makeInstall();
+    writeFileSync(join(stateDir, 'last-update-check'), 'UP_TO_DATE 1.60.1.0\n');
+    advanceRemoteMain();
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+  });
+
+  test('URL and SHA overrides stay independent', () => {
+    const install = makeInstall();
+    advanceRemoteMain();
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    const alternateVersion = join(fixtureRoot, 'alternate-VERSION');
+    writeFileSync(alternateVersion, '1.60.2.0\n');
+    const result = run({
+      GSTACK_DIR: install,
+      GSTACK_REMOTE_URL: `file://${alternateVersion}`,
+      GSTACK_REMOTE_SHA: gitEnv.GSTACK_REMOTE_SHA,
+    });
+    expect(result.stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.2.0');
+  });
+
+  test('missing origin/main ref falls back to VERSION behavior', () => {
+    const install = makeInstall();
+    git(install, 'update-ref', '-d', 'refs/remotes/origin/main');
+    advanceRemoteMain();
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe('');
+    expect(readFileSync(join(stateDir, 'last-update-check'), 'utf-8')).toContain('UP_TO_DATE');
+  });
+
+  test('malformed remote SHA keeps the legacy VERSION verdict', () => {
+    const install = makeInstall();
+    advanceRemoteMain();
+    expect(run({ ...gitEnv, GSTACK_DIR: install, GSTACK_REMOTE_SHA: 'not-a-sha' }).stdout).toBe('');
+  });
+
+  test('uppercase remote SHA does not trigger the commit-clock check', () => {
+    const install = makeInstall();
+    advanceRemoteMain();
+    const sha = git(upstreamBare, 'rev-parse', 'main').toUpperCase();
+    expect(run({ ...gitEnv, GSTACK_DIR: install, GSTACK_REMOTE_SHA: sha }).stdout).toBe('');
+  });
   test('GSTACK_REMOTE_URL override alone (no SHA) keeps legacy behavior — cross-check inert', () => {
     const install = makeInstall();
     advanceRemoteMain();

--- a/browse/test/gstack-update-check.test.ts
+++ b/browse/test/gstack-update-check.test.ts
@@ -922,6 +922,28 @@ describe('gstack-update-check commit-clock cross-check (#2378)', () => {
     expect(stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.61.0.0');
   });
 
+  test('git install whose HEAD will not resolve replays a fresh cache (no slow path per preamble)', () => {
+    // Deliberate, and it matches upstream/main: this install's verdict never
+    // depended on git state (the clock check cannot run for it), so a fresh
+    // VERSION verdict is still valid. The interim version of this branch
+    // forced a slow path here instead, which meant an ls-remote + curl on
+    // EVERY skill preamble for a repo that is already broken.
+    const broken = join(fixtureRoot, 'broken-cached');
+    mkdirSync(join(broken, 'bin'), { recursive: true });
+    writeFileSync(join(broken, 'VERSION'), '1.60.1.0\n');
+    symlinkSync(join(ROOT, 'bin', 'gstack-config'), join(broken, 'bin', 'gstack-config'));
+    symlinkSync(join(ROOT, 'bin', 'gstack-egress-lib.sh'), join(broken, 'bin', 'gstack-egress-lib.sh'));
+    git(fixtureRoot, 'init', '-q', broken);
+    writeFileSync(join(stateDir, 'last-update-check'), 'UP_TO_DATE 1.60.1.0\n');
+    const newer = join(fixtureRoot, 'VERSION-newer-cached');
+    writeFileSync(newer, '1.61.0.0\n');
+    const result = run({ GSTACK_DIR: broken, GSTACK_REMOTE_URL: `file://${newer}` });
+    expect(result.exitCode).toBe(0);
+    expectSilent(result, 'a fresh UP_TO_DATE cache is replayable for an install with no usable git state');
+    // The cache is untouched — nothing re-fetched and nothing overwrote it.
+    expect(readFileSync(join(stateDir, 'last-update-check'), 'utf-8').trim()).toBe('UP_TO_DATE 1.60.1.0');
+  });
+
   test('a cached commit-clock verdict does NOT hide a real release (60-min TTL, not the 720-min nag bucket)', () => {
     const install = makeInstall();
     expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe(expectedCommitsLine(install));

--- a/browse/test/gstack-update-check.test.ts
+++ b/browse/test/gstack-update-check.test.ts
@@ -6,12 +6,19 @@
  * for full isolation.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, beforeAll } from 'bun:test';
+import * as fs from 'fs';
 import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync, mkdirSync, symlinkSync, utimesSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
 const SCRIPT = join(import.meta.dir, '..', '..', 'bin', 'gstack-update-check');
+const ROOT = join(import.meta.dir, '..', '..');
+
+// Shared per-file scratch root. Windows free-tests exclude bash-spawn tests,
+// but mkdtemp cleanup uses force anyway; the tmpdir location keeps POSIX CI
+// and macOS dev boxes on the same hermetic path (os.tmpdir(), never /tmp).
+const tmpRoot = mkdtempSync(join(tmpdir(), 'gstack-upd-clock-'));
 
 let gstackDir: string;
 let stateDir: string;
@@ -560,5 +567,210 @@ describe('gstack-update-check', () => {
     const { exitCode, stdout } = run();
     expect(exitCode).toBe(0);
     expect(stdout).toBe('UPGRADE_AVAILABLE 0.3.3 0.4.0');
+  });
+});
+
+// ─── Commit-clock cross-check (#2378) ─────────────────────────
+//
+// update-check decides "current?" on VERSION strings, but /gstack-upgrade
+// installs origin/main HEAD. Between releases the two agree while main moves,
+// and a merge that bypasses the VERSION bump makes that window permanent —
+// installs sit silently behind, including security fixes. The fix compares
+// the remote main SHA (ls-remote / GSTACK_REMOTE_SHA) against the install's
+// HEAD and its own origin/main sync ref, and flags only the provably-safe
+// state: a pristine git sync of an older main. Every inconclusive state
+// (non-git install, no git binary, fork origin, local commits) stays silent
+// — the VERSION verdict is untouched.
+describe('gstack-update-check commit-clock cross-check (#2378)', () => {
+  let gitEnv: Record<string, string>;
+
+  // A local bare "upstream" plus a seed clone for the VERSION file, built
+  // once per describe. The fixture install's origin points at the garrytan
+  // slug WITHOUT fetching from it: the SHA comes from GSTACK_REMOTE_SHA and
+  // the VERSION from a file:// URL, so the whole block is hermetic.
+  const upstreamBare = join(tmpRoot, 'uc-clock-upstream.git');
+  const seedClone = join(tmpRoot, 'uc-clock-seed');
+  const plainDir = join(tmpRoot, 'uc-clock-plain');
+
+  function git(cwd: string, ...args: string[]) {
+    const r = Bun.spawnSync(['git', '-C', cwd, ...args], { stdout: 'pipe', stderr: 'pipe' });
+    if (r.exitCode !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr.toString()}`);
+    return r.stdout.toString().trim();
+  }
+
+  beforeAll(() => {
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    git(tmpRoot, 'init', '--bare', '-q', upstreamBare);
+    git(tmpRoot, 'clone', '-q', upstreamBare, seedClone);
+    git(seedClone, 'config', 'user.email', 'test@example.com');
+    git(seedClone, 'config', 'user.name', 'test');
+    writeFileSync(join(seedClone, 'VERSION'), '1.60.1.0\n');
+    git(seedClone, 'add', 'VERSION');
+    git(seedClone, 'commit', '-q', '-m', 'release 1.60.1.0');
+    git(seedClone, 'push', '-q', 'origin', 'HEAD:main');
+    // plain (non-git) install with the same VERSION and the same bin/ links
+    fs.mkdirSync(join(plainDir, 'bin'), { recursive: true });
+    writeFileSync(join(plainDir, 'VERSION'), '1.60.1.0\n');
+    symlinkSync(join(ROOT, 'bin', 'gstack-config'), join(plainDir, 'bin', 'gstack-config'));
+    symlinkSync(join(ROOT, 'bin', 'gstack-egress-lib.sh'), join(plainDir, 'bin', 'gstack-egress-lib.sh'));
+  });
+
+  // A pristine install of the CURRENT remote main: origin slug matches
+  // REMOTE_REPO, refs/remotes/origin/main exists, HEAD == origin/main.
+  function makeInstall(): string {
+    const dir = mkdtempSync(join(tmpRoot, 'uc-clock-install-'));
+    git(tmpRoot, 'clone', '-q', upstreamBare, dir);
+    git(dir, 'remote', 'set-url', 'origin', 'https://github.com/garrytan/gstack.git');
+    mkdirSync(join(dir, 'bin'), { recursive: true });
+    symlinkSync(join(ROOT, 'bin', 'gstack-config'), join(dir, 'bin', 'gstack-config'));
+    symlinkSync(join(ROOT, 'bin', 'gstack-egress-lib.sh'), join(dir, 'bin', 'gstack-egress-lib.sh'));
+    return dir;
+  }
+
+  // One local commit on the fixture upstream that does NOT bump VERSION —
+  // the #2378 scenario. Returns the new remote main SHA.
+  function advanceRemoteMain(): string {
+    git(seedClone, 'commit', '-q', '--allow-empty', '-m', 'security fix (no VERSION bump)');
+    git(seedClone, 'push', '-q', 'origin', 'HEAD:main');
+    return git(upstreamBare, 'rev-parse', 'main');
+  }
+
+  beforeEach(() => {
+    gstackDir = mkdtempSync(join(tmpdir(), 'gstack-upd-test-'));
+    stateDir = mkdtempSync(join(tmpdir(), 'gstack-state-test-'));
+    const binDir = join(gstackDir, 'bin');
+    mkdirSync(binDir);
+    symlinkSync(join(import.meta.dir, '..', '..', 'bin', 'gstack-config'), join(binDir, 'gstack-config'));
+    symlinkSync(
+      join(import.meta.dir, '..', '..', 'bin', 'gstack-egress-lib.sh'),
+      join(binDir, 'gstack-egress-lib.sh'),
+    );
+    // The cross-check needs both the remote SHA and a VERSION source; the
+    // fixture seed's VERSION (identical string, never bumped) stands in for
+    // the remote raw file so no network is touched.
+    gitEnv = {
+      GSTACK_REMOTE_URL: `file://${join(seedClone, 'VERSION')}`,
+      GSTACK_REMOTE_SHA: git(upstreamBare, 'rev-parse', 'main'),
+    };
+  });
+
+  afterEach(() => {
+    rmSync(gstackDir, { recursive: true, force: true });
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  test('THE BUG: pristine sync, main moved without a VERSION bump → flags even though versions are equal', () => {
+    const install = makeInstall();
+    advanceRemoteMain(); // upstream is now 1 ahead of the install, VERSION unchanged
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main'); // refresh: the check compares against the CURRENT tip
+    const { exitCode, stdout } = run(
+      { ...gitEnv, GSTACK_DIR: install },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+    // The flag is cached, so the TTL replay keeps nagging.
+    const replay = run({ ...gitEnv, GSTACK_DIR: install });
+    expect(replay.stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+  });
+
+  test('install on remote main HEAD, versions equal → silent', () => {
+    const install = makeInstall(); // HEAD == origin/main == GSTACK_REMOTE_SHA
+    const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('');
+  });
+
+  test('install left its sync point (local commits) → silent, VERSION verdict stands', () => {
+    const install = makeInstall();
+    advanceRemoteMain();
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    git(install, 'commit', '-q', '--allow-empty', '-m', 'local experiment');
+    const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('');
+    // Silent means UP_TO_DATE — the VERSION path is untouched, not the flag.
+    const cache = readFileSync(join(stateDir, 'last-update-check'), 'utf-8');
+    expect(cache).toContain('UP_TO_DATE');
+  });
+
+  test('non-git install (plain dir) → silent, unchanged behavior', () => {
+    const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: plainDir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('');
+  });
+
+  test('fork origin (slug mismatch with REMOTE_REPO) while behind → silent', () => {
+    const install = makeInstall();
+    advanceRemoteMain();
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    git(install, 'remote', 'set-url', 'origin', 'https://github.com/someone/else.git');
+    const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('');
+  });
+
+  test('after the user upgrades (HEAD moves, VERSION unchanged) the cached flag goes silent', () => {
+    const install = makeInstall();
+    const sha1 = advanceRemoteMain();
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+    // Upgrade = ff the install to the new main. VERSION string is identical.
+    git(install, 'fetch', '-q', upstreamBare, 'main');
+    git(install, 'reset', '-q', '--hard', sha1);
+    // Fresh cache TTL (60 min) has NOT expired — only the HEAD moved.
+    const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('');
+    const cache = readFileSync(join(stateDir, 'last-update-check'), 'utf-8');
+    expect(cache).toContain('UP_TO_DATE');
+  });
+
+  test('snooze applies to the same-version flag (level 1, within 24h)', () => {
+    const install = makeInstall();
+    advanceRemoteMain();
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    writeSnooze('1.60.1.0', 1, nowEpoch() - 3600);
+    const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('');
+    // The flag is still cached — the snooze only silences this replay.
+    const cache = readFileSync(join(stateDir, 'last-update-check'), 'utf-8');
+    expect(cache).toContain('UPGRADE_AVAILABLE');
+  });
+
+  test('expired snooze → the same-version flag prints again', () => {
+    const install = makeInstall();
+    advanceRemoteMain();
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    writeSnooze('1.60.1.0', 1, nowEpoch() - 90000);
+    const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+  });
+
+  test('JUST_UPGRADED marker + stale install emits both lines', () => {
+    const install = makeInstall();
+    advanceRemoteMain();
+    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    writeFileSync(join(stateDir, 'just-upgraded-from'), '1.59.0.0\n');
+    const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('JUST_UPGRADED 1.59.0.0 1.60.1.0');
+    expect(stdout).toContain('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+  });
+
+  test('GSTACK_REMOTE_URL override alone (no SHA) keeps legacy behavior — cross-check inert', () => {
+    const install = makeInstall();
+    advanceRemoteMain();
+    // Deliberately NO GSTACK_REMOTE_SHA here (delete the beforeEach default):
+    // without a remote tip and without ls-remote (URL override active), the
+    // cross-check cannot fire. The seed VERSION matches the install, so the
+    // legacy verdict is silence.
+    const { exitCode, stdout } = run({
+      GSTACK_REMOTE_URL: `file://${join(seedClone, 'VERSION')}`,
+      GSTACK_DIR: install,
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('');
   });
 });

--- a/browse/test/gstack-update-check.test.ts
+++ b/browse/test/gstack-update-check.test.ts
@@ -6,7 +6,7 @@
  * for full isolation.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeAll, beforeEach, afterEach, afterAll } from 'bun:test';
 import * as fs from 'fs';
 import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync, mkdirSync, symlinkSync, utimesSync } from 'fs';
 import { join } from 'path';
@@ -15,10 +15,14 @@ import { tmpdir } from 'os';
 const SCRIPT = join(import.meta.dir, '..', '..', 'bin', 'gstack-update-check');
 const ROOT = join(import.meta.dir, '..', '..');
 
-// Shared per-file scratch root. Windows free-tests exclude bash-spawn tests,
-// but mkdtemp cleanup uses force anyway; the tmpdir location keeps POSIX CI
-// and macOS dev boxes on the same hermetic path (os.tmpdir(), never /tmp).
+// Shared per-file scratch root, removed in afterAll. Everything the
+// commit-clock block creates goes UNDER a per-test fixtureRoot inside this,
+// so afterEach reclaims the git clones and afterAll reclaims the root itself.
 const tmpRoot = mkdtempSync(join(tmpdir(), 'gstack-upd-clock-'));
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
 
 let gstackDir: string;
 let stateDir: string;
@@ -27,7 +31,10 @@ function run(extraEnv: Record<string, string> = {}, args: string[] = []) {
   // gstack-config (which this script shells out to for update_check) resolves
   // state as GSTACK_STATE_ROOT > GSTACK_HOME > GSTACK_STATE_DIR > ~/.gstack.
   // Strip the higher-precedence vars so harness-env leftovers can never
-  // outrank the per-test GSTACK_STATE_DIR isolation.
+  // outrank the per-test GSTACK_STATE_DIR isolation. GSTACK_REMOTE_SHA and
+  // GSTACK_REMOTE_REPO are stripped for the same reason: the tests that
+  // assert "no remote SHA supplied" only mean anything if the ambient env
+  // cannot supply one.
   const env: Record<string, string | undefined> = {
     ...process.env,
     GSTACK_DIR: gstackDir,
@@ -36,6 +43,8 @@ function run(extraEnv: Record<string, string> = {}, args: string[] = []) {
   };
   delete env.GSTACK_STATE_ROOT;
   delete env.GSTACK_HOME;
+  delete env.GSTACK_REMOTE_SHA;
+  delete env.GSTACK_REMOTE_REPO;
   Object.assign(env, extraEnv); // per-test overrides always win, deliberately
   const result = Bun.spawnSync(['bash', SCRIPT, ...args], {
     env,
@@ -584,9 +593,15 @@ describe('gstack-update-check', () => {
 describe('gstack-update-check commit-clock cross-check (#2378)', () => {
   let gitEnv: Record<string, string>;
   let fixtureRoot: string;
+  let sharedRoot: string;
   let upstreamBare: string;
   let seedClone: string;
   let plainDir: string;
+  let templateBehind: string;
+  let templateCurrent: string;
+  let BASE_SHA: string;
+  let TIP_SHA: string;
+  let installSeq = 0;
 
   function git(cwd: string, ...args: string[]) {
     const r = Bun.spawnSync(['git', '-C', cwd, ...args], { stdout: 'pipe', stderr: 'pipe', timeout: 30_000 });
@@ -594,84 +609,139 @@ describe('gstack-update-check commit-clock cross-check (#2378)', () => {
     return r.stdout.toString().trim();
   }
 
-  beforeEach(() => {
-    fixtureRoot = mkdtempSync(join(tmpRoot, 'uc-clock-fixture-'));
-    upstreamBare = join(fixtureRoot, 'upstream.git');
-    seedClone = join(fixtureRoot, 'seed');
-    plainDir = join(fixtureRoot, 'plain');
-    git(fixtureRoot, 'init', '--bare', '-q', upstreamBare);
-    git(fixtureRoot, 'clone', '-q', upstreamBare, seedClone);
+  /** Copy a prepared fixture tree. Keeps symlinks as symlinks, and costs
+   *  ~0.3 ms against ~400 ms for a local `git clone`. */
+  function cpR(src: string, dest: string) {
+    fs.cpSync(src, dest, { recursive: true });
+  }
+
+  // The upstream is built ONCE and never changes: two commits, where the
+  // second bumps nothing (BASE ships VERSION 1.60.1.0, TIP is the "security
+  // fix with no VERSION bump" that #2378 is about). Per-test isolation comes
+  // from copying a prepared install template, not from rebuilding the world.
+  //
+  // Why a template copy instead of `git clone` per test: a local clone
+  // measured 397 ms against 43 ms for `cp -R`, and this file already ran
+  // longer than any other file in the free suite. An immutable upstream also
+  // removes the shared-mutable-state hazard the previous fixture had, where
+  // one test advancing main changed what a later test was looking at.
+  beforeAll(() => {
+    sharedRoot = mkdtempSync(join(tmpRoot, 'shared-'));
+    upstreamBare = join(sharedRoot, 'upstream.git');
+    seedClone = join(sharedRoot, 'seed');
+    plainDir = join(sharedRoot, 'plain');
+    templateBehind = join(sharedRoot, 'tpl-behind');
+    templateCurrent = join(sharedRoot, 'tpl-current');
+
+    git(sharedRoot, 'init', '--bare', '-q', upstreamBare);
+    git(sharedRoot, 'clone', '-q', upstreamBare, seedClone);
     git(seedClone, 'config', 'user.email', 'test@example.com');
     git(seedClone, 'config', 'user.name', 'test');
     writeFileSync(join(seedClone, 'VERSION'), '1.60.1.0\n');
     git(seedClone, 'add', 'VERSION');
     git(seedClone, 'commit', '-q', '-m', 'release 1.60.1.0');
+    BASE_SHA = git(seedClone, 'rev-parse', 'HEAD');
+    git(seedClone, 'commit', '-q', '--allow-empty', '-m', 'security fix (no VERSION bump)');
+    TIP_SHA = git(seedClone, 'rev-parse', 'HEAD');
     git(seedClone, 'push', '-q', 'origin', 'HEAD:main');
+    git(seedClone, 'reset', '-q', '--hard', BASE_SHA); // seed VERSION == the install's
+
+    // A pristine install of an OLDER main: origin slug matches REMOTE_REPO,
+    // refs/remotes/origin/main exists, HEAD == origin/main == BASE.
+    git(sharedRoot, 'clone', '-q', upstreamBare, templateBehind);
+    git(templateBehind, 'remote', 'set-url', 'origin', 'https://github.com/garrytan/gstack.git');
+    git(templateBehind, 'reset', '-q', '--hard', BASE_SHA);
+    git(templateBehind, 'update-ref', 'refs/remotes/origin/main', BASE_SHA);
+    mkdirSync(join(templateBehind, 'bin'), { recursive: true });
+    symlinkSync(join(ROOT, 'bin', 'gstack-config'), join(templateBehind, 'bin', 'gstack-config'));
+    symlinkSync(join(ROOT, 'bin', 'gstack-egress-lib.sh'), join(templateBehind, 'bin', 'gstack-egress-lib.sh'));
+
+    // ...and the same install already sitting on the remote tip.
+    cpR(templateBehind, templateCurrent);
+    git(templateCurrent, 'reset', '-q', '--hard', TIP_SHA);
+    git(templateCurrent, 'update-ref', 'refs/remotes/origin/main', TIP_SHA);
+
     // plain (non-git) install with the same VERSION and the same bin/ links
     fs.mkdirSync(join(plainDir, 'bin'), { recursive: true });
     writeFileSync(join(plainDir, 'VERSION'), '1.60.1.0\n');
     symlinkSync(join(ROOT, 'bin', 'gstack-config'), join(plainDir, 'bin', 'gstack-config'));
     symlinkSync(join(ROOT, 'bin', 'gstack-egress-lib.sh'), join(plainDir, 'bin', 'gstack-egress-lib.sh'));
+  });
 
-    gstackDir = mkdtempSync(join(tmpdir(), 'gstack-upd-test-'));
-    stateDir = mkdtempSync(join(tmpdir(), 'gstack-state-test-'));
-    const binDir = join(gstackDir, 'bin');
-    mkdirSync(binDir);
-    symlinkSync(join(import.meta.dir, '..', '..', 'bin', 'gstack-config'), join(binDir, 'gstack-config'));
-    symlinkSync(
-      join(import.meta.dir, '..', '..', 'bin', 'gstack-egress-lib.sh'),
-      join(binDir, 'gstack-egress-lib.sh'),
-    );
-    // The cross-check needs both the remote SHA and a VERSION source; the
-    // fixture seed's VERSION (identical string, never bumped) stands in for
-    // the remote raw file so no network is touched.
+  beforeEach(() => {
+    fixtureRoot = mkdtempSync(join(tmpRoot, 'uc-clock-fixture-'));
+    // gstackDir / stateDir come from the module-level beforeEach, which runs
+    // first and already links bin/. Re-creating them here would orphan that
+    // pair before any afterEach could see it.
+    //
+    // The cross-check needs both a remote SHA and a VERSION source; the seed's
+    // VERSION (identical string, never bumped) stands in for the remote raw
+    // file, so no network is touched.
     gitEnv = {
       GSTACK_REMOTE_URL: `file://${join(seedClone, 'VERSION')}`,
-      GSTACK_REMOTE_SHA: git(upstreamBare, 'rev-parse', 'main'),
+      GSTACK_REMOTE_SHA: TIP_SHA,
     };
   });
 
   afterEach(() => {
-    rmSync(gstackDir, { recursive: true, force: true });
-    rmSync(stateDir, { recursive: true, force: true });
     rmSync(fixtureRoot, { recursive: true, force: true });
   });
-  // A pristine install of the CURRENT remote main: origin slug matches
-  // REMOTE_REPO, refs/remotes/origin/main exists, HEAD == origin/main.
-  function makeInstall(origin = 'https://github.com/garrytan/gstack.git'): string {
-    const dir = mkdtempSync(join(tmpRoot, 'uc-clock-install-'));
-    git(fixtureRoot, 'clone', '-q', upstreamBare, dir);
-    git(dir, 'remote', 'set-url', 'origin', origin);
-    mkdirSync(join(dir, 'bin'), { recursive: true });
-    symlinkSync(join(ROOT, 'bin', 'gstack-config'), join(dir, 'bin', 'gstack-config'));
-    symlinkSync(join(ROOT, 'bin', 'gstack-egress-lib.sh'), join(dir, 'bin', 'gstack-egress-lib.sh'));
+
+  /** An install one commit behind the remote tip, VERSION strings equal. */
+  function makeInstall(origin?: string): string {
+    const dir = join(fixtureRoot, `install-${installSeq++}`);
+    cpR(templateBehind, dir);
+    if (origin) git(dir, 'remote', 'set-url', 'origin', origin);
     return dir;
   }
 
-  // One local commit on the fixture upstream that does NOT bump VERSION —
-  // the #2378 scenario. Returns the new remote main SHA.
-  function advanceRemoteMain(): string {
-    git(seedClone, 'commit', '-q', '--allow-empty', '-m', 'security fix (no VERSION bump)');
-    git(seedClone, 'push', '-q', 'origin', 'HEAD:main');
-    return git(upstreamBare, 'rev-parse', 'main');
+  /** An install already sitting on the remote tip. */
+  function makeCurrentInstall(): string {
+    const dir = join(fixtureRoot, `current-${installSeq++}`);
+    cpR(templateCurrent, dir);
+    return dir;
+  }
+
+  /** What a `git fetch` does: move origin/main without moving HEAD. */
+  function fetchOnly(install: string) {
+    git(install, 'fetch', '-q', upstreamBare, 'main:refs/remotes/origin/main');
+  }
+
+  /** What a successful upgrade does: fast-forward HEAD to the fetched tip. */
+  function fastForward(install: string, sha = TIP_SHA) {
+    fetchOnly(install);
+    git(install, 'reset', '-q', '--hard', sha);
+  }
+
+  /** The line the script emits for a commit-clock-behind install. */
+  function expectedCommitsLine(install: string, remoteSha = TIP_SHA, version = '1.60.1.0'): string {
+    const local = git(install, 'rev-parse', 'HEAD');
+    return `UPGRADE_COMMITS ${version} ${local.slice(0, 7)} ${remoteSha.slice(0, 7)}`;
+  }
+
+  function ageCache(minutes: number) {
+    const when = new Date(Date.now() - minutes * 60 * 1000);
+    utimesSync(join(stateDir, 'last-update-check'), when, when);
+  }
+
+  /** Silence is the up-to-date signal, so a spurious line here is the whole
+   *  bug class. Surface stdout AND stderr on failure: a bare toBe('') tells
+   *  you the assertion failed and nothing about why. */
+  function expectSilent(result: { stdout: string; stderr: string }, why: string) {
+    expect(result.stdout, `${why}\nstderr: ${result.stderr}`).toBe('');
   }
 
   test('THE BUG: pristine sync, main moved without a VERSION bump → flags even though versions are equal', () => {
     const install = makeInstall();
-    advanceRemoteMain(); // upstream is now 1 ahead of the install, VERSION unchanged
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main'); // refresh: the check compares against the CURRENT tip
-    const { exitCode, stdout } = run(
-      { ...gitEnv, GSTACK_DIR: install },
-    );
+    const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
     expect(exitCode).toBe(0);
-    expect(stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+    expect(stdout).toBe(expectedCommitsLine(install));
     // The flag is cached, so the TTL replay keeps nagging.
-    const replay = run({ ...gitEnv, GSTACK_DIR: install });
-    expect(replay.stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe(expectedCommitsLine(install));
   });
 
   test('install on remote main HEAD, versions equal → silent', () => {
-    const install = makeInstall(); // HEAD == origin/main == GSTACK_REMOTE_SHA
+    const install = makeCurrentInstall();
     const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
     expect(exitCode).toBe(0);
     expect(stdout).toBe('');
@@ -679,15 +749,14 @@ describe('gstack-update-check commit-clock cross-check (#2378)', () => {
 
   test('install left its sync point (local commits) → silent, VERSION verdict stands', () => {
     const install = makeInstall();
-    advanceRemoteMain();
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
+    git(install, 'config', 'user.email', 'test@example.com');
+    git(install, 'config', 'user.name', 'test');
     git(install, 'commit', '-q', '--allow-empty', '-m', 'local experiment');
     const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
     expect(exitCode).toBe(0);
     expect(stdout).toBe('');
     // Silent means UP_TO_DATE — the VERSION path is untouched, not the flag.
-    const cache = readFileSync(join(stateDir, 'last-update-check'), 'utf-8');
-    expect(cache).toContain('UP_TO_DATE');
+    expect(readFileSync(join(stateDir, 'last-update-check'), 'utf-8')).toContain('UP_TO_DATE');
   });
 
   test('non-git install (plain dir) → silent, unchanged behavior', () => {
@@ -697,10 +766,7 @@ describe('gstack-update-check commit-clock cross-check (#2378)', () => {
   });
 
   test('fork origin (slug mismatch with REMOTE_REPO) while behind → silent', () => {
-    const install = makeInstall();
-    advanceRemoteMain();
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
-    git(install, 'remote', 'set-url', 'origin', 'https://github.com/someone/else.git');
+    const install = makeInstall('https://github.com/someone/else.git');
     const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
     expect(exitCode).toBe(0);
     expect(stdout).toBe('');
@@ -708,86 +774,56 @@ describe('gstack-update-check commit-clock cross-check (#2378)', () => {
 
   test('after the user upgrades (HEAD moves, VERSION unchanged) the cached flag goes silent', () => {
     const install = makeInstall();
-    const sha1 = advanceRemoteMain();
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
-    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
-    // Upgrade = ff the install to the new main. VERSION string is identical.
-    git(install, 'fetch', '-q', upstreamBare, 'main');
-    git(install, 'reset', '-q', '--hard', sha1);
-    // Fresh cache TTL (60 min) has NOT expired — only the HEAD moved.
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe(expectedCommitsLine(install));
+    fastForward(install); // VERSION string is identical after the upgrade
+    // The cache is still FRESH — only the install state moved.
     const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
     expect(exitCode).toBe(0);
     expect(stdout).toBe('');
-    const cache = readFileSync(join(stateDir, 'last-update-check'), 'utf-8');
-    expect(cache).toContain('UP_TO_DATE');
+    expect(readFileSync(join(stateDir, 'last-update-check'), 'utf-8')).toContain('UP_TO_DATE');
   });
 
   test('snooze applies to the same-version flag (level 1, within 24h)', () => {
     const install = makeInstall();
-    advanceRemoteMain();
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
     writeSnooze('1.60.1.0', 1, nowEpoch() - 3600);
     const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
     expect(exitCode).toBe(0);
     expect(stdout).toBe('');
     // The flag is still cached — the snooze only silences this replay.
-    const cache = readFileSync(join(stateDir, 'last-update-check'), 'utf-8');
-    expect(cache).toContain('UPGRADE_AVAILABLE');
+    expect(readFileSync(join(stateDir, 'last-update-check'), 'utf-8')).toContain('UPGRADE_COMMITS');
   });
 
   test('expired snooze → the same-version flag prints again', () => {
     const install = makeInstall();
-    advanceRemoteMain();
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
     writeSnooze('1.60.1.0', 1, nowEpoch() - 90000);
     const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
     expect(exitCode).toBe(0);
-    expect(stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+    expect(stdout).toBe(expectedCommitsLine(install));
   });
 
   test('JUST_UPGRADED marker + stale install emits both lines', () => {
     const install = makeInstall();
-    advanceRemoteMain();
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
     writeFileSync(join(stateDir, 'just-upgraded-from'), '1.59.0.0\n');
     const { exitCode, stdout } = run({ ...gitEnv, GSTACK_DIR: install });
     expect(exitCode).toBe(0);
     expect(stdout).toContain('JUST_UPGRADED 1.59.0.0 1.60.1.0');
-    expect(stdout).toContain('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+    expect(stdout).toContain(expectedCommitsLine(install));
   });
 
-  test('SSH origins receive the commit-clock check', () => {
-    const install = makeInstall('git@github.com:garrytan/gstack.git');
-    advanceRemoteMain();
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
-    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
-  });
-
-  test('ssh:// origins receive the commit-clock check', () => {
-    const install = makeInstall('ssh://git@github.com/garrytan/gstack.git');
-    advanceRemoteMain();
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
-    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
-  });
-
-  test('missing HEAD cache forces a fresh check for git installs', () => {
+  test('missing state stamp forces a fresh check for git installs', () => {
     const install = makeInstall();
     writeFileSync(join(stateDir, 'last-update-check'), 'UP_TO_DATE 1.60.1.0\n');
-    advanceRemoteMain();
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
-    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0');
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe(expectedCommitsLine(install));
   });
 
   test('URL and SHA overrides stay independent', () => {
     const install = makeInstall();
-    advanceRemoteMain();
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
     const alternateVersion = join(fixtureRoot, 'alternate-VERSION');
     writeFileSync(alternateVersion, '1.60.2.0\n');
     const result = run({
       GSTACK_DIR: install,
       GSTACK_REMOTE_URL: `file://${alternateVersion}`,
-      GSTACK_REMOTE_SHA: gitEnv.GSTACK_REMOTE_SHA,
+      GSTACK_REMOTE_SHA: TIP_SHA,
     });
     expect(result.stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.60.2.0');
   });
@@ -795,36 +831,246 @@ describe('gstack-update-check commit-clock cross-check (#2378)', () => {
   test('missing origin/main ref falls back to VERSION behavior', () => {
     const install = makeInstall();
     git(install, 'update-ref', '-d', 'refs/remotes/origin/main');
-    advanceRemoteMain();
-    gitEnv.GSTACK_REMOTE_SHA = git(upstreamBare, 'rev-parse', 'main');
     expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe('');
     expect(readFileSync(join(stateDir, 'last-update-check'), 'utf-8')).toContain('UP_TO_DATE');
   });
 
   test('malformed remote SHA keeps the legacy VERSION verdict', () => {
     const install = makeInstall();
-    advanceRemoteMain();
-    expect(run({ ...gitEnv, GSTACK_DIR: install, GSTACK_REMOTE_SHA: 'not-a-sha' }).stdout).toBe('');
+    expectSilent(run({ ...gitEnv, GSTACK_DIR: install, GSTACK_REMOTE_SHA: 'not-a-sha' }), 'a malformed remote SHA must be inconclusive');
   });
 
   test('uppercase remote SHA does not trigger the commit-clock check', () => {
     const install = makeInstall();
-    advanceRemoteMain();
-    const sha = git(upstreamBare, 'rev-parse', 'main').toUpperCase();
-    expect(run({ ...gitEnv, GSTACK_DIR: install, GSTACK_REMOTE_SHA: sha }).stdout).toBe('');
+    expectSilent(run({ ...gitEnv, GSTACK_DIR: install, GSTACK_REMOTE_SHA: TIP_SHA.toUpperCase() }), 'an uppercase remote SHA must be inconclusive (ls-remote only ever returns lowercase)');
   });
+
   test('GSTACK_REMOTE_URL override alone (no SHA) keeps legacy behavior — cross-check inert', () => {
     const install = makeInstall();
-    advanceRemoteMain();
-    // Deliberately NO GSTACK_REMOTE_SHA here (delete the beforeEach default):
-    // without a remote tip and without ls-remote (URL override active), the
-    // cross-check cannot fire. The seed VERSION matches the install, so the
-    // legacy verdict is silence.
+    // Deliberately NO GSTACK_REMOTE_SHA: without a remote tip and without
+    // ls-remote (URL override active), the cross-check cannot fire. The seed
+    // VERSION matches the install, so the legacy verdict is silence.
     const { exitCode, stdout } = run({
       GSTACK_REMOTE_URL: `file://${join(seedClone, 'VERSION')}`,
       GSTACK_DIR: install,
     });
     expect(exitCode).toBe(0);
     expect(stdout).toBe('');
+  });
+
+  // ─── Negative paths ────────────────────────────────────────
+  // The states that made the first cut of this feature look green: a git repo
+  // whose HEAD will not resolve, a moved origin/main ref, a remote tip on the
+  // wrong side of HEAD, two installs sharing one state dir, and a real
+  // release landing while a commit-clock verdict is cached.
+
+  test('bare `git fetch` moves origin/main ahead of HEAD → still flags (ancestry, not equality)', () => {
+    // /gstack-upgrade runs `git fetch origin` BEFORE `git pull --ff-only`, so
+    // an upgrade that failed after the fetch leaves exactly this state. A
+    // HEAD == origin/main gate would silence such an install permanently.
+    const install = makeInstall();
+    fetchOnly(install);
+    expect(git(install, 'rev-parse', 'HEAD')).toBe(BASE_SHA);   // HEAD did NOT move
+    expect(git(install, 'rev-parse', 'refs/remotes/origin/main')).toBe(TIP_SHA); // the ref did
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe(expectedCommitsLine(install));
+  });
+
+  test('remote tip is an ANCESTOR of HEAD (install ahead) → silent, never a backwards flag', () => {
+    // The install is ON the tip and the supplied "remote tip" is the older
+    // commit. Nothing to upgrade to; --ff-only could not apply it.
+    const install = makeCurrentInstall();
+    const result = run({ ...gitEnv, GSTACK_DIR: install, GSTACK_REMOTE_SHA: BASE_SHA });
+    expect(result.exitCode).toBe(0);
+    expectSilent(result, 'the install is AHEAD of the supplied tip');
+  });
+
+  test('remote tip on unrelated history (present locally) → silent', () => {
+    const install = makeInstall();
+    const alt = join(fixtureRoot, 'alt');
+    git(fixtureRoot, 'init', '-q', alt);
+    git(alt, 'config', 'user.email', 'test@example.com');
+    git(alt, 'config', 'user.name', 'test');
+    git(alt, 'commit', '-q', '--allow-empty', '-m', 'unrelated root');
+    const altSha = git(alt, 'rev-parse', 'HEAD');
+    git(install, 'fetch', '-q', alt, 'HEAD');
+    const result = run({ ...gitEnv, GSTACK_DIR: install, GSTACK_REMOTE_SHA: altSha });
+    expect(result.exitCode).toBe(0);
+    expectSilent(result, 'an unrelated-history tip is not an upgrade');
+  });
+
+  test('git install whose HEAD will not resolve → VERSION verdict stands, no CHECK_FAILED leak', () => {
+    // An unborn HEAD is inconclusive, not a crash: the design says fall back
+    // to the VERSION verdict. What must never happen is the ERR trap firing
+    // INSIDE a command substitution, which would put the #1974 sentinel into
+    // a shell variable instead of on stdout — silently swallowing it.
+    const broken = join(fixtureRoot, 'broken');
+    mkdirSync(join(broken, 'bin'), { recursive: true });
+    writeFileSync(join(broken, 'VERSION'), '1.60.1.0\n');
+    symlinkSync(join(ROOT, 'bin', 'gstack-config'), join(broken, 'bin', 'gstack-config'));
+    symlinkSync(join(ROOT, 'bin', 'gstack-egress-lib.sh'), join(broken, 'bin', 'gstack-egress-lib.sh'));
+    git(fixtureRoot, 'init', '-q', broken); // .git exists, no commit → rev-parse HEAD fails
+    const newer = join(fixtureRoot, 'VERSION-newer');
+    writeFileSync(newer, '1.61.0.0\n');
+    const { exitCode, stdout, stderr } = run({
+      GSTACK_DIR: broken,
+      GSTACK_REMOTE_URL: `file://${newer}`,
+      GSTACK_REMOTE_SHA: TIP_SHA,
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain('CHECK_FAILED');
+    expect(stderr).not.toContain('CHECK_FAILED');
+    expect(stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.61.0.0');
+  });
+
+  test('a cached commit-clock verdict does NOT hide a real release (60-min TTL, not the 720-min nag bucket)', () => {
+    const install = makeInstall();
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe(expectedCommitsLine(install));
+    ageCache(100); // past the 60-min bucket, well inside the 720-min one
+    const realRelease = join(fixtureRoot, 'VERSION-161');
+    writeFileSync(realRelease, '1.61.0.0\n');
+    const { stdout } = run({ ...gitEnv, GSTACK_DIR: install, GSTACK_REMOTE_URL: `file://${realRelease}` });
+    expect(stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.61.0.0');
+  });
+
+  test('a snooze on the commit-clock nag does NOT silence a later real release', () => {
+    const install = makeInstall();
+    writeSnooze('1.60.1.0', 1, nowEpoch() - 3600);
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe(''); // snoozed
+    ageCache(100);
+    const realRelease = join(fixtureRoot, 'VERSION-161');
+    writeFileSync(realRelease, '1.61.0.0\n');
+    const { stdout } = run({ ...gitEnv, GSTACK_DIR: install, GSTACK_REMOTE_URL: `file://${realRelease}` });
+    expect(stdout).toBe('UPGRADE_AVAILABLE 1.60.1.0 1.61.0.0');
+  });
+
+  test('two installs sharing one state dir do not silence each other', () => {
+    // STATE_DIR is machine-global ($HOME/.gstack). A global install plus a dev
+    // clone — or sibling Conductor workspaces — land on the same cache file.
+    const behind = makeInstall();
+    const current = makeCurrentInstall();
+    // The up-to-date install writes UP_TO_DATE first...
+    expect(run({ ...gitEnv, GSTACK_DIR: current }).stdout).toBe('');
+    // ...and must not mute the one that is genuinely behind, on any run.
+    expect(run({ ...gitEnv, GSTACK_DIR: behind }).stdout).toBe(expectedCommitsLine(behind));
+    expect(run({ ...gitEnv, GSTACK_DIR: behind }).stdout).toBe(expectedCommitsLine(behind));
+  });
+
+  test('same HEAD, different origin/main, shared state dir → no cross-replay', () => {
+    const a = makeInstall();
+    const b = makeInstall();
+    fetchOnly(b); // only b fetched; both are still on the same commit
+    expect(git(a, 'rev-parse', 'HEAD')).toBe(git(b, 'rev-parse', 'HEAD'));
+    expect(git(a, 'rev-parse', 'refs/remotes/origin/main'))
+      .not.toBe(git(b, 'rev-parse', 'refs/remotes/origin/main'));
+    // Both are behind, so both must flag — neither replays the other's stamp.
+    expect(run({ ...gitEnv, GSTACK_DIR: b }).stdout).toBe(expectedCommitsLine(b));
+    expect(run({ ...gitEnv, GSTACK_DIR: a }).stdout).toBe(expectedCommitsLine(a));
+  });
+
+  test('invalid/empty remote response still stamps, so the fresh cache stays replayable', () => {
+    const install = makeInstall();
+    const { stdout } = run({
+      GSTACK_DIR: install,
+      GSTACK_REMOTE_URL: 'file:///nonexistent/VERSION',
+      GSTACK_REMOTE_SHA: TIP_SHA,
+    });
+    expect(stdout).toBe('');
+    expect(readFileSync(join(stateDir, 'last-update-check'), 'utf-8')).toContain('UP_TO_DATE');
+    const stamp = readFileSync(join(stateDir, 'last-update-check-stamp'), 'utf-8').trim();
+    expect(stamp.split(' ')[0]).toBe(git(install, 'rev-parse', 'HEAD'));
+  });
+
+  test('snoozed commit-clock verdict still stamps', () => {
+    const install = makeInstall();
+    writeSnooze('1.60.1.0', 1, nowEpoch() - 3600);
+    expect(run({ ...gitEnv, GSTACK_DIR: install }).stdout).toBe('');
+    expect(existsSync(join(stateDir, 'last-update-check-stamp'))).toBe(true);
+  });
+
+  test('non-git install leaves no stamp file at all', () => {
+    // Not a 0-byte file and not the literal string "HEAD": either would fail
+    // every later comparison and pin the install to the slow path.
+    run({ ...gitEnv, GSTACK_DIR: plainDir });
+    expect(existsSync(join(stateDir, 'last-update-check-stamp'))).toBe(false);
+  });
+
+  test('--force clears the state stamp along with the cache', () => {
+    const install = makeInstall();
+    run({ ...gitEnv, GSTACK_DIR: install });
+    expect(existsSync(join(stateDir, 'last-update-check-stamp'))).toBe(true);
+    // --force re-runs the check, so a fresh stamp exists afterwards; what
+    // matters is that the pre-force one was removed rather than left behind
+    // to authorize a replay against state it no longer describes.
+    fastForward(install);
+    run({ ...gitEnv, GSTACK_DIR: install }, ['--force']);
+    const stamp = readFileSync(join(stateDir, 'last-update-check-stamp'), 'utf-8').trim();
+    expect(stamp.split(' ')[0]).toBe(TIP_SHA);
+  });
+
+  test('canonical origin URL forms receive the commit-clock check', () => {
+    // One install, re-pointed per form: a separate install per form costs a
+    // template copy for no extra coverage. --force resets cache + stamp.
+    const install = makeInstall();
+    for (const origin of [
+      'https://github.com/garrytan/gstack.git',
+      'git@github.com:garrytan/gstack.git',
+      'ssh://git@github.com/garrytan/gstack.git',
+      'https://github.com/garrytan/gstack',                      // no .git suffix
+    ]) {
+      git(install, 'remote', 'set-url', 'origin', origin);
+      const { stdout } = run({ ...gitEnv, GSTACK_DIR: install }, ['--force']);
+      expect(stdout, `origin ${origin} should be checked`).toBe(expectedCommitsLine(install));
+    }
+  });
+
+  test('origin URL forms the first cut silently skipped now receive the check', () => {
+    const install = makeInstall();
+    for (const origin of [
+      'https://ghp_exampletoken@github.com/garrytan/gstack.git', // CI clone shape
+      'ssh://github.com/garrytan/gstack.git',                    // no git@ userinfo
+      'git://github.com/garrytan/gstack.git',
+      'https://github.com:443/garrytan/gstack.git',              // explicit port
+      'https://github.com/GarryTan/GStack.git',                  // mixed case
+    ]) {
+      git(install, 'remote', 'set-url', 'origin', origin);
+      const { stdout } = run({ ...gitEnv, GSTACK_DIR: install }, ['--force']);
+      expect(stdout, `origin ${origin} should be checked`).toBe(expectedCommitsLine(install));
+    }
+  });
+
+  test('origin URL forms that are rejected → silent, VERSION verdict stands', () => {
+    const install = makeInstall();
+    for (const origin of [
+      'https://evil.com/github.com/garrytan/gstack.git',   // host-confusion prefix
+      'https://github.com.evil.com/garrytan/gstack.git',   // host-confusion suffix
+      'https://github.com/garrytan/gstack/extra.git',      // deeper than owner/repo
+      'https://gitlab.com/garrytan/gstack.git',            // different host
+      'https://github.com/garrytan',                       // no repo half
+      '/srv/mirrors/gstack.git',                           // local path, no host
+    ]) {
+      git(install, 'remote', 'set-url', 'origin', origin);
+      const { stdout } = run({ ...gitEnv, GSTACK_DIR: install }, ['--force']);
+      expect(stdout, `origin ${origin} should be rejected`).toBe('');
+      // Non-vacuous: the install IS behind, so silence must come from the slug
+      // gate, and the VERSION verdict must be what got cached.
+      expect(readFileSync(join(stateDir, 'last-update-check'), 'utf-8')).toContain('UP_TO_DATE');
+    }
+  });
+
+  test('GSTACK_REMOTE_REPO mirror is compared against ITS OWN slug, not a hardcoded one', () => {
+    // The origin slug gate used to hardcode garrytan/gstack, so any mirror
+    // configured through GSTACK_REMOTE_REPO silently lost the check.
+    const install = makeInstall('https://github.com/acme/gstack-mirror.git');
+    expect(run({
+      ...gitEnv,
+      GSTACK_DIR: install,
+      GSTACK_REMOTE_REPO: 'https://github.com/acme/gstack-mirror.git',
+    }).stdout).toBe(expectedCommitsLine(install));
+    // ...and a mirror whose origin does NOT match it still stays silent.
+    expect(run({
+      ...gitEnv,
+      GSTACK_DIR: install,
+      GSTACK_REMOTE_REPO: 'https://github.com/acme/other.git',
+    }, ['--force']).stdout).toBe('');
   });
 });

--- a/gstack-upgrade/COMMIT-CLOCK.md
+++ b/gstack-upgrade/COMMIT-CLOCK.md
@@ -1,0 +1,63 @@
+# Commit-clock upgrades (`UPGRADE_COMMITS`)
+
+Read this only when `gstack-update-check` emitted
+`UPGRADE_COMMITS <version> <local_sha7> <remote_sha7>`. It replaces the
+`{old}` / `{new}` wording in Steps 1 and 6 of `SKILL.md`. Every other step
+applies unchanged.
+
+Deliberately a separate file: this verdict fires only in the window where a
+merge reached `main` without a VERSION bump, so its instructions must not be
+loaded on every skill invocation (`test/context-budget-ratchet.test.ts`
+enforces the eager ceiling that would otherwise pay for it).
+
+## Why the version does not change
+
+`UPGRADE_AVAILABLE <old> <new>` means a newer release exists. `UPGRADE_COMMITS`
+means the opposite half of #2378: the VERSION strings agree, and `main` has
+moved past this install anyway. So:
+
+- `{version}` is the same before and after the upgrade. There is no `{new}`.
+- `CHANGELOG.md` is keyed by released version headings, so it has **no
+  entries** between the two points. Do not read it for this verdict.
+- Never render this as "v{version} is available (you're on v{version})". It
+  reads as a bug, and the rational answer to a broken prompt is "Never ask
+  again" — which disables update checks permanently.
+
+## Step 1 replacement — the prompt
+
+Auto-upgrade log line: `Auto-upgrading gstack v{version} to main {remote_sha7}...`
+
+AskUserQuestion:
+
+- Question: "gstack main has moved past your install (**{local_sha7} →
+  {remote_sha7}**), with no version bump since v{version}. Upgrade now?"
+- Options: unchanged — ["Yes, upgrade now", "Always keep me up to date",
+  "Not now", "Never ask again"]
+
+Snooze ("Not now"): use `{version}` as `_REMOTE_VER`. The snooze is keyed on
+the version string for both verdicts, which is what `gstack-update-check`
+compares it against.
+
+## Step 6 replacement — Show What's New
+
+Summarize the commit range instead of the changelog:
+
+```bash
+git -C "$INSTALL_DIR" log --oneline --no-merges {local_sha7}..HEAD | head -40
+```
+
+Up to 7 bullets grouped by theme. Say plainly when the range is small ("3
+commits since your install"). If it comes back empty, say the install was
+already current — do not invent entries.
+
+Format:
+
+```
+gstack v{version} — now on main {remote_sha7} (was {local_sha7})
+
+What landed:
+- [bullet 1]
+- ...
+
+Happy shipping!
+```

--- a/gstack-upgrade/SKILL.md
+++ b/gstack-upgrade/SKILL.md
@@ -30,7 +30,9 @@ Upgrade gstack to the latest version and show what's new.
 
 ## Inline upgrade flow
 
-This section is referenced by all skill preambles when they detect `UPGRADE_AVAILABLE`.
+This section is referenced by all skill preambles when they detect `UPGRADE_AVAILABLE` or `UPGRADE_COMMITS`.
+
+**If the verdict is `UPGRADE_COMMITS <version> <local_sha7> <remote_sha7>`** — main moved past this install with no VERSION bump, so the version does not change — read `COMMIT-CLOCK.md` beside this file first: it replaces the `{old}`/`{new}` wording in Steps 1 and 6. Everything else below applies unchanged.
 
 ### Step 1: Ask the user (or auto-upgrade)
 
@@ -352,7 +354,7 @@ When invoked directly as `/gstack-upgrade` (not from a preamble):
 ```
 Use the output to determine if an upgrade is available.
 
-2. If `UPGRADE_AVAILABLE <old> <new>`: follow Steps 2-6 above.
+2. If `UPGRADE_AVAILABLE` or `UPGRADE_COMMITS`: follow Steps 2-6 above.
 
 3. If no output (primary is up to date): check for a stale local vendored copy.
 

--- a/gstack-upgrade/SKILL.md.tmpl
+++ b/gstack-upgrade/SKILL.md.tmpl
@@ -27,7 +27,9 @@ Upgrade gstack to the latest version and show what's new.
 
 ## Inline upgrade flow
 
-This section is referenced by all skill preambles when they detect `UPGRADE_AVAILABLE`.
+This section is referenced by all skill preambles when they detect `UPGRADE_AVAILABLE` or `UPGRADE_COMMITS`.
+
+**If the verdict is `UPGRADE_COMMITS <version> <local_sha7> <remote_sha7>`** — main moved past this install with no VERSION bump, so the version does not change — read `COMMIT-CLOCK.md` beside this file first: it replaces the `{old}`/`{new}` wording in Steps 1 and 6. Everything else below applies unchanged.
 
 ### Step 1: Ask the user (or auto-upgrade)
 
@@ -349,7 +351,7 @@ When invoked directly as `/gstack-upgrade` (not from a preamble):
 ```
 Use the output to determine if an upgrade is available.
 
-2. If `UPGRADE_AVAILABLE <old> <new>`: follow Steps 2-6 above.
+2. If `UPGRADE_AVAILABLE` or `UPGRADE_COMMITS`: follow Steps 2-6 above.
 
 3. If no output (primary is up to date): check for a stale local vendored copy.
 


### PR DESCRIPTION
## Why (in your own words)

`gstack-update-check` used the release `VERSION` file as its only clock, while `/gstack-upgrade` updates git installs to `origin/main`. That meant a canonical git install could be behind newer commits, including security fixes, while still reporting that it was up to date when `VERSION` had not changed. This change compares the installed commit with the current remote `main` commit and reports an upgrade only when the install is a pristine, fast-forwardable upstream checkout. Because the version string does not change in that state, it reports a **new** verdict — `UPGRADE_COMMITS <version> <local_sha7> <remote_sha7>` — rather than reusing `UPGRADE_AVAILABLE <v> <v>`, which every consumer would render as "v1.60.1.0 is available (you're on v1.60.1.0)" with an empty changelog range behind it. VERSION remains the displayed release value, and inconclusive states keep the existing behavior.

## Live evidence

All blocks below are verbatim output from the same hermetic fixture: a local bare upstream, a pristine install whose VERSION stays `1.60.1.0`, and one upstream commit that does not bump VERSION. `before` is this PR's previous head (`86b0c64d`), `after` is `4d4ba940`.

**1. A cached same-version verdict hid a real release for up to 12 hours.** The same-version flag inherited the `UPGRADE_AVAILABLE` 720-minute nag bucket, so when a genuine `1.61.0.0` shipped, the cached line kept being replayed instead:

```text
--- before ---
$ gstack-update-check                       # install 1 commit behind, VERSION equal
UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0
$ cat $STATE_DIR/last-update-check
UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0
# ...100 minutes pass (past the 60-min bucket, inside the 720-min one), and v1.61.0.0 ships
$ gstack-update-check
UPGRADE_AVAILABLE 1.60.1.0 1.60.1.0          <- the real release is invisible

--- after ---
$ gstack-update-check                       # install 1 commit behind, VERSION equal
UPGRADE_COMMITS 1.60.1.0 994fbe0 485ab9f
$ cat $STATE_DIR/last-update-check
UPGRADE_COMMITS 1.60.1.0 994fbe0 485ab9f
# ...100 minutes pass (past the 60-min bucket, inside the 720-min one), and v1.61.0.0 ships
$ gstack-update-check
UPGRADE_AVAILABLE 1.60.1.0 1.61.0.0          <- reported, same latency as before this PR
```

**2. A bare `git fetch` silenced the check permanently.** The pristine-sync gate required `HEAD == origin/main`. A fetch moves the ref without moving HEAD, and `/gstack-upgrade` runs `git fetch origin` *before* `git pull --ff-only` — so an upgrade that failed after the fetch left the install muted, which is the silent-staleness class #2378 documents. The gate is now `merge-base --is-ancestor`:

```text
--- before ---
$ git rev-parse --short HEAD; git rev-parse --short refs/remotes/origin/main
HEAD        9f9e762
origin/main bb367d2   <- moved by the fetch; HEAD did not
$ git merge-base --is-ancestor HEAD bb367d2 && echo 'ff-only would succeed'
ff-only would succeed
$ gstack-update-check
(no output)                                  <- verifiably behind, verifiably safe, silent

--- after ---
$ git rev-parse --short HEAD; git rev-parse --short refs/remotes/origin/main
HEAD        be90085
origin/main 22cc501   <- moved by the fetch; HEAD did not
$ git merge-base --is-ancestor HEAD 22cc501 && echo 'ff-only would succeed'
ff-only would succeed
$ gstack-update-check
UPGRADE_COMMITS 1.60.1.0 be90085 22cc501
```

**3. The #1974 crash sentinel was being swallowed into a variable.** `set -E` propagates the ERR trap into command substitutions, so `_CURRENT_HEAD="$(git rev-parse HEAD | tr -d ...)"` under `pipefail` fired the trap *inside* the `$( )` when HEAD would not resolve — its `echo` became the variable's value, not output. Note the `+++` depth on the firing line:

```text
--- before ---
$ git -C $GSTACK_DIR rev-parse HEAD; echo "rc=$?"
HEAD
rc=128
$ bash -x gstack-update-check 2>&1 | grep CHECK_FAILED   # where did the sentinel go?
+ trap 'rc=$?; echo "CHECK_FAILED gstack-update-check crashed (line $LINENO, rc=$rc) — update status UNKNOWN, not up-to-date"; exit 0' ERR
+++ echo 'CHECK_FAILED gstack-update-check crashed (line 185, rc=128) — update status UNKNOWN, not up-to-date'

--- after ---
$ git -C $GSTACK_DIR rev-parse HEAD; echo "rc=$?"
HEAD
rc=128
$ bash -x gstack-update-check 2>&1 | grep CHECK_FAILED   # where did the sentinel go?
+ trap 'rc=$?; echo "CHECK_FAILED gstack-update-check crashed (line $LINENO, rc=$rc) — update status UNKNOWN, not up-to-date"; exit 0' ERR
```

**4. Two verdict writes skipped the state stamp, turning cached runs into network runs.** The invalid/empty-remote path and the snoozed same-version path wrote a cache with no stamp, so every later run re-fetched while still offline:

```text
--- before ---   HEAD moved, then the network broke; cache is FRESH
$ bash -x gstack-update-check 2>&1 | grep -c 'curl -sf --max-time 5'
2

--- after ---
$ bash -x gstack-update-check 2>&1 | grep -c 'curl -sf --max-time 5'
0
```

**5. Behavior against `upstream/main` for a git install with an unresolvable HEAD and a fresh cache.** `after` matches base exactly; the interim commit was the outlier that forced an `ls-remote` + `curl` on every skill preamble for an already-broken repo:

```text
  base     stdout=[]                                     network fetches=0
  interim  stdout=[UPGRADE_AVAILABLE 1.60.1.0 1.61.0.0]  network fetches=1
  now      stdout=[]                                     network fetches=0
```

**6. Cache-hit path cost** (the path every skill preamble pays), external processes and wall time over 10 runs. The stamp read is a real cost and this states it plainly — but it is one `git rev-parse` for both refs, down from the interim version's five extra subprocesses:

```text
  base    external calls=6    mean 101 ms
  before  external calls=14   mean 175 ms
  now     external calls=8    mean 138 ms
```

**7. Tests.**

```text
$ bun test browse/test/gstack-update-check.test.ts
70 pass
0 fail
Ran 70 tests across 1 file. [31.14s]

$ bun test browse/test/gstack-update-check.test.ts test/update-check-crash-sentinel.test.ts test/egress-receipt-wiring.test.ts
82 pass
0 fail
Ran 82 tests across 3 files. [33.85s]
```

Consumer-side and budget contracts, since this PR edits `bin/gstack-skill-start` and `gstack-upgrade/SKILL.md.tmpl`:

```text
$ bun test test/skill-validation.test.ts test/gstack-skill-start.test.ts test/context-budget-ratchet.test.ts test/gen-skill-docs.test.ts test/spawnsync-timeout-tripwire.test.ts
0 fail
```

**8. CI on `4d4ba940`** — all six checks green, including the Windows lane:

```text
actionlint           success
build-image          success
check-freshness      success
free-tests           success
quality              success
windows-free-tests   success
```

`free-tests` produced no flake-ledger artifact, i.e. it passed with zero failures rather than through the runner's retry-and-downgrade path.

## Scope

- **Changed:** `bin/gstack-update-check` cross-checks the commit clock for canonical upstream git installs, emitting a distinct `UPGRADE_COMMITS` verdict with its own 60-minute TTL bucket; gates on `merge-base --is-ancestor` rather than ref equality; writes every verdict together with a state stamp (HEAD, the install's own `origin/main`, and which install it is) through one helper, so a cached verdict can never be replayed against state it never saw; guards every git capture against the ERR trap; derives the origin slug from `REMOTE_REPO` instead of hardcoding it, and recognizes token-in-URL, `ssh://` without `git@`, `git://` and explicit-port GitHub origins while still rejecting host-confusion forms. `bin/gstack-skill-start` routes the new verdict. `gstack-upgrade/SKILL.md.tmpl` (+ regenerated `SKILL.md`) points at the new `gstack-upgrade/COMMIT-CLOCK.md`, which holds the commit-clock prompt wording and a `git log` range summary — a separate file so this rare verdict costs no eager tokens on every skill invocation (+81 tokens in SKILL.md, no context-budget ceiling moved). `browse/test/gstack-update-check.test.ts` grows to 70 tests.
- **Verified live by:** The eight blocks above — before/after on the TTL bucket, the bare-fetch gate, the swallowed sentinel, the missing stamps, and a three-way comparison against `upstream/main`; plus focused, adjacent-contract, consumer-side and budget-ratchet suites, the cache-hit process count, and green CI on both Linux and Windows lanes. Also exercised end-to-end under bash 3.2 (macOS system bash) as well as 5.x, covering the `${var/pat/repl}` and `${#1}` use in the new helpers.
- **Did NOT test:** A real GitHub `ls-remote` against an equal-VERSION live `main`, or a real user `~/.gstack` install — every run above is hermetic. The full local `bun run test` did not complete cleanly on my machine (three shards hit their wall-clock deadline under six concurrent browser shards, and three unrelated files failed that also fail or time out on a clean `upstream/main` checkout), so the suite evidence here is the CI `free-tests` and `windows-free-tests` runs rather than a local claim. Vendored source-SHA recording, the semver-order guard #2378 also raises, `_SHA_URL` hardcoding `garrytan/gstack` for the raw VERSION fetch, the state-file symlink-follow class shared by four existing files, SHA-256 object-format repos, and re-keying the machine-global cache per install are all out of scope and untouched — the state stamp bounds the last one without re-keying.

The tag-pinned-versus-HEAD release policy stays with the maintainers per the TODOS.md deferral; this implements the issue's Option A without deciding it, and the emission is one `if` block plus one companion file to remove if you'd rather settle the policy first. Per your 2026-08-22 comment the 31-commit window no longer occurs in practice, so what this closes is the residual risk of a merge bypassing `version-gate.yml`. The cheaper mitigation the issue also names — CI failing when `main` drifts N commits past its last VERSION bump — addresses the other half of that risk rather than the same half: it makes drift visible to maintainers before any install is affected, while this makes it visible to an install once the drift has already happened. Neither covers the other, and I'm happy to file the CI one separately if you want it.

No VERSION/CHANGELOG bump — release bookkeeping left to maintainers / `/ship`, matching community PR practice.

## Liveness proof (required)

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
<img width="343" height="37" alt="image" src="https://github.com/user-attachments/assets/00131d08-5df3-4e77-8a45-e8e2a5191c74" />

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A)
- [x] Linked issue or reproduction: #2378

Fixes #2378