### PR TITLE
Optional Memorable workflow memory (default off, Claude Code only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+- Added `bin/gstack-memorable enable|status|disable`, a default-off, Claude
+  Code-only bridge to the external `memorable` CLI. When enabled, its hooks
+  capture all Claude Code prompts, not only gstack commands, and inject relevant
+  workflow guidance. Hook failures fail open so Claude continues normally. This
+  is procedural guidance, not deterministic replay, and is unrelated to Aside.
+
 ## [1.81.0.0] - 2026-09-06
 
 **Aside is the browser gstack drives first. Every browsing skill, the PDF and diagram renderer, and web research go through it.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## [Unreleased]
-
-- Added `bin/gstack-memorable enable|status|disable`, a default-off, Claude
-  Code-only bridge to the external `memorable` CLI. When enabled, its hooks
-  capture all Claude Code prompts, not only gstack commands, and inject relevant
-  workflow guidance. Hook failures fail open so Claude continues normally. This
-  is procedural guidance, not deterministic replay, and is unrelated to Aside.
-
 ## [1.81.0.0] - 2026-09-06
 
 **Aside is the browser gstack drives first. Every browsing skill, the PDF and diagram renderer, and web research go through it.**

--- a/README.md
+++ b/README.md
@@ -292,6 +292,25 @@ prune-stale --repoint` removes dead gstack hook entries, re-points stale ones
 at the stable install, and collapses duplicates, printing one line (and
 writing a backup beside the file) only when it changed something.
 
+### Optional Memorable workflow memory (Claude Code only)
+
+gstack can connect Claude Code to the external `memorable` CLI for workflow
+capture and injection. It is off by default, and gstack does not install or
+bundle Memorable. When enabled, its hooks capture all Claude Code prompts, not
+only gstack commands, and inject relevant workflow guidance into later prompts.
+Review Memorable's storage and privacy settings before enabling it; Memorable,
+not gstack, owns the captured data and any network access.
+
+```bash
+bin/gstack-memorable enable
+bin/gstack-memorable status
+bin/gstack-memorable disable
+```
+
+The hooks fail open: if Memorable is missing or errors, Claude continues
+normally. This is recalled procedural guidance, not deterministic replay, and
+it is unrelated to Aside or browser automation.
+
 ### Continuous checkpoint mode (opt-in, local by default)
 
 Set `gstack-config set checkpoint_mode continuous` and skills auto-commit your work as you go with a `WIP:` prefix plus a structured `[gstack-context]` body (decisions, remaining work, failed approaches). Survives crashes and context switches. `/context-restore` reads those commits to reconstruct session state. `/ship` filter-squashes WIP commits before the PR (preserving non-WIP commits) so bisect stays clean. Push is opt-in via `checkpoint_push=true` — default is local-only so you don't trigger CI on every WIP commit.

--- a/README.md
+++ b/README.md
@@ -311,6 +311,27 @@ The hooks fail open: if Memorable is missing or errors, Claude continues
 normally. This is recalled procedural guidance, not deterministic replay, and
 it is unrelated to Aside or browser automation.
 
+**Exactly what leaves the machine, per command this bridge can trigger.** The
+hook makes no network call of its own; every row below is the third-party CLI
+acting under its own consent, which is why there is no gstack egress receipt to
+read. `gstack-egress` will not show these.
+
+| Command | What leaves the machine |
+|---|---|
+| `command -v memorable`, `gstack-memorable status` | Nothing. Both are local reads. |
+| `gstack-memorable enable` | Nothing from gstack. It runs `memorable enable`, which records consent on your machine. |
+| the hook, on every prompt | The prompt text you typed, to Memorable's embed endpoint, when the local lexical match misses. Nothing else at prompt time. |
+| capture, at session end | Memorable's own hook, not this bridge and not gstack's consent. It sends the finished session's tool calls and their arguments to Memorable's extraction API under `memorable enable`. Turn it off with `memorable disable`. |
+
+**What gstack pin-tests, and what is Memorable's own claim.** gstack tests the
+gating and the wiring: that `enable` refuses when Memorable already registered
+the hook itself, that `disable` removes only gstack's entry and never a foreign
+one, that the hook exits zero and silent when the binary is missing, and that
+`status` writes nothing. Everything past the process boundary is Memorable's
+claim and not ours: what it stores, where it stores it, what it sends, and what
+`memorable disable` and `memorable forget` actually erase. The CLI is a
+closed-source npm package from a third party.
+
 ### Continuous checkpoint mode (opt-in, local by default)
 
 Set `gstack-config set checkpoint_mode continuous` and skills auto-commit your work as you go with a `WIP:` prefix plus a structured `[gstack-context]` body (decisions, remaining work, failed approaches). Survives crashes and context switches. `/context-restore` reads those commits to reconstruct session state. `/ship` filter-squashes WIP commits before the PR (preserving non-WIP commits) so bisect stays clean. Push is opt-in via `checkpoint_push=true` — default is local-only so you don't trigger CI on every WIP commit.

--- a/README.md
+++ b/README.md
@@ -332,6 +332,9 @@ claim and not ours: what it stores, where it stores it, what it sends, and what
 `memorable disable` and `memorable forget` actually erase. The CLI is a
 closed-source npm package from a third party.
 
+Full guide, including what to do when Memorable already registered the hook
+itself: [docs/memorable-workflow-memory.md](docs/memorable-workflow-memory.md).
+
 ### Continuous checkpoint mode (opt-in, local by default)
 
 Set `gstack-config set checkpoint_mode continuous` and skills auto-commit your work as you go with a `WIP:` prefix plus a structured `[gstack-context]` body (decisions, remaining work, failed approaches). Survives crashes and context switches. `/context-restore` reads those commits to reconstruct session state. `/ship` filter-squashes WIP commits before the PR (preserving non-WIP commits) so bisect stays clean. Push is opt-in via `checkpoint_push=true` — default is local-only so you don't trigger CI on every WIP commit.

--- a/bin/gstack-memorable
+++ b/bin/gstack-memorable
@@ -5,6 +5,7 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SETTINGS_HOOK="$SCRIPT_DIR/gstack-settings-hook"
+SETTINGS_FILE="${GSTACK_SETTINGS_FILE:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json}"
 MEMORABLE_HOOK="$ROOT_DIR/hosts/claude/hooks/memorable-user-prompt-hook"
 HOOK_SOURCE="gstack-memorable"
 
@@ -41,6 +42,36 @@ require_memorable() {
   [ -n "$MEMORABLE_CLI" ] || return 1
 }
 
+# Memorable's own installer registers the SAME UserPromptSubmit hook, under
+# its own name and outside gstack's table. `memorable start`, `memorable setup`
+# and `memorable install-hooks` all do it, and that is the documented way to
+# install the CLI — so on most machines it is already there before gstack is
+# asked. Registering ours beside it runs the same command twice on every
+# prompt: context injected twice, and the session captured twice against the
+# user's own extraction allowance.
+#
+# Matched on the command, not on a tag, for the same reason the hook table in
+# gstack-settings-hook matches on command: Claude Code rewrites settings and
+# private tags do not survive it.
+memorable_own_hook() {
+  [ -f "$SETTINGS_FILE" ] || return 1
+  GSTACK_SETTINGS_PATH="$SETTINGS_FILE" bun -e '
+    const fs = require("fs");
+    let s = {};
+    try { s = JSON.parse(fs.readFileSync(process.env.GSTACK_SETTINGS_PATH, "utf8")); } catch { process.exit(1); }
+    const groups = (s.hooks && s.hooks.UserPromptSubmit) || [];
+    const ours = process.env.GSTACK_MEMORABLE_HOOK || "";
+    for (const g of groups) {
+      for (const h of (g.hooks || [])) {
+        const c = String(h.command || "");
+        if (c === ours || c.includes("memorable-user-prompt-hook")) continue;
+        if (/memorable/i.test(c) && /hook\s+user-prompt/.test(c)) { console.log(c); process.exit(0); }
+      }
+    }
+    process.exit(1);
+  ' 2>/dev/null
+}
+
 hook_present() {
   [ -x "$SETTINGS_HOOK" ] || return 1
   if "$SETTINGS_HOOK" list-sources 2>/dev/null |
@@ -67,6 +98,7 @@ hook_present() {
 }
 
 enable_memorable() {
+  local existing
   require_memorable || return 1
   [ -x "$SETTINGS_HOOK" ] || {
     echo "gstack-memorable: missing hook manager: $SETTINGS_HOOK" >&2
@@ -74,6 +106,21 @@ enable_memorable() {
   }
   [ -x "$MEMORABLE_HOOK" ] || {
     echo "gstack-memorable: missing executable hook: $MEMORABLE_HOOK" >&2
+    return 1
+  }
+
+  existing="$(GSTACK_MEMORABLE_HOOK="$MEMORABLE_HOOK" memorable_own_hook)" && {
+    cat >&2 <<EOF
+gstack-memorable: Memorable already registers this hook itself:
+  $existing
+
+Registering gstack's as well would run it twice on every prompt: injected
+twice, and the session captured twice against your extraction allowance.
+
+Keep the one you have, or hand it to gstack: delete that entry from
+  $SETTINGS_FILE
+and run this again. Memorable has no command to remove its own hook.
+EOF
     return 1
   }
 
@@ -104,6 +151,7 @@ disable_memorable() {
 }
 
 status_memorable() {
+  local existing
   if MEMORABLE_CLI="$(resolve_memorable 2>/dev/null)" && [ -n "$MEMORABLE_CLI" ]; then
     printf 'Memorable CLI: available (%s)\n' "$MEMORABLE_CLI"
   else
@@ -111,7 +159,10 @@ status_memorable() {
   fi
 
   if hook_present; then
-    echo "Claude UserPromptSubmit hook: registered"
+    echo "Claude UserPromptSubmit hook: registered by gstack"
+  elif existing="$(GSTACK_MEMORABLE_HOOK="$MEMORABLE_HOOK" memorable_own_hook)"; then
+    printf 'Claude UserPromptSubmit hook: registered by Memorable itself (%s)\n' "$existing"
+    echo "  gstack is not managing it; 'gstack-memorable enable' would double it."
   else
     echo "Claude UserPromptSubmit hook: not registered"
   fi

--- a/bin/gstack-memorable
+++ b/bin/gstack-memorable
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Opt-in wiring between gstack's Claude hook manager and Memorable.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SETTINGS_HOOK="$SCRIPT_DIR/gstack-settings-hook"
+MEMORABLE_HOOK="$ROOT_DIR/hosts/claude/hooks/memorable-user-prompt-hook"
+HOOK_SOURCE="gstack-memorable"
+
+usage() {
+  cat <<EOF
+Usage: gstack-memorable <enable|disable|status>
+
+  enable   Enable Memorable, then register its Claude UserPromptSubmit hook
+  disable  Remove the gstack hook, then disable Memorable
+  status   Report Memorable CLI availability and hook registration
+EOF
+}
+
+resolve_memorable() {
+  if [ -n "${MEMORABLE_BIN:-}" ]; then
+    [ -f "$MEMORABLE_BIN" ] && [ -x "$MEMORABLE_BIN" ] || return 1
+    printf '%s\n' "$MEMORABLE_BIN"
+    return 0
+  fi
+
+  if [ -n "${HOME:-}" ] && [ -f "$HOME/.memorable/bin/memorable" ] && [ -x "$HOME/.memorable/bin/memorable" ]; then
+    printf '%s\n' "$HOME/.memorable/bin/memorable"
+    return 0
+  fi
+
+  command -v memorable 2>/dev/null
+}
+
+require_memorable() {
+  MEMORABLE_CLI="$(resolve_memorable 2>/dev/null)" || {
+    echo "gstack-memorable: Memorable CLI not found; install memorable-cli or set MEMORABLE_BIN." >&2
+    return 1
+  }
+  [ -n "$MEMORABLE_CLI" ] || return 1
+}
+
+hook_present() {
+  [ -x "$SETTINGS_HOOK" ] || return 1
+  if "$SETTINGS_HOOK" list-sources 2>/dev/null |
+    awk -F '\t' -v source="$HOOK_SOURCE" '
+      $1 == "UserPromptSubmit" && $2 == source { found = 1 }
+      END { exit(found ? 0 : 1) }
+    '; then
+    return 0
+  fi
+
+  # Claude Code may strip the private source tag when it rewrites settings.
+  # A no-op diff still proves that the canonical command itself is present.
+  "$SETTINGS_HOOK" diff-event \
+    --event UserPromptSubmit \
+    --command "$MEMORABLE_HOOK" \
+    --source "$HOOK_SOURCE" 2>/dev/null |
+    awk '
+      /^--- BEFORE$/ { section = 1; saw_before = 1; next }
+      /^--- AFTER$/  { section = 2; saw_after = 1; next }
+      section == 1 { before = before $0 "\n" }
+      section == 2 { after = after $0 "\n" }
+      END { exit(saw_before && saw_after && before == after ? 0 : 1) }
+    '
+}
+
+enable_memorable() {
+  require_memorable || return 1
+  [ -x "$SETTINGS_HOOK" ] || {
+    echo "gstack-memorable: missing hook manager: $SETTINGS_HOOK" >&2
+    return 1
+  }
+  [ -x "$MEMORABLE_HOOK" ] || {
+    echo "gstack-memorable: missing executable hook: $MEMORABLE_HOOK" >&2
+    return 1
+  }
+
+  "$MEMORABLE_CLI" enable || return $?
+  "$SETTINGS_HOOK" ensure-event \
+    --event UserPromptSubmit \
+    --command "$MEMORABLE_HOOK" \
+    --source "$HOOK_SOURCE"
+}
+
+disable_memorable() {
+  local hook_rc=0 cli_rc=0
+
+  if [ -x "$SETTINGS_HOOK" ]; then
+    "$SETTINGS_HOOK" remove-source --source "$HOOK_SOURCE" || hook_rc=$?
+  else
+    echo "gstack-memorable: missing hook manager: $SETTINGS_HOOK" >&2
+    hook_rc=1
+  fi
+
+  if require_memorable; then
+    "$MEMORABLE_CLI" disable || cli_rc=$?
+  else
+    cli_rc=1
+  fi
+
+  [ "$hook_rc" -eq 0 ] && [ "$cli_rc" -eq 0 ]
+}
+
+status_memorable() {
+  if MEMORABLE_CLI="$(resolve_memorable 2>/dev/null)" && [ -n "$MEMORABLE_CLI" ]; then
+    printf 'Memorable CLI: available (%s)\n' "$MEMORABLE_CLI"
+  else
+    echo "Memorable CLI: unavailable"
+  fi
+
+  if hook_present; then
+    echo "Claude UserPromptSubmit hook: registered"
+  else
+    echo "Claude UserPromptSubmit hook: not registered"
+  fi
+}
+
+case "${1:-}" in
+  enable)  enable_memorable ;;
+  disable) disable_memorable ;;
+  status)  status_memorable ;;
+  -h|--help|help) usage ;;
+  *) usage >&2; exit 1 ;;
+esac

--- a/bin/gstack-settings-hook
+++ b/bin/gstack-settings-hook
@@ -115,6 +115,7 @@ var KNOWN_HOOKS = {
   "question-preference-hook": { source: "plan-tune-cathedral", event: "PreToolUse",   matcher: "(AskUserQuestion|mcp__.*__AskUserQuestion)", relpath: "hosts/claude/hooks/question-preference-hook" },
   "auq-error-fallback-hook":  { source: "auq-error-fallback",  event: "PostToolUse",  matcher: "(AskUserQuestion|mcp__.*__AskUserQuestion)", relpath: "hosts/claude/hooks/auq-error-fallback-hook" },
   "timeline-stop-hook":       { source: "gstack-timeline-stop", event: "Stop",        matcher: "", relpath: "hosts/claude/hooks/timeline-stop-hook" },
+  "memorable-user-prompt-hook": { source: "gstack-memorable", event: "UserPromptSubmit", matcher: "", relpath: "hosts/claude/hooks/memorable-user-prompt-hook" },
   "gstack-session-update":    { source: "gstack-session-update", event: "SessionStart", matcher: "", relpath: "bin/gstack-session-update" },
   "gstack-verify-gate":       { source: "verify-gate", event: "Stop", matcher: "", relpath: "bin/gstack-verify-gate" }
 };

--- a/docs/memorable-workflow-memory.md
+++ b/docs/memorable-workflow-memory.md
@@ -1,0 +1,125 @@
+# Workflow memory with Memorable (optional, third party)
+
+The third time you ask Claude Code to do the same shape of work, it starts
+from nothing again. It re-reads the same files, re-runs the same searches, and
+arrives at the fix it already wrote last month. **Memorable** is a third-party
+CLI that records how a task was done and hands that back the next time you ask
+for something close to it.
+
+gstack does not install it, bundle it, or depend on it. This is a bridge: two
+commands that wire Memorable's `UserPromptSubmit` hook into gstack's own hook
+manager, so the entry is registered, listed and removed the same way every
+other gstack hook is. It is off until you turn it on, and Claude Code is the
+only host it works with.
+
+## What you get
+
+- The prompt hook asks Memorable, before each turn, whether a past session
+  already solved something close to this, and injects that procedure if so.
+- Registration through `gstack-settings-hook`, so `list-sources`,
+  `prune-stale` and `rollback` all see it.
+- An off switch that removes gstack's entry and nothing else.
+- No daemon, no dependency, and nothing at all if the binary is absent.
+
+## What this is not
+
+- Not deterministic replay. It is recalled guidance the model may ignore.
+- Not related to Aside or to browser automation.
+- Not a gstack feature with gstack's guarantees. Everything past the process
+  boundary belongs to a closed-source npm package from another vendor.
+
+## Exactly what leaves your machine
+
+The hook makes no network call of its own. Every row below is the Memorable
+CLI acting under its own consent, which is why **`gstack-egress` will not show
+any of it**: gstack issues no request here, so there is no receipt to write.
+
+| Command | What leaves the machine |
+|---|---|
+| `command -v memorable`, `gstack-memorable status` | Nothing. Both are local reads. |
+| `gstack-memorable enable` | Nothing from gstack. It runs `memorable enable`, which records consent on your machine. |
+| the hook, on every prompt | The prompt text you typed, to Memorable's embed endpoint, when the local lexical match misses. Nothing else at prompt time. |
+| capture, at session end | Memorable's own hook, not this bridge. It sends the finished session's tool calls and their arguments to Memorable's extraction API under `memorable enable`. |
+
+Two things follow from that table and are worth saying out loud. The hook sees
+**every** Claude Code prompt, not only the ones that came from a gstack skill.
+And capture is a separate consent from this bridge: turning the bridge off does
+not turn capture off. `memorable disable` does.
+
+## What gstack pin-tests, and what is Memorable's claim
+
+gstack tests the gating and the wiring, in `test/gstack-memorable.test.ts`:
+
+- `enable` refuses when Memorable already registered the hook itself, and
+  touches neither consent nor the settings file when it refuses.
+- `disable` removes only gstack's entry and never a foreign one.
+- The hook exits zero and silent when the binary is missing.
+- `status` writes nothing.
+
+Everything else is Memorable's claim and not ours: what it stores, where it
+stores it, what it sends, and what `memorable disable` and `memorable forget`
+actually erase.
+
+## Turning it on (three steps, the middle one is yours)
+
+```bash
+npm i -g memorable-cli   # the CLI, from npm, not from gstack
+memorable login          # opens a browser; only you can do this
+bin/gstack-memorable enable
+```
+
+`enable` runs `memorable enable` to record capture consent, then registers the
+hook. Check it with:
+
+```bash
+bin/gstack-memorable status
+```
+
+## If Memorable already registered the hook
+
+`memorable start`, `memorable setup` and `memorable install-hooks` each
+register the same `UserPromptSubmit` hook under Memorable's own name, outside
+gstack's table. That is the documented way to install the CLI, so on most
+machines the hook is already there before gstack is asked.
+
+`enable` refuses in that case rather than adding a second entry. Two entries
+run the same command twice on every prompt: the context is injected twice, and
+the session is captured twice against your extraction allowance.
+
+To hand it to gstack instead, delete that entry from
+`~/.claude/settings.json` and run `enable` again. Memorable has no command that
+removes its own hook; `uninstall-hooks` is not a command in 0.5.18.
+
+## Turning it off
+
+```bash
+bin/gstack-memorable disable
+```
+
+That removes gstack's hook entry and runs `memorable disable`, which stops
+capture. It does not delete anything Memorable has already stored. For that,
+use `memorable forget`, or remove the binary.
+
+## Under the hood
+
+`bin/gstack-memorable` is the front door. It resolves the CLI from
+`MEMORABLE_BIN`, then `~/.memorable/bin/memorable`, then `PATH`, and refuses
+with a message naming the variable if it finds none.
+
+`hosts/claude/hooks/memorable-user-prompt-hook` is what actually gets
+registered. It resolves the same three ways, execs `memorable hook
+user-prompt`, and exits zero on every failure path. A missing or broken
+integration must never interrupt Claude Code, so the hook has no way to fail
+loudly: if it cannot find the binary it prints nothing and returns success.
+
+Registration itself goes through `bin/gstack-settings-hook ensure-event`, and
+the entry is in that file's `KNOWN_HOOKS` table, so it is identified by its
+command rather than by a tag. Claude Code rewrites `settings.json` and does not
+preserve private tags; the same reason the rest of the table matches on
+command.
+
+## Credits
+
+The integration and its hook contract are by
+[Advaiyt Sane](https://github.com/AdvaiytSane) and
+[Nikhil Krishnaswamy](https://github.com/NIkhil-cmd-cmd) at Memorable.

--- a/hosts/claude/hooks/memorable-user-prompt-hook
+++ b/hosts/claude/hooks/memorable-user-prompt-hook
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Optional Memorable UserPromptSubmit hook. Missing or failing integrations
+# must never interrupt Claude Code.
+set -u
+
+resolve_memorable() {
+  if [ -n "${MEMORABLE_BIN:-}" ]; then
+    [ -f "$MEMORABLE_BIN" ] && [ -x "$MEMORABLE_BIN" ] || return 1
+    printf '%s\n' "$MEMORABLE_BIN"
+    return 0
+  fi
+
+  if [ -n "${HOME:-}" ] && [ -f "$HOME/.memorable/bin/memorable" ] && [ -x "$HOME/.memorable/bin/memorable" ]; then
+    printf '%s\n' "$HOME/.memorable/bin/memorable"
+    return 0
+  fi
+
+  command -v memorable 2>/dev/null
+}
+
+MEMORABLE_CLI="$(resolve_memorable 2>/dev/null)" || exit 0
+[ -n "$MEMORABLE_CLI" ] || exit 0
+
+(exec "$MEMORABLE_CLI" hook user-prompt) || exit 0
+exit 0

--- a/test/gstack-memorable.test.ts
+++ b/test/gstack-memorable.test.ts
@@ -73,6 +73,50 @@ describe('gstack-memorable', () => {
     expect(missing.stderr).toBe('');
   });
 
+  test('enable refuses when Memorable already registered the hook itself', () => {
+    // Memorable's own installer (`memorable start`, `setup`, `install-hooks`)
+    // writes this same UserPromptSubmit hook under its own name, and that is
+    // the documented way to install the CLI. Registering ours beside it runs
+    // the command twice per prompt: injected twice, captured twice against the
+    // user's own allowance.
+    const f = fixture();
+    const theirs = `"${join(f.home, '.memorable', 'bin', 'memorable')}" hook user-prompt`;
+    writeFileSync(f.settings, JSON.stringify({
+      hooks: { UserPromptSubmit: [{ hooks: [{ type: 'command', command: theirs }] }] },
+    }));
+
+    const enabled = spawnSync(COMMAND, ['enable'], { env: envFor(f), encoding: 'utf8' });
+    expect(enabled.status).not.toBe(0);
+    expect(enabled.stderr).toContain('already registers this hook itself');
+    // It refused before doing anything: no consent recorded, settings untouched.
+    expect(existsSync(f.log)).toBe(false);
+    const after = JSON.parse(readFileSync(f.settings, 'utf8'));
+    const commands = after.hooks.UserPromptSubmit.flatMap((e: any) => e.hooks.map((h: any) => h.command));
+    expect(commands).toEqual([theirs]);
+  });
+
+  test('status names Memorable\'s own registration rather than reporting none', () => {
+    const f = fixture();
+    const theirs = `"${join(f.home, '.memorable', 'bin', 'memorable')}" hook user-prompt`;
+    writeFileSync(f.settings, JSON.stringify({
+      hooks: { UserPromptSubmit: [{ hooks: [{ type: 'command', command: theirs }] }] },
+    }));
+
+    const status = spawnSync(COMMAND, ['status'], { env: envFor(f), encoding: 'utf8' });
+    expect(status.status).toBe(0);
+    expect(status.stdout).toContain('registered by Memorable itself');
+    expect(status.stdout).not.toContain('not registered');
+  });
+
+  test('a foreign UserPromptSubmit hook is not mistaken for Memorable\'s', () => {
+    const f = fixture();
+    writeFileSync(f.settings, JSON.stringify({
+      hooks: { UserPromptSubmit: [{ hooks: [{ type: 'command', command: '/foreign/hook' }] }] },
+    }));
+    const enabled = spawnSync(COMMAND, ['enable'], { env: envFor(f), encoding: 'utf8' });
+    expect(enabled.status).toBe(0);
+  });
+
   test('status is read-only and reports both dependencies', () => {
     const f = fixture();
     const status = spawnSync(COMMAND, ['status'], { env: envFor(f), encoding: 'utf8' });

--- a/test/gstack-memorable.test.ts
+++ b/test/gstack-memorable.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { spawnSync } from 'child_process';
+
+const ROOT = resolve(import.meta.dir, '..');
+const COMMAND = join(ROOT, 'bin', 'gstack-memorable');
+const HOOK = join(ROOT, 'hosts', 'claude', 'hooks', 'memorable-user-prompt-hook');
+const homes: string[] = [];
+
+afterEach(() => {
+  for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true });
+});
+
+function fixture() {
+  const home = mkdtempSync(join(tmpdir(), 'gstack-memorable-'));
+  homes.push(home);
+  const claude = join(home, '.claude');
+  mkdirSync(claude, { recursive: true });
+  const settings = join(claude, 'settings.json');
+  const log = join(home, 'calls.log');
+  const fake = join(home, 'memorable');
+  writeFileSync(fake, `#!/bin/sh\nprintf '%s\\n' "$*" >> "${log}"\nif [ "$1" = hook ]; then printf '%s' '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"remembered"}}'; fi\n`);
+  chmodSync(fake, 0o700);
+  return { home, settings, log, fake };
+}
+
+function envFor(f: ReturnType<typeof fixture>) {
+  return {
+    ...process.env,
+    HOME: f.home,
+    GSTACK_SETTINGS_FILE: f.settings,
+    MEMORABLE_BIN: f.fake,
+  };
+}
+
+describe('gstack-memorable', () => {
+  test('enable registers the hook; disable removes it without deleting foreign hooks', () => {
+    const f = fixture();
+    writeFileSync(f.settings, JSON.stringify({
+      hooks: { UserPromptSubmit: [{ hooks: [{ type: 'command', command: '/foreign/hook' }] }] },
+    }));
+
+    const enabled = spawnSync(COMMAND, ['enable'], { env: envFor(f), encoding: 'utf8' });
+    expect(enabled.status).toBe(0);
+    expect(readFileSync(f.log, 'utf8')).toContain('enable');
+    let settings = JSON.parse(readFileSync(f.settings, 'utf8'));
+    const commands = settings.hooks.UserPromptSubmit.flatMap((e: any) => e.hooks.map((h: any) => h.command));
+    expect(commands).toContain('/foreign/hook');
+    expect(commands).toContain(HOOK);
+
+    const disabled = spawnSync(COMMAND, ['disable'], { env: envFor(f), encoding: 'utf8' });
+    expect(disabled.status).toBe(0);
+    expect(readFileSync(f.log, 'utf8')).toContain('disable');
+    settings = JSON.parse(readFileSync(f.settings, 'utf8'));
+    const remaining = settings.hooks.UserPromptSubmit.flatMap((e: any) => e.hooks.map((h: any) => h.command));
+    expect(remaining).toEqual(['/foreign/hook']);
+  });
+
+  test('hook delegates stdin/stdout and fails open when Memorable is unavailable', () => {
+    const f = fixture();
+    const payload = '{"session_id":"s1","prompt":"repeat the task"}';
+    const delegated = spawnSync(HOOK, [], { env: envFor(f), input: payload, encoding: 'utf8' });
+    expect(delegated.status).toBe(0);
+    expect(delegated.stdout).toContain('"additionalContext":"remembered"');
+    expect(readFileSync(f.log, 'utf8')).toContain('hook user-prompt');
+
+    const missingEnv = { ...process.env, HOME: f.home, MEMORABLE_BIN: join(f.home, 'missing') };
+    const missing = spawnSync(HOOK, [], { env: missingEnv, input: payload, encoding: 'utf8' });
+    expect(missing.status).toBe(0);
+    expect(missing.stdout).toBe('');
+    expect(missing.stderr).toBe('');
+  });
+
+  test('status is read-only and reports both dependencies', () => {
+    const f = fixture();
+    const status = spawnSync(COMMAND, ['status'], { env: envFor(f), encoding: 'utf8' });
+    expect(status.status).toBe(0);
+    expect(status.stdout).toContain('Memorable CLI: available');
+    expect(status.stdout).toContain('Claude UserPromptSubmit hook: not registered');
+    expect(existsSync(f.log)).toBe(false);
+  });
+});

