### PR TITLE
fix(aside): run the probe deadline through a function so zsh can detect Aside

### DIFF
--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -161,19 +161,32 @@ Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXI
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: **read the `PROBE_OUTPUT:` line before concluding anything** — it distinguishes states that need different fixes. "No browser window is open for account <id>" means Aside is running and the CLI works, but that profile has no window (often because the account is signed out) — ask the user to open a window and sign in, not to launch the app. A `command not found` naming the deadline helper means the probe itself broke, not Aside. Otherwise ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -166,19 +166,32 @@ section below maps every cookbook step onto it.
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: **read the `PROBE_OUTPUT:` line before concluding anything** — it distinguishes states that need different fixes. "No browser window is open for account <id>" means Aside is running and the CLI works, but that profile has no window (often because the account is signed out) — ask the user to open a window and sign in, not to launch the app. A `command not found` naming the deadline helper means the probe itself broke, not Aside. Otherwise ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -401,19 +401,32 @@ Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXI
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: **read the `PROBE_OUTPUT:` line before concluding anything** — it distinguishes states that need different fixes. "No browser window is open for account <id>" means Aside is running and the CLI works, but that profile has no window (often because the account is signed out) — ask the user to open a window and sign in, not to launch the app. A `command not found` naming the deadline helper means the probe itself broke, not Aside. Otherwise ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -443,14 +443,27 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -512,19 +512,32 @@ If the codebase is empty and purpose is unclear, say: *"I don't have a clear pic
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: **read the `PROBE_OUTPUT:` line before concluding anything** — it distinguishes states that need different fixes. "No browser window is open for account <id>" means Aside is running and the CLI works, but that profile has no window (often because the account is signed out) — ask the user to open a window and sign in, not to launch the app. A `command not found` naming the deadline helper means the probe itself broke, not Aside. Otherwise ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser
@@ -762,14 +775,27 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -486,19 +486,32 @@ After the user chooses, execute their choice (commit or stash), then continue wi
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: **read the `PROBE_OUTPUT:` line before concluding anything** — it distinguishes states that need different fixes. "No browser window is open for account <id>" means Aside is running and the CLI works, but that profile has no window (often because the account is signed out) — ask the user to open a window and sign in, not to launch the app. A `command not found` naming the deadline helper means the probe itself broke, not Aside. Otherwise ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -474,19 +474,32 @@ branch name wherever the instructions say "the base branch" or `<default>`.
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: **read the `PROBE_OUTPUT:` line before concluding anything** — it distinguishes states that need different fixes. "No browser window is open for account <id>" means Aside is running and the CLI works, but that profile has no window (often because the account is signed out) — ask the user to open a window and sign in, not to launch the app. A `command not found` naming the deadline helper means the probe itself broke, not Aside. Otherwise ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -560,14 +560,27 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -430,14 +430,27 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   # Deadline chain as a function, NOT a string held in a variable: zsh does not
+   # word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+   # bare word makes zsh search for a command whose name contains a space, fail, and
+   # report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+   _gs_bounded() {
+     if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+     elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+     elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+     else "$@"
+     fi
+   }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT: $_gs_out"
+     fi
    fi
    ```
 
@@ -456,19 +469,32 @@ A step sometimes requires action on an external website the user controls: regis
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: **read the `PROBE_OUTPUT:` line before concluding anything** — it distinguishes states that need different fixes. "No browser window is open for account <id>" means Aside is running and the CLI works, but that profile has no window (often because the account is signed out) — ask the user to open a window and sign in, not to launch the app. A `command not found` naming the deadline helper means the probe itself broke, not Aside. Otherwise ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -468,14 +468,27 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   # Deadline chain as a function, NOT a string held in a variable: zsh does not
+   # word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+   # bare word makes zsh search for a command whose name contains a space, fail, and
+   # report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+   _gs_bounded() {
+     if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+     elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+     elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+     else "$@"
+     fi
+   }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT: $_gs_out"
+     fi
    fi
    ```
 
