### PR TITLE
browse: honor GSTACK_CHROMIUM_PATH in the headless launch path (macOS 13 fix)

### DIFF
--- a/browse/src/browser-manager.ts
+++ b/browse/src/browser-manager.ts
@@ -520,13 +520,23 @@ export class BrowserManager {
       launchArgs.push(...headlessGpuArgs(process.platform, process.env));
     }
 
+    // Support custom Chromium/Chrome binary via GSTACK_CHROMIUM_PATH env var
+    // in the headless path too (macOS 13 fix): Playwright dropped its bundled
+    // Chromium/chrome-headless-shell builds for older macOS, but a stock system
+    // Chrome (which is Chromium-based) launches fine here via executablePath.
+    // When the env var supplies the bundle, scope out the XProtect self-heal —
+    // that bundle belongs to the wrapper/embedder, exactly as launchHeaded does.
+    const headlessExecutablePath = process.env.GSTACK_CHROMIUM_PATH || undefined;
+
     // XProtect self-heal wrapper (P0 #2554): a macOS definition update can
     // start SIGKILLing the pinned Chromium at spawn. On the classified
     // signature, clear quarantine on the Playwright cache + force-reinstall
-    // once, then retry this launch once. This headless path always uses the
-    // Playwright cache (no executablePath), so the heal is never scoped out.
+    // once, then retry this launch once. With no GSTACK_CHROMIUM_PATH this path
+    // uses the Playwright cache, so the heal applies; a custom executable is
+    // scoped out via usesCustomExecutable below.
     this.browser = await launchWithXProtectHeal(() => chromium.launch({
       headless: useHeadless,
+      ...(headlessExecutablePath ? { executablePath: headlessExecutablePath } : {}),
       // #2220: the daemon owns signal policy, not Playwright. Playwright's
       // default handlers close Chromium the moment THIS process receives
       // SIGINT/SIGTERM/SIGHUP — which fights the deliberate headless
@@ -545,7 +555,7 @@ export class BrowserManager {
       chromiumSandbox: shouldEnableChromiumSandbox(),
       ...(launchArgs.length > 0 ? { args: launchArgs } : {}),
       ...(this.proxyConfig ? { proxy: this.proxyConfig } : {}),
-    }));
+    }), { usesCustomExecutable: Boolean(headlessExecutablePath) });
 
     // Chromium disconnect → distinguish clean user-quit from crash. Both
     // events look identical to Playwright (one 'disconnected' fires), but


### PR DESCRIPTION
## Problem

On macOS 13, `./setup` and `/browse` fail because Playwright no longer ships a
bundled Chromium / `chrome-headless-shell` build for that OS:

```
launch: Executable doesn't exist at .../ms-playwright/chromium_headless_shell-1234/chrome-headless-shell-mac-x64/chrome-headless-shell
Looks like Playwright was just installed or updated. Please run: npx playwright install
```

`setup` hard-exits at the `ensure_playwright_browser` gate before any skills are
linked, and even after linking, `browse goto` can't start its daemon.

`GSTACK_CHROMIUM_PATH` already lets `launchHeaded()` (the persistent-context /
headed path) point at a custom Chromium/Chrome bundle, but the default
**headless** `launch()` path deliberately ignored it and always used the
Playwright cache. So there was no way to run headless browse against a stock
system Chrome on an OS Playwright no longer bundles for.

## Fix

Make the headless `launch()` path honor `GSTACK_CHROMIUM_PATH` too, mirroring
`launchHeaded()`:

- when the env var is set, pass it as `executablePath`;
- scope out the XProtect self-heal for that launch via
  `usesCustomExecutable: Boolean(headlessExecutablePath)` — a
  `GSTACK_CHROMIUM_PATH` bundle belongs to the wrapper/embedder and must never
  be quarantine-cleared or reinstalled over (same contract `launchHeaded()` and
  `probePoisonedChromiumBundle` already follow).

When `GSTACK_CHROMIUM_PATH` is unset, behavior is unchanged: `executablePath` is
omitted and `usesCustomExecutable` is `false`, so the Playwright cache is used
and the heal applies exactly as before.

## Testing

Manually verified on **macOS 13.7.8 (22H730), Google Chrome 152**:

```
export GSTACK_CHROMIUM_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
browse goto https://example.com      # -> Navigated to https://example.com (200)
browse text                          # -> "Example Domain ..."
browse status                        # -> healthy, Mode: launched, Tabs: 1
browse js "navigator.userAgent"      # -> HeadlessChrome/152 ...
```

Also confirmed a direct Playwright probe launches system Chrome headless via
`chromium.launch({ executablePath })` on this OS.

Note: the `launch()` method isn't currently under unit test upstream (it calls
`chromium.launch` directly), so this change ships without one; happy to add a
seam/test if you'd like.