### PR TITLE
fix(retro): count pytest/minitest test_*.py in the test-file census

### DIFF
--- a/bin/gstack-retro-metrics
+++ b/bin/gstack-retro-metrics
@@ -297,10 +297,14 @@ echo "PRS_REFERENCED: $(printf '%s' "$_PRS" | wc -w | tr -d ' ')"
 [ -n "$_PRS" ] && echo "PR_REFS: $_PRS" || true
 
 # ── Test health (repo-wide + window) ─────────────────────────────────────────
-# Deliberately suffix-only (narrower than is_test's dir-based patterns): the
-# repo-wide census counts conventional test FILES; is_test additionally counts
-# dir-homed helpers toward test-insertion ratios.
-_TF_TOTAL=$(git ls-files 2>/dev/null | grep -cE '(\.test\.|\.spec\.|_test\.|_spec\.)' || true)
+# Deliberately filename-convention-only (narrower than is_test's dir-based
+# patterns): the repo-wide census counts conventional test FILES; is_test
+# additionally counts dir-homed helpers toward test-insertion ratios.
+# Suffix forms cover JS/TS (.test./.spec.), Go (_test.), Ruby (_spec.).
+# The trailing prefix form covers pytest/unittest and minitest, whose default
+# discovery is `test_*.py` / `test_*.rb` -- a filename convention, not a
+# directory one, so it does not readmit dir-homed helpers like tests/utils.py.
+_TF_TOTAL=$(git ls-files 2>/dev/null | grep -cE '(\.test\.|\.spec\.|_test\.|_spec\.|(^|/)test_[^/]*\.(py|rb)$)' || true)
 case "$_TF_TOTAL" in ''|*[!0-9]*) _TF_TOTAL=0 ;; esac
 echo "TEST_FILES_TOTAL: $_TF_TOTAL"
 _REG=$(git log "$REF" "$_S" ${_U:+"$_U"} --oneline --grep="test(qa):" --grep="test(design):" --grep="test: coverage" 2>/dev/null || true)

--- a/test/gstack-retro-metrics.test.ts
+++ b/test/gstack-retro-metrics.test.ts
@@ -306,6 +306,37 @@ describe('gstack-retro-metrics edges', () => {
     }
   });
 