@@ -680,14 +693,27 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -565,14 +565,27 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -771,14 +771,27 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -546,14 +546,27 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -451,19 +451,32 @@ You are a QA engineer. Test web applications like a real user — click everythi
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: **read the `PROBE_OUTPUT:` line before concluding anything** — it distinguishes states that need different fixes. "No browser window is open for account <id>" means Aside is running and the CLI works, but that profile has no window (often because the account is signed out) — ask the user to open a window and sign in, not to launch the app. A `command not found` naming the deadline helper means the probe itself broke, not Aside. Otherwise ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -536,19 +536,32 @@ After the user chooses, execute their choice (commit or stash), then continue wi
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: **read the `PROBE_OUTPUT:` line before concluding anything** — it distinguishes states that need different fixes. "No browser window is open for account <id>" means Aside is running and the CLI works, but that profile has no window (often because the account is signed out) — ask the user to open a window and sign in, not to launch the app. A `command not found` naming the deadline helper means the probe itself broke, not Aside. Otherwise ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -649,14 +649,27 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 

--- a/scrape/SKILL.md
+++ b/scrape/SKILL.md
@@ -156,19 +156,32 @@ Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXI
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: **read the `PROBE_OUTPUT:` line before concluding anything** — it distinguishes states that need different fixes. "No browser window is open for account <id>" means Aside is running and the CLI works, but that profile has no window (often because the account is signed out) — ask the user to open a window and sign in, not to launch the app. A `command not found` naming the deadline helper means the probe itself broke, not Aside. Otherwise ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/scripts/resolvers/aside.ts
+++ b/scripts/resolvers/aside.ts
@@ -74,19 +74,32 @@ export function generateAsideSetup(_ctx: TemplateContext): string {
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 \`\`\`bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+# Deadline chain as a function, NOT a string held in a variable: zsh does not
+# word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+# bare word makes zsh search for a command whose name contains a space, fail, and
+# report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+_gs_bounded() {
+  if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+  elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+  elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+  else "$@"
+  fi
+}
 if [ "\${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT: $_gs_out"
+  fi
 fi
 \`\`\`
 
 1. \`NEEDS_ASIDE\`: if \`uname -s\` prints \`Darwin\`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. \`ASIDE_NOT_RUNNING\`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. \`ASIDE_NOT_RUNNING\`: **read the \`PROBE_OUTPUT:\` line before concluding anything** — it distinguishes states that need different fixes. "No browser window is open for account <id>" means Aside is running and the CLI works, but that profile has no window (often because the account is signed out) — ask the user to open a window and sign in, not to launch the app. A \`command not found\` naming the deadline helper means the probe itself broke, not Aside. Otherwise ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote \`PROBE_OUTPUT\` verbatim and continue with the Browser fallback section below.
 3. \`READY\`: continue. \`aside --help\` and \`aside <command> --help\` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -406,14 +406,27 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   # Deadline chain as a function, NOT a string held in a variable: zsh does not
+   # word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+   # bare word makes zsh search for a command whose name contains a space, fail, and
+   # report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+   _gs_bounded() {
+     if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+     elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+     elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+     else "$@"
+     fi
+   }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT: $_gs_out"
+     fi
    fi
    ```
 

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -435,14 +435,27 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   # Deadline chain as a function, NOT a string held in a variable: zsh does not
+   # word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+   # bare word makes zsh search for a command whose name contains a space, fail, and
+   # report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+   _gs_bounded() {
+     if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+     elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+     elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+     else "$@"
+     fi
+   }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT: $_gs_out"
+     fi
    fi
    ```
 

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -433,14 +433,27 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   # Deadline chain as a function, NOT a string held in a variable: zsh does not
+   # word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+   # bare word makes zsh search for a command whose name contains a space, fail, and
+   # report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+   _gs_bounded() {
+     if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+     elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+     elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+     else "$@"
+     fi
+   }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT: $_gs_out"
+     fi
    fi
    ```
 

