### PR TITLE
fix: engines.bun floor must match the CI pin, and a test that says so

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "socks": "^2.8.9"
   },
   "engines": {
-    "bun": ">=1.0.0"
+    "bun": ">=1.3.13"
   },
   "keywords": [
     "browser",

--- a/test/bun-version-drift.test.ts
+++ b/test/bun-version-drift.test.ts
@@ -73,4 +73,21 @@ describe('bun version pins', () => {
     expect(versions, `bun version drift across CI surfaces:\n${detail}`).toHaveLength(1);
     expect(versions[0]).toMatch(/^\d+\.\d+\.\d+$/);
   });
+
+  // engines.bun is a RANGE, so it cannot join the all-equal assertion above —
+  // but a floor below the CI pin lets a contributor run an older bun whose
+  // failures read as repo bugs. Observed: on bun 1.2.20 the suite's
+  // `Bun.YAML.parse` calls (Bun.YAML landed in 1.2.21) threw
+  // "undefined is not an object", and the resulting red was diagnosed twice as
+  // a repo defect before anyone compared toolchains.
+  test('package.json engines.bun floor matches the CI pin', () => {
+    const ciVersion = [...new Set(collectPins().map((p) => p.version))][0];
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
+    const floor = String(pkg.engines?.bun ?? '<missing engines.bun>');
+    expect(
+      floor,
+      `engines.bun must state the CI bun as its floor (CI pins ${ciVersion})`,
+    ).toBe(`>=${ciVersion}`);
+  });
 });


### PR DESCRIPTION
`engines.bun` is `>=1.0.0` while every CI surface pins `1.3.13` — a nine-minor
gap that nothing enforces. `bun-version-drift.test.ts` already keeps the CI
surfaces in lockstep, but it says nothing about the version a contributor
actually runs, so the gap is invisible until the suite goes red for reasons
that look like repo bugs.

That is not hypothetical. On bun 1.2.20 (below the floor, but allowed by
`>=1.0.0`):

- `gen-skill-docs > every generated SKILL.md frontmatter parses as strict YAML`
  and its Codex twin threw `undefined is not an object (evaluating
  'Bun.YAML.parse')`. `Bun.YAML` landed in bun 1.2.21, one patch above the
  installed version.
- `browse/test/commands.test.ts`, `parity-suite`, and `openclaw-native-skills`
  failed 54-56 tests, and the count moved between runs on an unchanged tree —
  which reads as flake.

Both were diagnosed as repo defects, twice, before anyone compared the local
bun to the CI pin. A single `bun upgrade` cleared all of them.

Changes:

- `package.json`: `engines.bun` `>=1.0.0` → `>=1.3.13`, matching the pin.
- `test/bun-version-drift.test.ts`: new assertion that the `engines.bun` floor
  equals the CI pin. It cannot join the existing all-equal check because
  `engines` is a range, so it derives the pin from `collectPins()` and compares
  against `>=${pin}`. This keeps the file's stated contract — "Bumping Bun:
  change every surface in one commit; this test names each one" — true of
  `engines` as well, so the next bump cannot silently leave the floor behind.

Verified both arms: the new test fails with
`engines.bun must state the CI bun as its floor (CI pins 1.3.13)` when the
floor is reverted to `>=1.0.0`, and passes at `>=1.3.13`.
