### PR TITLE
fix(investigate): resolve the scope lock to an absolute path and release it in Phase 5 (#2845)

### DIFF
--- a/freeze/SKILL.md
+++ b/freeze/SKILL.md
@@ -72,7 +72,8 @@ echo "Freeze boundary set: $FREEZE_DIR"
 
 Tell the user: "Edits are now restricted to `<path>/`. Any Edit or Write
 outside this directory will be blocked. To change the boundary, run `/freeze`
-again. To remove it, run `/unfreeze` or end the session."
+again. To remove it, run `/unfreeze`. The boundary is a state file on disk, so
+it survives the end of this session and governs the next one until cleared."
 
 ## How it works
 
@@ -89,8 +90,10 @@ but has no `file_path` (a non-file tool) is allowed. Symlinks are resolved
 through their FINAL component, so an in-boundary symlink pointing outside the
 boundary is checked against its target.
 
-The freeze boundary persists for the session via the state file. The hook
-script reads it on every Edit/Write invocation. Boundaries containing spaces
+The freeze boundary persists across sessions via the state file, which is
+machine-global (one per gstack state root, not per session or per repo). The
+hook script reads it on every Edit/Write invocation, in every session whose
+skill registered the hook, until `/unfreeze` removes the file (#2845). Boundaries containing spaces
 are supported.
 
 ## Notes

--- a/freeze/SKILL.md.tmpl
+++ b/freeze/SKILL.md.tmpl
@@ -67,7 +67,8 @@ echo "Freeze boundary set: $FREEZE_DIR"
 
 Tell the user: "Edits are now restricted to `<path>/`. Any Edit or Write
 outside this directory will be blocked. To change the boundary, run `/freeze`
-again. To remove it, run `/unfreeze` or end the session."
+again. To remove it, run `/unfreeze`. The boundary is a state file on disk, so
+it survives the end of this session and governs the next one until cleared."
 
 ## How it works
 
@@ -84,8 +85,10 @@ but has no `file_path` (a non-file tool) is allowed. Symlinks are resolved
 through their FINAL component, so an in-boundary symlink pointing outside the
 boundary is checked against its target.
 
-The freeze boundary persists for the session via the state file. The hook
-script reads it on every Edit/Write invocation. Boundaries containing spaces
+The freeze boundary persists across sessions via the state file, which is
+machine-global (one per gstack state root, not per session or per repo). The
+hook script reads it on every Edit/Write invocation, in every session whose
+skill registered the hook, until `/unfreeze` removes the file (#2845). Boundaries containing spaces
 are supported.
 
 ## Notes

--- a/guard/SKILL.md
+++ b/guard/SKILL.md
@@ -82,7 +82,7 @@ Tell the user:
 - "**Guard mode active.** Two protections are now running:"
 - "1. **Destructive command guard** — rm -rf, DROP TABLE, force-push, etc. warn before executing (overridable); catastrophic shapes (recursive delete of / or ~, force-push to the default branch) are hard-denied"
 - "2. **Edit boundary** — file edits restricted to `<path>/`. Edits outside this directory are blocked."
-- "To remove the edit boundary, run `/unfreeze`. To deactivate everything, end the session."
+- "To remove the edit boundary, run `/unfreeze`; the boundary is a state file that survives the session. To deactivate everything, run `/unfreeze` and end the session."
 
 ## What's protected
 

--- a/guard/SKILL.md.tmpl
+++ b/guard/SKILL.md.tmpl
@@ -78,7 +78,7 @@ Tell the user:
 - "**Guard mode active.** Two protections are now running:"
 - "1. **Destructive command guard** — rm -rf, DROP TABLE, force-push, etc. warn before executing (overridable); catastrophic shapes (recursive delete of / or ~, force-push to the default branch) are hard-denied"
 - "2. **Edit boundary** — file edits restricted to `<path>/`. Edits outside this directory are blocked."
-- "To remove the edit boundary, run `/unfreeze`. To deactivate everything, end the session."
+- "To remove the edit boundary, run `/unfreeze`; the boundary is a state file that survives the session. To deactivate everything, run `/unfreeze` and end the session."
 
 ## What's protected
 

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -535,19 +535,29 @@ _FREEZE_SCRIPT="$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh"
 [ -x "$_FREEZE_SCRIPT" ] && echo "FREEZE_AVAILABLE" || echo "FREEZE_UNAVAILABLE"
 ```
 
-**If FREEZE_AVAILABLE:** Identify the narrowest directory containing the affected files. Write it to the freeze state file:
+**If FREEZE_AVAILABLE:** Identify the narrowest directory containing the affected files. Resolve it to an absolute path, then write it to the freeze state file:
 
 ```bash
-eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
-STATE_DIR="$GSTACK_STATE_ROOT"
-mkdir -p "$STATE_DIR"
-echo "<detected-directory>/" > "$STATE_DIR/freeze-dir.txt"
-echo "Debug scope locked to: <detected-directory>/"
+# Absolute, like /freeze and /guard (#2845): freeze-dir.txt is one machine-global
+# file and check-freeze.sh resolves a relative boundary against whatever
+# directory the NEXT tool call runs in, so a relative `src/` written here would
+# govern <other-repo>/src/ in every later session on the machine.
+FREEZE_DIR=$(cd "<detected-directory>" 2>/dev/null && pwd)
+if [ -z "$FREEZE_DIR" ]; then
+  echo "SCOPE_LOCK_SKIPPED: <detected-directory> does not resolve from $(pwd)"
+else
+  FREEZE_DIR="${FREEZE_DIR%/}/"
+  eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+  STATE_DIR="$GSTACK_STATE_ROOT"
+  mkdir -p "$STATE_DIR"
+  echo "$FREEZE_DIR" > "$STATE_DIR/freeze-dir.txt"
+  echo "Debug scope locked to: $FREEZE_DIR"
+fi
 ```
 
-Substitute `<detected-directory>` with the actual directory path (e.g., `src/auth/`). Tell the user: "Edits restricted to `<dir>/` for this debug session. This prevents changes to unrelated code. Run `/unfreeze` to remove the restriction."
+Substitute `<detected-directory>` with the directory path as you found it (e.g., `src/auth/`); the block resolves it. Remember the absolute path it prints: Phase 5 releases exactly that lock. Tell the user: "Edits restricted to `<absolute-dir>/` for this debug session. This prevents changes to unrelated code. The lock is released when this run reports; run `/unfreeze` to remove it sooner."
 
-If the bug spans the entire repo or the scope is genuinely unclear, skip the lock and note why.
+If the block prints `SCOPE_LOCK_SKIPPED`, if the bug spans the entire repo, or if the scope is genuinely unclear, skip the lock and note why.
 
 **If FREEZE_UNAVAILABLE:** Skip scope lock. Edits are unrestricted.
 
@@ -681,6 +691,23 @@ Status:          DONE | DONE_WITH_CONCERNS | BLOCKED
 ════════════════════════════════════════
 ```
 
+**Release the scope lock.** If the Scope Lock step wrote a boundary in this run, remove it now, whatever the completion status. The state file outlives the session (#2845): a lock left behind here is enforced on every later session on the machine until someone runs `/unfreeze`. The block compares before deleting, so a boundary the user set with `/freeze` before invoking this skill is left alone. Substitute the absolute path the Scope Lock step printed:
+
+```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+STATE_DIR="$GSTACK_STATE_ROOT"
+LOCKED="<locked-directory>"; LOCKED="${LOCKED%/}/"
+CURRENT=$(head -n 1 "$STATE_DIR/freeze-dir.txt" 2>/dev/null)
+if [ -n "$CURRENT" ] && [ "${CURRENT%/}/" = "$LOCKED" ]; then
+  rm -f "$STATE_DIR/freeze-dir.txt"
+  echo "Debug scope lock released: $LOCKED"
+else
+  echo "No debug scope lock from this run to release (state file holds: ${CURRENT:-nothing})."
+fi
+```
+
+If the Scope Lock step was skipped, skip this too.
+
 Log the investigation as a learning for future sessions. Use `type: "investigation"` and include the affected files so future investigations on the same area can find this:
 
 ```bash
@@ -722,6 +749,7 @@ already knows. A good test: would this insight save time in a future session? If
 - **Never apply a fix you cannot verify.** If you can't reproduce and confirm, don't ship it.
 - **Never say "this should fix it."** Verify and prove it. Run the tests.
 - **If fix touches >5 files → AskUserQuestion** about blast radius before proceeding.
+- **The scope lock is per run.** Phase 5 releases the boundary the Scope Lock step wrote, on DONE, DONE_WITH_CONCERNS and BLOCKED alike. `freeze-dir.txt` is machine-global and survives the session, so a lock left behind governs every later session until `/unfreeze`.
 - **Completion status:**
   - DONE — root cause found, fix applied, regression test written, all tests pass
   - DONE_WITH_CONCERNS — fixed but cannot fully verify (e.g., intermittent bug, requires staging)

--- a/investigate/SKILL.md.tmpl
+++ b/investigate/SKILL.md.tmpl
@@ -125,19 +125,29 @@ _FREEZE_SCRIPT="$HOME/.claude/skills/gstack/freeze/bin/check-freeze.sh"
 [ -x "$_FREEZE_SCRIPT" ] && echo "FREEZE_AVAILABLE" || echo "FREEZE_UNAVAILABLE"
 ```
 
-**If FREEZE_AVAILABLE:** Identify the narrowest directory containing the affected files. Write it to the freeze state file:
+**If FREEZE_AVAILABLE:** Identify the narrowest directory containing the affected files. Resolve it to an absolute path, then write it to the freeze state file:
 
 ```bash
-eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
-STATE_DIR="$GSTACK_STATE_ROOT"
-mkdir -p "$STATE_DIR"
-echo "<detected-directory>/" > "$STATE_DIR/freeze-dir.txt"
-echo "Debug scope locked to: <detected-directory>/"
+# Absolute, like /freeze and /guard (#2845): freeze-dir.txt is one machine-global
+# file and check-freeze.sh resolves a relative boundary against whatever
+# directory the NEXT tool call runs in, so a relative `src/` written here would
+# govern <other-repo>/src/ in every later session on the machine.
+FREEZE_DIR=$(cd "<detected-directory>" 2>/dev/null && pwd)
+if [ -z "$FREEZE_DIR" ]; then
+  echo "SCOPE_LOCK_SKIPPED: <detected-directory> does not resolve from $(pwd)"
+else
+  FREEZE_DIR="${FREEZE_DIR%/}/"
+  eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+  STATE_DIR="$GSTACK_STATE_ROOT"
+  mkdir -p "$STATE_DIR"
+  echo "$FREEZE_DIR" > "$STATE_DIR/freeze-dir.txt"
+  echo "Debug scope locked to: $FREEZE_DIR"
+fi
 ```
 
-Substitute `<detected-directory>` with the actual directory path (e.g., `src/auth/`). Tell the user: "Edits restricted to `<dir>/` for this debug session. This prevents changes to unrelated code. Run `/unfreeze` to remove the restriction."
+Substitute `<detected-directory>` with the directory path as you found it (e.g., `src/auth/`); the block resolves it. Remember the absolute path it prints: Phase 5 releases exactly that lock. Tell the user: "Edits restricted to `<absolute-dir>/` for this debug session. This prevents changes to unrelated code. The lock is released when this run reports; run `/unfreeze` to remove it sooner."
 
-If the bug spans the entire repo or the scope is genuinely unclear, skip the lock and note why.
+If the block prints `SCOPE_LOCK_SKIPPED`, if the bug spans the entire repo, or if the scope is genuinely unclear, skip the lock and note why.
 
 **If FREEZE_UNAVAILABLE:** Skip scope lock. Edits are unrestricted.
 
@@ -244,6 +254,23 @@ Status:          DONE | DONE_WITH_CONCERNS | BLOCKED
 ════════════════════════════════════════
 ```
 
+**Release the scope lock.** If the Scope Lock step wrote a boundary in this run, remove it now, whatever the completion status. The state file outlives the session (#2845): a lock left behind here is enforced on every later session on the machine until someone runs `/unfreeze`. The block compares before deleting, so a boundary the user set with `/freeze` before invoking this skill is left alone. Substitute the absolute path the Scope Lock step printed:
+
+```bash
+eval "$(~/.claude/skills/gstack/bin/gstack-paths)"
+STATE_DIR="$GSTACK_STATE_ROOT"
+LOCKED="<locked-directory>"; LOCKED="${LOCKED%/}/"
+CURRENT=$(head -n 1 "$STATE_DIR/freeze-dir.txt" 2>/dev/null)
+if [ -n "$CURRENT" ] && [ "${CURRENT%/}/" = "$LOCKED" ]; then
+  rm -f "$STATE_DIR/freeze-dir.txt"
+  echo "Debug scope lock released: $LOCKED"
+else
+  echo "No debug scope lock from this run to release (state file holds: ${CURRENT:-nothing})."
+fi
+```
+
+If the Scope Lock step was skipped, skip this too.
+
 Log the investigation as a learning for future sessions. Use `type: "investigation"` and include the affected files so future investigations on the same area can find this:
 
 ```bash
@@ -262,6 +289,7 @@ Log the investigation as a learning for future sessions. Use `type: "investigati
 - **Never apply a fix you cannot verify.** If you can't reproduce and confirm, don't ship it.
 - **Never say "this should fix it."** Verify and prove it. Run the tests.
 - **If fix touches >5 files → AskUserQuestion** about blast radius before proceeding.
+- **The scope lock is per run.** Phase 5 releases the boundary the Scope Lock step wrote, on DONE, DONE_WITH_CONCERNS and BLOCKED alike. `freeze-dir.txt` is machine-global and survives the session, so a lock left behind governs every later session until `/unfreeze`.
 - **Completion status:**
   - DONE — root cause found, fix applied, regression test written, all tests pass
   - DONE_WITH_CONCERNS — fixed but cannot fully verify (e.g., intermittent bug, requires staging)

--- a/test/investigate-freeze-path.test.ts
+++ b/test/investigate-freeze-path.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
+import { spawnSync } from 'child_process';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const FILES = ['investigate/SKILL.md.tmpl', 'investigate/SKILL.md'];
@@ -31,4 +33,123 @@ describe('investigate freeze path resolution', () => {
       expect(content).toContain('[ -x "$_FREEZE_SCRIPT" ] && echo "FREEZE_AVAILABLE" || echo "FREEZE_UNAVAILABLE"');
     });
   }
+});
+
+// #2845: the Scope Lock wrote `<detected-directory>/` verbatim (the skill's own
+// example is the relative `src/auth/`) into the machine-global freeze-dir.txt,
+// and no later phase removed it. check-freeze.sh resolves a relative boundary
+// against $(pwd) of whatever tool call comes next, so one debug session's lock
+// re-anchored to `<other-repo>/src/` in every later session on the machine, and
+// stayed there until someone ran /unfreeze. The writer must resolve an absolute
+// path the way /freeze and /guard do, and Phase 5 must release what it wrote.
+const CHECK_FREEZE = path.join(ROOT, 'freeze', 'bin', 'check-freeze.sh');
+
+function freezeVerdict(stateDir: string, cwd: string, filePath: string): 'allow' | 'deny' {
+  const r = spawnSync('bash', [CHECK_FREEZE], {
+    cwd,
+    input: JSON.stringify({ tool_name: 'Write', tool_input: { file_path: filePath } }),
+    env: { ...process.env, GSTACK_HOME: stateDir, CLAUDE_PLUGIN_DATA: '', CLAUDE_PLUGIN_ROOT: '' },
+    encoding: 'utf-8',
+    timeout: 5000,
+  });
+  const out = JSON.parse(r.stdout.trim() || '{}');
+  return out?.hookSpecificOutput?.permissionDecision === 'deny' ? 'deny' : 'allow';
+}
+
+describe('investigate scope lock is absolute and released (#2845)', () => {
+  for (const rel of FILES) {
+    const content = fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+    test(`${rel} resolves the lock directory to an absolute path before writing it`, () => {
+      expect(content).toContain('FREEZE_DIR=$(cd "<detected-directory>" 2>/dev/null && pwd)');
+      expect(content).toContain('echo "$FREEZE_DIR" > "$STATE_DIR/freeze-dir.txt"');
+      expect(content).not.toContain('echo "<detected-directory>/" > "$STATE_DIR/freeze-dir.txt"');
+    });
+
+    test(`${rel} skips the lock loudly when the directory does not resolve`, () => {
+      // An empty FREEZE_DIR would otherwise become "/" and freeze nothing.
+      expect(content).toContain('SCOPE_LOCK_SKIPPED');
+    });
+
+    test(`${rel} releases its own lock in Phase 5, by compare-and-delete`, () => {
+      const report = content.indexOf('DEBUG REPORT');
+      const release = content.indexOf('rm -f "$STATE_DIR/freeze-dir.txt"');
+      expect(report).toBeGreaterThan(-1);
+      expect(release).toBeGreaterThan(report);
+      // Never remove a boundary the user set with /freeze before invoking the skill.
+      expect(content).toContain('[ "${CURRENT%/}/" = "$LOCKED" ]');
+    });
+  }
+
+  test('a relative boundary re-anchors to the working directory; an absolute one does not', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-scope-lock-'));
+    const stateDir = path.join(tmp, 'state');
+    const wtA = path.join(tmp, 'wt-a');
+    const wtB = path.join(tmp, 'wt-b');
+    for (const d of [stateDir, path.join(wtA, 'src'), path.join(wtB, 'src'), path.join(wtB, 'scratch')]) {
+      fs.mkdirSync(d, { recursive: true });
+    }
+    const freezeFile = path.join(stateDir, 'freeze-dir.txt');
+    const inA = path.join(wtA, 'src', 'a.ts');
+    const inB = path.join(wtB, 'src', 'b.ts');
+    const scratchB = path.join(wtB, 'scratch', 'notes.md');
+    try {
+      // What the pre-fix Scope Lock wrote: the verdict for ONE file flips with cwd.
+      fs.writeFileSync(freezeFile, 'src/\n');
+      expect(freezeVerdict(stateDir, wtA, inA)).toBe('allow');
+      expect(freezeVerdict(stateDir, wtB, inA)).toBe('deny');
+      // ...and a session in wt-b that never locked anything is now confined to wt-b/src.
+      expect(freezeVerdict(stateDir, wtB, scratchB)).toBe('deny');
+      expect(freezeVerdict(stateDir, wtB, inB)).toBe('allow');
+
+      // What the fixed Scope Lock writes: verdicts are independent of cwd.
+      fs.writeFileSync(freezeFile, `${path.join(wtA, 'src')}/\n`);
+      expect(freezeVerdict(stateDir, wtA, inA)).toBe('allow');
+      expect(freezeVerdict(stateDir, wtB, inA)).toBe('allow');
+      expect(freezeVerdict(stateDir, wtB, inB)).toBe('deny');
+      expect(freezeVerdict(stateDir, wtB, scratchB)).toBe('deny');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('Phase 5 release block removes only the boundary this run wrote', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gstack-scope-release-'));
+    const stateDir = path.join(tmp, 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    const freezeFile = path.join(stateDir, 'freeze-dir.txt');
+    // The release block as rendered, with <locked-directory> substituted.
+    const release = (locked: string) => spawnSync('bash', ['-c', [
+      `STATE_DIR="${stateDir}"`,
+      `LOCKED="${locked}"; LOCKED="\${LOCKED%/}/"`,
+      'CURRENT=$(head -n 1 "$STATE_DIR/freeze-dir.txt" 2>/dev/null)',
+      'if [ -n "$CURRENT" ] && [ "${CURRENT%/}/" = "$LOCKED" ]; then rm -f "$STATE_DIR/freeze-dir.txt"; echo released; else echo kept; fi',
+    ].join('\n')], { encoding: 'utf-8', timeout: 5000 }).stdout.trim();
+    try {
+      fs.writeFileSync(freezeFile, '/tmp/repo/src/\n');
+      expect(release('/tmp/repo/src')).toBe('released');       // trailing slash optional
+      expect(fs.existsSync(freezeFile)).toBe(false);
+
+      fs.writeFileSync(freezeFile, '/tmp/other/lib/\n');        // a /freeze the user set
+      expect(release('/tmp/repo/src/')).toBe('kept');
+      expect(fs.existsSync(freezeFile)).toBe(true);
+
+      fs.rmSync(freezeFile);
+      expect(release('/tmp/repo/src/')).toBe('kept');           // nothing to release, no error
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('freeze prose does not promise a session-scoped boundary (#2845)', () => {
+  test.each(['freeze/SKILL.md.tmpl', 'freeze/SKILL.md', 'guard/SKILL.md.tmpl', 'guard/SKILL.md'])(
+    '%s',
+    (rel) => {
+      const content = fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+      expect(content).not.toContain('`/unfreeze` or end the session');
+      expect(content).not.toContain('persists for the session');
+      expect(content).not.toContain('To deactivate everything, end the session');
+    },
+  );
 });


### PR DESCRIPTION
## Why (in your own words)

`/investigate`'s Scope Lock writes the debug boundary into `freeze-dir.txt` as a relative path (`src/`, its own example is `src/auth/`) and no phase ever removes it. That file is one machine-global state file, and `check-freeze.sh` resolves a relative boundary against the working directory of whatever tool call comes next. So a lock set while debugging one repo re-anchors to `<other-repo>/src/` in every later Claude Code session on the machine, blocking edits nobody froze and permitting edits to the wrong tree, until someone happens to run `/unfreeze`. On my machine a `src/` lock from 2026-09-07 blocked a scratchpad write in an unrelated session on 2026-09-10.

This PR makes the Scope Lock resolve an absolute path the same way `/freeze` and `/guard` already do (skipping loudly when the directory does not resolve, rather than freezing `/`), adds a Phase 5 step that releases the lock this run wrote by compare-and-delete (so a `/freeze` the user set beforehand is left alone), and corrects the `/freeze` and `/guard` prose that told users the boundary ends with the session.

Fixes #2845.

## Live evidence

**The defect, against the real hook.** Temp state root, two directories standing in for two worktrees, state file holding `src/`, exactly what the skill wrote. Same `Write`, two working directories:

```
$ HOOK=~/.claude/skills/gstack/freeze/bin/check-freeze.sh
$ T=$(mktemp -d); mkdir -p $T/state $T/wt-a/src $T/wt-b/src $T/wt-b/scratch
$ echo "src/" > $T/state/freeze-dir.txt
$ (cd $T/wt-a && printf '{"tool_input":{"file_path":"%s/wt-a/src/a.ts"}}' $T | GSTACK_HOME=$T/state bash $HOOK)
{}
$ (cd $T/wt-b && printf '{"tool_input":{"file_path":"%s/wt-a/src/a.ts"}}' $T | GSTACK_HOME=$T/state bash $HOOK)
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"[freeze] Blocked: .../wt-a/src/a.ts is outside the freeze boundary (.../wt-b/src). Only edits within the frozen directory are allowed."}}
$ (cd $T/wt-b && printf '{"tool_input":{"file_path":"%s/wt-b/scratch/notes.md"}}' $T | GSTACK_HOME=$T/state bash $HOOK)
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"[freeze] Blocked: .../wt-b/scratch/notes.md is outside the freeze boundary (.../wt-b/src). ..."}}