--- a/test/aside-driver.test.ts
+++ b/test/aside-driver.test.ts
@@ -121,13 +121,23 @@ describe('Aside driver contract ({{ASIDE_SETUP}})', () => {
     // Opt-out short-circuits to NEEDS_ASIDE before `command -v aside` is even consulted.
     expect(setupProbe).toMatch(/if \[ "\$\{GSTACK_SKIP_ASIDE:-\}" = "1" \] \|\| ! command -v aside >\/dev\/null 2>&1; then\n\s*echo "NEEDS_ASIDE"/);
     // Deadline chain: gtimeout (coreutils on macOS) → timeout (Linux) → perl alarm (stock macOS ships neither).
-    expect(setupProbe).toContain('_T="gtimeout 30"');
-    expect(setupProbe).toContain('_T="timeout 30"');
-    expect(setupProbe).toContain('_T="perl -e alarm(shift);exec(@ARGV) 30"');
-    expect(setupProbe.indexOf('gtimeout 30')).toBeLessThan(setupProbe.indexOf('perl -e alarm'));
+    expect(setupProbe).toContain('gtimeout 30 "$@"');
+    expect(setupProbe).toContain('timeout 30 "$@"');
+    expect(setupProbe).toContain('perl -e \'alarm(shift); exec(@ARGV)\' 30 "$@"');
+    expect(setupProbe.indexOf('gtimeout 30')).toBeLessThan(setupProbe.indexOf('perl -e \'alarm'));
+    // REGRESSION GUARD: the deadline must be a function, never a string expanded as a
+    // bare word. zsh does not word-split unquoted parameter expansions, so `_T="gtimeout
+    // 30"; $_T cmd` makes zsh search for a command literally named "gtimeout 30" and
+    // print ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+    expect(setupProbe).not.toMatch(/_T="(gtimeout|timeout|perl) /);
+    expect(setupProbe).not.toContain('$_T aside repl');
+    expect(setupProbe).toContain('_gs_bounded() {');
     // The bounded call is the readiness probe itself, and READY quotes the version.
-    expect(setupProbe).toContain('$_T aside repl \'console.log("ASIDE_READY " + pwd)\'');
+    expect(setupProbe).toContain('_gs_bounded aside repl \'console.log("ASIDE_READY " + pwd)\'');
     expect(setupProbe).toContain('echo "READY: aside $(aside --version 2>/dev/null)"');
+    // The failure branch surfaces WHY, so "no window / signed out" is distinguishable
+    // from "app not running" instead of collapsing into one opaque string.
+    expect(setupProbe).toContain('echo "PROBE_OUTPUT: $_gs_out"');
   });
 
   test('LOCAL host rule: .localhost and .test count, .local (mDNS) does not', () => {

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -435,14 +435,27 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   # Deadline chain as a function, NOT a string held in a variable: zsh does not
+   # word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+   # bare word makes zsh search for a command whose name contains a space, fail, and
+   # report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+   _gs_bounded() {
+     if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+     elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+     elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+     else "$@"
+     fi
+   }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT: $_gs_out"
+     fi
    fi
    ```
 

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -443,14 +443,27 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   # Deadline chain as a function, NOT a string held in a variable: zsh does not
+   # word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+   # bare word makes zsh search for a command whose name contains a space, fail, and
+   # report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+   _gs_bounded() {
+     if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+     elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+     elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+     else "$@"
+     fi
+   }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT: $_gs_out"
+     fi
    fi
    ```
 

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -423,14 +423,27 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   # Deadline chain as a function, NOT a string held in a variable: zsh does not
+   # word-split unquoted parameter expansions, so a helper-plus-seconds string run as a
+   # bare word makes zsh search for a command whose name contains a space, fail, and
+   # report ASIDE_NOT_RUNNING against a perfectly healthy Aside.
+   _gs_bounded() {
+     if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"
+     elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"
+     elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"
+     else "$@"
+     fi
+   }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _gs_out=$(_gs_bounded aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_gs_out" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT: $_gs_out"
+     fi
    fi
    ```
 


### PR DESCRIPTION
## Why (in your own words)

On macOS the default shell is zsh, and agent harnesses usually run their shell tool as zsh too. Under zsh, the BROWSER SETUP probe reports `ASIDE_NOT_RUNNING` on every run, even with Aside installed, running and signed in, so every browse-family skill silently falls back to `$B` and the user loses their real logged-in sessions. The probe stores its deadline as a string (`_T="gtimeout 30"`) and runs `$_T aside repl …`, and zsh doesn't word-split that, so it searches for a single command named `gtimeout 30`. This PR makes the deadline a small `_gs_bounded()` function instead. A function passing `"$@"` needs no word splitting, so it behaves the same in zsh, bash and sh. It also makes the failure branch print why it failed, so a signed-out or windowless Aside is no longer reported as "not running".

## Relationship to #2824

#2824 (@AntonioVitalic) diagnosed the same bug first and fixes the common case, zsh with Homebrew `gtimeout`. I'm opening this as an alternative because its `eval` form regresses stock macOS. The perl fallback string `perl -e alarm(shift);exec(@ARGV) 30` only works when it is word-split and never re-parsed, and `eval` re-parses it, so the probe hits `syntax error near unexpected token '('` in every shell. That includes bash users on a stock Mac who detect Aside correctly today (matrix below). Happy for this to be folded into #2824, or closed in its favour if it adopts the function form.

Fixes #2842.

## Live evidence

macOS 26.6.2, zsh 5.9, Aside CLI 1.26.906.1630, Aside signed in.

**The bug, reproduced:**

```
$ zsh <probe from origin/main>
ASIDE_NOT_RUNNING

$ zsh -c '_T="gtimeout 30"; $_T aside --version'
zsh:1: command not found: gtimeout 30
```

**The fix:**

```
$ zsh  <patched probe>   ->  READY: aside 1.26.906.1630
$ bash <patched probe>   ->  READY: aside 1.26.906.1630
$ sh   <patched probe>   ->  READY: aside 1.26.906.1630
```

**All three probes on a stock-macOS PATH** (`/usr/bin:/bin:/usr/sbin:/sbin` plus `~/.local/bin`: no `gtimeout`, no `timeout`, only `/usr/bin/perl`), plus the Homebrew case. #2824 was rebuilt by hand from its diff, not run from its branch:

| Probe | zsh + Homebrew | zsh, stock | bash, stock |
|---|---|---|---|
| `origin/main` | ASIDE_NOT_RUNNING | ASIDE_NOT_RUNNING | READY |
| #2824 (`eval`) | READY | ASIDE_NOT_RUNNING | ASIDE_NOT_RUNNING |
| this PR | READY | READY | READY (sh too) |

What `grep -q` hides on #2824's stock-macOS path:

```
$ env PATH=<stock> bash -c '_T="perl -e alarm(shift);exec(@ARGV) 30"; eval "${_T:+$_T }aside --version"'
bash: eval: line 0: syntax error near unexpected token `('
bash: eval: line 0: `perl -e alarm(shift);exec(@ARGV) 30 aside --version'
```

The perl deadline inside the function really fires:

```
$ perl -e 'alarm(shift); exec(@ARGV)' 2 sleep 10
exit=142 after 2s
```

**The new diagnostic**, captured live while the Aside profile was signed out. `grep -q` used to throw this away, although rule 2 already told agents to quote it:

```
ASIDE_NOT_RUNNING
PROBE_OUTPUT: No browser window is open for account u0 ("Profile 0"). Open a window in that Aside profile and retry, or pick another account with --account.
```

**Tests:**

```
$ bun test test/aside-driver.test.ts test/third-party-actions.test.ts
 55 pass, 0 fail
$ bun test test/parity-baseline-integrity.test.ts test/parity-sectioned.test.ts test/catalog-budget.test.ts test/context-budget-ratchet.test.ts
 26 pass, 0 fail
```

## Scope

- **Changed:** `scripts/resolvers/aside.ts` (the probe and the `ASIDE_NOT_RUNNING` guidance); `test/aside-driver.test.ts` (it asserted the buggy strings verbatim, which is how the bug survived; it now asserts the function form and guards against the string form coming back); 20 SKILL.md files regenerated with `bun run gen:skill-docs`; the three ship goldens, updated only in the probe block because no script regenerates them.
- **Verified live by:** running the rendered probe from `browse/SKILL.md` under zsh, bash and sh against a real, signed-in Aside, on both the Homebrew PATH and a stock-macOS PATH, then driving a real page through `aside repl`.
- **Did NOT test:** the Linux `timeout` branch (no Linux machine; it has the same shape as the `gtimeout` branch), Windows, or the paid evals. The full free suite shows 17 failures in 8 files. None of those files reference the resolver or the generated docs, and two of them, re-run on a clean `origin/main` tree, failed the same way.

## Liveness proof (required)

> ⚠️ **Pending.** This stays a draft until @welchsteven attaches the live `GSTACK PR` screenshot.

## Checklist

- [ ] Liveness screenshot attached: `GSTACK PR` typed live into a real surface (not edited onto the image)
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A): N/A
- [x] Linked issue or reproduction: #2842

🤖 Generated with [Claude Code](https://claude.com/claude-code)
