### PR TITLE
fix: avoid worktree conflicts during PR merge

### DIFF
--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -983,7 +983,7 @@ the source of truth — STOP, Read it now, and redo that step.
 - **Poll with backoff.** Don't hammer GitHub API. 30-second intervals for CI/deploy, with reasonable timeouts.
 - **Revert is always an option.** At every failure point, offer revert as an escape hatch. Explain what reverting does in plain English.
 - **Single-pass verification, not continuous monitoring.** `/land-and-deploy` checks once. `/canary` does the extended monitoring loop.
-- **Clean up.** Delete the feature branch after merge (via `--delete-branch`).
+- **Clean up safely.** Use `--delete-branch` only when the base branch is not checked out in another worktree.
 - **First run = teacher mode.** Walk the user through everything. Explain what each check does and why it matters. Show them their infrastructure. Let them confirm before proceeding. Build trust through transparency.
 - **Subsequent runs = efficient mode.** Brief status updates, no re-explanations. The user already trusts the tool — just do the job and report results.
 - **The goal is: first-timers think "wow, this is thorough — I trust it." Repeat users think "that was fast — it just works."**

--- a/land-and-deploy/SKILL.md.tmpl
+++ b/land-and-deploy/SKILL.md.tmpl
@@ -481,7 +481,7 @@ the source of truth — STOP, Read it now, and redo that step.
 - **Poll with backoff.** Don't hammer GitHub API. 30-second intervals for CI/deploy, with reasonable timeouts.
 - **Revert is always an option.** At every failure point, offer revert as an escape hatch. Explain what reverting does in plain English.
 - **Single-pass verification, not continuous monitoring.** `/land-and-deploy` checks once. `/canary` does the extended monitoring loop.
-- **Clean up.** Delete the feature branch after merge (via `--delete-branch`).
+- **Clean up safely.** Use `--delete-branch` only when the base branch is not checked out in another worktree.
 - **First run = teacher mode.** Walk the user through everything. Explain what each check does and why it matters. Show them their infrastructure. Let them confirm before proceeding. Build trust through transparency.
 - **Subsequent runs = efficient mode.** Brief status updates, no re-explanations. The user already trusts the tool — just do the job and report results.
 - **The goal is: first-timers think "wow, this is thorough — I trust it." Repeat users think "that was fast — it just works."**

--- a/land-and-deploy/sections/merge-and-deploy.md
+++ b/land-and-deploy/sections/merge-and-deploy.md
@@ -5,7 +5,14 @@
 Record the start timestamp for timing data. Also record which merge path is taken
 (auto-merge vs direct) for the deploy report.
 
-Try auto-merge first (respects repo merge settings and merge queues):
+Before either merge command, read the PR base branch and run `git worktree list --porcelain`.
+If another worktree has `branch refs/heads/<base>`, set `BASE_WORKTREE_IN_USE=true`, omit
+`--delete-branch` from both merge commands, and do not switch, remove, or modify that
+worktree. Report that local and remote branch cleanup was skipped because the base branch
+is in use.
+
+If required checks are still pending, use auto-merge (respects repo merge settings and
+merge queues):
 
 ```bash
 gh pr merge --squash --auto --delete-branch
@@ -14,25 +21,15 @@ gh pr merge --squash --auto --delete-branch
 If `--auto` succeeds: record `MERGE_PATH=auto`. This means the repo has auto-merge enabled
 and may use merge queues.
 
-`--auto` fails for two unrelated reasons. Both fall through to the direct merge below, so
-the flow is unaffected — but do not report the second one as "auto-merge is disabled":
-
-1. **Auto-merge is disabled for the repo** — `Auto-merge is not allowed for this repository`.
-2. **The PR is not waiting on anything.** `--auto` only *queues* a merge behind pending
-   required checks. When every required check has already settled — or the repo declares
-   no required status checks at all — GitHub treats the PR as immediately mergeable and
-   rejects the mutation:
-   `Pull request is in clean status` (everything green) or
-   `Pull request is in unstable status` (something red, but nothing required).
-   A repo with zero required status checks therefore takes the direct path 100% of the
-   time no matter how auto-merge is configured, and so does any repo whose CI finishes
-   before this step runs.
+If no required check is pending, use the direct merge instead. Choose one path; do not
+run auto-merge and direct merge in sequence.
 
 ```bash
 gh pr merge --squash --delete-branch
 ```
 
-If direct merge succeeds: record `MERGE_PATH=direct`. Tell the user: "PR merged successfully. The branch has been cleaned up."
+If direct merge succeeds: record `MERGE_PATH=direct`. Tell the user: "PR merged successfully."
+Only say the branch was cleaned up when `--delete-branch` was used and branch state confirms it.
 
 If the merge fails with a permission error: **STOP.** "I don't have permission to merge this PR. You'll need a maintainer to merge it, or check your repo's branch protection rules."
 
@@ -71,11 +68,17 @@ git worktree list --porcelain
 ```
 Identify candidates: a worktree is stale if (a) it is checked out on the base branch, AND (b) it is not the user's current main working tree, AND (c) `git status --porcelain` inside it is empty (no uncommitted work).
 
