### PR TITLE
fix: Aside readiness probe reports a false ASIDE_NOT_RUNNING on zsh

### DIFF
--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -161,11 +161,14 @@ Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXI
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -166,11 +166,14 @@ section below maps every cookbook step onto it.
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -401,11 +401,14 @@ Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXI
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -443,11 +443,14 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -512,11 +512,14 @@ If the codebase is empty and purpose is unclear, say: *"I don't have a clear pic
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"
@@ -762,11 +765,14 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -486,11 +486,14 @@ After the user chooses, execute their choice (commit or stash), then continue wi
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -474,11 +474,14 @@ branch name wherever the instructions say "the base branch" or `<default>`.
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -560,11 +560,14 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -430,11 +430,14 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+   elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+   elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+   else _gs_t() { "$@"; }
+   fi
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+   elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
      echo "READY: aside $(aside --version 2>/dev/null)"
    else
      echo "ASIDE_NOT_RUNNING"
@@ -456,11 +459,14 @@ A step sometimes requires action on an external website the user controls: regis
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -468,11 +468,14 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+   elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+   elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+   else _gs_t() { "$@"; }
+   fi
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+   elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
      echo "READY: aside $(aside --version 2>/dev/null)"
    else
      echo "ASIDE_NOT_RUNNING"
@@ -680,11 +683,14 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -565,11 +565,14 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -771,11 +771,14 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -546,11 +546,14 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -451,11 +451,14 @@ You are a QA engineer. Test web applications like a real user — click everythi
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -536,11 +536,14 @@ After the user chooses, execute their choice (commit or stash), then continue wi
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -649,11 +649,14 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/scrape/SKILL.md
+++ b/scrape/SKILL.md
@@ -156,11 +156,14 @@ Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXI
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/scripts/resolvers/aside.ts
+++ b/scripts/resolvers/aside.ts
@@ -74,11 +74,14 @@ export function generateAsideSetup(_ctx: TemplateContext): string {
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 \`\`\`bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+else _gs_t() { "$@"; }
+fi
 if [ "\${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
   echo "READY: aside $(aside --version 2>/dev/null)"
 else
   echo "ASIDE_NOT_RUNNING"

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -406,11 +406,14 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+   elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+   elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+   else _gs_t() { "$@"; }
+   fi
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+   elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
      echo "READY: aside $(aside --version 2>/dev/null)"
    else
      echo "ASIDE_NOT_RUNNING"

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -435,11 +435,14 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+   elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+   elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+   else _gs_t() { "$@"; }
+   fi
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+   elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
      echo "READY: aside $(aside --version 2>/dev/null)"
    else
      echo "ASIDE_NOT_RUNNING"

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -433,11 +433,14 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+   elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+   elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+   else _gs_t() { "$@"; }
+   fi
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+   elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
      echo "READY: aside $(aside --version 2>/dev/null)"
    else
      echo "ASIDE_NOT_RUNNING"

--- a/test/aside-driver.test.ts
+++ b/test/aside-driver.test.ts
@@ -117,16 +117,23 @@ describe('Aside driver contract ({{ASIDE_SETUP}})', () => {
     }
   });
 
-  test('probe honors the GSTACK_SKIP_ASIDE=1 opt-out and bounds the readiness call even on stock macOS', () => {
+  test('probe honors the GSTACK_SKIP_ASIDE=1 opt-out and bounds the readiness call even on stock macOS, in bash and zsh alike', () => {
     // Opt-out short-circuits to NEEDS_ASIDE before `command -v aside` is even consulted.
     expect(setupProbe).toMatch(/if \[ "\$\{GSTACK_SKIP_ASIDE:-\}" = "1" \] \|\| ! command -v aside >\/dev\/null 2>&1; then\n\s*echo "NEEDS_ASIDE"/);
     // Deadline chain: gtimeout (coreutils on macOS) → timeout (Linux) → perl alarm (stock macOS ships neither).
-    expect(setupProbe).toContain('_T="gtimeout 30"');
-    expect(setupProbe).toContain('_T="timeout 30"');
-    expect(setupProbe).toContain('_T="perl -e alarm(shift);exec(@ARGV) 30"');
-    expect(setupProbe.indexOf('gtimeout 30')).toBeLessThan(setupProbe.indexOf('perl -e alarm'));
+    expect(setupProbe).toContain('_gs_t() { gtimeout 30 "$@"; }');
+    expect(setupProbe).toContain('_gs_t() { timeout 30 "$@"; }');
+    expect(setupProbe).toContain(`_gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }`);
+    expect(setupProbe.indexOf('gtimeout 30')).toBeLessThan(setupProbe.indexOf("perl -e 'alarm"));
+    // The deadline is applied through a FUNCTION, never a variable holding a command word.
+    // zsh does not word-split unquoted expansions, so the old `$_T aside repl ...` tried to
+    // exec a command literally named "gtimeout 30", failed, and reported a false
+    // ASIDE_NOT_RUNNING — silently downgrading every browsing skill to the headless
+    // fallback (no user cookies, no signed-in sessions) on the shell Claude Code uses.
+    // The old perl branch was broken in bash too: unquoted, the `;` split the command.
+    expect(setupProbe).not.toMatch(/\$_T\s/);
     // The bounded call is the readiness probe itself, and READY quotes the version.
-    expect(setupProbe).toContain('$_T aside repl \'console.log("ASIDE_READY " + pwd)\'');
+    expect(setupProbe).toContain('_gs_t aside repl \'console.log("ASIDE_READY " + pwd)\'');
     expect(setupProbe).toContain('echo "READY: aside $(aside --version 2>/dev/null)"');
   });
 

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -435,11 +435,14 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+   elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+   elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+   else _gs_t() { "$@"; }
+   fi
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+   elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
      echo "READY: aside $(aside --version 2>/dev/null)"
    else
      echo "ASIDE_NOT_RUNNING"

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -443,11 +443,14 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+   elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+   elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+   else _gs_t() { "$@"; }
+   fi
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+   elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
      echo "READY: aside $(aside --version 2>/dev/null)"
    else
      echo "ASIDE_NOT_RUNNING"

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -423,11 +423,14 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   if command -v gtimeout >/dev/null 2>&1; then _gs_t() { gtimeout 30 "$@"; }
+   elif command -v timeout >/dev/null 2>&1; then _gs_t() { timeout 30 "$@"; }
+   elif command -v perl >/dev/null 2>&1; then _gs_t() { perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; }
+   else _gs_t() { "$@"; }
+   fi
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
+   elif _gs_t aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
      echo "READY: aside $(aside --version 2>/dev/null)"
    else
      echo "ASIDE_NOT_RUNNING"


### PR DESCRIPTION
## Why (in your own words)

On any machine whose shell is zsh, the BROWSER SETUP probe reports
`ASIDE_NOT_RUNNING` while Aside is running perfectly. The status line is the
small part. The real damage is that every browsing skill then drops to the
bundled headless browser, which has none of the user's cookies or signed-in
sessions — so a page behind a login comes back signed-out with no error, and
the skill blames the site instead of the probe. #2810 made Aside the browser
gstack drives first; on zsh hosts that contract was quietly unreachable.

I hit this doing real outreach work: I needed live newsletter metrics off a
media-kit page, the probe said Aside was down, and I spent the task on the
headless fallback before noticing Aside had been up the whole time.

The cause is a bash-ism. The probe builds its deadline into a variable and
invokes it unquoted:

```bash
_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"
elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' ...
```

zsh does not word-split unquoted parameter expansions, so `$_T` expands to one
word and it execs a command literally named `"gtimeout 30"`. Command not found,
sentinel missed, false negative. The perl branch was broken on bash too —
unquoted, the `;` in `_T="perl -e alarm(shift);exec(@ARGV) 30"` split it into
two commands.

Fix applies the deadline through a shell function, which behaves the same in
bash, zsh, and sh. The gtimeout → timeout → perl alarm chain, the
`GSTACK_SKIP_ASIDE=1` opt-out, and the version echo all survive.

## Live evidence

Environment: macOS 15 (Darwin 25.6.0), zsh 5.9, aside 1.26.906.1630.

**The false negative, before the fix.** Aside was running throughout:

```
$ # the shipped probe, verbatim from browse/SKILL.md
ASIDE_NOT_RUNNING

