### PR TITLE
fix: scope routing and support report-only plan audits

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -171,10 +171,10 @@ If `PROACTIVE` is `false`: do NOT proactively invoke or suggest other gstack ski
 this session. Only run skills the user explicitly invokes. This preference persists across
 sessions via `gstack-config`.
 
-If `PROACTIVE` is `true` (default): **invoke the Skill tool** when the user's request
-matches a skill's purpose. Do NOT answer directly when a skill exists for the task.
-Use the Skill tool to invoke it. The skill has specialized workflows, checklists, and
-quality gates that produce better results than answering inline.
+If `PROACTIVE` is `true` (default), invoke a skill when its purpose matches the
+requested outcome and its workflow adds useful guidance. A matching keyword alone
+is not enough: a small edit or a question about a tool does not require a full
+review, redesign, or release workflow. Honor an explicitly chosen skill.
 
 **Routing rules — when you see these patterns, INVOKE the skill via the Skill tool:**
 - User describes a new idea, asks "is this worth building", brainstorms, pitches a concept → invoke `/office-hours`
@@ -213,11 +213,9 @@ quality gates that produce better results than answering inline.
 - User asks to tune question sensitivity, "stop asking me that" → invoke `/plan-tune`
 - User asks for code quality dashboard, "health check" → invoke `/health`
 
-**When in doubt, invoke the skill.** A false positive (invoking a skill that wasn't
-needed) is cheaper than a false negative (answering ad-hoc when a structured workflow
-exists). The skill provides multi-step workflows, checklists, and quality gates that
-always produce better results than an ad-hoc answer. If no skill matches, answer
-directly as usual.
+When the match is unclear, use the request and available context to decide whether
+the specialized workflow helps. Answer directly when it does not; do not treat
+extra skill loading as inherently safer or better.
 
 If the user opts out of suggestions, run `gstack-config set proactive false`.
 If they opt back in, run `gstack-config set proactive true`.

--- a/SKILL.md.tmpl
+++ b/SKILL.md.tmpl
@@ -39,10 +39,10 @@ If `PROACTIVE` is `false`: do NOT proactively invoke or suggest other gstack ski
 this session. Only run skills the user explicitly invokes. This preference persists across
 sessions via `gstack-config`.
 
-If `PROACTIVE` is `true` (default): **invoke the Skill tool** when the user's request
-matches a skill's purpose. Do NOT answer directly when a skill exists for the task.
-Use the Skill tool to invoke it. The skill has specialized workflows, checklists, and
-quality gates that produce better results than answering inline.
+If `PROACTIVE` is `true` (default), invoke a skill when its purpose matches the
+requested outcome and its workflow adds useful guidance. A matching keyword alone
+is not enough: a small edit or a question about a tool does not require a full
+review, redesign, or release workflow. Honor an explicitly chosen skill.
 
 **Routing rules — when you see these patterns, INVOKE the skill via the Skill tool:**
 - User describes a new idea, asks "is this worth building", brainstorms, pitches a concept → invoke `/office-hours`
@@ -81,11 +81,9 @@ quality gates that produce better results than answering inline.
 - User asks to tune question sensitivity, "stop asking me that" → invoke `/plan-tune`
 - User asks for code quality dashboard, "health check" → invoke `/health`
 
-**When in doubt, invoke the skill.** A false positive (invoking a skill that wasn't
-needed) is cheaper than a false negative (answering ad-hoc when a structured workflow
-exists). The skill provides multi-step workflows, checklists, and quality gates that
-always produce better results than an ad-hoc answer. If no skill matches, answer
-directly as usual.
+When the match is unclear, use the request and available context to decide whether
+the specialized workflow helps. Answer directly when it does not; do not treat
+extra skill loading as inherently safer or better.
 
 If the user opts out of suggestions, run `gstack-config set proactive false`.
 If they opt back in, run `gstack-config set proactive true`.

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -494,6 +494,28 @@ branch name wherever the instructions say "the base branch" or `<default>`.
 
 # Mega Plan Review Mode
 