--- a/test/gstack-settings-hook-schema-aware.test.ts
+++ b/test/gstack-settings-hook-schema-aware.test.ts
@@ -772,6 +772,80 @@ describe('remove-source: per-item', () => {
   });
 });
 
+describe('Memorable UserPromptSubmit hook ownership', () => {
+  const source = 'gstack-memorable';
+  const stale = '/old/worktree/hosts/claude/hooks/memorable-user-prompt-hook';
+  const canonical = '/stable/gstack/hosts/claude/hooks/memorable-user-prompt-hook';
+  const foreign = '/Users/me/my-user-prompt-hook';
+
+  test('ensure-event is idempotent once the canonical wrapper is registered', () => {
+    const args = [
+      'ensure-event', '--event', 'UserPromptSubmit',
+      '--command', canonical, '--source', source,
+    ];
+    const first = runIso(args);
+    expect(first.exitCode).toBe(0);
+    expect(first.stdout).toContain('hook registered');
+    const afterFirst = fs.readFileSync(settingsFile, 'utf-8');
+    const backupsAfterFirst = backups();
+
+    const second = runIso(args);
+    expect(second.exitCode).toBe(0);
+    expect(second.stdout).toContain('hook unchanged');
+    expect(fs.readFileSync(settingsFile, 'utf-8')).toBe(afterFirst);
+    expect(backups()).toEqual(backupsAfterFirst);
+    expect(settings().hooks.UserPromptSubmit).toHaveLength(1);
+  });
+
+  test('ensure-event re-points only the wrapper in a mixed entry and preserves the foreign hook', () => {
+    fs.writeFileSync(settingsFile, JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [{
+          hooks: [
+            { type: 'command', command: foreign },
+            { type: 'command', command: stale },
+          ],
+        }],
+      },
+    }, null, 2));
+
+    const r = runIso([
+      'ensure-event', '--event', 'UserPromptSubmit',
+      '--command', canonical, '--source', source,
+    ]);
+    expect(r.exitCode).toBe(0);
+    const entries = settings().hooks.UserPromptSubmit;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hooks).toEqual([
+      { type: 'command', command: foreign },
+      { type: 'command', command: canonical },
+    ]);
+    expect(entries[0]._gstack_source).toBeUndefined();
+  });
+
+  test('remove-source removes only the Memorable wrapper from a tagged mixed entry', () => {
+    fs.writeFileSync(settingsFile, JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [{
+          _gstack_source: source,
+          hooks: [
+            { type: 'command', command: foreign },
+            { type: 'command', command: stale },
+          ],
+        }],
+      },
+    }, null, 2));
+
+    const r = runIso(['remove-source', '--source', source]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/removed 1 hook/);
+    const entries = settings().hooks.UserPromptSubmit;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hooks).toEqual([{ type: 'command', command: foreign }]);
+    expect(entries[0]._gstack_source).toBeUndefined();
+  });
+});
+
 describe('prune-stale', () => {
   test('prunes dead gstack items; keeps live gstack and dead non-gstack', () => {
     const canon = mkCanon(tmpDir);


### PR DESCRIPTION
Optional, default off, Claude Code only. gstack does not install, bundle or depend on anything here; without the binary the whole thing is inert.

The third time you ask Claude Code to do the same shape of work it starts from nothing again: same files re-read, same searches re-run, the fix it already wrote last month rediscovered. [Memorable](https://memorable.sh) is a third-party CLI that records how a task was done and hands it back when you ask for something close. This is the bridge, not the tool: two commands that register its `UserPromptSubmit` hook through gstack's own hook manager, so `list-sources`, `prune-stale` and `rollback` all see it and `disable` removes gstack's entry and nothing else.

```bash
npm i -g memorable-cli   # from npm, not from gstack
memorable login          # a browser step, only the human can do it
bin/gstack-memorable enable
```

## Exactly what leaves the machine

The hook makes no network call of its own. Every row is the third-party CLI acting under its own consent, which is why `gstack-egress` shows none of it: gstack issues no request here, so there is no receipt to write.

| Command | What leaves the machine |
|---|---|
| `command -v memorable`, `gstack-memorable status` | Nothing. Both are local reads. |
| `gstack-memorable enable` | Nothing from gstack. Runs `memorable enable`, which records consent on the machine. |
| the hook, on every prompt | The prompt text you typed, to Memorable's embed endpoint, when the local lexical match misses. Nothing else at prompt time. |
| capture, at session end | Memorable's own hook, not this bridge. Sends the finished session's tool calls and their arguments to its extraction API under `memorable enable`. |

Two things that table implies, said plainly in the README and the guide: the hook sees **every** Claude Code prompt, not only the ones a gstack skill produced; and capture is a separate consent, so turning this bridge off does not turn capture off.

## What gstack pin-tests, and what is Memorable's claim

Tested here (`test/gstack-memorable.test.ts`, six cases): `enable` refuses when Memorable already registered the hook itself and touches neither consent nor settings when it does; `disable` removes only gstack's entry and never a foreign one; the hook exits zero and silent when the binary is missing; `status` writes nothing. Tests drive a fake binary through `MEMORABLE_BIN` rather than the real CLI.

Not ours, and labelled as such: what Memorable stores, where, what it sends, and what `disable` and `forget` erase. It is a closed-source npm package from another vendor.

## The collision this had to solve

`memorable start`, `memorable setup` and `memorable install-hooks` each register the same `UserPromptSubmit` hook under Memorable's own name, outside gstack's table, and that is the documented way to install the CLI. So on most machines it is already there before gstack is asked. A second entry runs the same command twice per prompt: context injected twice, session captured twice against the user's own extraction allowance.

`enable` now detects it, refuses, and names both the entry and the file. Matched on the command rather than a tag, for the reason `KNOWN_HOOKS` already gives: Claude Code rewrites `settings.json` and private tags do not survive it. The message says to delete the entry by hand, because Memorable has no command that removes its own hook (`uninstall-hooks` answers "unknown command" in 0.5.18).

## Notes for review

- **No CHANGELOG entry.** This file has never carried an `[Unreleased]` heading; every entry is a version and a date written at release. Suggested line, yours to place: *Added `bin/gstack-memorable enable|status|disable`, a default-off, Claude Code-only bridge to the external `memorable` CLI. Its hooks capture all Claude Code prompts, not only gstack commands. Hook failures fail open.*
- **No egress receipt.** The shell helpers wrap `curl` and `git`, and there is no gstack-issued network call here to wrap. If you would rather it appear in `gstack-egress grants` as a declared third-party sink, say so and I will wire it.
- **Naming.** `gstack-memorable` is vendor-first. If you would prefer a capability-first seam with Memorable as one provider, that is a bigger change and I am happy to make it.
- Verified: `test/gstack-memorable.test.ts`, `test/gstack-settings-hook-schema-aware.test.ts` and `test/egress-receipt-wiring.test.ts` are 72 pass, 0 fail. The scanner does not flag the new files: neither contains a network op and `hosts/` is outside its sweep.

By [Advaiyt Sane](https://github.com/AdvaiytSane) and [Nikhil Krishnaswamy](https://github.com/NIkhil-cmd-cmd) at Memorable.
