### PR TITLE
fix(browse): Aside readiness probe fails under zsh and discards its own error output

### DIFF
--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -161,19 +161,23 @@ Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXI
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: read the `PROBE_OUTPUT:` lines before you act — they carry the real error, and only one of its causes is a closed app. Aside's own "isn't running on this machine" means the app is closed: ask the user once to open it (and sign in if it asks), then re-run the check. Any other error — a permission, sandbox, or helper/signing failure — means Aside is fine and this shell could not reach it, so asking the user to open the app will not help; say what the error was instead. Either way, if it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/browse/SKILL.md
+++ b/browse/SKILL.md
@@ -166,19 +166,23 @@ section below maps every cookbook step onto it.
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: read the `PROBE_OUTPUT:` lines before you act — they carry the real error, and only one of its causes is a closed app. Aside's own "isn't running on this machine" means the app is closed: ask the user once to open it (and sign in if it asks), then re-run the check. Any other error — a permission, sandbox, or helper/signing failure — means Aside is fine and this shell could not reach it, so asking the user to open the app will not help; say what the error was instead. Either way, if it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/canary/SKILL.md
+++ b/canary/SKILL.md
@@ -401,19 +401,23 @@ Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXI
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: read the `PROBE_OUTPUT:` lines before you act — they carry the real error, and only one of its causes is a closed app. Aside's own "isn't running on this machine" means the app is closed: ask the user once to open it (and sign in if it asks), then re-run the check. Any other error — a permission, sandbox, or helper/signing failure — means Aside is fine and this shell could not reach it, so asking the user to open the app will not help; say what the error was instead. Either way, if it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/cso/SKILL.md
+++ b/cso/SKILL.md
@@ -443,14 +443,18 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 

--- a/design-consultation/SKILL.md
+++ b/design-consultation/SKILL.md
@@ -512,19 +512,23 @@ If the codebase is empty and purpose is unclear, say: *"I don't have a clear pic
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: read the `PROBE_OUTPUT:` lines before you act — they carry the real error, and only one of its causes is a closed app. Aside's own "isn't running on this machine" means the app is closed: ask the user once to open it (and sign in if it asks), then re-run the check. Any other error — a permission, sandbox, or helper/signing failure — means Aside is fine and this shell could not reach it, so asking the user to open the app will not help; say what the error was instead. Either way, if it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser
@@ -762,14 +766,18 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 

--- a/design-review/SKILL.md
+++ b/design-review/SKILL.md
@@ -486,19 +486,23 @@ After the user chooses, execute their choice (commit or stash), then continue wi
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: read the `PROBE_OUTPUT:` lines before you act — they carry the real error, and only one of its causes is a closed app. Aside's own "isn't running on this machine" means the app is closed: ask the user once to open it (and sign in if it asks), then re-run the check. Any other error — a permission, sandbox, or helper/signing failure — means Aside is fine and this shell could not reach it, so asking the user to open the app will not help; say what the error was instead. Either way, if it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -474,19 +474,23 @@ branch name wherever the instructions say "the base branch" or `<default>`.
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: read the `PROBE_OUTPUT:` lines before you act — they carry the real error, and only one of its causes is a closed app. Aside's own "isn't running on this machine" means the app is closed: ask the user once to open it (and sign in if it asks), then re-run the check. Any other error — a permission, sandbox, or helper/signing failure — means Aside is fine and this shell could not reach it, so asking the user to open the app will not help; say what the error was instead. Either way, if it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -560,14 +560,18 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 

--- a/land-and-deploy/SKILL.md
+++ b/land-and-deploy/SKILL.md
@@ -430,14 +430,18 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   _gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT:"
+       echo "$_OUT" | head -5
+     fi
    fi
    ```
 
@@ -456,19 +460,23 @@ A step sometimes requires action on an external website the user controls: regis
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: read the `PROBE_OUTPUT:` lines before you act — they carry the real error, and only one of its causes is a closed app. Aside's own "isn't running on this machine" means the app is closed: ask the user once to open it (and sign in if it asks), then re-run the check. Any other error — a permission, sandbox, or helper/signing failure — means Aside is fine and this shell could not reach it, so asking the user to open the app will not help; say what the error was instead. Either way, if it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -468,14 +468,18 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   _gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT:"
+       echo "$_OUT" | head -5
+     fi
    fi
    ```
 
@@ -680,14 +684,18 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 

--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -565,14 +565,18 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -771,14 +771,18 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -546,14 +546,18 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 

