### PR TITLE
fix(codex): a retired-model 404 must not report CODEX_MODE: ready

### DIFF
--- a/bin/gstack-codex-probe
+++ b/bin/gstack-codex-probe
@@ -46,8 +46,12 @@ _gstack_codex_model_probe() {
   #
   # Contract:
   #   MODEL_OK (exit 0)              — round trip succeeded; cached 1h.
-  #   MODEL_UNUSABLE (exit 1)        — deterministic model 400; hints printed.
-  #     Cached 15 min: the 400 is model/entitlement-driven, so re-probing every preflight
+  #   MODEL_UNUSABLE (exit 1)        — deterministic model rejection (a 400
+  #     "is not supported", a 400 "requires a newer version of Codex", or a
+  #     404 "does not exist or you do not have access to it"); hints printed,
+  #     branched by cause because the first two are fixed by model selection
+  #     and the third by upgrading the CLI.
+  #     Cached 15 min: the rejection is model/entitlement-driven, so re-probing every preflight
   #     charged the affected user a 30s round trip + real tokens per review
   #     section, forever. Editing config.toml (the fix) changes the cache
   #     signature and re-probes immediately; the short TTL covers server-side
@@ -110,14 +114,37 @@ _gstack_codex_model_probe() {
     echo "MODEL_OK"
     return 0
   fi
-  if printf '%s' "$_out" | grep -qiE 'model.{0,40}is not supported|"status":[[:space:]]*400'; then
+  # Model rejection arrives in three shapes, and only the first two were matched
+  # before. The 404 is the one that mattered: a retired model answers
+  # `404 Not Found: The model \`X\` does not exist or you do not have access to
+  # it` on the /responses path, which carries neither "is not supported" nor a
+  # 400, so it fell through to the fail-open branch below and the preflight
+  # reported CODEX_MODE: ready on a CLI that could not reach a single model —
+  # the #2742 failure one bucket over. Anchor the 404 on the model-not-found
+  # wording rather than the bare status so an unrelated 404 (a proxy, a wrong
+  # base URL) keeps its fail-open contract.
+  _MODEL_REJECT_SIG='model.{0,40}is not supported|"status":[[:space:]]*400|(does not exist or you do not have access|model.{0,40}does not exist)'
+  if printf '%s' "$_out" | grep -qiE "$_MODEL_REJECT_SIG"; then
     mkdir -p "$_gstack_home" 2>/dev/null || true
     printf 'MODEL_UNUSABLE %s %s\n' "$_now" "$_sig" > "$_cache" 2>/dev/null || true
     echo "MODEL_UNUSABLE"
     printf '%s\n' "$_out" | grep -i "model" | head -3
-    echo "HINT: gstack requested model '$_model'."
-    echo "HINT: set GSTACK_CODEX_MODEL=<supported-model> or pass an explicit -c model=... override."
-    _gstack_codex_log_event "codex_model_unusable" 2>/dev/null || true
+    # Two different fixes hide behind one status. "requires a newer version of
+    # Codex" is the server telling us the CLI is too old, and no amount of
+    # model selection repairs that — pointing the user at GSTACK_CODEX_MODEL
+    # there sends them to edit config forever while the actual fix is an
+    # upgrade. Branch the hint on the cause.
+    if printf '%s' "$_out" | grep -qiE 'requires a newer version|upgrade to the latest (app|version)'; then
+      echo "HINT: the server refused model '$_model' because this Codex CLI is too old."
+      echo "HINT: upgrade the CLI — \`codex doctor\` prints the command for your install"
+      echo "HINT: (typically \`brew upgrade --cask codex\` or \`npm install -g @openai/codex\`)."
+      _gstack_codex_log_event "codex_cli_outdated" 2>/dev/null || true
+    else
+      echo "HINT: gstack requested model '$_model'."
+      echo "HINT: set GSTACK_CODEX_MODEL=<supported-model> or pass an explicit -c model=... override."
+      echo "HINT: if every model is refused, the CLI itself may be outdated — check \`codex doctor\`."
+      _gstack_codex_log_event "codex_model_unusable" 2>/dev/null || true
+    fi
     return 1
   fi
   # A CLI that cannot execute is deterministic, not transient: the fail-open
@@ -138,8 +165,8 @@ _gstack_codex_model_probe() {
     return 2
   fi
   # Timeout (124) or transient failure: fail-open with a warning. The probe
-  # exists to catch the deterministic model 400, not to gate on network luck.
-  echo "MODEL_PROBE_INCONCLUSIVE (exit $_code) — proceeding; if invocations fail with a model 400, see the codex skill's Error Handling entry."
+  # exists to catch a deterministic model rejection, not to gate on network luck.
+  echo "MODEL_PROBE_INCONCLUSIVE (exit $_code) — proceeding; if invocations fail with a model 400/404, see the codex skill's Error Handling entry."
   return 0
 }
 

--- a/codex/SKILL.md
+++ b/codex/SKILL.md
@@ -545,12 +545,13 @@ model reviewing itself, and nested spawns have burned 15M tokens in one
 If the output contains `AUTH_FAILED`, stop and tell the user:
 "No Codex authentication found. Run `codex login` or set `$CODEX_API_KEY` / `$OPENAI_API_KEY`, then re-run this skill."
 
-If the output contains `MODEL_UNUSABLE`, stop — auth exists but the account
-cannot use gstack's selected model (`GSTACK_CODEX_MODEL` or the `gpt-6-astra`
-default). Relay the probe's HINT lines and
-follow the "Model not supported (HTTP 400)" recovery steps in
-`## Error Handling` below. Running the modes anyway just burns four
-invocations on the same 400 (#2477).
+If the output contains `MODEL_UNUSABLE`, stop — auth exists but the round trip
+was refused: either the account cannot use gstack's selected model
+(`GSTACK_CODEX_MODEL` or the `gpt-6-astra` default), or the CLI is too old for
+any model. Relay the probe's HINT lines, which say which of the two it is, and
+follow the matching "Model rejected" recovery steps in `## Error Handling`
+below. Running the modes anyway just burns four invocations on the same
+rejection (#2477).
 
 `MODEL_PROBE_INCONCLUSIVE` is non-blocking (timeout/transient network): pass
 the warning through and continue.
@@ -866,18 +867,33 @@ If token count is not available, display: `Tokens: unknown`
   missing or wrong. A prompt-only `codex review` defaults to uncommitted changes, so a
   clean working tree reads as an empty review even when `<base>...HEAD` is large. Confirm
   `--base <base>` is actually on the command line.
-- **Model not supported (HTTP 400):** stderr shows
-  `The '<model>' model is not supported when using Codex with a ChatGPT account`
-  (a `status: 400` / `invalid_request_error` naming a model). This is a
-  model-entitlement problem, not an auth or network failure, and the auth probe
-  cannot catch it. Recovery, in order:
-  1. Check whether `GSTACK_CODEX_MODEL` is set. If so, update it to a model the
-     account can use.
-  2. If no override is set, gstack defaults to `gpt-6-astra`. If the account cannot
-     use it yet, set `GSTACK_CODEX_MODEL=<supported-model>` or replace the default
-     flag with `-c "model=\"<supported-model>\""`.
-  3. If Codex printed `[notice.model_migrations]`, use that replacement model.
-  Never present this as a model stall or a PASS — it is a fail-closed gate result.
+- **Model rejected — read WHICH rejection before acting.** Three different
+  failures name a model, and two of them are not fixed by changing the model.
+  None is an auth or network failure, and the auth probe catches none of them.
+  - **`is not supported when using Codex with a ChatGPT account`** (`status: 400`)
+    — a model-entitlement problem. Recovery, in order:
+    1. Check whether `GSTACK_CODEX_MODEL` is set. If so, update it to a model the
+       account can use.
+    2. If no override is set, gstack defaults to `gpt-6-astra`. If the account cannot
+       use it yet, set `GSTACK_CODEX_MODEL=<supported-model>` or replace the default
+       flag with `-c "model=\"<supported-model>\""`.
+    3. If Codex printed `[notice.model_migrations]`, use that replacement model —
+       but verify it: a migration table can name a model that has since been
+       retired itself, in which case it sends you in a circle.
+  - **`requires a newer version of Codex. Please upgrade to the latest app or CLI`**
+    (`status: 400`) — the CLI is too old, and **no model selection repairs it**.
+    Run `codex doctor` and upgrade (`brew upgrade --cask codex`, or
+    `npm install -g @openai/codex`). Changing `GSTACK_CODEX_MODEL` here just
+    moves between models that are all refused.
+  - **`404 Not Found: The model '<model>' does not exist or you do not have
+    access to it`** — the model is retired or invisible to this account.
+    Note this arrives as a **404, not a 400**, and on the `/responses` URL.
+    Treat it exactly like the entitlement case above. Beware two traps: a model
+    still listed in `~/.codex/models_cache.json` as `visibility: list` /
+    `supported_in_api: true` can **still** 404 — that file is not proof of
+    entitlement — and if every model is refused, suspect the CLI version first.
+  Never present any of these as a model stall or a PASS — they are fail-closed
+  gate results.
 - **Empty response:** If `$TMPRESP` is empty or doesn't exist, tell the user:
   "Codex returned no response. Check stderr for errors."
 - **Session resume failure:** If resume fails, delete the session file and start fresh.

--- a/codex/SKILL.md.tmpl
+++ b/codex/SKILL.md.tmpl
@@ -99,12 +99,13 @@ model reviewing itself, and nested spawns have burned 15M tokens in one
 If the output contains `AUTH_FAILED`, stop and tell the user:
 "No Codex authentication found. Run `codex login` or set `$CODEX_API_KEY` / `$OPENAI_API_KEY`, then re-run this skill."
 
-If the output contains `MODEL_UNUSABLE`, stop — auth exists but the account
-cannot use gstack's selected model (`GSTACK_CODEX_MODEL` or the `gpt-6-astra`
-default). Relay the probe's HINT lines and
-follow the "Model not supported (HTTP 400)" recovery steps in
-`## Error Handling` below. Running the modes anyway just burns four
-invocations on the same 400 (#2477).
+If the output contains `MODEL_UNUSABLE`, stop — auth exists but the round trip
+was refused: either the account cannot use gstack's selected model
+(`GSTACK_CODEX_MODEL` or the `gpt-6-astra` default), or the CLI is too old for
+any model. Relay the probe's HINT lines, which say which of the two it is, and
+follow the matching "Model rejected" recovery steps in `## Error Handling`
+below. Running the modes anyway just burns four invocations on the same
+rejection (#2477).
 
 `MODEL_PROBE_INCONCLUSIVE` is non-blocking (timeout/transient network): pass
 the warning through and continue.
@@ -295,18 +296,33 @@ If token count is not available, display: `Tokens: unknown`
   missing or wrong. A prompt-only `codex review` defaults to uncommitted changes, so a
   clean working tree reads as an empty review even when `<base>...HEAD` is large. Confirm
   `--base <base>` is actually on the command line.
-- **Model not supported (HTTP 400):** stderr shows
-  `The '<model>' model is not supported when using Codex with a ChatGPT account`
-  (a `status: 400` / `invalid_request_error` naming a model). This is a
-  model-entitlement problem, not an auth or network failure, and the auth probe
-  cannot catch it. Recovery, in order:
-  1. Check whether `GSTACK_CODEX_MODEL` is set. If so, update it to a model the
-     account can use.
-  2. If no override is set, gstack defaults to `gpt-6-astra`. If the account cannot
-     use it yet, set `GSTACK_CODEX_MODEL=<supported-model>` or replace the default
-     flag with `-c "model=\"<supported-model>\""`.
-  3. If Codex printed `[notice.model_migrations]`, use that replacement model.
-  Never present this as a model stall or a PASS — it is a fail-closed gate result.
+- **Model rejected — read WHICH rejection before acting.** Three different
+  failures name a model, and two of them are not fixed by changing the model.
+  None is an auth or network failure, and the auth probe catches none of them.
+  - **`is not supported when using Codex with a ChatGPT account`** (`status: 400`)
+    — a model-entitlement problem. Recovery, in order:
+    1. Check whether `GSTACK_CODEX_MODEL` is set. If so, update it to a model the
+       account can use.
+    2. If no override is set, gstack defaults to `gpt-6-astra`. If the account cannot
+       use it yet, set `GSTACK_CODEX_MODEL=<supported-model>` or replace the default
+       flag with `-c "model=\"<supported-model>\""`.
+    3. If Codex printed `[notice.model_migrations]`, use that replacement model —
+       but verify it: a migration table can name a model that has since been
+       retired itself, in which case it sends you in a circle.
+  - **`requires a newer version of Codex. Please upgrade to the latest app or CLI`**
+    (`status: 400`) — the CLI is too old, and **no model selection repairs it**.
+    Run `codex doctor` and upgrade (`brew upgrade --cask codex`, or
+    `npm install -g @openai/codex`). Changing `GSTACK_CODEX_MODEL` here just
+    moves between models that are all refused.
+  - **`404 Not Found: The model '<model>' does not exist or you do not have
+    access to it`** — the model is retired or invisible to this account.
+    Note this arrives as a **404, not a 400**, and on the `/responses` URL.
+    Treat it exactly like the entitlement case above. Beware two traps: a model
+    still listed in `~/.codex/models_cache.json` as `visibility: list` /
+    `supported_in_api: true` can **still** 404 — that file is not proof of
+    entitlement — and if every model is refused, suspect the CLI version first.
+  Never present any of these as a model stall or a PASS — they are fail-closed
+  gate results.
 - **Empty response:** If `$TMPRESP` is empty or doesn't exist, tell the user:
   "Codex returned no response. Check stderr for errors."
 - **Session resume failure:** If resume fails, delete the session file and start fresh.

--- a/test/codex-model-probe.test.ts
+++ b/test/codex-model-probe.test.ts
@@ -37,6 +37,18 @@ case "\${STUB_MODE:-ok}" in
     echo 'ERROR: {"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The '"'"'gpt-6-astra'"'"' model is not supported when using Codex with a ChatGPT account."}}' >&2
     exit 1 ;;
   transient) echo "stream error: network unreachable" >&2; exit 7 ;;
+  model404)
+    # A retired model on the /responses path. Carries no 400 and no
+    # "is not supported", which is why this used to fail open.
+    echo 'ERROR: unexpected status 404 Not Found: The model \`gpt-6-astra\` does not exist or you do not have access to it., url: https://chatgpt.com/backend-api/codex/responses' >&2
+    exit 1 ;;
+  staleCli)
+    echo 'ERROR: {"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The '"'"'gpt-6-astra'"'"' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."}}' >&2
+    exit 1 ;;
+  notfound404)
+    # An unrelated 404 (bad base URL, proxy). Must KEEP the fail-open contract.
+    echo 'ERROR: unexpected status 404 Not Found, url: https://example.invalid/v1/responses' >&2
+    exit 1 ;;
 esac
 `;
 
@@ -144,6 +156,56 @@ describe('codex model probe (#2477)', () => {
       expect(second.stdout).toContain('GSTACK_CODEX_MODEL');
       expect(second.status).toBe(1);
       expect(invocations(f)).toBe(1);
+    } finally {
+      fs.rmSync(f.home, { recursive: true, force: true });
+    }
+  });
+
+  test('a retired-model 404 is MODEL_UNUSABLE, not fail-open', () => {
+    // Regression: the classifier matched only /is not supported/ and
+    // /"status": *400/. A retired model answers 404 with neither, so the probe
+    // fell through to MODEL_PROBE_INCONCLUSIVE (return 0) and the preflight
+    // printed CODEX_MODE: ready while every codex invocation died. Measured
+    // against codex-cli 0.153.4 with a retired pin.
+    const f = makeFixture();
+    try {
+      const r = runProbe(f, 'model404');
+      expect(r.stdout).toContain('MODEL_UNUSABLE');
+      expect(r.stdout).not.toContain('MODEL_PROBE_INCONCLUSIVE');
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('GSTACK_CODEX_MODEL');
+    } finally {
+      fs.rmSync(f.home, { recursive: true, force: true });
+    }
+  });
+
+  test('"requires a newer version of Codex" points at the CLI, not the model pin', () => {
+    // Same status class, different fix. Telling the user to change
+    // GSTACK_CODEX_MODEL here sends them to edit config forever while every
+    // model stays refused; the actual repair is upgrading the CLI.
+    const f = makeFixture();
+    try {
+      const r = runProbe(f, 'staleCli');
+      expect(r.stdout).toContain('MODEL_UNUSABLE');
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('too old');
+      expect(r.stdout).toContain('codex doctor');
+      // The model-selection hint must NOT be the advice offered here.
+      expect(r.stdout).not.toContain('set GSTACK_CODEX_MODEL=<supported-model>');
+    } finally {
+      fs.rmSync(f.home, { recursive: true, force: true });
+    }
+  });
+
+  test('an unrelated 404 keeps the fail-open contract', () => {
+    // The 404 signature is anchored on the model-not-found wording precisely
+    // so a proxy or wrong-base-URL 404 stays a network-luck problem.
+    const f = makeFixture();
+    try {
+      const r = runProbe(f, 'notfound404');
+      expect(r.stdout).toContain('MODEL_PROBE_INCONCLUSIVE');
+      expect(r.stdout).not.toContain('MODEL_UNUSABLE');
+      expect(r.status).toBe(0);
     } finally {
       fs.rmSync(f.home, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Why

`_gstack_codex_model_probe` reports `MODEL_OK`/fail-open on a Codex CLI that cannot reach a single model, so every skill's preflight prints **`CODEX_MODE: ready`** and then burns its invocations discovering the rejection one at a time.

The classifier matches only two shapes:

```bash
grep -qiE 'model.{0,40}is not supported|"status":[[:space:]]*400'
```

A retired model answers with neither:

```
ERROR: unexpected status 404 Not Found: The model `gpt-5.5` does not exist or
you do not have access to it., url: https://chatgpt.com/backend-api/codex/responses
```

…so it reaches the `MODEL_PROBE_INCONCLUSIVE` fail-open branch and `return 0`. This is [#2742](https://github.com/garrytan/gstack/issues/2742)'s failure one bucket over — the gate built to catch a dead model reports healthy.

Reproduced live while diagnosing a real outage. Measured against a ChatGPT account:

| Model | Response |
|---|---|
| `gpt-5.5` (the pin) | **404** `does not exist or you do not have access to it` |
| `gpt-5.6-sol` / `-terra` / `-luna` | **400** `requires a newer version of Codex` |
| `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-max` | **400** `not supported when using Codex with a ChatGPT account` |

Every model refused, `CODEX_MODE: ready` on both codex-cli 0.141.0 and 0.153.4.

## What changed

That table holds **two** faults, so there are two fixes.

1. **The 404 now classifies as `MODEL_UNUSABLE` (exit 1)** instead of failing open. The signature is anchored on the model-not-found wording rather than the bare status, so an unrelated 404 (proxy, wrong base URL) keeps its fail-open contract — there's a test for that.

2. **The HINT branches by cause.** `requires a newer version of Codex` is the server saying the *CLI* is too old; no model selection repairs it. The old hint sent the user to `GSTACK_CODEX_MODEL` forever while every model stayed refused. It now points at `codex doctor` and the upgrade command. The entitlement hint gains a line: if *every* model is refused, suspect the CLI.

No exit-code contract change — both land on the existing exit 1, so `decideScope`-style callers are untouched.

**Docs** (`codex/SKILL.md.tmpl`, regenerated): the Error Handling entry covered only the 400 "is not supported" case. It now splits all three shapes and records two traps found the hard way:

- a `[notice.model_migrations]` target can itself be retired — on the affected machine the table said `"gpt-5.1-codex-max" = "gpt-5.4"`, and **gpt-5.4 is dead**, so the documented recovery led in a circle;
- `models_cache.json` listing a model as `visibility: list` / `supported_in_api: true` is **not** proof of entitlement — `gpt-5.5` was listed exactly that way and still 404'd.

## How to verify

```bash
bun test test/codex-model-probe.test.ts
```

Two of the three new tests are genuine regression tests — they fail against the unpatched probe:

- `a retired-model 404 is MODEL_UNUSABLE, not fail-open` → fails on `toContain('MODEL_UNUSABLE')` (the 404 falls open)
- `"requires a newer version of Codex" points at the CLI, not the model pin` → fails on `toContain('too old')`. Note its `MODEL_UNUSABLE` assertion *passes* unpatched, since that stub emits `"status":400`; the test isolates hint routing, not classification.

The third (`an unrelated 404 keeps the fail-open contract`) passes both ways by design — it guards against the new pattern over-matching.

Also green: `codex-hardening`, `codex-web-search-flag`, `codex-generation-model`, `setup-codex-model`, `context-budget-ratchet`, `carve-guard-completeness`, `catalog-budget` (160 tests total).

## Watch out for

The 404 pattern is deliberately two alternatives — `does not exist or you do not have access` and `model.{0,40}does not exist` — to cover wording drift while still refusing to match a bare status-404. If you'd rather it be stricter, narrowing to the first alternative alone still passes every test here.