+If `BASE_WORKTREE_IN_USE=true`, the worktree found before merge is expected, not stale;
+do not offer to remove it.
+
 - For each clean candidate: OFFER to remove it. Say: "There's a stale worktree at `<path>` checked out on `<branch>` with no uncommitted work. Remove it?" Remove only if user confirms (`git worktree remove <path> && git worktree prune`).
 - If any candidate has uncommitted work: list the files, tell the user, and STOP worktree cleanup without removing anything.
 - Do NOT use `--force`. Do NOT remove the user's primary working tree.
 
-Remote-branch reconciliation — the failed `gh pr merge` carried `--delete-branch`, and this recovery path must not silently drop that half. The success path above says "The branch has been cleaned up"; this path states the branch outcome explicitly instead of staying silent:
+Remote-branch reconciliation — run this only when the merge command carried
+`--delete-branch`; this recovery path must not silently drop that half. If
+`BASE_WORKTREE_IN_USE=true`, branch cleanup was deliberately omitted, so report that and
+skip this reconciliation.
 
 ```bash
 # NB: gh leaves .headRepository.nameWithOwner EMPTY (verified against gh

--- a/land-and-deploy/sections/merge-and-deploy.md.tmpl
+++ b/land-and-deploy/sections/merge-and-deploy.md.tmpl
@@ -3,7 +3,14 @@
 Record the start timestamp for timing data. Also record which merge path is taken
 (auto-merge vs direct) for the deploy report.
 
-Try auto-merge first (respects repo merge settings and merge queues):
+Before either merge command, read the PR base branch and run `git worktree list --porcelain`.
+If another worktree has `branch refs/heads/<base>`, set `BASE_WORKTREE_IN_USE=true`, omit
+`--delete-branch` from both merge commands, and do not switch, remove, or modify that
+worktree. Report that local and remote branch cleanup was skipped because the base branch
+is in use.
+
+If required checks are still pending, use auto-merge (respects repo merge settings and
+merge queues):
 
 ```bash
 gh pr merge --squash --auto --delete-branch
@@ -12,25 +19,15 @@ gh pr merge --squash --auto --delete-branch
 If `--auto` succeeds: record `MERGE_PATH=auto`. This means the repo has auto-merge enabled
 and may use merge queues.
 
-`--auto` fails for two unrelated reasons. Both fall through to the direct merge below, so
-the flow is unaffected — but do not report the second one as "auto-merge is disabled":
-
-1. **Auto-merge is disabled for the repo** — `Auto-merge is not allowed for this repository`.
-2. **The PR is not waiting on anything.** `--auto` only *queues* a merge behind pending
-   required checks. When every required check has already settled — or the repo declares
-   no required status checks at all — GitHub treats the PR as immediately mergeable and
-   rejects the mutation:
-   `Pull request is in clean status` (everything green) or
-   `Pull request is in unstable status` (something red, but nothing required).
-   A repo with zero required status checks therefore takes the direct path 100% of the
-   time no matter how auto-merge is configured, and so does any repo whose CI finishes
-   before this step runs.
+If no required check is pending, use the direct merge instead. Choose one path; do not
+run auto-merge and direct merge in sequence.
 
 ```bash
 gh pr merge --squash --delete-branch
 ```
 
