### PR TITLE
fix(review): extend the suppressions list with common LLM false positives

### DIFF
--- a/review/checklist.md
+++ b/review/checklist.md
@@ -171,6 +171,8 @@ the fix, it's ASK.
 
 ## Suppressions — DO NOT flag these
 
+Zero findings is a valid, expected outcome. Before flagging anything, ask: would a senior engineer on this team actually change it in review? If not, skip it. Do not withhold approval to look rigorous — if the diff is clean, say so.
+
 - "X is redundant with Y" when the redundancy is harmless and aids readability (e.g., `present?` redundant with `length > 20`)
 - "Add a comment explaining why this threshold/constant was chosen" — thresholds change during tuning, comments rot
 - "This assertion could be tighter" when the assertion already covers the behavior
@@ -180,4 +182,12 @@ the fix, it's ASK.
 - Eval threshold changes (max_actionable, min scores) — these are tuned empirically and change constantly
 - Harmless no-ops (e.g., `.reject` on an element that's never in the array)
 - ANYTHING already addressed in the diff you're reviewing — read the FULL diff before commenting
+- "Consider adding error handling" on a call whose error path is owned by the caller or framework (error middleware, error boundaries, a top-level try/catch, an upstream `.catch`)
+- "Missing input validation" on an internal function whose callers already validate — trace at least one caller before flagging
+- "Function too long" for an exhaustive `switch`, a config object, a test table, or generated code — length is not complexity
+- "Possible null dereference" when the preceding line narrows the type or an `if` guard is in scope — trace the type flow instead of pattern-matching on `?.`
+- "N+1 query" on a fixed-cardinality loop or a path that is already batched
+- "Missing await" on an intentionally detached fire-and-forget call (logging, metrics, queue push) — look for a `void` prefix or a comment first
+- "Hardcoded value" in test fixtures, example code, or docs — tests are supposed to hardcode their expectations
+- `Math.random()` in a non-cryptographic context (jitter, sampling, animation) — the Crypto & Entropy specialist owns the real cases
 - A gap covered by a `gstack-shortcut(dec-*)` marker naming a ceiling and upgrade trigger — that is acknowledged debt with a ledger entry, not a Completeness Gaps finding. **Verify before honoring:** resolve the id with `~/.claude/skills/gstack/bin/gstack-decision-search --query "<dec-id>"` — a marker whose decision id has no ledger entry is UNVERIFIED (any diff author can type a marker); report the gap normally and flag the orphan marker itself


### PR DESCRIPTION
## Why (in your own words)

The suppressions list in `review/checklist.md` ("DO NOT flag these") is good but short. This adds eight more entries in the same voice, chosen by the same criterion as the existing ones (would a senior engineer on this team actually change it in review?): error handling the framework owns, validation on an internal function whose callers validate, long exhaustive switches, null deref after a type guard, "N+1" on a fixed-cardinality loop, deliberate fire-and-forget, hardcoded values in test fixtures, `Math.random()` for jitter. These are the non-findings we dismiss by hand most often when running `/review` on our own repos. Plus one sentence at the top of the section: zero findings is a valid, expected outcome; do not withhold approval to look rigorous.

The behaviour this targets is concrete and shows up live (below): on a clean 19-line diff, the current skill promoted a pre-existing design contract to a CRITICAL 10/10 finding and rewrote the PR's public API, test and description to "fix" it. With this change, same model, same diff, same prompt, it reports the same observation as "one thing to know, not a finding" and touches nothing.

What I tried and dropped: a "green is not verified" block in `SKILL.md.tmpl` (typecheck is a separate gate, `skipped` is never PASS, exit codes through pipes, numbers need `pwd`/branch). On a fixture with a piped typecheck, a `test.skip` and a real `TS2322`, the unpatched skill already measured the pipe (`raw exit 2 vs piped 0`), re-enabled the skip and corrected the PR description, so the block showed no delta in findings. It also pushed the always-loaded skeleton to 62539 bytes, over the parity gate's 61500. This PR touches only `checklist.md`; the skeleton is unchanged at 61314 bytes.

## Live evidence

A fixture repo, a tiny `TokenBucket` package with `bun test` and a `bun run typecheck` CI step. The skill directory (`review/`) was copied into `.claude/skills/review/` from upstream `main` ("before") and from this branch ("after"), and each copy was run with `GSTACK_SESSION_KIND=spawned claude -p "/review this branch (...) against main. The PR description is in PR.md ..." --setting-sources project`, same prompt, same fixture, same model. One disclosure: the skill reads its checklist from `~/.claude/skills/gstack/review/checklist.md`, so in both copies that one path was rewritten to point at the copied checklist; nothing else differs from upstream `main` / this branch respectively.

### A clean branch

Branch `feature/peek`, 19 lines: a `peek(): number` accessor that returns the current token count without consuming, one test, `PR.md` with an honest green claim (`typecheck` exit 0, 4 pass, 0 skip). Nothing wrong with the diff for a reviewer who accepts the module's existing contract (refill is caller-driven; `take()` reads the same lazily-refilled counter).

**Before (upstream `main`):** *"3 issues (1 critical, 2 informational) — all fixed."* It rated the lazily-refilled count a **CRITICAL 10/10** (*"`peek()` returned a stale count, defeating the PR's own purpose"*), then, without being asked, changed the public signature to `peek(nowMs = Date.now())`, added a private `tokensAt()` helper shared with `refill()`, rewrote the test, and edited `PR.md`. It closed with `STATUS: DONE_WITH_CONCERNS` and three pre-existing `main` bugs (`take(NaN)`, `take(-1000)`, backwards clock).

**After (this branch):** *"Pre-Landing Review: No issues found."* It made the same observation and classified it differently:

> One thing to know, not a finding: `peek()` reads the lazily-refilled counter, so an idle bucket that has actually recovered still reports its depleted count until someone calls `refill(nowMs)`. That's the pre-existing contract — `take()` at `src/rate-limit.ts:19` behaves identically ... Nothing to change here. ... Both adversarial passes landed on this same observation and both classified it as no-fix.

Zero files touched, `STATUS: DONE`. Same model, same diff, same prompt. The difference is the skill telling it that a clean diff is allowed to come back clean, and that pre-existing contracts are not findings against the PR.

Caveat: the auto-applied fix in the "before" run happened because `GSTACK_SESSION_KIND=spawned` makes the skill take the recommended option instead of asking; interactively it would have been an ASK. The finding itself (critical, 10/10) is the point, not the auto-apply.

**Repeated, because one run each proves nothing.** Five runs in total on this fixture:

| run | skill | result |
|---|---|---|
| 1 | upstream `main` | 3 issues, 1 CRITICAL 10/10; changed `peek()` signature, test and `PR.md`; `DONE_WITH_CONCERNS` |
| 2 | upstream `main` | "FIXED (1 critical)", confidence 10/10, same signature change; `DONE_WITH_CONCERNS` |
| 3 | this change, draft form* | "No issues found"; 0 files touched; `DONE` |
| 4 | this change, draft form* | 1 informational at confidence 5/10 ("verify this is actually an issue"), *"Skip — no code changed"* |
| 5 | this change, as committed | "No issues found"; 0 files touched; `DONE` |

\* Runs 3 and 4 used an earlier draft of this branch that also carried the "zero findings" sentence in `SKILL.md.tmpl` and a "green is not verified" block there (dropped, see Why). Run 5 is the exact content of this PR: the sentence and the eight entries in `checklist.md`, `SKILL.md` identical to upstream. The quotes above ("One thing to know, not a finding...") are from run 3; run 5 says the same thing in its own words: *"correct-by-design here: `take()` reads `this.tokens` identically ... neither charged against this PR"*.

Same observation every time. Upstream promoted it to a critical finding and rewrote the PR 2 out of 2 times; with the checklist change it stayed a note 3 out of 3 times.

Full `claude -p` transcripts for all runs are attached as a comment on this PR.

## Scope

- **Changed:** `review/checklist.md` only: one sentence at the top of "Suppressions — DO NOT flag these" and eight entries appended to it. `bun run gen:skill-docs` produces no diff.
- **Verified live by:** `claude -p` runs of upstream `main` vs this branch on a clean 19-line fixture branch; see Live evidence. Tier 1 `bun run test` on this branch (see note below).
- **Did NOT test:** Tier 2 E2E (`bun run test:e2e`).

**Tier 1 note.** `bun run test` on this branch on my machine (macOS, no Aside): 2 files fail, `test/codex-hardening.test.ts` (bash-native watchdog timing) and `test/aside-render.test.ts` (needs a browse binary). Both fail identically on upstream `main` (05303928) on the same machine, and neither touches `review/`. `test/parity-suite.test.ts` and the skill budget tests pass (this PR keeps `review/SKILL.md` byte-identical to upstream). A per-branch comparison against `main` is in a comment below.

## Liveness proof (required)

<!-- screenshot to be attached by the PR author -->

## Checklist

- [ ] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (`checklist.md` is hand-written; no generated file changes)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A) — N/A
- [ ] Linked issue or reproduction: see Live evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYQXGocbEnQvhMgpPFhVZu
