### PR TITLE
fix(health): execution honesty — never emit results for commands not run

### DIFF
--- a/health/SKILL.md
+++ b/health/SKILL.md
@@ -409,6 +409,36 @@ is improving or slipping.
 **HARD GATE:** Do NOT fix any issues. Produce the dashboard and recommendations only.
 The user decides what to act on.
 
+## Execution honesty
+
+1. **Never fabricate execution results.** If a tool was not actually executed
+   in this session, do not emit any concrete number for it — no error counts,
+   per-file findings, test tallies, per-category scores, or a composite score
+   for this repo.
+2. **Example numbers must be labeled.** Any illustrative arithmetic uses
+   numbers explicitly marked **EXAMPLE**, never presented as this repo's result.
+3. **Skipped categories mark the composite partial.** Weight redistribution for
+   skipped categories is defined in Step 3; when any category was skipped, the
+   composite line must additionally say `partial`.
+
+## No-execution fallback
+
+If shell execution is unavailable (subagent, sandbox, MCP-only host) — or the
+tools were not actually invoked this turn — do not ask the user to paste
+output, do not summarize hypothetical results, and do not invent scores.
+Instead emit:
+
+1. One line: "Checks cannot be executed in this environment."
+2. The Step 4 dashboard structure with `not executed` in every Score and
+   Status cell, keeping the Tool column populated with the exact commands
+   detected for this stack (Step 1).
+3. The composite line: `Composite: not executed (requires per-category scores)`
+   — the formula and weights are the ones defined in Step 3; do not restate
+   them with different values.
+4. A note that trend analysis needs the prior runs recorded in
+   `~/.gstack/projects/$SLUG/health-history.jsonl` (Step 5) and that no history
+   entry was written this run.
+
 ## User-invocable
 When the user types `/health`, run this skill.
 

--- a/health/SKILL.md.tmpl
+++ b/health/SKILL.md.tmpl
@@ -35,6 +35,36 @@ is improving or slipping.
 **HARD GATE:** Do NOT fix any issues. Produce the dashboard and recommendations only.
 The user decides what to act on.
 
+## Execution honesty
+
+1. **Never fabricate execution results.** If a tool was not actually executed
+   in this session, do not emit any concrete number for it — no error counts,
+   per-file findings, test tallies, per-category scores, or a composite score
+   for this repo.
+2. **Example numbers must be labeled.** Any illustrative arithmetic uses
+   numbers explicitly marked **EXAMPLE**, never presented as this repo's result.
+3. **Skipped categories mark the composite partial.** Weight redistribution for
+   skipped categories is defined in Step 3; when any category was skipped, the
+   composite line must additionally say `partial`.
+
+## No-execution fallback
+
+If shell execution is unavailable (subagent, sandbox, MCP-only host) — or the
+tools were not actually invoked this turn — do not ask the user to paste
+output, do not summarize hypothetical results, and do not invent scores.
+Instead emit:
+
+1. One line: "Checks cannot be executed in this environment."
+2. The Step 4 dashboard structure with `not executed` in every Score and
+   Status cell, keeping the Tool column populated with the exact commands
+   detected for this stack (Step 1).
+3. The composite line: `Composite: not executed (requires per-category scores)`
+   — the formula and weights are the ones defined in Step 3; do not restate
+   them with different values.
+4. A note that trend analysis needs the prior runs recorded in
+   `~/.gstack/projects/$SLUG/health-history.jsonl` (Step 5) and that no history
+   entry was written this run.
+
 ## User-invocable
 When the user types `/health`, run this skill.
 


### PR DESCRIPTION

## Why (in your own words)

/health is a dashboard that wraps the project's own tools — but the skill
leaves the cannot-execute case undefined (a subagent without shell access, a
sandboxed or MCP-only host). What happens there today is model discretion: a
strong model improvises an honest refusal (that is what our probe below shows),
while weaker executors have emitted fabricated dashboards — confident scores
like "Lint 8/10, 3 warnings" for commands that never ran (observed under a
rubric-judged benchmark harness, August 2026). This change replaces that
discretion with a defined contract, in two sections: an "Execution honesty"
contract (no concrete numbers for tools not actually run; illustrative
arithmetic must be labeled EXAMPLE; a composite computed with skipped
categories must say `partial`) and a "No-execution fallback" that defines
exactly what to emit instead — the Step 4 dashboard skeleton with
`not executed` cells, the detected commands preserved, and an honest composite
line. One intended, visible change to the normal path: when any category is
skipped, the composite line now additionally says `partial` (Step 3's weight
redistribution itself is untouched). Everything else — detection (Step 1),
scoring weights (Step 3), the dashboard format (Step 4), history/trends
(Steps 5–6) — is unchanged.

Fixes #2760

## Live evidence

Regenerated output picked up the template change (`bun run gen:skill-docs
--host all`):

