### PR TITLE
review, cso: three authorization checks a route-guard read walks past

### DIFF
--- a/cso/sections/audit-phases.md
+++ b/cso/sections/audit-phases.md
@@ -165,6 +165,9 @@ For each OWASP category, perform targeted analysis. Use the Grep tool for all se
 - Check for direct object reference patterns (params[:id], req.params.id, request.args.get)
 - Can user A access user B's resources by changing IDs?
 - Is there horizontal/vertical privilege escalation?
+- Does the shared error/exception renderer (403/404/500) compose its body outside the authorization path, so a correctly blocked route still returns internal names, counts, or navigation?
+- After a role downgrade plus reauthentication, does ownership recorded earlier still grant object access instead of being re-checked against the current role policy?
+- Are list, detail, and file/artifact-download routes for the same object checked separately, given that each resolves it through a different code path?
 
 #### A02: Cryptographic Failures
 - Weak crypto (MD5, SHA1, DES, ECB) or hardcoded secrets

--- a/cso/sections/audit-phases.md.tmpl
+++ b/cso/sections/audit-phases.md.tmpl
@@ -163,6 +163,9 @@ For each OWASP category, perform targeted analysis. Use the Grep tool for all se
 - Check for direct object reference patterns (params[:id], req.params.id, request.args.get)
 - Can user A access user B's resources by changing IDs?
 - Is there horizontal/vertical privilege escalation?
+- Does the shared error/exception renderer (403/404/500) compose its body outside the authorization path, so a correctly blocked route still returns internal names, counts, or navigation?
+- After a role downgrade plus reauthentication, does ownership recorded earlier still grant object access instead of being re-checked against the current role policy?
+- Are list, detail, and file/artifact-download routes for the same object checked separately, given that each resolves it through a different code path?
 
 #### A02: Cryptographic Failures
 - Weak crypto (MD5, SHA1, DES, ECB) or hardcoded secrets

--- a/review/specialists/security.md
+++ b/review/specialists/security.md
@@ -27,6 +27,10 @@ This checklist goes deeper than the main CRITICAL pass. The main agent already c
 - Session fixation or session hijacking opportunities
 - Token/API key validation that doesn't check expiration
 
+- Authorization enforced only at route admission — the shared error/exception renderer (403/404/500, maintenance) composes its body outside the guard, so a correctly blocked request still returns internal names, counts, or navigation the role must not see (read the error template and its context builder, not just the route guard)
+- Object access that survives a role downgrade — ownership recorded at creation still grants reads after the role map changes and the user logs in again; ownership must be re-evaluated against the current role policy on every read, not treated as a standing grant
+- List, detail, and file/artifact-download routes for one object audited as a single entry — each usually resolves the object through a different code path, so check each against the role matrix separately
+- Account or identity switch that mutates the session before the incoming authentication is validated — a callback handler that clears, regenerates, or rebinds the existing session on entry, instead of after verifying the single-use value the app itself issued and stored, turns any forced navigation to that URL into a CSRF logout; check the denied, cancelled, and network-error branches of the same handler too, since leaving the prior session live there silently keeps the operator acting as the previous identity
 ### Injection Vectors (beyond SQL)
 - Command injection via subprocess calls with user-controlled arguments
 - Template injection (Jinja2, ERB, Handlebars) with user input


### PR DESCRIPTION
All three are places where the guard itself is correct and the object still
leaks, so an audit that reads route guards reports nothing.

- The shared error/exception renderer composes its body OUTSIDE the guard. A
  correctly blocked 403 still returns internal names, counts, or navigation the
  role must not see. Read the error template and its context builder, not just
  the guard.
- Ownership recorded at creation survives a role downgrade. The user logs in
  again under the reduced role and the standing grant still opens the object;
  ownership has to be re-evaluated against the current role policy on every read.
- List, detail, and file/artifact-download for one object get audited as a
  single entry, when each usually resolves the object through a different code
  path. Check each against the role matrix separately.

Also adds the session-fixation shape of an account/identity switch: a callback
handler that clears, regenerates, or rebinds the session ON ENTRY instead of
after verifying the single-use value the app issued turns any forced navigation
to that URL into a CSRF logout — and the denied, cancelled, and network-error
branches of the same handler leave the prior session live, silently keeping the
operator acting as the previous identity.

`cso/sections/audit-phases.md.tmpl` is the edited source (A01); the `.md` is
regenerated output. `review/specialists/security.md` is hand-maintained.
Parity suite: 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)