$ # the same readiness call, run bare
$ aside repl 'console.log("ASIDE_READY " + pwd)'
ASIDE_READY /Users/…/.aside/u/0/sessions/2026-09-12_NGeOq0yyEg8vCK3U
[ok | 4ms]
```

**The mechanism, isolated:**

```
$ _T="gtimeout 30"
$ $_T echo hi          # unquoted, as the probe does it
(eval):4: command not found: gtimeout 30
$ ${=_T} echo hi       # zsh word-split forced
hi
```

**After the fix — the probe extracted from the regenerated `browse/SKILL.md`
and run under each shell:**

```
zsh (the shell Claude Code uses): READY: aside 1.26.906.1630
bash:                             READY: aside 1.26.906.1630
sh:                               READY: aside 1.26.906.1630
opt-out honored:                  NEEDS_ASIDE
```

**The perl branch still enforces its deadline** (2s alarm against a 10s sleep):

```
$ _gs_t() { perl -e "alarm(shift); exec(@ARGV)" 2 "$@"; }; _gs_t sleep 10
Alarm clock: 14
exit=142
real 2.012s
```

**End to end through the fixed path** — the same page that started this,
now read through Aside rather than the fallback:

```
$ aside repl '... openTab("https://www.passionfroot.me/heynews") ...'
URL=https://www.passionfroot.me/heynews
TEXT_START … Subscribers 3.2K … Open rate 35.2% … TEXT_END
GSTACK_STEP_OK
[ok | 2178ms]
```

**Tests:**

```
$ bun test test/aside-driver.test.ts
 28 pass  0 fail  249 expect() calls

