### PR TITLE
fix(learnings-search): rank by whole-word relevance so an exact match cannot be truncated away (#2762)

### DIFF
--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -66,6 +66,37 @@ const now = Date.now();
 const type = process.env.GSTACK_SEARCH_TYPE || '';
 const queryRaw = (process.env.GSTACK_SEARCH_QUERY || '').toLowerCase();
 const queryTokens = queryRaw.split(/\s+/).filter(Boolean);
+// #2762: score over DISTINCT tokens. Repeating a word must not let an entry
+// matching one concept outrank an entry matching several. Deduping cannot change
+// the filter's result, so this is a ranking-only concern.
+const scoreTokens = Array.from(new Set(queryTokens));
+
+// #2762: word-boundary containment, used for RELEVANCE only (never for recall).
+// Hand-rolled rather than a RegExp because building one from caller input needs
+// the standard escape idiom, and that idiom requires a literal dollar sign --
+// which cannot appear in this block, since the whole thing is a double-quoted
+// bash string. (Backslash escapes are fine here and this file already uses
+// them; the dollar sign is the constraint.) Hyphens, dots and slashes are all
+// separators, so hyphenated keys and file paths yield their individual words.
+function isWordChar(c) {
+  // Case-folding identifies letters without a character-class escape: a letter
+  // has distinct cases, so accented Latin and Cyrillic count as word characters
+  // and 'caf' stops matching inside 'cafe' with an accent. Scripts without case
+  // (CJK) stay separators, which is what keeps an embedded Latin term findable
+  // in text that has no spaces around it.
+  return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c === '_'
+    || c.toLowerCase() !== c.toUpperCase();
+}
+function hasWholeWord(hay, tok) {
+  let i = hay.indexOf(tok);
+  while (i !== -1) {
+    const before = i === 0 ? '' : hay.charAt(i - 1);
+    const after = i + tok.length >= hay.length ? '' : hay.charAt(i + tok.length);
+    if (!isWordChar(before) && !isWordChar(after)) return true;
+    i = hay.indexOf(tok, i + 1);
+  }
+  return false;
+}
 const limit = parseInt(process.env.GSTACK_SEARCH_LIMIT || '10', 10);
 
 const entries = [];
@@ -77,6 +108,14 @@ for (const taggedLine of lines) {
     const e = JSON.parse(line);
     if (!e.key || !e.type) continue;
 
+    // #2762: strip every underscore-prefixed key the moment a row is parsed.
+    // Internal ranking fields live in this namespace, and gstack-learnings-log
+    // re-serializes whatever it is handed, so a stored _field would otherwise
+    // arrive as a live sort key. Doing it here, once, immunizes every internal
+    // field including ones added later, instead of relying on each new one
+    // remembering to initialize itself.
+    for (const k of Object.keys(e)) { if (k.charAt(0) === '_') delete e[k]; }
+
     // Apply confidence decay: observed/inferred lose 1pt per 30 days
     let conf = e.confidence || 5;
     if (e.source === 'observed' || e.source === 'inferred') {
@@ -84,6 +123,14 @@ for (const taggedLine of lines) {
       conf = Math.max(0, conf - Math.floor(days / 30));
     }
     e._effectiveConfidence = conf;
+
+    // #2762: initialize the relevance score here, beside the other internal
+    // fields, NOT in the query filter. The filter runs only when a query was
+    // given, so a value assigned there would leave the no-query path reading
+    // whatever JSON.parse produced -- and gstack-learnings-log re-serializes
+    // unknown keys, so a stored _tokenHits would become a live sort key on the
+    // preamble call that runs in every session.
+    e._tokenHits = 0;
 
     // Determine if this is from the current project or cross-project
     // Cross-project entries are tagged for display
@@ -120,13 +167,53 @@ let results = Array.from(seen.values());
 if (type) results = results.filter(e => e.type === type);
 
 // Filter by query (token-OR: match if ANY whitespace-split token appears in ANY haystack)
+// #2762: recall and relevance are now two different questions, answered separately.
+//
+// RECALL (this predicate) is unchanged from before: substring containment across
+// key, insight and files. Every entry that used to come back still comes back.
+//
+// RELEVANCE (_tokenHits) is a stricter, narrower measure, because reusing the
+// recall net as a ranking signal ranks badly in two ways that were measured on
+// gstack's own shipped queries:
+//   - Substring hits are not concept hits. Under /investigate's shipped query,
+//     'bug' hits inside 'debug', 'cause' inside 'because', 'fix' inside
+//     'fixture', so prose that merely says 'debug output interleaves because the
+//     fixture is parallel' outscores a real insight about root causes. Whole-word
+//     matching is what makes a hit mean the concept is present.
+//   - Naming is weaker evidence than substance, but it is not worthless. Keys and
+//     file paths are long and descriptive by convention, so scoring them equally
+//     with the insight lets verbosity beat quality: a thin entry whose key or file
+//     list happens to carry the query words would outrank a strong insight that
+//     answers it. Scoring them at zero overcorrects in the other direction, and an
+//     entry named exactly after the query then loses to incidental prose.
+//
+// So relevance is two tiers. What the entry SAYS (insight) decides first; what it
+// is ABOUT (key and file paths) only orders entries that already tie on substance.
+// Both are recall-neutral: the predicate below is unchanged.
 if (queryTokens.length > 0) results = results.filter(e => {
-  const haystacks = [(e.key || '').toLowerCase(), (e.insight || '').toLowerCase(), ...(e.files || []).map(f => f.toLowerCase())];
-  return queryTokens.some(tok => haystacks.some(h => h.includes(tok)));
+  const key = (e.key || '').toLowerCase();
+  const insight = (e.insight || '').toLowerCase();
+  const files = (e.files || []).map(f => f.toLowerCase());
+  e._insightHits = scoreTokens.filter(tok => hasWholeWord(insight, tok)).length;
+  e._contextHits = scoreTokens.filter(tok => hasWholeWord(key, tok) || files.some(f => hasWholeWord(f, tok))).length;
+  return queryTokens.some(tok => key.includes(tok) || insight.includes(tok) || files.some(f => f.includes(tok)));
 });
 
-// Sort by effective confidence desc, then recency
+// How many entries survived the filters, before the limit truncates. Feeds the
+// truncation notice on the summary line below.
+const totalMatched = results.length;
+
+// Sort by insight relevance, then naming relevance, then effective confidence,
+// then recency (#2762). No-query calls are unaffected: both hit counts are 0 for
+// every entry, the first two comparisons always tie, and the order is exactly the
+// previous confidence-then-recency one. Queried calls DO re-rank, single-token
+// included -- that is the point of the change, and it is why relevance is measured
+// on whole words rather than on the substrings the recall filter accepts.
 results.sort((a, b) => {
+  const aIns = a._insightHits || 0, bIns = b._insightHits || 0;
+  if (bIns !== aIns) return bIns - aIns;
+  const aCtx = a._contextHits || 0, bCtx = b._contextHits || 0;
+  if (bCtx !== aCtx) return bCtx - aCtx;
   if (b._effectiveConfidence !== a._effectiveConfidence) return b._effectiveConfidence - a._effectiveConfidence;
   return new Date(b.ts).getTime() - new Date(a.ts).getTime();
 });
@@ -145,8 +232,20 @@ for (const e of results) {
 }
 
 // Summary line
+// #2762: when a query matched more than the limit shows, say so. A caller that
+// searched for something specific and got back a full page of confident but
+// unrelated entries would otherwise read the list as a complete answer. Gated on a
+// non-empty query because the no-query preamble call (gstack-skill-start, --limit 3)
+// runs every session and must not grow a line. Emitted on stdout because this block
+// ends with its own stderr redirected to /dev/null, so stdout is the only channel
+// that reaches a caller. Phrased as a whole-and-part after gstack-retro-metrics
+// ('showing 300 of %d'), so the reader never has to add two numbers together, and
+// stated once rather than beside a second count of the same number.
 const counts = Object.entries(byType).map(([t, arr]) => arr.length + ' ' + t + (arr.length > 1 ? 's' : ''));
-console.log('LEARNINGS: ' + results.length + ' loaded (' + counts.join(', ') + ')');
+const truncated = queryTokens.length > 0 && totalMatched > results.length;
+const loaded = truncated ? results.length + ' of ' + totalMatched + ' matched' : results.length + ' loaded';
+const hint = truncated ? '; raise --limit for the rest' : '';
+console.log('LEARNINGS: ' + loaded + ' (' + counts.join(', ') + ')' + hint);
 console.log('');
 
 for (const [t, arr] of Object.entries(byType)) {

--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -237,7 +237,7 @@ results = results.slice(0, limit);
 if (results.length === 0) process.exit(0);
 
 // Format output
-const byType = {};
+const byType = Object.create(null);
 for (const e of results) {
   const t = e.type || 'unknown';
   if (!byType[t]) byType[t] = [];

--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -84,7 +84,7 @@ function isWordChar(c) {
   // and 'caf' stops matching inside 'cafe' with an accent. Scripts without case
   // (CJK) stay separators, which is what keeps an embedded Latin term findable
   // in text that has no spaces around it.
-  return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c === '_'
+  return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
     || c.toLowerCase() !== c.toUpperCase();
 }
 function hasWholeWord(hay, tok) {

--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -87,12 +87,25 @@ function isWordChar(c) {
   return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
     || c.toLowerCase() !== c.toUpperCase();
 }
+// #2762: a query is written in the base form; prose is written in whatever form
+// the sentence needs. Scoring only the exact form makes a real answer invisible to
+// the query it answers, so a token also scores against its regular inflections.
+// The list holds only suffixes that are true suffixes OF THE BASE FORM: 'flaky' is
+// not flake+y and 'policies' is not policy+ies, so reaching those would take stem
+// rewriting, and adding them as bare suffixes would widen the false-positive
+// surface while matching neither. Irregulars are out of scope for the same reason.
+const INFLECTIONS = ['', 's', 'es', 'd', 'ed', 'ing'];
 function hasWholeWord(hay, tok) {
   let i = hay.indexOf(tok);
   while (i !== -1) {
     const before = i === 0 ? '' : hay.charAt(i - 1);
-    const after = i + tok.length >= hay.length ? '' : hay.charAt(i + tok.length);
-    if (!isWordChar(before) && !isWordChar(after)) return true;
+    if (!isWordChar(before)) {
+      const j = i + tok.length;
+      for (const suf of INFLECTIONS) {
+        const k = j + suf.length;
+        if (hay.slice(j, k) === suf && !isWordChar(k >= hay.length ? '' : hay.charAt(k))) return true;
+      }
+    }
     i = hay.indexOf(tok, i + 1);
   }
   return false;

--- a/bin/gstack-learnings-search
+++ b/bin/gstack-learnings-search
@@ -137,14 +137,6 @@ for (const taggedLine of lines) {
     }
     e._effectiveConfidence = conf;
 
-    // #2762: initialize the relevance score here, beside the other internal
-    // fields, NOT in the query filter. The filter runs only when a query was
-    // given, so a value assigned there would leave the no-query path reading
-    // whatever JSON.parse produced -- and gstack-learnings-log re-serializes
-    // unknown keys, so a stored _tokenHits would become a live sort key on the
-    // preamble call that runs in every session.
-    e._tokenHits = 0;
-
     // Determine if this is from the current project or cross-project
     // Cross-project entries are tagged for display
     const isCrossProject = sourceTag === 'cross';
@@ -185,7 +177,7 @@ if (type) results = results.filter(e => e.type === type);
 // RECALL (this predicate) is unchanged from before: substring containment across
 // key, insight and files. Every entry that used to come back still comes back.
 //
-// RELEVANCE (_tokenHits) is a stricter, narrower measure, because reusing the
+// RELEVANCE (the hit counts below) is a stricter, narrower measure, because reusing the
 // recall net as a ranking signal ranks badly in two ways that were measured on
 // gstack's own shipped queries:
 //   - Substring hits are not concept hits. Under /investigate's shipped query,

--- a/test/gstack-learnings-search.test.ts
+++ b/test/gstack-learnings-search.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const BIN = path.join(ROOT, 'bin', 'gstack-learnings-search');
@@ -45,6 +45,10 @@ beforeAll(() => {
 afterAll(() => {
   fs.rmSync(tmpHome, { recursive: true, force: true });
   fs.rmSync(tmpCwd, { recursive: true, force: true });
+  // #2762: rankCwd is created at module scope, so it must be removed at module
+  // scope too. A describe-scoped afterAll leaks it whenever a filtered run
+  // (bun test -t ...) skips that describe.
+  fs.rmSync(rankCwd, { recursive: true, force: true });
 });
 
 describe('gstack-learnings-search token-OR query semantics', () => {
@@ -89,5 +93,259 @@ describe('gstack-learnings-search cross-project trust gating', () => {
   test('cross-project mode excludes foreign rows missing the trusted field (#1745)', () => {
     const out = run(['--cross-project', '--query', 'foreign']);
     expect(out).not.toContain('foreign-legacy');
+  });
+});
+
+// #2762: relevance ranking. The query filter is token-OR over substrings, so a
+// broad token can admit most of a store. Ranking on confidence alone then lets a
+// high-confidence single-token match outrank an entry that matched every token,
+// and the default --limit 10 truncates the exact answer off the end. The caller
+// gets ten confident, well-formed, wrong entries and reads them as a complete
+// answer -- a false absence, which is the dangerous failure direction.
+//
+// This fixture lives in its own project dir so the assertions above (which depend
+// on a three-entry store) keep their meaning. Every entry is `user-stated` because
+// that source is exempt from confidence decay -- an `observed` fixture would drift
+// as wall-clock time passes and turn these into date-dependent flakes. Every entry
+// is the same `type` so the formatter emits one group and printed order is rank order.
+const rankCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-search-rank-cwd-'));
+const rankSlug = path.basename(rankCwd).replace(/[^a-zA-Z0-9._-]/g, '');
+const rankProjDir = path.join(tmpHome, 'projects', rankSlug);
+
+const TARGET = 'verify-preflight-project-line-before-trusting-report';
+// Twelve decoys, each matching ONLY the token `line`, via substring hits inside
+// guideline / pipeline / deadline / etc. All outrank the target on confidence.
+const DECOY_WORDS = [
+  'guideline', 'pipeline', 'deadline', 'headline', 'baseline', 'timeline',
+  'outline', 'airline', 'lifeline', 'sideline', 'streamline', 'underline',
+];
+
+function rankEntry(over: Record<string, unknown>): Record<string, unknown> {
+  return { ts: '2026-05-01T00:00:00Z', skill: 'test', type: 'pattern', confidence: 8, source: 'user-stated', trusted: false, files: [], ...over };
+}
+
+// #2762 / I11: assert on the printed order as an ARRAY, never with indexOf
+// comparisons. indexOf returns -1 for an absent key, and -1 is less than every
+// real index, so `indexOf(a) < indexOf(b)` reports green when `a` has vanished
+// entirely -- the exact false-absence this suite exists to catch.
+function rankedKeys(args: string[]): string[] {
+  return runRank(args)
+    .split('\n')
+    .map(line => /^- \[([^\]]+)\]/.exec(line))
+    .filter((m): m is RegExpExecArray => m !== null)
+    .map(m => m[1]);
+}
+
+function runRank(args: string[]): string {
+  return execFileSync(BIN, args, {
+    timeout: 30_000,
+    env: { ...process.env, GSTACK_HOME: tmpHome },
+    cwd: rankCwd,
+    encoding: 'utf-8',
+  });
+}
+
+describe('gstack-learnings-search relevance ranking (#2762)', () => {
+  beforeAll(() => {
+    fs.mkdirSync(rankProjDir, { recursive: true });
+    const rows = [
+      // Matches all three tokens of "preflight project line", at LOWER confidence
+      // than every decoy. This is the entry the caller is looking for.
+      rankEntry({ key: TARGET, insight: 'Check the project line in the preflight report before trusting it', confidence: 8 }),
+      // 1-of-3 matches (`line` only) at max confidence: enough of them to fill the
+      // default limit on their own.
+      ...DECOY_WORDS.map((w, i) => rankEntry({
+        ts: '2026-05-' + String(4 + i).padStart(2, '0') + 'T00:00:00Z',
+        key: 'decoy-' + w + '-rule',
+        insight: 'A ' + w + ' related insight',
+        confidence: 10,
+      })),
+      // Tie-break probes for the query "alpha beta": 2 hits at confidence 9, 2 hits
+      // at confidence 5, 1 hit at confidence 10. Correct order is 9, 5, 10 -- hits
+      // outrank confidence, and confidence still breaks a tie between equal hits.
+      // The lower-confidence row is deliberately the NEWER one, so recency alone
+      // would order these backwards. Only the confidence tier produces the
+      // expected order, which is what makes the assertion able to fail.
+      rankEntry({ ts: '2026-05-01T00:00:00Z', key: 'tiebreak-alpha-beta-high', insight: 'alpha beta both present', confidence: 9 }),
+      rankEntry({ ts: '2026-06-01T00:00:00Z', key: 'tiebreak-alpha-beta-low', insight: 'alpha beta both present', confidence: 5 }),
+      rankEntry({ key: 'tiebreak-alpha-solo', insight: 'alpha only here', confidence: 10 }),
+      // Recency probes for "gamma delta": identical hits AND identical confidence,
+      // so the third comparison (recency) has to decide.
+      rankEntry({ ts: '2026-05-01T00:00:00Z', key: 'recency-gamma-delta-older', insight: 'gamma delta pair', confidence: 7 }),
+      rankEntry({ ts: '2026-06-01T00:00:00Z', key: 'recency-gamma-delta-newer', insight: 'gamma delta pair', confidence: 7 }),
+      // A row carrying a stored _tokenHits, the shape gstack-learnings-log will
+      // happily persist because it re-serializes unknown keys. Worst entry in the
+      // store on every legacy signal: lowest confidence, oldest timestamp.
+      rankEntry({ ts: '2020-01-01T00:00:00Z', key: 'planted-token-hits', insight: 'isolated poison row', confidence: 1,
+        _insightHits: 9999, _contextHits: 9999, _tokenHits: 9999, _somethingAddedLater: 9999 }),
+      // Substring-vs-word probes. The decoy satisfies "cause", "bug" and "fix" only
+      // as substrings (be-CAUSE, de-BUG, FIX-ture); the real answer contains three
+      // of them as whole words.
+      rankEntry({ key: 'nested-substring-decoy', insight: 'debug output ran because the fixture was parallel', confidence: 10 }),
+      rankEntry({ key: 'nested-whole-word-match', insight: 'form a root cause hypothesis first', confidence: 2 }),
+      // Key-verbosity probes. The verbose key carries four query tokens; its
+      // content carries none. The plain key carries none; its content carries one.
+      rankEntry({ key: 'kappa-lambda-sigma-omega-verbose-key', insight: 'unrelated content', confidence: 4 }),
+      rankEntry({ key: 'plain-key', insight: 'kappa appears here', confidence: 10 }),
+      // Naming-tier probes: identical insight relevance (both score 1 on "sigma"),
+      // so the key/file tier has to break the tie -- and it must beat confidence.
+      rankEntry({ key: 'tau-rho-xi-named', insight: 'tau noted', confidence: 2 }),
+      rankEntry({ key: 'unnamed-probe', insight: 'tau noted', confidence: 8 }),
+      // files is a scored field; give it tokens that appear nowhere else, so a hit
+      // can only have come from the path.
+      rankEntry({ key: 'path-carrier', insight: 'nothing relevant here', confidence: 3, files: ['test/zulu/yankee.test.ts'] }),
+      rankEntry({ key: 'insight-carrier', insight: 'zulu and yankee explained properly', confidence: 3, files: [] }),
+      // Non-ASCII boundary probes. 'chi' is a real word in the CJK row and only an
+      // incidental substring in 'chile'.
+      rankEntry({ key: 'accented-neighbour', insight: 'psi\u00e9 deploy', confidence: 5 }),
+      rankEntry({ key: 'ascii-neighbour', insight: 'psi deploy', confidence: 5 }),
+      // Dedup probes. The repeated-token entry must NOT also match the other
+      // concepts, or repetition inflates both rows equally and the ordering cannot
+      // reveal whether tokens were deduped.
+      rankEntry({ key: 'repeated-token-only', insight: 'nu only here', confidence: 9 }),
+      rankEntry({ key: 'two-distinct-concepts', insight: 'omicron and kirin together', confidence: 2 }),
+    ];
+    fs.writeFileSync(path.join(rankProjDir, 'learnings.jsonl'), rows.map(e => JSON.stringify(e)).join('\n') + '\n');
+  });
+
+  // The reported defect: adding a discriminating token made the search WORSE.
+  // On the pre-fix binary the first two queries find the target and the third
+  // does not, even though its key contains all three tokens.
+  test('an entry matching every query token survives the default limit', () => {
+    expect(runRank(['--query', 'preflight'])).toContain(TARGET);
+    expect(runRank(['--query', 'preflight project'])).toContain(TARGET);
+    expect(runRank(['--query', 'preflight project line'])).toContain(TARGET);
+  });
+
+  test('a 3-of-3 match outranks twelve higher-confidence 1-of-3 matches', () => {
+    expect(rankedKeys(['--query', 'preflight project line'])[0]).toBe(TARGET);
+  });
+
+  test('token hits outrank confidence, and confidence still breaks a hit tie', () => {
+    expect(rankedKeys(['--query', 'alpha beta'])).toEqual([
+      'tiebreak-alpha-beta-high',  // 2 hits, confidence 9
+      'tiebreak-alpha-beta-low',   // 2 hits, confidence 5 -- hits tie, confidence decides
+      'tiebreak-alpha-solo',       // 1 hit, confidence 10 -- outranked despite the best confidence
+    ]);
+  });
+
+  test('equal hits and equal confidence still fall through to recency', () => {
+    expect(rankedKeys(['--query', 'gamma delta'])).toEqual([
+      'recency-gamma-delta-newer',
+      'recency-gamma-delta-older',
+    ]);
+  });
+
+  // Relevance applies to single-token queries too, and this is the case that shows
+  // why it has to. `line` appears in all twelve decoys only inside guideline,
+  // pipeline, deadline and friends; the target contains it as an actual word. The
+  // pre-fix binary ranked on confidence alone and truncated the target away.
+  test('a single token still discriminates a real word from an incidental substring', () => {
+    const ranked = rankedKeys(['--query', 'line']);
+    expect(ranked[0]).toBe(TARGET);
+    // Recall is untouched: the substring-only decoys are all still returned.
+    expect(ranked).toContain('decoy-underline-rule');
+  });
+
+  test('a truncated query reports the part and the whole, stated once', () => {
+    const out = runRank(['--query', 'preflight project line']);
+    expect(out).toContain('LEARNINGS: 10 of 13 matched');
+    expect(out).toContain('raise --limit for the rest');
+    // The count is stated as a fraction instead of alongside a second copy of itself.
+    expect(out).not.toContain('10 loaded');
+  });
+
+  test('a query that fits under the limit says nothing about truncation', () => {
+    const out = runRank(['--query', 'gamma delta']);
+    expect(out).toContain('recency-gamma-delta-newer');
+    expect(out).toContain('loaded');
+    expect(out).not.toContain('matched');
+  });
+
+  // The preamble calls this with --limit 3 and no query on every skill invocation
+  // in every session. It must not grow a line.
+  test('the no-query preamble path never emits a truncation notice', () => {
+    const out = runRank(['--limit', '3']);
+    expect(out).toContain('LEARNINGS: 3 loaded');
+    expect(out).not.toContain('matched');
+  });
+
+  // The script ends with the bun stage's own stderr redirected to /dev/null, so
+  // stdout is the only channel that can reach a caller at all. Assert the notice
+  // is on it and that the process still succeeds.
+  test('the truncation notice is delivered on stdout with a zero exit', () => {
+    const res = spawnSync(BIN, ['--query', 'preflight project line'], {
+      timeout: 30_000,
+      env: { ...process.env, GSTACK_HOME: tmpHome },
+      cwd: rankCwd,
+      encoding: 'utf-8',
+    });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('10 of 13 matched');
+  });
+
+  // A stored internal field must never become a live sort key. The query filter is
+  // the only writer, so on the no-query path -- which gstack-skill-start runs at
+  // --limit 3 in every session -- an unstripped field would be read straight off
+  // disk. gstack-learnings-log persists unknown keys, so this row is a shape the
+  // supported writer can actually produce, not a hand-edit. The fixture plants the
+  // current sort fields AND a name that does not exist yet, because the defense is
+  // the underscore-namespace strip rather than a list of known fields.
+  test('a stored internal field cannot hijack the no-query preamble ranking', () => {
+    const ranked = rankedKeys(['--limit', '3']);
+    expect(ranked).not.toContain('planted-token-hits');
+    expect(ranked[0]).not.toBe('planted-token-hits');
+  });
+
+  // Relevance counts whole words, not substrings. Under /investigate's shipped
+  // query shape, substring scoring gave prose containing "because"/"debug"/
+  // "fixture" three free hits and buried the real answer below it.
+  test('substring-only hits do not score, so incidental prose cannot outrank', () => {
+    const ranked = rankedKeys(['--query', 'root cause hypothesis bug fix']);
+    expect(ranked[0]).toBe('nested-whole-word-match');
+    // Recall unchanged: the decoy still matches the substring filter and is returned.
+    expect(ranked).toContain('nested-substring-decoy');
+  });
+
+  // Naming is weaker evidence than substance. A verbose key carrying four query
+  // tokens must not outrank an insight that actually says one of them.
+  test('a verbose key never outranks an insight that answers the query', () => {
+    const ranked = rankedKeys(['--query', 'kappa lambda sigma omega']);
+    expect(ranked[0]).toBe('plain-key');
+    expect(ranked).toContain('kappa-lambda-sigma-omega-verbose-key');
+  });
+
+  // But naming is not worthless: on an insight tie it breaks the tie, ahead of
+  // confidence. Without this tier an entry named exactly after the query loses to
+  // incidental prose and can be truncated away.
+  test('on an insight tie, key and file naming breaks it ahead of confidence', () => {
+    expect(rankedKeys(['--query', 'tau rho xi'])).toEqual([
+      'tau-rho-xi-named',  // insight 1, naming 3, confidence 2
+      'unnamed-probe',     // insight 1, naming 0, confidence 8
+    ]);
+  });
+
+  test('a query token found only in files scores as naming, below a real insight', () => {
+    const ranked = rankedKeys(['--query', 'zulu yankee']);
+    expect(ranked[0]).toBe('insight-carrier');
+    expect(ranked).toContain('path-carrier');
+  });
+
+  test('a letter with an accent is a word character, so it does not fake a boundary', () => {
+    const ranked = rankedKeys(['--query', 'psi']);
+    expect(ranked[0]).toBe('ascii-neighbour');
+  });
+
+  // Repeating a word must not promote an entry matching fewer concepts. Asserted
+  // as an OUTCOME, not by comparing two runs: a run-vs-run comparison cannot see
+  // uniform score inflation, so it stays green when the dedup is deleted.
+  test('a repeated query token cannot outrank an entry matching more concepts', () => {
+    // Deduped: repeated-token-only scores 1 (nu), two-distinct-concepts scores 2.
+    // Undeduped it would score 3 for the same one concept and take the lead, even
+    // though it answers less of the query and the other row is the better match.
+    expect(rankedKeys(['--query', 'nu nu nu omicron kirin'])).toEqual([
+      'two-distinct-concepts',  // 2 distinct hits, confidence 2
+      'repeated-token-only',    // 1 distinct hit, confidence 9
+    ]);
   });
 });

--- a/test/gstack-learnings-search.test.ts
+++ b/test/gstack-learnings-search.test.ts
@@ -232,6 +232,14 @@ describe('gstack-learnings-search relevance ranking (#2762)', () => {
       // scores fully -- the same entry ranked on its separator, not its content.
       rankEntry({ key: 'iota_upsilon_probe', insight: 'no query words in this text', confidence: 2 }),
       rankEntry({ key: 'plain-row-iota', insight: 'no query words in this text', confidence: 10 }),
+      // Decay-vs-relevance probes. Fixed at a date far enough back that the
+      // observed rows are pinned to the 0 floor by Math.max, so they are stable
+      // forever rather than drifting with wall clock -- which is why the rest of
+      // this fixture is user-stated.
+      rankEntry({ key: 'decayed-two-hits', insight: 'quasar and nebula both discussed', confidence: 9, source: 'observed', ts: '2019-01-01T00:00:00Z' }),
+      rankEntry({ key: 'current-one-hit', insight: 'quasar alone here', confidence: 10 }),
+      rankEntry({ key: 'decayed-tied-hit', insight: 'pulsar mentioned', confidence: 9, source: 'observed', ts: '2019-01-01T00:00:00Z' }),
+      rankEntry({ key: 'current-tied-hit', insight: 'pulsar mentioned too', confidence: 5 }),
     ];
     fs.writeFileSync(path.join(rankProjDir, 'learnings.jsonl'), rows.map(e => JSON.stringify(e)).join('\n') + '\n');
   });
@@ -405,6 +413,26 @@ describe('gstack-learnings-search relevance ranking (#2762)', () => {
     expect(rankedKeys(['--query', 'iota upsilon'])).toEqual([
       'iota_upsilon_probe',  // 2 naming hits, confidence 2
       'plain-row-iota',      // 1 naming hit, confidence 10
+    ]);
+  });
+
+  // #2762 ranks tokens matched ahead of confidence by design, and decay feeds
+  // confidence. This pins the consequence so it is deliberate and visible rather
+  // than discovered later: a fully decayed row that answers more of the query is
+  // still ranked above a current row that answers less of it.
+  test('relevance outranks confidence decay when the decayed row matches more', () => {
+    expect(rankedKeys(['--query', 'quasar nebula'])).toEqual([
+      'decayed-two-hits',  // 2 hits, observed and decayed to the 0 floor
+      'current-one-hit',   // 1 hit, confidence 10, exempt from decay
+    ]);
+  });
+
+  // ...and decay is still live underneath it: once the hit counts tie, the decayed
+  // row loses on the confidence it has lost.
+  test('confidence decay still demotes a stale row once relevance ties', () => {
+    expect(rankedKeys(['--query', 'pulsar'])).toEqual([
+      'current-tied-hit',  // 1 hit, confidence 5
+      'decayed-tied-hit',  // 1 hit, decayed to 0
     ]);
   });
 });

--- a/test/gstack-learnings-search.test.ts
+++ b/test/gstack-learnings-search.test.ts
@@ -15,7 +15,7 @@ const projDir = path.join(tmpHome, 'projects', slug);
 const otherProjDir = path.join(tmpHome, 'projects', 'other-project');
 
 function run(args: string[]): string {
-  return execFileSync(BIN, args, {
+  return execFileSync('bash', [BIN, ...args], {
     timeout: 30_000,
     env: { ...process.env, GSTACK_HOME: tmpHome },
     cwd: tmpCwd,
@@ -137,7 +137,7 @@ function rankedKeys(args: string[]): string[] {
 }
 
 function runRank(args: string[]): string {
-  return execFileSync(BIN, args, {
+  return execFileSync('bash', [BIN, ...args], {
     timeout: 30_000,
     env: { ...process.env, GSTACK_HOME: tmpHome },
     cwd: rankCwd,
@@ -274,7 +274,7 @@ describe('gstack-learnings-search relevance ranking (#2762)', () => {
   // stdout is the only channel that can reach a caller at all. Assert the notice
   // is on it and that the process still succeeds.
   test('the truncation notice is delivered on stdout with a zero exit', () => {
-    const res = spawnSync(BIN, ['--query', 'preflight project line'], {
+    const res = spawnSync('bash', [BIN, '--query', 'preflight project line'], {
       timeout: 30_000,
       env: { ...process.env, GSTACK_HOME: tmpHome },
       cwd: rankCwd,

--- a/test/gstack-learnings-search.test.ts
+++ b/test/gstack-learnings-search.test.ts
@@ -204,6 +204,20 @@ describe('gstack-learnings-search relevance ranking (#2762)', () => {
       // reveal whether tokens were deduped.
       rankEntry({ key: 'repeated-token-only', insight: 'nu only here', confidence: 9 }),
       rankEntry({ key: 'two-distinct-concepts', insight: 'omicron and kirin together', confidence: 2 }),
+      // #2762: inflection probes. A query is written in the base form; prose is
+      // written in whatever form the sentence needs. The insight below carries one
+      // regular inflection of each query token and no token verbatim, so under
+      // exact-form scoring it takes ZERO insight hits and loses to a row that only
+      // has the words in its NAME -- the shipped `--query "<keyword>" --limit 5`
+      // shape, where a real answer saying "tests interleave" lost to decoys whose
+      // only claim was a `.test.ts` filename.
+      rankEntry({ key: 'inflected-insight', insight: 'quarks and vortexes pulsed while orbited and drifting', confidence: 2 }),
+      rankEntry({ key: 'quark-vortex-pulse-orbit-drift-in-the-name', insight: 'nothing to say here', confidence: 10 }),
+      // Over-reach probe: 'orbital' merely STARTS with the query token. It is
+      // recalled by the substring filter, so it is present to be ranked, and it
+      // must score nothing -- suffix tolerance is a closed list of inflections,
+      // not a prefix match.
+      rankEntry({ key: 'orbital-overreach-decoy', insight: 'an orbital note about nothing', confidence: 10 }),
       // Underscore separator probes. gstack-learnings-log's key regex admits
       // [a-zA-Z0-9_-], so snake_case keys are supported and file paths carry
       // underscores constantly. If `_` counts as a word character the whole key is
@@ -353,6 +367,28 @@ describe('gstack-learnings-search relevance ranking (#2762)', () => {
     expect(rankedKeys(['--query', 'nu nu nu omicron kirin'])).toEqual([
       'two-distinct-concepts',  // 2 distinct hits, confidence 2
       'repeated-token-only',    // 1 distinct hit, confidence 9
+    ]);
+  });
+
+  // A query is written in the base form; prose is written in whatever form the
+  // sentence needs. Scoring only the exact form re-opens the truncation this fix
+  // exists to close: the answer is in the insight, the query words are only in
+  // someone else's name, and the name wins.
+  test('a base-form query scores against the inflected form in the insight', () => {
+    expect(rankedKeys(['--query', 'quark vortex pulse orbit drift'])).toEqual([
+      'inflected-insight',                          // 5 insight hits via -s -es -d -ed -ing, confidence 2
+      'quark-vortex-pulse-orbit-drift-in-the-name', // 0 insight, 5 naming, confidence 10
+      'orbital-overreach-decoy',                    // 0 insight, 0 naming, confidence 10
+    ]);
+  });
+
+  test('inflection tolerance does not degrade into loose prefix matching', () => {
+    // 'orbited' is 'orbit' plus a listed inflection and scores; 'orbital' merely
+    // starts with it and must not, even though it holds the better confidence.
+    expect(rankedKeys(['--query', 'orbit'])).toEqual([
+      'inflected-insight',                          // 1 insight hit via -ed, confidence 2
+      'quark-vortex-pulse-orbit-drift-in-the-name', // 0 insight, 1 naming hit
+      'orbital-overreach-decoy',                    // 0 hits, confidence 10 -- recalled, never scored
     ]);
   });
 

--- a/test/gstack-learnings-search.test.ts
+++ b/test/gstack-learnings-search.test.ts
@@ -49,6 +49,7 @@ afterAll(() => {
   // scope too. A describe-scoped afterAll leaks it whenever a filtered run
   // (bun test -t ...) skips that describe.
   fs.rmSync(rankCwd, { recursive: true, force: true });
+  fs.rmSync(badCwd, { recursive: true, force: true });
 });
 
 describe('gstack-learnings-search token-OR query semantics', () => {
@@ -111,6 +112,12 @@ describe('gstack-learnings-search cross-project trust gating', () => {
 const rankCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-search-rank-cwd-'));
 const rankSlug = path.basename(rankCwd).replace(/[^a-zA-Z0-9._-]/g, '');
 const rankProjDir = path.join(tmpHome, 'projects', rankSlug);
+
+// #2762: the malformed-row store lives apart from every other fixture because the
+// defect it probes blanks the ENTIRE run, which would mask each of them in turn.
+const badCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-search-bad-cwd-'));
+const badSlug = path.basename(badCwd).replace(/[^a-zA-Z0-9._-]/g, '');
+const badProjDir = path.join(tmpHome, 'projects', badSlug);
 
 const TARGET = 'verify-preflight-project-line-before-trusting-report';
 // Twelve decoys, each matching ONLY the token `line`, via substring hits inside
@@ -400,4 +407,58 @@ describe('gstack-learnings-search relevance ranking (#2762)', () => {
       'plain-row-iota',      // 1 naming hit, confidence 10
     ]);
   });
+});
+
+// The formatter groups rows into a plain object keyed by the row's own `type`.
+// A row whose type names an inherited Object property finds that property already
+// truthy, so the array is never created and .push throws. The bun stage ends with
+// `2>/dev/null || exit 0`, which converts the throw into empty stdout at exit 0 --
+// indistinguishable from "this project has no learnings". Ranking is what makes it
+// reachable: it promotes the malformed row past the --limit cut that used to hide it.
+describe('gstack-learnings-search malformed row containment', () => {
+  const POISON_TYPES = ['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__'];
+
+  beforeAll(() => {
+    fs.mkdirSync(badProjDir, { recursive: true });
+  });
+
+  function writeBadStore(poisonType: string): void {
+    const rows = [
+      ...Array.from({ length: 3 }, (_, i) => rankEntry({
+        ts: '2026-05-0' + (i + 1) + 'T00:00:00Z',
+        key: 'healthy-' + i,
+        insight: 'alpha only insight ' + i,
+        confidence: 10,
+      })),
+      // Scores higher than every healthy row, so ranking floats it to the top.
+      rankEntry({ key: 'poison-row', type: poisonType, insight: 'alpha beta both here', confidence: 1 }),
+    ];
+    fs.writeFileSync(path.join(badProjDir, 'learnings.jsonl'), rows.map(e => JSON.stringify(e)).join('\n') + '\n');
+  }
+
+  function runBad(args: string[]): ReturnType<typeof spawnSync> {
+    return spawnSync('bash', [BIN, ...args], {
+      timeout: 30_000,
+      env: { ...process.env, GSTACK_HOME: tmpHome },
+      cwd: badCwd,
+      encoding: 'utf-8',
+    });
+  }
+
+  for (const poisonType of POISON_TYPES) {
+    test('a row typed "' + poisonType + '" cannot blank the whole store', () => {
+      writeBadStore(poisonType);
+      const res = runBad(['--query', 'alpha beta']);
+      const keys = String(res.stdout).split('\n')
+        .map(line => /^- \[([^\]]+)\]/.exec(line))
+        .filter((m): m is RegExpExecArray => m !== null)
+        .map(m => m[1]);
+      // Every healthy row still reaches the caller. Asserted by presence, not by
+      // count: the failure mode is silence, and a count assertion on an empty
+      // result reads the same as a count assertion on a truncated one.
+      expect(keys).toContain('healthy-0');
+      expect(keys).toContain('healthy-1');
+      expect(keys).toContain('healthy-2');
+    });
+  }
 });

--- a/test/gstack-learnings-search.test.ts
+++ b/test/gstack-learnings-search.test.ts
@@ -204,6 +204,13 @@ describe('gstack-learnings-search relevance ranking (#2762)', () => {
       // reveal whether tokens were deduped.
       rankEntry({ key: 'repeated-token-only', insight: 'nu only here', confidence: 9 }),
       rankEntry({ key: 'two-distinct-concepts', insight: 'omicron and kirin together', confidence: 2 }),
+      // Underscore separator probes. gstack-learnings-log's key regex admits
+      // [a-zA-Z0-9_-], so snake_case keys are supported and file paths carry
+      // underscores constantly. If `_` counts as a word character the whole key is
+      // one word and scores nothing, while a kebab-case key holding the same words
+      // scores fully -- the same entry ranked on its separator, not its content.
+      rankEntry({ key: 'iota_upsilon_probe', insight: 'no query words in this text', confidence: 2 }),
+      rankEntry({ key: 'plain-row-iota', insight: 'no query words in this text', confidence: 10 }),
     ];
     fs.writeFileSync(path.join(rankProjDir, 'learnings.jsonl'), rows.map(e => JSON.stringify(e)).join('\n') + '\n');
   });
@@ -346,6 +353,15 @@ describe('gstack-learnings-search relevance ranking (#2762)', () => {
     expect(rankedKeys(['--query', 'nu nu nu omicron kirin'])).toEqual([
       'two-distinct-concepts',  // 2 distinct hits, confidence 2
       'repeated-token-only',    // 1 distinct hit, confidence 9
+    ]);
+  });
+
+  // Same entry, same words, different separator. Underscore must break words or a
+  // snake_case key scores nothing while its kebab-case twin scores fully.
+  test('an underscore separates words in a key, exactly as a hyphen does', () => {
+    expect(rankedKeys(['--query', 'iota upsilon'])).toEqual([
+      'iota_upsilon_probe',  // 2 naming hits, confidence 2
+      'plain-row-iota',      // 1 naming hit, confidence 10
     ]);
   });
 });


### PR DESCRIPTION
## Why (in your own words)

If you search your learnings store for something specific, gstack can tell you the thing isn't there when it is. `gstack-learnings-search --query` filters with token-OR over substrings, so every word admits its own set of entries, and the union is then ranked by confidence alone and cut to `--limit` (10 by default). Nothing errors, nothing comes back empty — you get ten confident, well-formed entries that simply aren't the one you asked for, and you read that as a complete answer. The search gets *worse* the more precisely you describe what you want: adding a discriminating word widens the candidate set, and the entry matching every word you typed can be pushed off the end by entries matching just one.

That's a false absence, which is the bad direction to fail in. A caller who already has reason to believe a learning exists gets a plausible list back and concludes it doesn't.

## What this changes

Recall and relevance were the same computation. They are now two questions answered separately.

**Recall is unchanged.** The filter predicate is still substring containment across key, insight and files. Every entry that used to come back still comes back — verified set-identical to the base binary across nine query shapes on a real 95-entry store, and byte-identical on the no-query and `--type` paths.

**Relevance is new, and deliberately stricter:** the number of distinct query tokens present *as whole words*, counted in **two tiers**. What an entry **says** (its insight) decides first; what it is **about** (its key and file paths) only orders entries that already tie on substance. Confidence breaks a remaining tie, then recency.

Four properties of that definition carry the weight, and each exists because the looser version ranks badly on gstack's own shipped queries:

- **Whole words, not substrings.** A net that accepts `bug` inside `debug`, `cause` inside `because`, and `fix` inside `fixture` is right for finding candidates and useless for ordering them. `/investigate` ships the query `debug investigation root cause hypothesis bug fix`; under substring scoring, prose that merely says *"debug output ran because the fixture was parallel"* collects three free hits and outranks a real insight about root causes.
- **Two tiers, not one.** Keys here are long and descriptive by convention — this PR's own fixture key is six tokens. Scoring key, insight and files together lets verbosity beat quality: a thin entry whose name or path happens to carry the query words outranks an insight that answers it. But scoring the key at zero overcorrects, because an entry named exactly after the query then loses to incidental prose — the same truncation this fix exists to prevent. So naming is a tie-breaker, never a substitute for substance.
- **Inflected forms count.** A query is written in the base form; prose is written in whatever form the sentence needs. Matching only the exact form makes a real answer invisible to the query it answers — `test` could not see `tests`, `cache` could not see `caching`. A token scores against the endings that attach to its unchanged base (`-s -es -ed -ing`, plus bare `-d` only after a final `e` — `use`/`used`, never `car`/`card`), and against the two regular English stem rewrites: drop a final `e` before `-ing` (`caching`, `merging`) and double a final consonant (`shipping`, `running`, `logged`). Irregular forms are out of scope. Over-reach stays bounded by the same word-boundary check: `orbital` still scores nothing for `orbit`. Because recall is untouched and `cache` is not a substring of `caching`, a rewritten stem only lifts a row that another field — usually its key — already recalled.
- **Distinct tokens.** Repeating a word must not promote an entry that matches fewer concepts.

Word boundaries are found by case-folding rather than an ASCII range, so accented letters do not fake a boundary. That test cannot work for scripts without case: every Japanese, Chinese, Thai, Hebrew or Arabic character looks like a separator to it, so every substring would score as a whole word. A query token in a caseless script is therefore boundary-checked with `Intl.Segmenter`, which refuses `バッグ` inside `デバッグ`. A Latin token keeps the character test — where caseless characters still separate, so an embedded Latin term stays findable in text with no spaces around it — and never builds a segmenter. Hyphens, dots, slashes **and underscores** all separate, so a `snake_case` key yields its individual words exactly as a `kebab-case` one does — `gstack-learnings-log`'s key regex admits `_`, and file paths carry it constantly.

The ranking fields live in an underscore namespace, and every underscore-prefixed key is stripped at parse time. The scores are only assigned when a query is given, and `bin/gstack-learnings-log` re-serializes unknown keys — so without the strip, a stored `_insightHits` would reach the sort on the no-query `gstack-skill-start --limit 3` call that runs at session start. Stripping the whole namespace once covers fields added later, rather than relying on each new one to remember to initialize itself.

When a query matched more than the limit shows, the summary line now states the part and the whole, following the phrasing already used in `bin/gstack-retro-metrics` (`showing 300 of %d`). It is gated on a non-empty query because that session-start preamble call must not grow a line, and written to stdout because the block redirects its own stderr to `/dev/null`.

**One pre-existing defect is fixed here because this change is what exposes it.** The formatter groups rows into a plain `{}` keyed by each row's own `type`. A row whose type names an inherited `Object` property — `constructor`, `toString`, `valueOf`, `hasOwnProperty`, `__proto__` — finds that key already truthy, never builds the array, and throws on `.push`. The block ends `2>/dev/null || exit 0`, so the throw becomes empty stdout at exit 0: one malformed row silently blanking every other row in the store, on every query, indistinguishable from "this project has no learnings". Relevance ranking is what makes it reachable, floating that row past the `--limit` cut that used to hide it. The map is now prototype-free.

## Live evidence

Self-contained reproduction — one target entry whose key and insight contain all three query tokens at confidence 8, plus twelve confidence-10 decoys that contain `line` only as a substring (guide**line**, pipe**line**, dead**line**, …):

```bash
H=$(mktemp -d); C=$(mktemp -d); S=$(basename "$C"); mkdir -p "$H/projects/$S"
{
  echo '{"ts":"2026-05-01T00:00:00Z","skill":"t","type":"pitfall","key":"verify-preflight-project-line-before-trusting-report","insight":"Check the project line in the preflight report before trusting it","confidence":8,"source":"user-stated","files":[]}'
  for w in guideline pipeline deadline headline baseline timeline outline airline lifeline sideline streamline underline; do
    echo '{"ts":"2026-05-04T00:00:00Z","skill":"t","type":"pattern","key":"decoy-'\"$w\"'-rule","insight":"A '\"$w\"' related insight","confidence":10,"source":"user-stated","files":[]}'
  done
} > "$H/projects/$S/learnings.jsonl"
cd "$C"
for q in "preflight" "preflight project" "preflight project line"; do
  echo "$ gstack-learnings-search --query \"$q\""
  GSTACK_HOME="$H" bin/gstack-learnings-search --query "$q" | head -1
  GSTACK_HOME="$H" bin/gstack-learnings-search --query "$q" | grep -q 'verify-preflight-project-line' \
    && echo '  target: FOUND' || echo '  target: NOT IN LIST'
done
```

**Before** — `upstream/main` at `0d1bd561`. The key contains all three tokens, in that order, and the third query is the one that loses it:

```
$ gstack-learnings-search --query "preflight"
LEARNINGS: 1 loaded (1 pitfall)
  target: FOUND
$ gstack-learnings-search --query "preflight project"
LEARNINGS: 1 loaded (1 pitfall)
  target: FOUND
$ gstack-learnings-search --query "preflight project line"
LEARNINGS: 10 loaded (10 patterns)
  target: NOT IN LIST
```

**After** — this branch:

```
$ gstack-learnings-search --query "preflight project line"
LEARNINGS: 10 of 13 matched (10 patterns); raise --limit for the rest

## Patterns
- [verify-preflight-project-line-before-trusting-report] (confidence: 8/10, user-stated, 2026-05-01)
  target: FOUND
```

**The shipped single-keyword shape.** `--query "<keyword>" --limit 5` is what `investigate/SKILL.md`, `qa/SKILL.md` and `ship/sections/adversarial.md` actually run. Store: one answer at confidence 6 whose insight opens *"Tests interleave when the runner is parallel"*, plus six confidence-10 rows whose only claim on the word is a `ui/panelN.test.ts` path:

```
$ gstack-learnings-search --query "test" --limit 5

main                   top hit = unrelated-5                  answer on page? 0
exact-form scoring     top hit = unrelated-5                  answer on page? 0
this branch            top hit = parallel-runner-interleave   answer on page? 1
```

Confidence-only ranking loses it, and so does scoring the exact form only — the insight says *tests* and the query says *test*. Matching a word together with its regular inflections is what finds it.

**Same entry, different separator.** Thirteen-row store, `--query "preflight project line"`:

```
key = preflight-project-line   -> rank 1
key = preflight_project_line   -> rank 1   (was rank 13 of 13, off the page at --limit 10)
```

**A malformed row can no longer blank the store.** One row typed `constructor` among ten healthy rows:

```
$ gstack-learnings-search --query "alpha beta"

main                   rows printed = 10  (exit 0)
without the fix        rows printed = 0   (exit 0)   <-- total silence, caught pre-merge
this branch            rows printed = 10  (exit 0)
```

Verified across all five reachable poison types.

**Scoring errors invert a correct order, because relevance sorts first.** A missed hit or a false hit outranks the whole confidence scale, so every matcher defect shows up as an ordering `main` got right and the matcher gets wrong. Each case below is a real answer at confidence 10 against a distractor at 1–2; *without the fix* is this branch's matcher before that correction:

```
$ gstack-learnings-search --query "cache"
    answer   "Caching the resolver output is what fixed the stall."      confidence 10
    aside    "a cache is mentioned here in passing"                      confidence 2

main              top hit = resolver-cache-gotcha  (confidence 10)
without the fix   top hit = minor-aside            (confidence 2)    <-- 'caching' scored nothing
this branch       top hit = resolver-cache-gotcha  (confidence 10)

$ gstack-learnings-search --query "バッグ ログ タグ"
    answer   "バッグの原因を調べた"                                       confidence 10
    decoy    "デバッグとカタログとハッシュタグ"                           confidence 1

main              top hit = cjk-answer  (confidence 10)
without the fix   top hit = cjk-decoy   (confidence 1)               <-- three substring hits
this branch       top hit = cjk-answer  (confidence 10)

$ gstack-learnings-search --query "min fin war car"
    answer   "the min heap ordering is what fixes the stall"             confidence 10
    decoy    "keep this in mind when you find the ward and the card"     confidence 1

main              top hit = real-answer  (confidence 10)
without the fix   top hit = false-hit    (confidence 1)              <-- mind/find/ward/card
this branch       top hit = real-answer  (confidence 10)
```

The CJK case is genuine segmentation, not blanket suppression: the segmenter splits `ハッシュタグ` into `ハッシュ` + `タグ`, so the decoy keeps its one real word and loses on confidence rather than scoring zero.

Recall is untouched. Per-token match counts on a real 95-entry store, base vs branch:

```
  token       base  branch
  pr           46     46
  merge        12     12
  ship          5      5
  version       1      1
  release       0      0
  changelog     0      0
```

Set-identity holds for whole queries too — the matched key sets are identical across nine shapes including all three shipped multi-token queries. The always-on preamble path is byte-identical:

```
$ diff <(tip --limit 3) <(branch --limit 3)                 # byte-identical
$ diff <(tip --limit 100) <(branch --limit 100)             # byte-identical
$ diff <(tip --type pitfall) <(branch --type pitfall)       # byte-identical
```

Forty-six tests, up from six on `main`; 34 of them fail against the `main` binary. Every behavioural claim is pinned by a test that dies when the corresponding line is reverted — each mutant applied in place and the suite re-run:

```
  reverted                                        tests that fail
  e-drop stem rewrite                                     1
  consonant-doubling stem rewrite                         1
  caseless-script segmentation                            1
  bare -d guard                                           1
  any one of -s / -es / -d / -ing                         1 each
  -ed                                                     2
  query lowercasing                                       1
  rescan after a failed first occurrence                  1
  file paths in the naming tier                           1
  digits as word characters                               1
  underscore restored as a word character                 1
  prototype-free type map -> {}                           5
  confidence decay disabled                               1
  confidence sorted ahead of relevance                   25
```

Against a binary that exits immediately with no output, 45 of the 46 fail. The one that passes is the pre-existing #1745 cross-project exclusion test, not one added here — no guard in this PR is satisfied by silence.

Every commit in the series passes on its own, so the history is genuinely bisectable:

```
1c29eb73  test: run the binary through bash      22 pass 0 fail
7dea1d8e  fix: underscore as a word separator    23 pass 0 fail
942f04ca  fix: score regular inflections         25 pass 0 fail
f838af4f  fix: malformed row containment         30 pass 0 fail
e634744d  test: decay x relevance                32 pass 0 fail
f0abb322  refactor: drop dead _tokenHits         32 pass 0 fail
8e4fac67  docs: correct the matcher rationale    32 pass 0 fail
be637e6c  fix: guard bare -d                     33 pass 0 fail
889e8cdb  fix: stem rewrites                     35 pass 0 fail
48e6c80a  fix: segment caseless scripts          37 pass 0 fail
19ca23a3  test: close mutation gaps              46 pass 0 fail
71396b2b  test: harden three weak guards         46 pass 0 fail
be478d70  build: add to curated Windows lane     46 pass 0 fail
```

CI on `be478d70`, the pushed head:

```
free-tests            success
windows-free-tests    success
quality               success
check-freshness       success
actionlint            success
build-image           success
eval slices           skipped
```

## What this deliberately does not do

**It does not narrow recall.** Substring matching still admits `pr` inside *provider*, *reports*, and *approach*, which is why one broad token can pull in half a store. Narrowing the filter would change which entries are findable at all, for every query in every skill; that is a semantics decision deserving its own issue, and this change is careful to leave it alone. What changes is only that such an entry no longer *outranks* a real match.

**The truncation notice is gated on a query, so a `--type`-only truncation stays silent.** `--type pitfall --limit 5` with no `--query` can still truncate without saying so. No shipped call site does that today, and widening the gate would risk the no-query preamble line, so I left it.

**The formatter still groups by type,** so the global rank order is visible within a type group rather than across the whole list. The limit is applied to the globally sorted list, so the exact match is no longer truncated away; but with mixed types it may not print first. Changing the output shape is a bigger call than this fix.

**Relevance sorts ahead of confidence, and decay only feeds confidence.** A row that has decayed to zero therefore still outranks a current row when it matches more of the query. That follows directly from the ordering #2762 asks for, so it is pinned as intended behaviour rather than asserted against, with a companion test showing decay still demotes the stale row as soon as the hit counts tie. Matching inflected forms makes this bite more often, because more rows now score: on a mixed store, `--query ship` can put a decayed 0/10 row that genuinely says *"Shipping the binary…"* above a 10/10 row whose only claim on the word is a `bin/ship.sh` path. Flagging it because it is a real consequence worth agreeing on, not a side effect to discover later.

**Two residual false positives in inflection matching.** Bare `-d` after a final `e` still lets `be` match `bed`, and `-es` lets `not` match `notes`. A minimum token length would remove both, but it would also remove `use`/`used` and `fix`/`fixes`, so I left them.

**Malformed rows beyond `type`.** The containment covers a `type` that names an inherited `Object` property. Row shapes `gstack-learnings-log` accepts that also blank the store — a non-array `files`, a non-string `insight` or `key` — throw inside the query filter, behave identically on `main`, and are not addressed here.

**Two pre-existing defects were found and left alone,** both verified identical on `main` and neither caused by this change:

1. On Windows, `Bun.stdin.text()` throws above exactly 65536 bytes and the same `|| exit 0` turns it into the same false-absence signature — so a store large enough to need the new truncation notice returns nothing at all there, and `--cross-project` crosses that threshold much sooner. The fix is different plumbing (spool and redirect rather than pipe), not ranking, so it wants its own issue. It shares that terminator with #2790, where a missing `bun` produces the same silent empty result.
2. Ranking has no current-project preference, so under `--cross-project` a foreign store whose rows restate the query can outrank local ones. `main` has no locality key either — this adds a second lever rather than the first — but whether locality should be structural is a product call, not a quiet one-liner here.

Diagnosis, mechanism breakdown, and both implementation traps — gate the notice on a non-empty query, and write it to stdout — are the issue author's from #2762.

## Scope

- **Changed:** `bin/gstack-learnings-search` (+177/-5), `test/gstack-learnings-search.test.ts` (+537/-2), `scripts/test-free-shards.ts` (+11, one `KNOWN_WINDOWS_SAFE` entry). No `VERSION`, no `CHANGELOG`, no generated files, no templates.
- **Verified live by:** the temp-fixture reproduction above against both the base binary and this branch; matched-key set identity across nine query shapes on a real 95-entry store; byte-identical output on the no-query and `--type` paths; forty-six tests, with every behavioural claim mutation-verified by reverting the line it pins and confirming the test dies; each commit in the series run independently green; CI green on the pushed head (`free-tests`, `windows-free-tests`, `quality`, `check-freshness`, `actionlint`); a differential on a 60-row natural-prose store with mixed sources and confidences, where matched sets are identical to `main` across 22 query shapes and every ranking change this round was checked by hand; 204,000 fuzzed haystack/token pairs through the matcher with no crash; no slowdown at 2,000 rows (faster than `main`); `bun run slop:diff` reporting no new findings in the three changed files; `bin/gstack-redact` clean on the binary, the test file and the added `KNOWN_WINDOWS_SAFE` entry (`scripts/test-free-shards.ts` carries four MEDIUM findings on lines this PR does not touch, identical on `main`). `bash -n` clean, and no `$`, backtick, backslash or double-quote character was added anywhere inside the double-quoted `bun -e` block.
- **Did NOT test:** paid evals — this is a fork PR, and a deterministic bash/JS change with no model in the path. The 95-entry recall measurement came from one real store on one machine, so treat the per-token counts as one data point rather than a distribution. `scripts/free-test-durations.json` still records the pre-existing 282 ms for this file; the added cases make it slower, and I left the shared durations seed alone rather than fold an unrelated regeneration into this diff.

  **On Windows:** the suite in this file previously could not execute at all — `gstack-learnings-search` is a shebang script and Windows has no shebang handling, so every test died at `execFileSync` with *"Executable not found in $PATH"* before reaching an assertion. They now run via the explicit `bash` invocation already used by `browse/test/learnings-injection.test.ts`, which is a no-op where the shebang would have been honoured anyway (`46 pass / 0 fail` locally on Windows 10). Running locally was not enough to reach CI: `scripts/test-free-shards.ts` excluded the file from the Windows lane by scanning its content for `path.join(ROOT, 'bin', …)`, which still matches after the fix. The file now carries a `KNOWN_WINDOWS_SAFE` entry with the same rationale as the two existing bash-spawned entries, the curated lane includes it, and `windows-free-tests` passed on `be478d70`.

## Liveness proof (required)

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
<img width="343" height="37" alt="image" src="https://github.com/user-attachments/assets/00131d08-5df3-4e77-8a45-e8e2a5191c74" />

## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A) — N/A, no new surface
- [x] Linked issue or reproduction: #2762

Fixes #2762