### PR TITLE
fix(browse): stop faking chrome.runtime.connect/sendMessage in Layer C stealth

### DIFF
--- a/browse/src/stealth.ts
+++ b/browse/src/stealth.ts
@@ -137,12 +137,14 @@ export function buildStealthScript(hw: HostProfile): string {
                      MAC: 'mac', OPENBSD: 'openbsd', WIN: 'win' },
         RequestUpdateCheckStatus: { NO_UPDATE: 'no_update', THROTTLED: 'throttled',
                                    UPDATE_AVAILABLE: 'update_available' },
-        connect: markNative(function connect() {
-          throw new TypeError('Error in invocation of runtime.connect: No matching signature.');
-        }, 'connect'),
-        sendMessage: markNative(function sendMessage() {
-          throw new TypeError('Error in invocation of runtime.sendMessage: No matching signature.');
-        }, 'sendMessage'),
+        // No connect/sendMessage here. Real Chrome only exposes callable
+        // chrome.runtime methods to a web page when an installed extension
+        // lists that origin in externally_connectable; on an ordinary page
+        // they are undefined. Faking them is itself an inconsistency, and
+        // sites that probe chrome.runtime.sendMessage to detect their own
+        // companion extension misfire (they assume the extension is
+        // installed and route auth through it). The enum shape alone
+        // satisfies the presence checks detectors actually run.
         id: undefined,
       };
     }