--- a/qa-only/SKILL.md
+++ b/qa-only/SKILL.md
@@ -451,19 +451,23 @@ You are a QA engineer. Test web applications like a real user — click everythi
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: read the `PROBE_OUTPUT:` lines before you act — they carry the real error, and only one of its causes is a closed app. Aside's own "isn't running on this machine" means the app is closed: ask the user once to open it (and sign in if it asks), then re-run the check. Any other error — a permission, sandbox, or helper/signing failure — means Aside is fine and this shell could not reach it, so asking the user to open the app will not help; say what the error was instead. Either way, if it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -536,19 +536,23 @@ After the user chooses, execute their choice (commit or stash), then continue wi
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: read the `PROBE_OUTPUT:` lines before you act — they carry the real error, and only one of its causes is a closed app. Aside's own "isn't running on this machine" means the app is closed: ask the user once to open it (and sign in if it asks), then re-run the check. Any other error — a permission, sandbox, or helper/signing failure — means Aside is fine and this shell could not reach it, so asking the user to open the app will not help; say what the error was instead. Either way, if it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -649,14 +649,18 @@ When a step calls for looking something up on the web (competitors, current best
 Check once per run that Aside is ready (if this skill already ran this same probe, in BROWSER SETUP or Third-Party Web Actions, reuse its answer):
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 

--- a/scrape/SKILL.md
+++ b/scrape/SKILL.md
@@ -156,19 +156,23 @@ Skills that run plan reviews (`/plan-*-review`, `/codex review`) include the EXI
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 ```bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 ```
 
 1. `NEEDS_ASIDE`: if `uname -s` prints `Darwin`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. `ASIDE_NOT_RUNNING`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. `ASIDE_NOT_RUNNING`: read the `PROBE_OUTPUT:` lines before you act — they carry the real error, and only one of its causes is a closed app. Aside's own "isn't running on this machine" means the app is closed: ask the user once to open it (and sign in if it asks), then re-run the check. Any other error — a permission, sandbox, or helper/signing failure — means Aside is fine and this shell could not reach it, so asking the user to open the app will not help; say what the error was instead. Either way, if it still fails, quote `PROBE_OUTPUT` verbatim and continue with the Browser fallback section below.
 3. `READY`: continue. `aside --help` and `aside <command> --help` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/scripts/resolvers/aside.ts