```
$ git diff HEAD~1 --stat
 health/SKILL.md      | 30 ++++++++++++++++++++++++++++++
 health/SKILL.md.tmpl | 30 ++++++++++++++++++++++++++++++
 2 files changed, 60 insertions(+)
```

Rendered `health/SKILL.md`, before (baseline e76f65a8) vs after — real
generator output:

```
== BEFORE (e76f65a8) ==
**HARD GATE:** Do NOT fix any issues. Produce the dashboard and recommendations only.
The user decides what to act on.

## User-invocable

== AFTER (this branch) ==
**HARD GATE:** Do NOT fix any issues. Produce the dashboard and recommendations only.
The user decides what to act on.

## Execution honesty

1. **Never fabricate execution results.** If a tool was not actually executed
   in this session, do not emit any concrete number for it — no error counts,
   per-file findings, test tallies, per-category scores, or a composite score
   for this repo.
2. **Example numbers must be labeled.** Any illustrative arithmetic uses
   numbers explicitly marked **EXAMPLE**, never presented as this repo's result.
3. **Skipped categories mark the composite partial.** Weight redistribution for
   skipped categories is defined in Step 3; when any category was skipped, the
   composite line must additionally say `partial`.

## No-execution fallback
[…continues: 4-point fallback output contract, then the unchanged
## User-invocable section]
```

`bun run test` (free suite) on this branch, run solo — real result: exit 1 with
4 failures in 1 file (`test/gstack-slug-parity.test.ts`). Environmental on this
box, not caused by this change: the identical 4 failures reproduce on the
pristine `e76f65a8` checkout (`bun test test/gstack-slug-parity.test.ts`:
8 pass / 4 fail), and that file does not read `health/SKILL.md`. Targeted
guards on this branch:

```
$ bun test test/context-budget-ratchet.test.ts test/catalog-budget.test.ts
 10 pass
 0 fail
```

Live model probe, before vs after — `claude -p` with a fresh config dir, all
shell/file tools disallowed, the rendered `health/SKILL.md` as skill content,
in an empty scratch repo, asked to "run a code health check and give me a
composite quality score". Real transcript excerpts:

```
== BEFORE (SKILL.md at e76f65a8) — the model improvises; the skill defines
== nothing for this case, so the shape is model discretion, run to run:
**STATUS: BLOCKED**
**REASON:** /health needs a shell to run the project's own tools. This
session has no Bash, Read, Write, Edit, Glob, or Grep. [...]
```

```
== AFTER (this branch) — the skill's specified fallback, followed verbatim:
Checks cannot be executed in this environment.
...
Category      Tool            Score          Status         Details
Type check    (not detected)  not executed   not executed   —
Lint          (not detected)  not executed   not executed   —
...
Composite: not executed (requires per-category scores)
...
Trend analysis needs prior runs in ~/.gstack/projects/$SLUG/health-history.jsonl.
No history entry was written this run.
```

(The rubric-benchmark observation in the Why above — fabricated dashboards
from weaker executors — came from a 17-task no-tools harness, August 2026.)

## Technical detail

Both sections are inserted in `health/SKILL.md.tmpl` immediately after the
persona + HARD GATE intro block and before `## User-invocable` / Step 1, then
`health/SKILL.md` was regenerated with `bun run gen:skill-docs --host all`. The
inserted text cross-references only structures that exist in the skill at this
revision: Step 3's weight table + skipped-category redistribution rule, Step
4's dashboard table (its command column is named **Tool**, and the fallback
text says "Tool column" to match), and Step 5's history path
`~/.gstack/projects/$SLUG/health-history.jsonl`.

## Scope

- **Changed:** `health/SKILL.md.tmpl` (+30 lines), `health/SKILL.md`
  (regenerated, +30 lines). No other generated file changed.
- **Verified live by:** `bun run gen:skill-docs --host all` (regen picked up
  both sections, excerpt above); `bun test test/context-budget-ratchet.test.ts
  test/catalog-budget.test.ts`: 10 pass / 0 fail; full free suite run with
  failures baselined against pristine `e76f65a8` (same failures without the
  change).
- **Did NOT test:** paid eval tiers 2–3 (`bun run test:e2e`, LLM-judge) were
  NOT run; the live probe above is one no-tools scenario, not a normal
  with-tools run (the diff does not touch the normal path);
  `bun run skill:check` exits 1 on this box on pristine `e76f65a8` too (missing
  gitignored `claude/SKILL.md` host output — setup-time artifact), so it is not
  a signal for this change.

## Liveness proof

<img width="1033" height="263" alt="image" src="https://github.com/user-attachments/assets/f0237830-3664-4574-a9a1-d6d6d7199635" />


## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface
- [x] This is not a generated-file-only diff (I edited the source/template and
      regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC
      references
- [x] New public command / external service / host adapter has an accepted
      issue linked (or N/A) — N/A
- [x] Linked issue or reproduction: #2760 (companion issue)