+## Explicit report-only requests
+
+If the user explicitly requests a read-only audit, a report without questions, or
+an autonomous review of an existing plan, use this report-only path. Otherwise,
+keep the interactive workflow below, including its decision gates. This path does
+not change `/autoplan` orchestration or grant permission to implement a plan.
+
+Read the supplied plan and relevant repository evidence. Review the requested
+scope, loading `sections/review-sections.md` for the applicable review dimensions.
+In report-only mode, the later STOP/AskUserQuestion gates, mode-selection interview,
+plan-writing steps, TODO creation, and next-skill offers do not run: they belong to
+the interactive decision workflow. Treat their review criteria as analysis guidance.
+Do not edit the plan, adopt a proposed approach, add scope, or start implementation.
+
+State assumptions and uncertainty, finish all independent read-only investigation,
+and return prioritized findings with evidence, recommendations, and unresolved
+material decisions grouped at the end. Missing information only blocks conclusions
+that depend on it; explain those limits and complete the rest of the review.
+An unanswered decision is not approval. Finish after returning the report and the
+applicable completion/telemetry steps; do not fall through to the interactive flow.
+
+
 ## Philosophy
 You are not here to rubber-stamp this plan. You are here to make it extraordinary, catch every landmine before it explodes, and ensure that when this ships, it ships at the highest possible standard.
 But your posture depends on what the user needs:

--- a/plan-ceo-review/SKILL.md.tmpl
+++ b/plan-ceo-review/SKILL.md.tmpl
@@ -57,6 +57,28 @@ gbrain:
 
 # Mega Plan Review Mode
 
+## Explicit report-only requests
+
+If the user explicitly requests a read-only audit, a report without questions, or
+an autonomous review of an existing plan, use this report-only path. Otherwise,
+keep the interactive workflow below, including its decision gates. This path does
+not change `/autoplan` orchestration or grant permission to implement a plan.
+
+Read the supplied plan and relevant repository evidence. Review the requested
+scope, loading `sections/review-sections.md` for the applicable review dimensions.
+In report-only mode, the later STOP/AskUserQuestion gates, mode-selection interview,
+plan-writing steps, TODO creation, and next-skill offers do not run: they belong to
+the interactive decision workflow. Treat their review criteria as analysis guidance.
+Do not edit the plan, adopt a proposed approach, add scope, or start implementation.
+
+State assumptions and uncertainty, finish all independent read-only investigation,
+and return prioritized findings with evidence, recommendations, and unresolved
+material decisions grouped at the end. Missing information only blocks conclusions
+that depend on it; explain those limits and complete the rest of the review.
+An unanswered decision is not approval. Finish after returning the report and the
+applicable completion/telemetry steps; do not fall through to the interactive flow.
+
+
 ## Philosophy
 You are not here to rubber-stamp this plan. You are here to make it extraordinary, catch every landmine before it explodes, and ensure that when this ships, it ships at the highest possible standard.
 But your posture depends on what the user needs:


### PR DESCRIPTION
## Why (in your own words)

The proactive router treats weak keyword matches as a reason to invoke a skill, and an explicit read-only plan audit can enter the interactive decision workflow. This narrows routing to the requested outcome and gives explicit report-only audits a bounded path that returns findings and missing decisions without changing the plan or starting implementation. Interactive reviews and `/autoplan` keep their existing flow.

## Live evidence

Pending: an actual model transcript demonstrating routing and report-only behavior before and after the change. This PR is a draft because automated tests do not satisfy that evidence requirement.

The following automated validation completed locally:

```
bun run gen:skill-docs --host all
npm exec --yes --package=bun@latest -- bun test test/gen-skill-docs.test.ts test/gen-skill-docs-idempotency.test.ts test/skill-ceo-section-ordering.test.ts test/catalog-budget.test.ts test/context-budget-ratchet.test.ts
436 pass
0 fail
6535 expect() calls
Ran 436 tests across 5 files.
```

The system Bun 1.2.18 lacked the YAML support needed by the tests; the final passing run used the current Bun package. This is test evidence, not live proof of model behavior.

## Scope

- **Changed:** root routing and CEO review source templates, plus their regenerated SKILL.md files.
- **Verified live by:** local generation and the five focused automated test files listed above; no live model behavior claim.
- **Did NOT test:** model-driven before/after behavior, interactive review sessions, or the complete test suite.

## Liveness proof (required)

Pending a human-provided screenshot of `GSTACK PR` typed live into a real surface. No screenshot has been synthesized or submitted as human evidence.

## Checklist

- [ ] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (N/A)
- [ ] Linked issue or reproduction: pending live behavior reproduction