# state file holding the absolute path instead: verdicts no longer depend on cwd
$ echo "$T/wt-a/src/" > $T/state/freeze-dir.txt
$ (cd $T/wt-b && printf '{"tool_input":{"file_path":"%s/wt-a/src/a.ts"}}' $T | GSTACK_HOME=$T/state bash $HOOK)
{}
$ (cd $T/wt-b && printf '{"tool_input":{"file_path":"%s/wt-b/src/b.ts"}}' $T | GSTACK_HOME=$T/state bash $HOOK)
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"[freeze] Blocked: .../wt-b/src/b.ts is outside the freeze boundary (.../wt-a/src). ..."}}
```

**Regression test, failing first.** Templates edited, generated files not yet regenerated:

```
$ bun test test/investigate-freeze-path.test.ts
(fail) investigate scope lock is absolute and released (#2845) > investigate/SKILL.md resolves the lock directory to an absolute path before writing it
(fail) investigate scope lock is absolute and released (#2845) > investigate/SKILL.md skips the lock loudly when the directory does not resolve
(fail) investigate scope lock is absolute and released (#2845) > investigate/SKILL.md releases its own lock in Phase 5, by compare-and-delete
(fail) freeze prose does not promise a session-scoped boundary (#2845) > freeze/SKILL.md
(fail) freeze prose does not promise a session-scoped boundary (#2845) > guard/SKILL.md
 11 pass
 5 fail
```

After `bun run gen:skill-docs`:

```
$ bun test test/investigate-freeze-path.test.ts
 16 pass
 0 fail
Ran 16 tests across 1 file. [1.78s]
$ bun run gen:skill-docs --dry-run | tail -3
FRESH: spec/sections/gate-and-file.md
FRESH: review/design-checklist.md
FRESH: lib/dom-dump.js
```

The new tests pin the template and the generated SKILL.md (absolute resolution, `SCOPE_LOCK_SKIPPED`, release block after the report, compare-and-delete guard), drive the real `check-freeze.sh` from two working directories to show the relative boundary flipping verdicts and the absolute one holding, and run the rendered release block against a state file it wrote, one it did not write, and no file at all.

**Full free suite.** `bun run test`:

```
$ bun run test
[test:free] FAIL — 6 failing test(s) in 2 file(s), 0 crashed worker(s)
  ✗ test/gstack-design-detect.test.ts (3)
  ✗ test/gstack-artifacts-init.test.ts (3)
6 shards, 6 failures. The other 4 shards: PASS (1542 / 1212 / 1619 / ... tests).

# The same 6 fail on an untouched main checkout (71f6048) on this machine, and neither
# file references investigate/, freeze/ or guard/:
$ cd <clean main checkout> && bun test test/gstack-artifacts-init.test.ts test/gstack-design-detect.test.ts
 81 pass
 6 fail
Ran 87 tests across 2 files. [49.54s]
# artifacts-init: this machine's gh git_protocol is ssh; design-detect: local impeccable install state.
# Machine-specific, pre-existing, unrelated to this diff.
```

## Scope

- **Changed:** `investigate/SKILL.md.tmpl` (Scope Lock resolves absolute, skips loudly on a non-directory; Phase 5 release block; one Important Rules bullet), `freeze/SKILL.md.tmpl` and `guard/SKILL.md.tmpl` (prose: the boundary is a state file that survives the session), the three regenerated `SKILL.md`, `test/investigate-freeze-path.test.ts`.
- **Verified live by:** the hook reproduction above (macOS 15, gstack 1.84.1.0, global install); the regression test failing then passing; `gen:skill-docs --dry-run` clean.
- **Did NOT test:** a full `/investigate` run under `claude -p` (the paid E2E lane). `check-freeze.sh` itself is unchanged.

## Liveness proof (required)

<img width="776" height="483" alt="image" src="https://github.com/user-attachments/assets/f27727ae-62f5-4936-aa3e-b2dcd879b996" />


## Checklist

- [x] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A)
- [x] Linked issue or reproduction: #2845