+  // Regression: the repo-wide census was suffix-only, so pytest/unittest's
+  // default `test_*.py` discovery name counted as zero. A Python repo whose
+  // whole suite is `tests/test_*.py` reported TEST_FILES_TOTAL: 0 while its
+  // TEST_RATIO was healthy -- the two lines disagreed and the low one was
+  // silently wrong. Dir-homed helpers (tests/utils.py) must still NOT count.
+  test('counts pytest-style test_*.py and minitest test_*.rb, not dir-homed helpers', () => {
+    const pyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-rm-py-'));
+    try {
+      git(pyDir, ['init', '-b', 'main']);
+      git(pyDir, ['config', 'user.email', 'py@example.com']);
+      git(pyDir, ['config', 'user.name', 'Py']);
+      fs.mkdirSync(path.join(pyDir, 'tests'), { recursive: true });
+      fs.mkdirSync(path.join(pyDir, 'app'), { recursive: true });
+      write(pyDir, 'tests/test_login.py', 'def test_login():\n    assert True\n');
+      write(pyDir, 'tests/test_logout.py', 'def test_logout():\n    assert True\n');
+      write(pyDir, 'tests/helper_test.rb', "require 'minitest'\n");
+      write(pyDir, 'tests/test_signup.rb', "require 'minitest'\n");
+      // Must NOT count: a dir-homed helper, and a source file merely prefixed
+      // with "test" but not "test_".
+      write(pyDir, 'tests/utils.py', 'HELPER = 1\n');
+      write(pyDir, 'app/testing.py', 'MODE = 1\n');
+      commit(pyDir, 'test: add suite', '2026-03-10T09:00:00');
+      const out = runMetrics(['--base', 'main', '--since', '2026-03-09T00:00:00'], pyDir);
+      // test_login.py, test_logout.py, test_signup.rb (prefix) + helper_test.rb (suffix) = 4
+      expect(out).toMatch(/^TEST_FILES_TOTAL: 4$/m);
+      expect(out).toMatch(/^RETRO_METRICS_END: ok$/m);
+    } finally {
+      fs.rmSync(pyDir, { recursive: true, force: true });
+    }
+  });
+
   test('local reads only: no network git ops or curl anywhere in the script', () => {
     const script = fs.readFileSync(SCRIPT, 'utf-8');
     expect(script).not.toMatch(/(^|[;|&`($!]|\s)git(\s+-C\s+\S+)?\s+(push|pull|fetch|clone|ls-remote)\b/m);


### PR DESCRIPTION
## The problem

`bin/gstack-retro-metrics` counts the repo-wide test census with suffix forms only:

```bash
_TF_TOTAL=$(git ls-files | grep -cE '(\.test\.|\.spec\.|_test\.|_spec\.)')
```

That covers JS/TS (`.test.` / `.spec.`), Go (`_test.`) and RSpec (`_spec.`), but misses pytest's **default** discovery name. pytest ships with `python_files = test_*.py *_test.py`, and the `test_*.py` prefix form is the dominant one in the wild — unittest and minitest use the same shape.

So a Python repo whose entire suite is `tests/test_*.py` gets a near-zero `TEST_FILES_TOTAL` while `TEST_RATIO` on the *same run* is healthy. Two lines of one retro disagree, and the wrong one is the low one.

That is not cosmetic: `retro/sections/report-format.md` feeds this count into a judgment —

> If test ratio < 20%: flag as growth area — "100% test coverage is the goal."

— and the Test Health section reports `Total test files: N` straight to the user.

**Measured** on a Python monorepo (FastAPI + React, ~20k tests):

| | before | after |
|---|---|---|
| `TEST_FILES_TOTAL` | **6** | **1,389** |
| `TEST_RATIO` (same run) | 38% | 38% |

The `6` were the handful of `*_test.py` / `.test.js` files that happened to match. Everything under `backend/tests/test_*.py` was invisible.

## The fix

One clause added to the census pattern:

```diff
-_TF_TOTAL=$(git ls-files | grep -cE '(\.test\.|\.spec\.|_test\.|_spec\.)')
+_TF_TOTAL=$(git ls-files | grep -cE '(\.test\.|\.spec\.|_test\.|_spec\.|(^|/)test_[^/]*\.(py|rb)$)')
```

The existing comment said "Deliberately suffix-only (narrower than `is_test`'s dir-based patterns)". I kept that intent and updated the wording, because the reason for the narrowness is **not counting dir-homed helpers** — and a filename prefix does not readmit them:

- `tests/test_login.py` counts (a test file by convention)
- `tests/utils.py` still does **not** count (dir-homed helper — `is_test` handles those for the insertion ratio)
- `app/testing.py` still does **not** count (`test` prefix, but not `test_`)

Verified against the same monorepo: of the 1,389 matches, 1,373 are under a `tests/` directory and the remaining 16 are real test files living elsewhere (e.g. `frontend/src/lib/*.test.js`). No helper files were readmitted.

## Test

New hermetic case in `test/gstack-retro-metrics.test.ts`, in the existing `edges` describe. It builds a throwaway repo with pytest- and minitest-named files plus the two files that must stay out, and pins `TEST_FILES_TOTAL: 4`.

The existing `TEST_FILES_TOTAL: 1` assertion and its fixture are untouched.

```
bun test test/gstack-retro-metrics.test.ts
 12 pass
 0 fail
```

Also verified on a fresh clone of the fork with **no `bun install`** — the case only uses `bun:test` plus node builtins.

**Mutation-checked**: removing the new clause from the pattern fails the new case (11 pass / 1 fail) and nothing else. Restoring it returns 12/12. The test bites the line it is meant to protect.

## Not in scope

- `is_test` (the dir-based insertion-ratio matcher) is unchanged.
- `REGRESSION_TEST_COMMITS` is unchanged — it greps `test(qa):` / `test(design):` / `test: coverage` commit subjects, and reporting `0` for a repo that doesn't use those prefixes is correct behaviour, not a bug.
- No `VERSION` bump — leaving release mechanics to the maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)