### PR TITLE
fix(redact): four-part version strings are not public IPv4 addresses

### DIFF
--- a/lib/redact-patterns.ts
+++ b/lib/redact-patterns.ts
@@ -159,6 +159,56 @@ export function isPublicIPv4(ip: string): boolean {
   return true;
 }
 
+/**
+ * True when a dotted quad is a four-part VERSION rather than an IP address.
+ *
+ * Four-segment version schemes (`MAJOR.MINOR.PATCH.BUILD` — .NET/NuGet
+ * assembly versions, Electron builds, and hand-rolled schemes) are
+ * syntactically indistinguishable from IPv4: `1.128.1.0` is a valid public
+ * address. A repo on such a scheme therefore trips `pii.ip_public` on EVERY
+ * release, once per file the version is written to — the changelog heading,
+ * a VERSION file, package.json, and both package-lock.json fields. A scanner
+ * that reports the same findings on every push is one nobody reads.
+ *
+ * The bias here is deliberate: a leaked IP costs more than a nuisance
+ * finding, so an exemption requires PROOF of version context, never mere
+ * proximity to the word "version". Two ways to earn it:
+ *
+ *   1. This occurrence sits in a version declaration — a `*version` key, a
+ *      `v` prefix, or a `[…]` changelog heading.
+ *   2. The IDENTICAL string is declared as a version elsewhere in the same
+ *      scanned text. That covers the bare `1.128.1.0` line of a VERSION file
+ *      without teaching this validator anything about diff or file formats:
+ *      if the same characters are proven a version in one place, a bare
+ *      repetition of them is the same version.
+ *
+ * So `8.8.8.8` on a line by itself stays flagged — nothing proves it a
+ * version — while a real address never becomes exempt by sharing a diff with
+ * an unrelated version string, because rule 2 matches on the exact value.
+ */
+export function isVersionNotIPv4(span: string, input: string, index: number): boolean {
+  // Immediate context: the ~48 chars before this occurrence, current line only.
+  const lineStart = input.lastIndexOf("\n", index - 1) + 1;
+  const before = input.slice(Math.max(lineStart, index - 48), index);
+  const after = input.slice(index + span.length, index + span.length + 2);
+
+  // `"version": "1.2.3.4"`, `app_version = 1.2.3.4`, `schema-version: 1.2.3.4`
+  if (/[\w.\-]*version["'\]]?\s*[:=]\s*["'(]?$/i.test(before)) return true;
+  // `v1.2.3.4` — a `v`-prefixed quad is a version, not an address.
+  if (/(?:^|[^\w.])[vV]$/.test(before)) return true;
+  // Keep a Changelog heading: `## [1.2.3.4] - 2026-09-02`
+  if (/^#{1,6}\s.*\[$/.test(before) && after.startsWith("]")) return true;
+
+  // Proven elsewhere in the same text. Escape the span: it is all digits and
+  // dots, but the dots must not act as wildcards.
+  const literal = span.replace(/[.]/g, "\\.");
+  const declaredElsewhere = new RegExp(
+    `(?:[\\w.\\-]*version["'\\]]?\\s*[:=]\\s*["'(]?${literal}|(?:^|[^\\w.])[vV]${literal}|^#{1,6}\\s.*\\[${literal}\\])`,
+    "im",
+  );
+  return declaredElsewhere.test(input);
+}
+
 // EIP-55 checksum is out of scope (heavy); we require a length+charset match and
 // reject all-same-char vanity strings to cut the worst FPs.
 function looksLikeWallet(span: string): boolean {
@@ -760,7 +810,7 @@ export const PATTERNS: RedactPattern[] = [
     category: "pii",
     description: "Public IPv4 address",
     regex: /\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b/,
-    validate: (span) => isPublicIPv4(span),
+    validate: (span, match) => isPublicIPv4(span) && !isVersionNotIPv4(span, match.input, match.index),
   },
   {
     id: "pii.wallet",

--- a/test/redact-engine.test.ts
+++ b/test/redact-engine.test.ts
@@ -379,6 +379,31 @@ describe("PII patterns", () => {
     expect(ids("card 4111-1111-1111-1111")).toContain("pii.cc");
     expect(ids("reach me on +1 415 555 2671")).toContain("pii.phone.e164");
   });
+
+  test("four-part version strings are not IP addresses", () => {
+    // A repo on MAJOR.MINOR.PATCH.BUILD writes its version to several files
+    // per release; each one used to land as a public-IPv4 finding.
+    expect(ids('  "version": "1.128.1.0",')).not.toContain("pii.ip_public");
+    expect(ids("app_version = 1.128.1.0")).not.toContain("pii.ip_public");
+    expect(ids("schema-version: 4.12.9.3")).not.toContain("pii.ip_public");
+    expect(ids("released v1.128.1.0 today")).not.toContain("pii.ip_public");
+    expect(ids("## [1.128.1.0] - 2026-09-02")).not.toContain("pii.ip_public");
+  });
+  test("a bare version line is exempt only when the same string is declared a version nearby", () => {
+    // The VERSION file's whole contents, inside a release diff.
+    const releaseDiff = ['+++ b/VERSION', '+1.128.1.0', '+++ b/package.json', '+  "version": "1.128.1.0",'].join("\n");
+    expect(ids(releaseDiff)).not.toContain("pii.ip_public");
+    // The same bare line with nothing proving it a version stays flagged.
+    expect(ids("1.128.1.0")).toContain("pii.ip_public");
+  });
+  test("the version exemption cannot launder a real address", () => {
+    // A genuine IP does not become exempt by sharing a diff with an
+    // unrelated version string — rule 2 matches the exact value only.
+    const mixed = ['  "version": "1.128.1.0",', "  resolver = 8.8.8.8"].join("\n");
+    expect(ids(mixed)).toContain("pii.ip_public");
+    // And a version-shaped key does not exempt a different value on its line.
+    expect(ids("version: 1.2.3.4 via 8.8.8.8")).toContain("pii.ip_public");
+  });
 });
 
 describe("internal + legal patterns", () => {


### PR DESCRIPTION
## The problem

A repo using a four-part `MAJOR.MINOR.PATCH.BUILD` version trips `pii.ip_public` on **every release**. `1.128.1.0` is a syntactically valid public IPv4 address, so each file the version is written to lands as a MEDIUM finding:

```
MEDIUM pii.ip_public   9:6   1.12*****     ## [1.128.1.0] - 2026-09-02
MEDIUM pii.ip_public  27:2   1.12*****     VERSION
MEDIUM pii.ip_public  53:16  1.12*****     package.json
MEDIUM pii.ip_public  60:20  1.12*****     package-lock.json  (top level)
MEDIUM pii.ip_public  72:16  1.12*****     package-lock.json  (packages."")
```

Five findings, every push, indefinitely — the count is structural, since those are exactly the files a version has to be written to. The practical cost isn't the noise: it's that a scanner reporting the same findings every time is one people stop reading, which is how a genuine finding gets waved through. (This surfaced on a repo where the standing advice had become "it's always five, ignore it" — and nobody had checked what the five were.)

Four-part schemes aren't unusual: .NET/NuGet assembly versions, Electron builds, and plenty of hand-rolled schemes all look like this.

## The fix

`pii.ip_public` now rejects a dotted quad that is *provably* a version.

The bias is deliberate and I'd rather state it than have it inferred: **a leaked address costs more than a nuisance finding**, so an exemption requires proof of version context, never mere proximity to the word "version". Two ways to earn it:

1. **This occurrence sits in a version declaration** — a `*version` key (`"version": "1.2.3.4"`, `app_version = 1.2.3.4`), a `v` prefix (`v1.2.3.4`), or a Keep-a-Changelog heading (`## [1.2.3.4] - date`).
2. **The identical string is declared a version elsewhere in the same scanned text.** This covers the bare `1.128.1.0` line of a `VERSION` file without teaching the validator anything about diff or file formats — if those exact characters are proven a version in one place, a bare repetition of them is the same version.

Consequences worth checking in review:

- A bare `8.8.8.8` stays flagged — nothing proves it a version.
- A real address **cannot** be laundered by sharing a diff with an unrelated version string, because rule 2 matches on the exact value.
- `version: 1.2.3.4 via 8.8.8.8` still flags the address — the key exempts its own value, not the line.

## Shape

No engine or `RedactPattern` change. It lives entirely in the existing `validate` hook, which already receives the `RegExpExecArray` (and therefore `.input`/`.index`). `nearRegex` is positive-only, so it couldn't express this.

## Tests

Four new cases in `test/redact-engine.test.ts`: the declaration forms, the bare-line-plus-proof case, and two laundering attempts.

- All **164 redact tests pass** across the 8 redact test files, including `redact-pattern-lint.test.ts` (the linear-time regex lint).
- Verified against the real-world diff that motivated this: **5 MEDIUM → 0**.
- Full `test/` suite: 6 failures, identical before and after this change (`gstack-gbrain-detect`, `resolve-user-slug` — environment-dependent, none touching redaction). Compared against a stashed baseline rather than assumed.