### PR TITLE
fix(browse): block the whole IPv4 link-local range (169.254.0.0/16) in navigation URL validation

### DIFF
--- a/browse/src/url-validation.ts
+++ b/browse/src/url-validation.ts
@@ -40,6 +40,28 @@ function isBlockedIpv6(addr: string): boolean {
 }
 
 /**
+ * Check if an IPv4 address is in the link-local range 169.254.0.0/16 (RFC 3927).
+ * The range hosts instance metadata (169.254.169.254) and, more dangerously,
+ * container credential endpoints — AWS ECS/Fargate at 169.254.170.2 and EKS Pod
+ * Identity at 169.254.170.23 — that hand out IAM credentials. Blocking the whole
+ * /16 mirrors the range treatment already given to IPv6 link-local/ULA above, and
+ * the cookie-domain guard in session-persist.ts. Matches dotted-quad literals only,
+ * so real hostnames like 169.254.example.com are left to DNS resolution rather than
+ * blocked as strings.
+ */
+function isBlockedIpv4LinkLocal(host: string): boolean {
+  // Dotted-quad literal (169.254.0.0/16). Numeric forms (hex/octal/decimal) are
+  // already normalized to dotted-quad by the URL parser before this runs.
+  if (/^169\.254\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
+  // IPv4-mapped IPv6 form: the URL parser normalizes ::ffff:169.254.x.x to
+  // ::ffff:a9fe:xxxx (a9fe == 169.254). The project already carries the metadata
+  // IP's mapped form (::ffff:a9fe:a9fe) in BLOCKED_METADATA_HOSTS; this covers the
+  // rest of the /16.
+  if (/^::ffff:a9fe:[0-9a-f]{1,4}$/.test(host)) return true;
+  return false;
+}
+
+/**
  * Normalize hostname for blocklist comparison:
  * - Strip trailing dot (DNS fully-qualified notation)
  * - Strip IPv6 brackets (URL.hostname includes [] for IPv6)
@@ -88,7 +110,9 @@ async function resolvesToBlockedIp(hostname: string): Promise<boolean> {
 
     // Check IPv4 A records
     const v4Check = resolve4(hostname).then(
-      (addresses) => addresses.some(addr => BLOCKED_METADATA_HOSTS.has(addr)),
+      (addresses) => addresses.some(
+        addr => BLOCKED_METADATA_HOSTS.has(addr) || isBlockedIpv4LinkLocal(addr),
+      ),
       () => false, // ENODATA / ENOTFOUND — no A records, not a risk
     );
 
@@ -96,7 +120,9 @@ async function resolvesToBlockedIp(hostname: string): Promise<boolean> {
     const v6Check = resolve6(hostname).then(
       (addresses) => addresses.some(addr => {
         const normalized = addr.toLowerCase();
-        return BLOCKED_METADATA_HOSTS.has(normalized) || isBlockedIpv6(normalized);
+        return BLOCKED_METADATA_HOSTS.has(normalized)
+          || isBlockedIpv6(normalized)
+          || isBlockedIpv4LinkLocal(normalized);
       }),
       () => false, // ENODATA / ENOTFOUND — no AAAA records, not a risk
     );
@@ -292,9 +318,14 @@ export async function validateNavigationUrl(url: string): Promise<string> {
 
   const hostname = normalizeHostname(parsed.hostname.toLowerCase());
 
-  if (BLOCKED_METADATA_HOSTS.has(hostname) || isMetadataIp(hostname) || isBlockedIpv6(hostname)) {
+  if (
+    BLOCKED_METADATA_HOSTS.has(hostname) ||
+    isMetadataIp(hostname) ||
+    isBlockedIpv4LinkLocal(hostname) ||
+    isBlockedIpv6(hostname)
+  ) {
     throw new Error(
-      `Blocked: ${parsed.hostname} is a cloud metadata endpoint. Access is denied for security.`
+      `Blocked: ${parsed.hostname} is a cloud metadata or link-local address (IPv4 169.254.0.0/16, IPv6 fe80::/10 and fc00::/7 — includes container credential endpoints). Access is denied for security.`
     );
   }
 

--- a/browse/test/url-validation.test.ts
+++ b/browse/test/url-validation.test.ts
@@ -133,6 +133,35 @@ describe('validateNavigationUrl', () => {
     await expect(validateNavigationUrl('https://fcustomer.com/')).resolves.toBe('https://fcustomer.com/');
   });
 
+  it('blocks AWS ECS/Fargate container-credentials endpoint (169.254.170.2)', async () => {
+    await expect(validateNavigationUrl('http://169.254.170.2/v2/credentials/')).rejects.toThrow(/link-local|cloud metadata/i);
+  });
+
+  it('blocks EKS Pod Identity credentials endpoint (169.254.170.23)', async () => {
+    await expect(validateNavigationUrl('http://169.254.170.23/')).rejects.toThrow(/link-local|cloud metadata/i);
+  });
+
+  it('blocks the whole IPv4 link-local /16, not just the metadata IP (169.254.1.2)', async () => {
+    await expect(validateNavigationUrl('http://169.254.1.2/')).rejects.toThrow(/link-local|cloud metadata/i);
+  });
+
+  it('blocks a link-local IPv4 address given in hex form (0xA9FEAA02 = 169.254.170.2)', async () => {
+    await expect(validateNavigationUrl('http://0xA9FEAA02/')).rejects.toThrow(/link-local|cloud metadata/i);
+  });
+
+  it('blocks the IPv4-mapped IPv6 form of a link-local address ([::ffff:169.254.170.2])', async () => {
+    await expect(validateNavigationUrl('http://[::ffff:169.254.170.2]/')).rejects.toThrow(/link-local|cloud metadata/i);
+  });
+
+  it('does not block real hostnames that merely start with 169.254. (e.g. 169.254.example.com)', async () => {
+    await expect(validateNavigationUrl('https://169.254.example.com/')).resolves.toBe('https://169.254.example.com/');
+  });
+
+  it('still allows private-network dev servers (192.168.x, 10.x)', async () => {
+    await expect(validateNavigationUrl('http://192.168.1.50:3000/app')).resolves.toBe('http://192.168.1.50:3000/app');
+    await expect(validateNavigationUrl('http://10.0.0.5/health')).resolves.toBe('http://10.0.0.5/health');
+  });
+
   it('throws on malformed URLs', async () => {
     await expect(validateNavigationUrl('not-a-url')).rejects.toThrow(/Invalid URL/i);
   });


### PR DESCRIPTION
## What

`validateNavigationUrl` blocks the cloud metadata IP `169.254.169.254` by exact match but allows the rest of the IPv4 link-local range `169.254.0.0/16`. This blocks the whole /16, matching the range treatment the same file already gives IPv6 link-local (`fe80::/10`) and ULA (`fc00::/7`), and the cookie-domain guard in `session-persist.ts`.

## Why

The navigation gate is the control that stops a prompt-injected page from steering the daemon's Chrome to an internal address (threat note in `browse/test/url-validation.test.ts` and `browse/src/write-commands.ts`). Today it covers IPv4 unevenly:

- IPv6: whole ranges blocked (`BLOCKED_IPV6_PREFIXES` in `url-validation.ts`).
- IPv4: only the single IP `169.254.169.254` (`BLOCKED_METADATA_HOSTS`).
- `session-persist.ts` already blocks the whole range for cookie domains: `if (/^169\.254\./.test(d)) return true; // link-local incl. cloud metadata`, with a test asserting "whole link-local block, not just metadata".

So the primary navigation control is weaker than a guard next to it, and out of line with the project's own policy. The gap leaves other link-local endpoints reachable, notably the container credential services that hand out IAM credentials:

- `169.254.170.2` (AWS ECS / Fargate task credentials, `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`)
- `169.254.170.23` (EKS Pod Identity)

Impact is defense-in-depth: it matters when the browse daemon runs in a cloud or container environment that exposes a link-local credentials service (CI on ECS/Fargate, for example). The unconditional part is the inconsistency itself.

## Fix

`isBlockedIpv4LinkLocal()` matches `169.254.0.0/16` in dotted-quad form and in the IPv4-mapped IPv6 form the URL parser normalizes to (`::ffff:a9fe:xxxx`, where `a9fe` == `169.254`). It is wired into the three places the IPv6 range check already runs: the direct navigation gate, and both the A and AAAA branches of the DNS-rebinding check. Numeric IPv4 forms (hex, octal, decimal) are covered because the URL parser normalizes them to dotted-quad before the check.

Only dotted-quad literals match, so real hostnames like `169.254.example.com` are left to DNS resolution rather than blocked as strings. RFC1918 private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) and loopback stay allowed, so the local-QA use case is unchanged.

## Tests

`browse/test/url-validation.test.ts`: the ECS and EKS credential endpoints, a generic in-range address, hex and IPv4-mapped forms, plus two negatives (a `169.254.`-prefixed hostname is not string-blocked, and private dev servers still pass). Full file: 59 pass, 0 fail.
