### PR TITLE
fix: design-doc discovery reads docs/designs/ only — a root DESIGN.md is the design system (#2839)

### DIFF
--- a/autoplan/SKILL.md
+++ b/autoplan/SKILL.md
@@ -523,12 +523,14 @@ _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | h
 [ -z "$_LOCALDOC" ] && _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 # Repo-local docs win when at least as fresh (#703): office-hours dual-writes
 # docs/designs/ alongside ~/.gstack, and the committed copy is what teammates
-# see. A stale old repo doc never shadows a newer private session.
+# see. A stale old repo doc never shadows a newer private session. Only
+# docs/designs/ is a design doc: a root DESIGN.md is the design system that
+# /design-consultation writes, and reading it here reviews a plan against a
+# token file while printing "Design doc found" (#2839).
 _REPOTOP=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 _REPODOC=""
 if [ -n "$_REPOTOP" ]; then
-  [ -f "$_REPOTOP/DESIGN.md" ] && _REPODOC="$_REPOTOP/DESIGN.md"
-  [ -z "$_REPODOC" ] && _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
+  _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
 fi
 DESIGN="$_LOCALDOC"
 if [ -n "$_REPODOC" ] && { [ -z "$_LOCALDOC" ] || [ "$_REPODOC" -nt "$_LOCALDOC" ]; }; then

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -608,12 +608,14 @@ _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | h
 [ -z "$_LOCALDOC" ] && _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 # Repo-local docs win when at least as fresh (#703): office-hours dual-writes
 # docs/designs/ alongside ~/.gstack, and the committed copy is what teammates
-# see. A stale old repo doc never shadows a newer private session.
+# see. A stale old repo doc never shadows a newer private session. Only
+# docs/designs/ is a design doc: a root DESIGN.md is the design system that
+# /design-consultation writes, and reading it here reviews a plan against a
+# token file while printing "Design doc found" (#2839).
 _REPOTOP=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 _REPODOC=""
 if [ -n "$_REPOTOP" ]; then
-  [ -f "$_REPOTOP/DESIGN.md" ] && _REPODOC="$_REPOTOP/DESIGN.md"
-  [ -z "$_REPODOC" ] && _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
+  _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
 fi
 DESIGN="$_LOCALDOC"
 if [ -n "$_REPODOC" ] && { [ -z "$_LOCALDOC" ] || [ "$_REPODOC" -nt "$_LOCALDOC" ]; }; then
@@ -692,12 +694,14 @@ _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | h
 [ -z "$_LOCALDOC" ] && _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 # Repo-local docs win when at least as fresh (#703): office-hours dual-writes
 # docs/designs/ alongside ~/.gstack, and the committed copy is what teammates
-# see. A stale old repo doc never shadows a newer private session.
+# see. A stale old repo doc never shadows a newer private session. Only
+# docs/designs/ is a design doc: a root DESIGN.md is the design system that
+# /design-consultation writes, and reading it here reviews a plan against a
+# token file while printing "Design doc found" (#2839).
 _REPOTOP=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 _REPODOC=""
 if [ -n "$_REPOTOP" ]; then
-  [ -f "$_REPOTOP/DESIGN.md" ] && _REPODOC="$_REPOTOP/DESIGN.md"
-  [ -z "$_REPODOC" ] && _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
+  _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
 fi
 DESIGN="$_LOCALDOC"
 if [ -n "$_REPODOC" ] && { [ -z "$_LOCALDOC" ] || [ "$_REPODOC" -nt "$_LOCALDOC" ]; }; then

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -603,12 +603,14 @@ _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | h
 [ -z "$_LOCALDOC" ] && _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 # Repo-local docs win when at least as fresh (#703): office-hours dual-writes
 # docs/designs/ alongside ~/.gstack, and the committed copy is what teammates
-# see. A stale old repo doc never shadows a newer private session.
+# see. A stale old repo doc never shadows a newer private session. Only
+# docs/designs/ is a design doc: a root DESIGN.md is the design system that
+# /design-consultation writes, and reading it here reviews a plan against a
+# token file while printing "Design doc found" (#2839).
 _REPOTOP=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 _REPODOC=""
 if [ -n "$_REPOTOP" ]; then
-  [ -f "$_REPOTOP/DESIGN.md" ] && _REPODOC="$_REPOTOP/DESIGN.md"
-  [ -z "$_REPODOC" ] && _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
+  _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
 fi
 DESIGN="$_LOCALDOC"
 if [ -n "$_REPODOC" ] && { [ -z "$_LOCALDOC" ] || [ "$_REPODOC" -nt "$_LOCALDOC" ]; }; then
@@ -676,12 +678,14 @@ _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | h
 [ -z "$_LOCALDOC" ] && _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 # Repo-local docs win when at least as fresh (#703): office-hours dual-writes
 # docs/designs/ alongside ~/.gstack, and the committed copy is what teammates
-# see. A stale old repo doc never shadows a newer private session.
+# see. A stale old repo doc never shadows a newer private session. Only
+# docs/designs/ is a design doc: a root DESIGN.md is the design system that
+# /design-consultation writes, and reading it here reviews a plan against a
+# token file while printing "Design doc found" (#2839).
 _REPOTOP=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 _REPODOC=""
 if [ -n "$_REPOTOP" ]; then
-  [ -f "$_REPOTOP/DESIGN.md" ] && _REPODOC="$_REPOTOP/DESIGN.md"
-  [ -z "$_REPODOC" ] && _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
+  _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
 fi
 DESIGN="$_LOCALDOC"
 if [ -n "$_REPODOC" ] && { [ -z "$_LOCALDOC" ] || [ "$_REPODOC" -nt "$_LOCALDOC" ]; }; then

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -579,12 +579,14 @@ _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | h
 [ -z "$_LOCALDOC" ] && _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 # Repo-local docs win when at least as fresh (#703): office-hours dual-writes
 # docs/designs/ alongside ~/.gstack, and the committed copy is what teammates
-# see. A stale old repo doc never shadows a newer private session.
+# see. A stale old repo doc never shadows a newer private session. Only
+# docs/designs/ is a design doc: a root DESIGN.md is the design system that
+# /design-consultation writes, and reading it here reviews a plan against a
+# token file while printing "Design doc found" (#2839).
 _REPOTOP=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 _REPODOC=""
 if [ -n "$_REPOTOP" ]; then
-  [ -f "$_REPOTOP/DESIGN.md" ] && _REPODOC="$_REPOTOP/DESIGN.md"
-  [ -z "$_REPODOC" ] && _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
+  _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
 fi
 DESIGN="$_LOCALDOC"
 if [ -n "$_REPODOC" ] && { [ -z "$_LOCALDOC" ] || [ "$_REPODOC" -nt "$_LOCALDOC" ]; }; then
@@ -647,12 +649,14 @@ _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | h
 [ -z "$_LOCALDOC" ] && _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 # Repo-local docs win when at least as fresh (#703): office-hours dual-writes
 # docs/designs/ alongside ~/.gstack, and the committed copy is what teammates
-# see. A stale old repo doc never shadows a newer private session.
+# see. A stale old repo doc never shadows a newer private session. Only
+# docs/designs/ is a design doc: a root DESIGN.md is the design system that
+# /design-consultation writes, and reading it here reviews a plan against a
+# token file while printing "Design doc found" (#2839).
 _REPOTOP=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 _REPODOC=""
 if [ -n "$_REPOTOP" ]; then
-  [ -f "$_REPOTOP/DESIGN.md" ] && _REPODOC="$_REPOTOP/DESIGN.md"
-  [ -z "$_REPODOC" ] && _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
+  _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
 fi
 DESIGN="$_LOCALDOC"
 if [ -n "$_REPODOC" ] && { [ -z "$_LOCALDOC" ] || [ "$_REPODOC" -nt "$_LOCALDOC" ]; }; then

--- a/scripts/resolvers/design-doc-discovery.ts
+++ b/scripts/resolvers/design-doc-discovery.ts
@@ -3,10 +3,13 @@
  *
  * Finds the design doc a plan review should read: newest branch-scoped doc
  * under ~/.gstack/projects/<slug>/, falling back to newest project-scoped
- * doc, then lets a repo-local doc (DESIGN.md or docs/designs/*.md) win when
- * it is at least as fresh. office-hours dual-writes docs/designs/ alongside
- * ~/.gstack, and the committed copy is what teammates see — but a stale old
- * repo doc must never shadow a newer private session.
+ * doc, then lets a repo-local doc (docs/designs/*.md) win when it is at
+ * least as fresh. office-hours dual-writes docs/designs/ alongside ~/.gstack,
+ * and the committed copy is what teammates see — but a stale old repo doc
+ * must never shadow a newer private session. A root DESIGN.md is never a
+ * design doc: since the open DESIGN.md format it is the design system that
+ * /design-consultation writes, and the plan reviews want the problem
+ * statement, not the token file (#2839).
  *
  * Single source of truth for the freshness-preference logic that previously
  * lived verbatim in plan-ceo-review, plan-eng-review, plan-devex-review, and
@@ -31,12 +34,14 @@ export const DESIGN_DOC_DISCOVERY_BLOCK = `_LOCALDOC=$(ls -t ~/.gstack/projects/
 [ -z "$_LOCALDOC" ] && _LOCALDOC=$(ls -t ~/.gstack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 # Repo-local docs win when at least as fresh (#703): office-hours dual-writes
 # docs/designs/ alongside ~/.gstack, and the committed copy is what teammates
-# see. A stale old repo doc never shadows a newer private session.
+# see. A stale old repo doc never shadows a newer private session. Only
+# docs/designs/ is a design doc: a root DESIGN.md is the design system that
+# /design-consultation writes, and reading it here reviews a plan against a
+# token file while printing "Design doc found" (#2839).
 _REPOTOP=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 _REPODOC=""
 if [ -n "$_REPOTOP" ]; then
-  [ -f "$_REPOTOP/DESIGN.md" ] && _REPODOC="$_REPOTOP/DESIGN.md"
-  [ -z "$_REPODOC" ] && _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
+  _REPODOC=$(ls -t "$_REPOTOP"/docs/designs/*.md 2>/dev/null | head -1)
 fi
 DESIGN="$_LOCALDOC"
 if [ -n "$_REPODOC" ] && { [ -z "$_LOCALDOC" ] || [ "$_REPODOC" -nt "$_LOCALDOC" ]; }; then

--- a/test/gen-skill-docs.test.ts
+++ b/test/gen-skill-docs.test.ts
@@ -1987,6 +1987,18 @@ describe('DESIGN_DETECTOR resolver', () => {
   });
 });
 
+// --- {{DESIGN_DOC_DISCOVERY}}: a root DESIGN.md is the design system, never the design doc (#2839) ---
+
+describe('design-doc discovery never takes a root DESIGN.md (#2839)', () => {
+  for (const skill of ['plan-ceo-review', 'plan-eng-review', 'plan-devex-review', 'autoplan']) {
+    test(`${skill} looks for a repo-local design doc in docs/designs/ only`, () => {
+      const c = readSkillUnion(skill);
+      expect(c).toContain('docs/designs/*.md');
+      expect(c).not.toContain('_REPOTOP/DESIGN.md');
+    });
+  }
+});
+
 // --- {{DESIGN_MD_CHECK}} resolver + open DESIGN.md adoption ---
 
 describe('DESIGN_MD_CHECK resolver and open DESIGN.md adoption', () => {


### PR DESCRIPTION
## What

`DESIGN_DOC_DISCOVERY` no longer takes a repo-root `DESIGN.md` as the phase's design doc. Only `docs/designs/*.md` is a repo-local design doc; the #703 freshness rule against the private copy is unchanged.

## Why

Since the open `DESIGN.md` format (v1.84.0.0), the root file is the design system `/design-consultation` writes — tokens and spec sections, no problem statement. The block preferred it to `docs/designs/*.md`, and to `~/.gstack/projects/<slug>/*-design-*.md` whenever it was newer; on a checkout with no private copy (a fresh clone, a server) unconditionally. So a project holding both files had `plan-ceo-review`, `plan-eng-review`, `plan-devex-review`, `autoplan` and `review`'s prerequisite re-check reasoning from a colour palette while printing `Design doc found: DESIGN.md`, and the `/office-hours` prerequisite offer never fired because a doc had been found. Full measurement in #2839.

## Changes

- `scripts/resolvers/design-doc-discovery.ts`: remove the `$_REPOTOP/DESIGN.md` branch; comments say why
- regenerated `autoplan`, `plan-ceo-review`, `plan-devex-review`, `plan-eng-review` (`bun run gen:skill-docs --host all`, no other file moved)
- `test/gen-skill-docs.test.ts`: the four skills look in `docs/designs/` only and never name `_REPOTOP/DESIGN.md`

## Verified

`bun test test/gen-skill-docs.test.ts` — 440 pass, 0 fail.

Fixes #2839

🤖 Generated with [Claude Code](https://claude.com/claude-code)
