### PR TITLE
fix(opencode): rewrite Claude-only interaction tools

### DIFF
--- a/hosts/opencode.ts
+++ b/hosts/opencode.ts
@@ -14,6 +14,14 @@ const opencode = defineHost({
       'review': ['checklist.md', 'design-checklist.md', 'greptile-triage.md', 'TODOS-format.md'],
     },
   },
+
+  // Generated skill prose is shared with Claude, but OpenCode exposes
+  // different native interaction tools. Keep the host-specific vocabulary
+  // in the host config so generated docs remain correct for each runtime.
+  toolRewrites: {
+    AskUserQuestion: 'question',
+    ExitPlanMode: 'end plan mode',
+  },
 });
 
 export default opencode;

--- a/test/opencode-host.test.ts
+++ b/test/opencode-host.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { claude, opencode } from '../hosts/index';
+
+describe('OpenCode host tool rewrites', () => {
+  test('rewrites Claude interaction tools to OpenCode equivalents', () => {
+    expect(opencode.toolRewrites).toEqual({
+      AskUserQuestion: 'question',
+      ExitPlanMode: 'end plan mode',
+    });
+  });
+
+  test('does not alter Claude host tool vocabulary', () => {
+    expect(claude.toolRewrites).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the OpenCode portion of #2626 by moving its Claude-specific interaction-tool vocabulary into the existing host `toolRewrites` configuration.

OpenCode exposes `question` rather than Claude Code's `AskUserQuestion`, and it does not provide `ExitPlanMode`. Generated OpenCode skill prose should therefore not instruct the agent to invoke those Claude-only tools.

## Changes

- Add OpenCode host rewrites:
  - `AskUserQuestion` → `question`
  - `ExitPlanMode` → `end plan mode`
- Add focused regression tests covering the OpenCode mapping and preserving Claude's empty rewrite set.

The existing generator already applies `hostConfig.toolRewrites` to generated skill content, so this change does not introduce a second rewrite mechanism.

## Testing

Added `test/opencode-host.test.ts` to assert the host configuration. The repository's documented focused test commands are `bun test test/gen-skill-docs.test.ts` and `bun test test/host-config.test.ts`; CI should provide the full project validation.

Closes part of #2626.

Related: #2626