$ bun test test/aside-driver.test.ts test/aside-render.test.ts \
    test/host-config.test.ts test/ship-review-loop.test.ts \
    test/build-script-shell-compat.test.ts test/binding-template-drift.test.ts \
    test/skill-validation.test.ts
 522 pass  2 fail
```

The 2 failures are `name: gstack-ship` / `name: gstack-codex` vs the
unprefixed upstream names — pre-existing on any `skill_prefix: true` install
after `gstack-relink`, present before this branch, and untouched by it. The
goldens in this PR are regenerated unprefixed so they stay correct for a clean
checkout.

## Scope

- **Changed:** `scripts/resolvers/aside.ts` (the probe, single source for
  `{{ASIDE_SETUP}}` and `{{ASIDE_RESEARCH}}`); `test/aside-driver.test.ts`
  (pins moved to the function form, plus a regression pin rejecting any `$_T`
  word-splitting reliance); the 20 regenerated SKILL.md files; the three ship
  goldens; `llms.txt` and the agents digest from the same regen.
- **Verified live by:** running the shipped probe under zsh, bash and sh;
  confirming the opt-out; confirming the perl deadline fires; driving a real
  page through Aside end to end; the test runs above.
- **Did NOT test:** Linux or Windows hosts (no `gtimeout`, so the `timeout`
  branch is the live one there — exercised only via the isolated function
  test above, not a full run). Did not run the complete `bun test` suite: it
  hung with no output past 10 minutes on this machine, before and independent
  of this change.
- **No CHANGELOG or VERSION edit** — the release commits suggest those are
  yours to cut. Happy to add an entry if you want it in the PR.

## Liveness proof (required)

**Not attached yet — @csarigoz will add it as the first comment on this PR.**

Being straight with you about why, because the check exists precisely for this
case. The code here was written by Claude Code in Cagri's session, on his
machine, against a bug he hit doing real work. He authorized opening the PR.
The liveness screenshot attests that *a human* opened it, so producing one from
inside the agent session would be manufacturing exactly the evidence the check
is designed to catch — no matter that the terminal and the typing would be
real. That's not Cagri's to waive on your behalf, so it is left for him.

Close this if an unattested PR is not worth your queue time. The diff and the
evidence above stand on their own either way, and the bug is reproducible on
any zsh host in two lines:

```bash
_T="gtimeout 30"; $_T echo hi
# zsh: command not found: gtimeout 30      <- probe dies here, reports ASIDE_NOT_RUNNING
# bash: hi
```

## Checklist

- [ ] Liveness screenshot attached — pending from @csarigoz, see above
- [x] This is not a generated-file-only diff (I edited the source/template and regenerated)
- [x] No ETHOS.md edits, and no changes to voice / founder perspective / YC references
- [x] New public command / external service / host adapter has an accepted issue linked (or N/A) — N/A
- [ ] Linked issue or reproduction: no existing issue found; reproduction is in the two-line snippet above and the Live evidence section

---

Authored by Claude Code (Opus 5) in @csarigoz's session. Regression-pinned in
`test/aside-driver.test.ts` so the bash-ism cannot return.
