### PR TITLE
Fix global binary fallback path for env-var hosts

### DIFF
--- a/scripts/resolvers/browse.ts
+++ b/scripts/resolvers/browse.ts
@@ -1,4 +1,4 @@
-import type { TemplateContext } from './types';
+import { globalBinDir, type TemplateContext } from './types';
 import { COMMAND_DESCRIPTIONS } from '../../browse/src/commands';
 import { SNAPSHOT_FLAGS } from '../../browse/src/snapshot';
 
@@ -106,7 +106,7 @@ export function generateBrowseSetup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 B=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse" ] && B="$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse"
-[ -z "$B" ] && B="$HOME${ctx.paths.browseDir.replace(/^~/, '')}/browse"
+[ -z "$B" ] && B="${globalBinDir(ctx.paths.browseDir)}/browse"
 if [ -x "$B" ]; then
   echo "READY: $B"
 else

--- a/scripts/resolvers/design.ts
+++ b/scripts/resolvers/design.ts
@@ -1,4 +1,4 @@
-import type { TemplateContext } from './types';
+import { globalBinDir, type TemplateContext } from './types';
 import { AI_SLOP_BLACKLIST, OPENAI_HARD_REJECTIONS, OPENAI_LITMUS_CHECKS } from './constants';
 
 export function generateDesignReviewLite(ctx: TemplateContext): string {
@@ -792,7 +792,7 @@ export function generateDesignSetup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 D=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design" ] && D="$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design"
-[ -z "$D" ] && D="$HOME${ctx.paths.designDir.replace(/^~/, '')}/design"
+[ -z "$D" ] && D="${globalBinDir(ctx.paths.designDir)}/design"
 if [ -x "$D" ]; then
   echo "DESIGN_READY: $D"
 else
@@ -800,7 +800,7 @@ else
 fi
 B=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse" ] && B="$_ROOT/${ctx.paths.localSkillRoot}/browse/dist/browse"
-[ -z "$B" ] && B="$HOME${ctx.paths.browseDir.replace(/^~/, '')}/browse"
+[ -z "$B" ] && B="${globalBinDir(ctx.paths.browseDir)}/browse"
 if [ -x "$B" ]; then
   echo "BROWSE_READY: $B"
 else
@@ -837,7 +837,7 @@ export function generateDesignMockup(ctx: TemplateContext): string {
 _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 D=""
 [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design" ] && D="$_ROOT/${ctx.paths.localSkillRoot}/design/dist/design"
-[ -z "$D" ] && D="$HOME${ctx.paths.designDir.replace(/^~/, '')}/design"
+[ -z "$D" ] && D="${globalBinDir(ctx.paths.designDir)}/design"
 [ -x "$D" ] && echo "DESIGN_READY" || echo "DESIGN_NOT_AVAILABLE"
 \`\`\`
 

--- a/scripts/resolvers/make-pdf.ts
+++ b/scripts/resolvers/make-pdf.ts
@@ -1,4 +1,4 @@
-import type { TemplateContext } from './types';
+import { globalBinDir, type TemplateContext } from './types';
 
 /**
  * {{MAKE_PDF_SETUP}} — emits the shell preamble that resolves $P to the
@@ -19,7 +19,7 @@ _ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 P=""
 [ -n "$MAKE_PDF_BIN" ] && [ -x "$MAKE_PDF_BIN" ] && P="$MAKE_PDF_BIN"
 [ -z "$P" ] && [ -n "$_ROOT" ] && [ -x "$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf" ] && P="$_ROOT/${ctx.paths.localSkillRoot}/make-pdf/dist/pdf"
-[ -z "$P" ] && P="$HOME${ctx.paths.makePdfDir.replace(/^~/, '')}/pdf"
+[ -z "$P" ] && P="${globalBinDir(ctx.paths.makePdfDir)}/pdf"
 if [ -x "$P" ]; then
   echo "MAKE_PDF_READY: $P"
   alias _p_="$P"   # shellcheck alias helper (not exported)

--- a/scripts/resolvers/types.ts
+++ b/scripts/resolvers/types.ts
@@ -50,6 +50,15 @@ function buildHostPaths(): Record<string, HostPaths> {
 
 export const HOST_PATHS: Record<string, HostPaths> = buildHostPaths();
 
+/**
+ * Shell expression for a global-install binary directory. Literal hosts store
+ * `~/...` paths, which become `$HOME/...`; env-var hosts store `$GSTACK_*`
+ * variables, which already expand to an absolute path and are used as-is.
+ */
+export function globalBinDir(dir: string): string {
+  return dir.startsWith('~') ? `$HOME${dir.slice(1)}` : dir;
+}
+
 import type { Model } from '../models';
 export type { Model } from '../models';
 

--- a/test/resolver-global-bin-path.test.ts
+++ b/test/resolver-global-bin-path.test.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Verifies the global-install binary fallback paths emitted by the
+// ABOUTME: browse/design/make-pdf setup resolvers for env-var and literal hosts.
+import { describe, test, expect } from 'bun:test';
+import { HOST_PATHS, type TemplateContext } from '../scripts/resolvers/types';
+import { generateBrowseSetup } from '../scripts/resolvers/browse';
+import { generateDesignSetup, generateDesignMockup } from '../scripts/resolvers/design';
+import { generateMakePdfSetup } from '../scripts/resolvers/make-pdf';
+
+function ctxFor(host: 'codex' | 'claude'): TemplateContext {
+  return { skillName: 'browse', tmplPath: 'browse/SKILL.md.tmpl', host, paths: HOST_PATHS[host] };
+}
+
+describe('global binary fallback paths', () => {
+  test('env-var hosts use the env var directly, never prefixed with $HOME', () => {
+    const ctx = ctxFor('codex');
+    const outputs = [
+      generateBrowseSetup(ctx),
+      generateDesignSetup(ctx),
+      generateDesignMockup(ctx),
+      generateMakePdfSetup(ctx),
+    ];
+    for (const out of outputs) {
+      expect(out).not.toContain('$HOME$GSTACK');
+    }
+    expect(generateBrowseSetup(ctx)).toContain('B="$GSTACK_BROWSE/browse"');
+    expect(generateDesignSetup(ctx)).toContain('D="$GSTACK_DESIGN/design"');
+    expect(generateDesignSetup(ctx)).toContain('B="$GSTACK_BROWSE/browse"');
+    expect(generateDesignMockup(ctx)).toContain('D="$GSTACK_DESIGN/design"');
+    expect(generateMakePdfSetup(ctx)).toContain('P="$GSTACK_MAKE_PDF/pdf"');
+  });
+
+  test('literal hosts expand ~ to $HOME', () => {
+    const ctx = ctxFor('claude');
+    expect(generateBrowseSetup(ctx)).toContain('B="$HOME/.claude/skills/gstack/browse/dist/browse"');
+    expect(generateDesignSetup(ctx)).toContain('D="$HOME/.claude/skills/gstack/design/dist/design"');
+    expect(generateMakePdfSetup(ctx)).toContain('P="$HOME/.claude/skills/gstack/make-pdf/dist/pdf"');
+  });
+});


### PR DESCRIPTION
## Summary

The browse, design, and make-pdf setup blocks build the global-install fallback path as `$HOME` plus the host's binary directory with a leading `~` stripped. Hosts with `usesEnvVars` (codex today) store `$GSTACK_BROWSE`-style variables there instead of `~` paths, so nothing is stripped and the generated shell reads:

```bash
[ -z "$B" ] && B="$HOME$GSTACK_BROWSE/browse"
```

which expands to `/Users/me/Users/me/.codex/skills/gstack/browse/dist/browse`. The `-x` check fails and every affected Codex skill (browse, benchmark, canary, the four design skills, make-pdf) reports `NEEDS_SETUP` or `DESIGN_NOT_AVAILABLE` even though the binary is installed, prompting the user for a pointless rebuild on each session.

## Fix

Add `globalBinDir()` in `scripts/resolvers/types.ts`, which expands a leading `~` to `$HOME` and passes env-var paths through unchanged, and use it at all six sites in `browse.ts`, `design.ts`, and `make-pdf.ts`.

Generated Codex output after the fix:

```bash
[ -z "$B" ] && B="$GSTACK_BROWSE/browse"
```

Claude and other literal-path hosts are unchanged (`$HOME/.claude/skills/gstack/browse/dist/browse`).

## Test plan

- [x] New `test/resolver-global-bin-path.test.ts` fails on main, passes with the fix, for both env-var and literal hosts
- [x] `bun test` unit suite: no new failures (the 7 pre-existing failures in gbrain-detect, parity-suite, and user-slug-fallback are identical on clean main)
- [x] `bun run gen:skill-docs --host codex` regenerated; setup block prints `READY` in a Codex CLI session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ko25nKXJXcKY2haaWwXDcG