-If direct merge succeeds: record `MERGE_PATH=direct`. Tell the user: "PR merged successfully. The branch has been cleaned up."
+If direct merge succeeds: record `MERGE_PATH=direct`. Tell the user: "PR merged successfully."
+Only say the branch was cleaned up when `--delete-branch` was used and branch state confirms it.
 
 If the merge fails with a permission error: **STOP.** "I don't have permission to merge this PR. You'll need a maintainer to merge it, or check your repo's branch protection rules."
 
@@ -69,11 +66,17 @@ git worktree list --porcelain
 ```
 Identify candidates: a worktree is stale if (a) it is checked out on the base branch, AND (b) it is not the user's current main working tree, AND (c) `git status --porcelain` inside it is empty (no uncommitted work).
 
+If `BASE_WORKTREE_IN_USE=true`, the worktree found before merge is expected, not stale;
+do not offer to remove it.
+
 - For each clean candidate: OFFER to remove it. Say: "There's a stale worktree at `<path>` checked out on `<branch>` with no uncommitted work. Remove it?" Remove only if user confirms (`git worktree remove <path> && git worktree prune`).
 - If any candidate has uncommitted work: list the files, tell the user, and STOP worktree cleanup without removing anything.
 - Do NOT use `--force`. Do NOT remove the user's primary working tree.
 
-Remote-branch reconciliation — the failed `gh pr merge` carried `--delete-branch`, and this recovery path must not silently drop that half. The success path above says "The branch has been cleaned up"; this path states the branch outcome explicitly instead of staying silent:
+Remote-branch reconciliation — run this only when the merge command carried
+`--delete-branch`; this recovery path must not silently drop that half. If
+`BASE_WORKTREE_IN_USE=true`, branch cleanup was deliberately omitted, so report that and
+skip this reconciliation.
 
 ```bash
 # NB: gh leaves .headRepository.nameWithOwner EMPTY (verified against gh

--- a/test/land-and-deploy-postfail.test.ts
+++ b/test/land-and-deploy-postfail.test.ts
@@ -39,6 +39,22 @@ function readMd(): string {
 }
 
 describe("PR #1620 §4a-postfail in land-and-deploy template", () => {
+  test("shared base worktree disables local branch cleanup before merge", () => {
+    const body = readTmpl();
+    expect(body).toMatch(/Before either merge command.*git worktree list --porcelain/s);
+    expect(body).toMatch(/branch refs\/heads\/<base>/);
+    expect(body).toMatch(/omit\s+`--delete-branch` from both merge commands/);
+    expect(body).toMatch(/do not switch, remove, or modify that\s+worktree/);
+    expect(body).toMatch(/local and remote branch cleanup was skipped/);
+    expect(body).toMatch(/expected, not stale/);
+    expect(body).toMatch(/skip this reconciliation/);
+  });
+
+  test("auto and direct merge are mutually exclusive", () => {
+    const body = readTmpl();
+    expect(body).toMatch(/Choose one path; do not\s+run auto-merge and direct merge in sequence/);
+  });
+
   test("§4a-postfail header present in template", () => {
     expect(readTmpl()).toMatch(/### 4a-postfail: Post-failure PR-state check/);
   });


### PR DESCRIPTION
## Summary

- detect when the PR base branch is checked out in another worktree
- omit branch deletion in that case and leave both worktrees untouched
- choose either auto-merge or direct merge instead of retrying both paths
- report skipped local and remote branch cleanup accurately

## Verification

- `bun test test/land-and-deploy-postfail.test.ts` (16 pass, 0 fail, 45 assertions)
- `git diff --check`

## Baseline behavior

Three pressure scenarios selected `--delete-branch` and exposed server-merge/local-cleanup partial success. Post-change scenarios select one merge path without branch deletion when the base worktree is in use.