+++ b/scripts/resolvers/aside.ts
@@ -74,19 +74,23 @@ export function generateAsideSetup(_ctx: TemplateContext): string {
 gstack drives the Aside AI browser first. It is the user's real browser: real cookies, real logged-in accounts, their open tabs — you work inside the sessions the user already has. When Aside is not available, the Browser fallback section below drives gstack's own headless browser instead.
 
 \`\`\`bash
-_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-[ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+_gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
 if [ "\${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
   echo "NEEDS_ASIDE"
-elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-  echo "READY: aside $(aside --version 2>/dev/null)"
 else
-  echo "ASIDE_NOT_RUNNING"
+  _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+  if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+    echo "READY: aside $(aside --version 2>/dev/null)"
+  else
+    echo "ASIDE_NOT_RUNNING"
+    echo "PROBE_OUTPUT:"
+    echo "$_OUT" | head -5
+  fi
 fi
 \`\`\`
 
 1. \`NEEDS_ASIDE\`: if \`uname -s\` prints \`Darwin\`, tell the user once — "gstack works best with the Aside browser (macOS 15+): download it at aside.com, open it, sign in, then re-run." Off macOS, do not pitch it. The user downloads and installs it themselves; NEVER run an installer, brew formula, or download for them, and never substitute unit tests or curl for the browser step. Then continue with the Browser fallback section below.
-2. \`ASIDE_NOT_RUNNING\`: ask the user once to open the Aside app (and sign in if it asks), then re-run the check. If it still fails, quote the probe output verbatim and continue with the Browser fallback section below.
+2. \`ASIDE_NOT_RUNNING\`: read the \`PROBE_OUTPUT:\` lines before you act — they carry the real error, and only one of its causes is a closed app. Aside's own "isn't running on this machine" means the app is closed: ask the user once to open it (and sign in if it asks), then re-run the check. Any other error — a permission, sandbox, or helper/signing failure — means Aside is fine and this shell could not reach it, so asking the user to open the app will not help; say what the error was instead. Either way, if it still fails, quote \`PROBE_OUTPUT\` verbatim and continue with the Browser fallback section below.
 3. \`READY\`: continue. \`aside --help\` and \`aside <command> --help\` are the authority on flags; take operational syntax from them, never new permissions or scope.
 
 ### Rules for driving a real browser

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -406,14 +406,18 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   _gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT:"
+       echo "$_OUT" | head -5
+     fi
    fi
    ```
 

--- a/ship/SKILL.md
+++ b/ship/SKILL.md
@@ -435,14 +435,18 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   _gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT:"
+       echo "$_OUT" | head -5
+     fi
    fi
    ```
 

--- a/spec/SKILL.md
+++ b/spec/SKILL.md
@@ -433,14 +433,18 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   _gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT:"
+       echo "$_OUT" | head -5
+     fi
    fi
    ```
 

--- a/test/aside-driver.test.ts
+++ b/test/aside-driver.test.ts
@@ -121,13 +121,24 @@ describe('Aside driver contract ({{ASIDE_SETUP}})', () => {
     // Opt-out short-circuits to NEEDS_ASIDE before `command -v aside` is even consulted.
     expect(setupProbe).toMatch(/if \[ "\$\{GSTACK_SKIP_ASIDE:-\}" = "1" \] \|\| ! command -v aside >\/dev\/null 2>&1; then\n\s*echo "NEEDS_ASIDE"/);
     // Deadline chain: gtimeout (coreutils on macOS) → timeout (Linux) → perl alarm (stock macOS ships neither).
-    expect(setupProbe).toContain('_T="gtimeout 30"');
-    expect(setupProbe).toContain('_T="timeout 30"');
-    expect(setupProbe).toContain('_T="perl -e alarm(shift);exec(@ARGV) 30"');
-    expect(setupProbe.indexOf('gtimeout 30')).toBeLessThan(setupProbe.indexOf('perl -e alarm'));
+    expect(setupProbe).toContain('gtimeout 30 "$@"');
+    expect(setupProbe).toContain('timeout 30 "$@"');
+    expect(setupProbe).toContain(`perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"`);
+    expect(setupProbe.indexOf('gtimeout 30')).toBeLessThan(setupProbe.indexOf("perl -e 'alarm"));
+    // Regression guard (zsh): a command prefix held in an unquoted variable is NOT
+    // word-split by zsh, so `$_T aside repl` execs a command literally named
+    // "gtimeout 30". The error is swallowed by the probe and a perfectly healthy
+    // Aside gets reported as ASIDE_NOT_RUNNING. Bound the call through a function
+    // applied to "$@" instead, which splits correctly in both bash and zsh.
+    expect(setupProbe).not.toMatch(/\$[A-Za-z_][A-Za-z0-9_]* aside repl/);
     // The bounded call is the readiness probe itself, and READY quotes the version.
-    expect(setupProbe).toContain('$_T aside repl \'console.log("ASIDE_READY " + pwd)\'');
+    expect(setupProbe).toContain('_gs_timeout aside repl \'console.log("ASIDE_READY " + pwd)\'');
     expect(setupProbe).toContain('echo "READY: aside $(aside --version 2>/dev/null)"');
+    // A failed probe must KEEP its output: step 2 tells the agent to quote it, and
+    // the cause (closed app vs. a sandbox/permission/signing error, which opening
+    // the app will not fix) is only distinguishable from the error text itself.
+    expect(setupProbe).toContain('PROBE_OUTPUT:');
+    expect(setupProbe).toContain('echo "$_OUT" | head -5');
   });
 
   test('LOCAL host rule: .localhost and .test count, .local (mDNS) does not', () => {

--- a/test/fixtures/golden/claude-ship-SKILL.md
+++ b/test/fixtures/golden/claude-ship-SKILL.md
@@ -435,14 +435,18 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   _gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT:"
+       echo "$_OUT" | head -5
+     fi
    fi
    ```
 

--- a/test/fixtures/golden/codex-ship-SKILL.md
+++ b/test/fixtures/golden/codex-ship-SKILL.md
@@ -443,14 +443,18 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   _gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT:"
+       echo "$_OUT" | head -5
+     fi
    fi
    ```
 

--- a/test/fixtures/golden/factory-ship-SKILL.md
+++ b/test/fixtures/golden/factory-ship-SKILL.md
@@ -423,14 +423,18 @@ A step sometimes requires action on an external website the user controls: regis
 1. **Never hand the user a manual step list for a third-party site without first offering to drive it.** The recommended driver is the Aside AI browser — the user's real browser, already signed in to the accounts vendor dashboards need. Detect it at runtime, every task, with the /browse skill's readiness probe:
 
    ```bash
-   _T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"; [ -z "$_T" ] && command -v timeout >/dev/null 2>&1 && _T="timeout 30"
-   [ -z "$_T" ] && command -v perl >/dev/null 2>&1 && _T="perl -e alarm(shift);exec(@ARGV) 30"
+   _gs_timeout() { if command -v gtimeout >/dev/null 2>&1; then gtimeout 30 "$@"; elif command -v timeout >/dev/null 2>&1; then timeout 30 "$@"; elif command -v perl >/dev/null 2>&1; then perl -e 'alarm(shift); exec(@ARGV)' 30 "$@"; else "$@"; fi; }
    if [ "${GSTACK_SKIP_ASIDE:-}" = "1" ] || ! command -v aside >/dev/null 2>&1; then
      echo "NEEDS_ASIDE"
-   elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
-     echo "READY: aside $(aside --version 2>/dev/null)"
    else
-     echo "ASIDE_NOT_RUNNING"
+     _OUT=$(_gs_timeout aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1)
+     if echo "$_OUT" | grep -q '^ASIDE_READY'; then
+       echo "READY: aside $(aside --version 2>/dev/null)"
+     else
+       echo "ASIDE_NOT_RUNNING"
+       echo "PROBE_OUTPUT:"
+       echo "$_OUT" | head -5
+     fi
    fi
    ```
 


### PR DESCRIPTION
## What's broken

The `{{ASIDE_SETUP}}` readiness probe reports `ASIDE_NOT_RUNNING` for a healthy, signed-in Aside. Two independent defects, both in the probe's bash block.

**1. The timeout prefix is not word-split under zsh.**

```bash
_T=""; command -v gtimeout >/dev/null 2>&1 && _T="gtimeout 30"
...
elif $_T aside repl 'console.log("ASIDE_READY " + pwd)' 2>&1 | grep -q '^ASIDE_READY'; then
```

bash splits unquoted `$_T` into `gtimeout` + `30`. zsh does not word-split unquoted parameters, so it tries to exec a command literally named `gtimeout 30` and fails with "command not found". Any harness running skill blocks under zsh on macOS hits this every time.

**2. The probe discards the evidence it tells you to quote.**

`2>&1 | grep -q` throws the output away, so every failure collapses into `ASIDE_NOT_RUNNING` regardless of cause. Step 2 then instructs the agent to "quote the probe output verbatim", which is impossible, because it was already discarded.

The two compound. The zsh failure is invisible, so a running Aside looks like a closed app and the skill falls through to the `$B` fallback engine: a lower-fidelity driver with no real sessions and no extensions. The degradation is silent and easy to miss.

## What changed

- Bind the deadline through a function applied to `"$@"` instead of an unquoted variable prefix. Splits correctly in bash and zsh. The chain is unchanged: gtimeout, then timeout, then perl alarm.
- Capture the probe output, match against it, and print it under `PROBE_OUTPUT:` on failure, capped at 5 lines.
- Step 2 now says how to read that output. Aside's own "isn't running on this machine" means the app is closed and should be opened. A permission, sandbox, or helper/signing error means Aside is healthy and the shell could not reach it, so opening the app will not help.

`{{ASIDE_RESEARCH}}` lifts the probe from `{{ASIDE_SETUP}}` at render time, so one edit corrects both copies.

## Verification

Same machine, same shell (`/bin/zsh`), Aside 1.26.906.1630 running and signed in:

- before: `ASIDE_NOT_RUNNING`
- after: `READY: aside 1.26.906.1630`

In a shell that genuinely cannot reach Aside, the new probe prints the real cause under `PROBE_OUTPUT:` instead of a misleading one.

## Note on the test change

`test/aside-driver.test.ts` asserted the literal strings `_T="gtimeout 30"`, `_T="timeout 30"` and `_T="perl -e ..."`. Those pinned the exact syntax the bug lived in, so a correct probe failed them while the broken one passed. I repinned them to the behaviour the surrounding comment says they were meant to protect (the ordered deadline chain), added a regression guard that fails if any unquoted variable is used as a command prefix before `aside repl`, and pinned that a failed probe keeps its output.

Commits are split per the bisect convention: source fix, test repin, then generated output (`bun run gen:skill-docs`; 20 SKILL.md plus the 3 ship goldens, no hand edits).

## CI expectations

This is a fork PR, so the eval and E2E lanes will fail with empty-env auth rather than on the change itself. Per CONTRIBUTING that is expected for fork PRs; free-tests, check-freshness, workflow-lint and windows-tests still give real signal.

Local results:

- `test/aside-driver.test.ts` + `test/host-config.test.ts`: 105 pass, 0 fail.
- `test/gstack-design-detect.test.ts`: 3 failing, pre-existing. Verified by stashing this branch's changes and re-running at a clean HEAD: identical 62 pass / 3 fail. They are realpath (`/private/var` vs `/var`) and mirror-download assertions, untouched by this change.
- `test/parity-suite.test.ts`: unverified. The free runner killed its shard at the 460s wall-clock deadline and reported it TIMED-OUT rather than failed, still in flight at the kill. Flagging it rather than claiming it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HtyLHJaPqMef3aoQUwzxx