--- a/browse/test/stealth-layer-c.test.ts
+++ b/browse/test/stealth-layer-c.test.ts
@@ -62,9 +62,19 @@ describe('buildStealthScript — T3 Layer C', () => {
     expect(s).toContain('PlatformArch');
     expect(s).toContain('PlatformOs');
     expect(s).toContain('RequestUpdateCheckStatus');
-    // sendMessage / connect must throw native-shaped errors
-    expect(s).toContain('runtime.connect');
-    expect(s).toContain('runtime.sendMessage');
+  });
+
+  test('window.chrome.runtime does NOT fake connect / sendMessage', () => {
+    // Real Chrome exposes callable runtime.connect / runtime.sendMessage to a
+    // web page only when an installed extension lists that origin in
+    // externally_connectable. On an ordinary page they are undefined, and
+    // sites probe `chrome.runtime.sendMessage` to detect their own companion
+    // extension — a fake makes them think it is installed.
+    const s = buildStealthScript(hw);
+    expect(s).not.toMatch(/\bconnect:\s*markNative/);
+    expect(s).not.toMatch(/\bsendMessage:\s*markNative/);
+    expect(s).not.toContain('runtime.sendMessage: No matching signature');
+    expect(s).not.toContain('runtime.connect: No matching signature');
   });
 
   test('chrome.csi and chrome.loadTimes provide method bodies', () => {
@@ -106,9 +116,9 @@ describe('buildStealthScript — T3 Layer C', () => {
     // Every getter (hardwareConcurrency, deviceMemory, webdriver, Notification.permission)
     // should be wrapped through markNative so the toString Proxy covers it.
     const markNativeMatches = s.match(/markNative\(/g) || [];
-    // At least 8 markNative wrappings (webdriver, csi, loadTimes, connect, sendMessage,
+    // At least 6 markNative wrappings (webdriver, csi, loadTimes,
     // notification permission, hwConcurrency, deviceMemory)
-    expect(markNativeMatches.length).toBeGreaterThanOrEqual(7);
+    expect(markNativeMatches.length).toBeGreaterThanOrEqual(6);
   });
 
   test('script does not include "GStackBrowser" branding string', () => {

--- a/browse/test/stealth-webdriver.test.ts
+++ b/browse/test/stealth-webdriver.test.ts
@@ -170,25 +170,30 @@ describe('applyStealth — context level', () => {
     }
   });
 
-  test('chrome.csi() and chrome.loadTimes() execute, runtime.connect() throws native-shaped', async () => {
+  test('chrome.csi() and chrome.loadTimes() execute; runtime.connect / sendMessage are absent', async () => {
     // Presence (typeof === 'function') is not enough — a real detector calls
-    // them. loadTimes() dereferences performance.timing; connect() must throw
-    // the native "No matching signature" TypeError.
+    // them. loadTimes() dereferences performance.timing. runtime.connect and
+    // runtime.sendMessage must NOT exist: real Chrome only exposes them to a
+    // page when an installed extension declares that origin in
+    // externally_connectable, and sites use `chrome.runtime.sendMessage` to
+    // detect their own companion extension.
     const page = await context.newPage();
     try {
       const r = await page.evaluate(() => {
         const c = (window as any).chrome;
-        let connectErr = '';
-        try { c.runtime.connect(); } catch (e) { connectErr = String(e); }
         return {
           csiOk: typeof c.csi().onloadT === 'number',
           loadTimesOk: typeof c.loadTimes().wasFetchedViaSpdy === 'boolean',
-          connectErr,
+          runtimePresent: typeof c.runtime === 'object',
+          connectType: typeof c.runtime.connect,
+          sendMessageType: typeof c.runtime.sendMessage,
         };
       });
       expect(r.csiOk).toBe(true);
       expect(r.loadTimesOk).toBe(true);
-      expect(r.connectErr).toContain('No matching signature');
+      expect(r.runtimePresent).toBe(true);
+      expect(r.connectType).toBe('undefined');
+      expect(r.sendMessageType).toBe('undefined');
     } finally {
       await page.close();
     }


### PR DESCRIPTION
## Why (in your own words)

Layer C stealth injects a fake `window.chrome.runtime` that includes callable `connect` and `sendMessage` stubs which throw `No matching signature` for any input. Real Chrome never shows that to an ordinary web page: `chrome.runtime` is either undefined, or (only when an installed extension lists the origin in `externally_connectable`) carries real, working methods. Web apps that ship a companion Chrome extension probe `chrome.runtime.sendMessage` to detect it. In GStack Browser the probe finds a function, the app assumes its extension is installed, routes auth through the extension flow, that flow 403s, and the user is bounced back to the login page in a loop. The same site logs in fine in stock Chrome, Edge, and incognito. There is no opt-out because Layer C is always-on.

This PR drops the two callable stubs and keeps the enum shape (`OnInstalledReason`, `PlatformOs`, ...) that the Cloudflare/DataDome presence checks actually look at. That is the shape real Chrome shows a page with no connectable extension, so it is also the more consistent fingerprint (the v1.28 / #1363 principle: inconsistent fakes make detection easier, not harder).

Fixes #2780

## Live evidence

**Before** (v1.79.0.0 unpatched, headed `browse connect`, on the affected site's login page):

```
$ browse js "JSON.stringify({hasChrome: !!window.chrome, hasRuntime: !!(window.chrome && window.chrome.runtime), hasSendMessage: !!(window.chrome && window.chrome.runtime && window.chrome.runtime.sendMessage), ua: navigator.userAgent})"
{"hasChrome":true,"hasRuntime":true,"hasSendMessage":true,"ua":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/151.0.7922.34 Safari/537.36"}
```

`.gstack/browse-console.log` during the login attempt:

```
[error] Failed to load resource: the server responded with a status of 403 ()
[error] ERROR TypeError: Error in invocation of runtime.sendMessage: No matching signature.
    at Object.sendMessage (<anonymous>:63:17)
    at <site>/main.<hash>.js:1:480593
    at _e.isExtensionInstalled (<site>/main.<hash>.js:1:480499)
```

`.gstack/browse-network.log` (site redacted): login POST 200 → tenant `/login/callback` → app POSTs `/logout` → redirect to `/logout?org=...&client_id=<extension-id>&client_name=extension` → **403** → back on the login page.

**After** (this branch, rebuilt with `./setup`, headed `browse connect`):

```
$ browse js "JSON.stringify({runtime: typeof chrome.runtime, enumKeys: Object.keys(chrome.runtime).length, connect: typeof chrome.runtime.connect, sendMessage: typeof chrome.runtime.sendMessage, csi: typeof chrome.csi, loadTimes: typeof chrome.loadTimes, webdriver: navigator.webdriver})"
{"runtime":"object","enumKeys":7,"connect":"undefined","sendMessage":"undefined","csi":"function","loadTimes":"function","webdriver":false}
```

Logging into the same site in the patched GStack Browser now succeeds on the first try and the session persists in the profile.

Static tests:

```
$ bun test browse/test/stealth-layer-c.test.ts browse/test/stealth-extended.test.ts
 39 pass
 0 fail
 101 expect() calls
Ran 39 tests across 2 files. [103.00ms]
```

## Scope

- **Changed:** `browse/src/stealth.ts` (remove `connect`/`sendMessage` from the injected `chrome.runtime`; enum shape, `id`, `chrome.app`, `csi`, `loadTimes` untouched), `browse/test/stealth-layer-c.test.ts` (new test asserting the two methods are absent; markNative floor 7 → 6), `browse/test/stealth-webdriver.test.ts` (runtime test now asserts `typeof runtime.connect/sendMessage === 'undefined'` instead of expecting a throw).
- **Verified live by:** rebuilding with `./setup`, `browse connect` (headed, Windows 11, bundled Chromium 151), the `browse js` probe above, and a real login on the affected site that previously looped.
- **Did NOT test:** `stealth-webdriver.test.ts` could not run on this machine. Playwright's `chromium.launch()` for `chrome-headless-shell` hangs under `bun test` here (120 s launch timeout before any test body runs). This matches the reason `scripts/test-free-shards.ts` excludes browser-launching tests from the Windows shard. The updated assertions mirror the live `browse js` result above; CI's macOS/Linux runners should exercise them. Not re-checked against bot.sannysoft.com / Cloudflare-fronted sites after the change; the enum shape they check is unchanged.

## Liveness proof (required)

_(maintainer note: the PR author will attach the `GSTACK PR` screenshot in a comment.)_

## Checklist

- [ ] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A)
- [x] Linked issue or reproduction: #2780
