### PR TITLE
feat(plan-ceo-review): every approach states whether its phases are independently mergeable

### DIFF
--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -904,6 +904,7 @@ APPROACH A: [Name]
   Pros:    [2-3 bullets]
   Cons:    [2-3 bullets]
   Reuses:  [existing code/patterns leveraged]
+  Phasing: [ships as independently mergeable phases? if not, why]
 
 APPROACH B: [Name]
   ...
@@ -920,6 +921,7 @@ Rules:
 - One approach must be the "ideal architecture" (best long-term trajectory).
 - **These two approaches have equal weight.** Don't default to "minimal viable" just because it's smaller. Recommend whichever best serves the user's goal. If the right answer is a rewrite, say so.
 - If only one approach exists, explain concretely why alternatives were eliminated.
+- Each phase of the chosen approach must be mergeable on its own. A plan where nothing works until every phase lands is a red flag — say so.
 - Do NOT proceed to mode selection (0F) without user approval of the chosen approach.
 
 Present these approach options via AskUserQuestion using the preamble's AskUserQuestion Format section: include RECOMMENDATION and `Completeness: N/10` on every option. These approaches differ in coverage (minimal viable vs ideal architecture), so completeness scoring applies directly.

--- a/plan-ceo-review/SKILL.md.tmpl
+++ b/plan-ceo-review/SKILL.md.tmpl
@@ -262,6 +262,7 @@ APPROACH A: [Name]
   Pros:    [2-3 bullets]
   Cons:    [2-3 bullets]
   Reuses:  [existing code/patterns leveraged]
+  Phasing: [ships as independently mergeable phases? if not, why]
 
 APPROACH B: [Name]
   ...
@@ -278,6 +279,7 @@ Rules:
 - One approach must be the "ideal architecture" (best long-term trajectory).
 - **These two approaches have equal weight.** Don't default to "minimal viable" just because it's smaller. Recommend whichever best serves the user's goal. If the right answer is a rewrite, say so.
 - If only one approach exists, explain concretely why alternatives were eliminated.
+- Each phase of the chosen approach must be mergeable on its own. A plan where nothing works until every phase lands is a red flag — say so.
 - Do NOT proceed to mode selection (0F) without user approval of the chosen approach.
 
 Present these approach options via AskUserQuestion using the preamble's AskUserQuestion Format section: include RECOMMENDATION and `Completeness: N/10` on every option. These approaches differ in coverage (minimal viable vs ideal architecture), so completeness scoring applies directly.


### PR DESCRIPTION
## Why (in your own words)

0C-bis makes the CEO review produce 2-3 approaches with effort, risk, pros and cons. It never asks whether the chosen approach can land in pieces. That question is cheap at approach-selection time and expensive later: a plan where nothing is observable until the last phase merges cannot be validated incrementally, and every defect surfaces at once at the end.

Our own closest incident (private KB): a fan-out where six agents built pinned-contract lanes in parallel, each lane green on its own, and the post-integration `/code-review` found 10 correctness-grade defects, the three worst being cross-lane integration bugs that no single lane could see. The lesson we took from it is the same one that applies to phased plans: if the plan only works once everything has landed, say so before choosing it.

This adds one line to the APPROACH template (`Phasing: ships as independently mergeable phases? if not, why`) and one rule: each phase of the chosen approach must be mergeable on its own, and a plan where nothing works until every phase lands is a red flag the review calls out.
## Live evidence

Setup: a fixture repo with a `PLAN.md` for migrating an invoices module to event sourcing in four phases (schema, dead code behind a hard-coded-off flag, behaviour-neutral refactor, then flip flag + backfill + `DROP TABLE` in one phase). An earlier draft of the plan named the problem itself ("phases 1-3 land with zero user-visible change and cannot be validated until phase 4"); two commits labelled `docs: tidy` removed those lines, so the plan reads clean. The skill directory was copied into `.claude/skills/plan-ceo-review/` (upstream `main` vs this branch), and each copy was run with `GSTACK_SESSION_KIND=spawned claude -p "/plan-ceo-review PLAN.md" --setting-sources project`, same prompt, same fixture, same model.

**Being honest about what changed:** both versions found the defect and led with it. Unpatched `main` already wrote *"Phases 1-3 produce zero validation signal … All correctness risk for a 40-call-site ledger rewrite lands in one instant"* and recommended re-sequencing into 7 phases where *"each phase ships alone and reverts alone."* So this PR does not make the review catch something it missed. What it changes is where the phasing question is answered.

**Before (upstream `main`):** the transcript contains no 0C-bis approach comparison at all. The approaches are only visible as a one-line auto-decision at the end (*"auto-selected Approach B (expand/dual-write/shadow/contract) as recommended"*). Phasing is discussed in the findings, after the approach has already been chosen. Occurrences of `Phasing:` in the transcript: 0.

**After (this branch):** the 0C-bis block is rendered with the new line on every approach, so mergeability is on the table at the moment the approach is picked:

```
APPROACH A: Append-only history table (minimal viable)
  ...
  Phasing: Single PR. Trivially revertible.

APPROACH B: Event-sourced repository with a real coexistence period (ideal architecture)
  ...
  Pros:    - Every phase is independently mergeable AND independently revertible
  ...
  Phasing: 7 phases, each shippable alone. This is the whole point.

APPROACH C: The plan exactly as written
  ...
  Phasing: Phases 1-3 mergeable alone. Phase 4 is not — it bundles 4 risk classes.
```

Occurrences of `Phasing:` in the transcript: 3 (one per approach). The final verdict, mode and recommendation were the same in both runs (NOT CLEARED, HOLD SCOPE, Approach B, 7-phase re-sequence).

Full `claude -p` transcripts for both runs are attached as a comment on this PR.

## Scope

- **Changed:** `plan-ceo-review/SKILL.md.tmpl` (one template line in 0C-bis, one rule), regenerated `plan-ceo-review/SKILL.md`.
- **Verified live by:** two `claude -p` runs (upstream `main` vs this branch) of the skill on the same fixture plan; see Live evidence. Tier 1 `bun run test` on this branch.
- **Did NOT test:** Tier 2 E2E (`bun run test:e2e`).

**Tier 1 note.** `bun run test` on this branch on my machine (macOS, no Aside) fails only in files unrelated to `plan-ceo-review/` (`test/codex-hardening.test.ts` watchdog timing, `test/aside-render.test.ts` browse binary, occasionally `test/gstack-slug-parity.test.ts` under load); the same files fail on upstream `main` (05303928) on the same machine, and the load-related ones pass when re-run in isolation (68 pass, 0 fail across the five files that had failed). `test/parity-suite.test.ts` and the skill budget tests pass. A per-branch comparison against `main` is in a comment below.

## Liveness proof (required)

<!-- screenshot to be attached by the PR author -->

## Checklist

- [ ] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A) — N/A
- [ ] Linked issue or reproduction: see Live evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYQXGocbEnQvhMgpPFhVZu
