### PR TITLE
docs: clarify autoplan and investigate routing

### DIFF
--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -2,7 +2,7 @@
 name: autoplan
 preamble-tier: 3
 version: 1.0.0
-description: Auto-review pipeline — reads the full CEO, design, eng, and DX review skills from disk and runs them sequentially with auto-decisions using 6 decision principles. (gstack)
+description: Run full GStack product, design, engineering, DX review.
 triggers:
   - run all reviews
   - automatic review pipeline
@@ -29,7 +29,7 @@ approval gate. One command, fully reviewed plan out.
 Use when asked to "auto review", "autoplan", "run all reviews", "review this plan
 automatically", or "make the decisions for me".
 Proactively suggest when the user has a plan file and wants to run the full review
-gauntlet without answering 15-30 intermediate questions.
+gauntlet without answering 15-30 intermediate questions. Part of GStack.
 
 Voice triggers (speech-to-text aliases): "auto plan", "automatic review".
 

--- a/autoplan/SKILL.md.tmpl
+++ b/autoplan/SKILL.md.tmpl
@@ -3,14 +3,13 @@ name: autoplan
 preamble-tier: 3
 version: 1.0.0
 description: |
-  Auto-review pipeline — reads the full CEO, design, eng, and DX review skills from disk
-  and runs them sequentially with auto-decisions using 6 decision principles. Surfaces
+  Run full GStack product, design, engineering, DX review. Surfaces
   taste decisions (close approaches, borderline scope, codex disagreements) at a final
   approval gate. One command, fully reviewed plan out.
   Use when asked to "auto review", "autoplan", "run all reviews", "review this plan
   automatically", or "make the decisions for me".
   Proactively suggest when the user has a plan file and wants to run the full review
-  gauntlet without answering 15-30 intermediate questions. (gstack)
+  gauntlet without answering 15-30 intermediate questions. Part of GStack.
 voice-triggers:
   - "auto plan"
   - "automatic review"

--- a/gstack/llms.txt
+++ b/gstack/llms.txt
@@ -10,7 +10,7 @@ Conventions:
 
 ## Skills
 
-- [/autoplan](autoplan/SKILL.md): Auto-review pipeline — reads the full CEO, design, eng, and DX review skills from disk and runs them sequentially with auto-decisions using 6 decision principles.
+- [/autoplan](autoplan/SKILL.md): Run full GStack product, design, engineering, DX review.
 - [/benchmark](benchmark/SKILL.md): Performance regression detection.
 - [/benchmark-models](benchmark-models/SKILL.md): Cross-model benchmark for gstack skills.
 - [/browse](browse/SKILL.md): Drive a real browser through Aside: open a page, read it, click through a flow, take screenshots, check console errors.
@@ -34,7 +34,7 @@ Conventions:
 - [/gstack-upgrade](gstack-upgrade/SKILL.md): Upgrade gstack to the latest version.
 - [/guard](guard/SKILL.md): Full safety mode: destructive command warnings + directory-scoped edits.
 - [/health](health/SKILL.md): Code quality dashboard.
-- [/investigate](investigate/SKILL.md): Systematic debugging with root cause investigation.
+- [/investigate](investigate/SKILL.md): Debug root causes with the full GStack runtime.
 - [/ios-clean](ios-clean/SKILL.md): Remove the DebugBridge SPM package and all #if DEBUG wiring from an iOS app.
 - [/ios-design-review](ios-design-review/SKILL.md): Visual design audit for iOS apps on real hardware.
 - [/ios-fix](ios-fix/SKILL.md): Autonomous iOS bug fixer.

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -2,7 +2,7 @@
 name: investigate
 preamble-tier: 2
 version: 1.0.0
-description: Systematic debugging with root cause investigation. (gstack)
+description: Debug root causes with the full GStack runtime.
 allowed-tools:
   - Bash
   - Read
@@ -65,7 +65,7 @@ Use when asked to "debug this", "fix this bug", "why is this broken",
 "investigate this error", or "root cause analysis".
 Proactively invoke this skill (do NOT debug directly) when the user reports
 errors, 500 errors, stack traces, unexpected behavior, "it was working
-yesterday", or is troubleshooting why something stopped working.
+yesterday", or is troubleshooting why something stopped working. Part of GStack.
 
 ## Preamble (run first)
 

--- a/investigate/SKILL.md.tmpl
+++ b/investigate/SKILL.md.tmpl
@@ -3,13 +3,13 @@ name: investigate
 preamble-tier: 2
 version: 1.0.0
 description: |
-  Systematic debugging with root cause investigation. Four phases: investigate,
+  Debug root causes with the full GStack runtime. Four phases: investigate,
   analyze, hypothesize, implement. Iron Law: no fixes without root cause.
   Use when asked to "debug this", "fix this bug", "why is this broken",
   "investigate this error", or "root cause analysis".
   Proactively invoke this skill (do NOT debug directly) when the user reports
   errors, 500 errors, stack traces, unexpected behavior, "it was working
-  yesterday", or is troubleshooting why something stopped working. (gstack)
+  yesterday", or is troubleshooting why something stopped working. Part of GStack.
 allowed-tools:
   - Bash
   - Read


### PR DESCRIPTION
## Summary
- shorten `/autoplan` and `/investigate` descriptions so their routing purpose is clear within the catalog lead
- preserve the detailed routing guidance in each generated skill body
- regenerate the canonical `SKILL.md` files and `gstack/llms.txt`

## Verification
- `bun run gen:skill-docs --dry-run`
- `bun test test/gen-skill-docs.test.ts test/gen-skill-docs-out-dir.test.ts test/llms-txt-shape.test.ts test/catalog-budget.test.ts test/catalog-trim.test.ts test/skill-validation.test.ts test/skill-preflight-budget.test.ts test/skill-size-budget.test.ts`
  - 829 passed
  - 2 existing environment-related failures: tracked binary classification and project-scoped MCP fixture

## Baseline caveat
- `bun run test` on the clean upstream base, before these edits, reported 77 failures across 20 files on this host; major causes included missing Playwright Chromium, missing `jq`, and host-state fixture leakage
- the scoped generator/catalog suite above isolates this documentation change from those baseline failures

## Scope
Documentation and generated catalog output only; no runtime behavior changes.