### PR TITLE
review, cso: a hand-built request cannot settle a header-derived gate

### DIFF
--- a/cso/sections/audit-phases.md
+++ b/cso/sections/audit-phases.md
@@ -165,6 +165,8 @@ For each OWASP category, perform targeted analysis. Use the Grep tool for all se
 - Check for direct object reference patterns (params[:id], req.params.id, request.args.get)
 - Can user A access user B's resources by changing IDs?
 - Is there horizontal/vertical privilege escalation?
+- Request-origin gating on state-changing endpoints (`Origin`, `Referer`, `Sec-Fetch-Site`/`Sec-Fetch-Mode`) — and the response headers the app sets that change what a browser will send. Ask what the gate does when `Origin` is absent or literally `null`: allowed is a CSRF bypass (the check is decorative — an attacker just omits the header); rejected breaks real sign-ins whenever the app also sends `Referrer-Policy: no-referrer`, under which the browser sends `Origin: null` on a same-origin form POST. Both branches are findings; neither is "missing hardening".
+- **A hand-built request cannot settle this class.** `curl -H "Origin: ..."`, an HTTP client, or an in-process test client fabricates the header set a browser derives from policy, navigation and form target — a green result there proves only what you typed. Report the finding as `UNVERIFIED` with the browser check named as the next step (`/qa`, `/browse`, or the user driving the real flow); never downgrade or discard it because a request tool succeeded.
 
 #### A02: Cryptographic Failures
 - Weak crypto (MD5, SHA1, DES, ECB) or hardcoded secrets

--- a/cso/sections/audit-phases.md.tmpl
+++ b/cso/sections/audit-phases.md.tmpl
@@ -163,6 +163,8 @@ For each OWASP category, perform targeted analysis. Use the Grep tool for all se
 - Check for direct object reference patterns (params[:id], req.params.id, request.args.get)
 - Can user A access user B's resources by changing IDs?
 - Is there horizontal/vertical privilege escalation?
+- Request-origin gating on state-changing endpoints (`Origin`, `Referer`, `Sec-Fetch-Site`/`Sec-Fetch-Mode`) — and the response headers the app sets that change what a browser will send. Ask what the gate does when `Origin` is absent or literally `null`: allowed is a CSRF bypass (the check is decorative — an attacker just omits the header); rejected breaks real sign-ins whenever the app also sends `Referrer-Policy: no-referrer`, under which the browser sends `Origin: null` on a same-origin form POST. Both branches are findings; neither is "missing hardening".
+- **A hand-built request cannot settle this class.** `curl -H "Origin: ..."`, an HTTP client, or an in-process test client fabricates the header set a browser derives from policy, navigation and form target — a green result there proves only what you typed. Report the finding as `UNVERIFIED` with the browser check named as the next step (`/qa`, `/browse`, or the user driving the real flow); never downgrade or discard it because a request tool succeeded.
 
 #### A02: Cryptographic Failures
 - Weak crypto (MD5, SHA1, DES, ECB) or hardcoded secrets

--- a/review/specialists/testing.md
+++ b/review/specialists/testing.md
@@ -22,6 +22,10 @@ If no findings: output `NO FINDINGS` and nothing else.
 - Unicode and special characters in user-facing inputs
 - Concurrent access patterns with no race-condition test
 
+### Header-Derived Gates Tested Without a Browser
+- `Origin` / `Referer` / `Sec-Fetch-*` gating covered only by a test that sets those headers by hand — a request client or an in-process test client fabricates the header set, so the test asserts what the author typed, not what a browser derives from policy, navigation and form target. Real coverage for this class is browser-driven.
+- Account/identity switch covered only by a clean-browser test — starting from no session proves the rejected account never gets one, and nothing about the transition; real coverage starts from a valid session already open and asserts, for each of the four outcomes (authorized, denied, cancelled, network failure), which identity remains authenticated afterwards
+
 ### Test Isolation Violations
 - Tests sharing mutable state (class variables, global singletons, DB records not cleaned up)
 - Order-dependent tests (pass in sequence, fail when randomized)


### PR DESCRIPTION
A server that gates state-changing requests on `Origin`, `Referer` or
`Sec-Fetch-*` reads a header set the browser DERIVES from policy, navigation
and form target. `curl -H "Origin: ..."`, an HTTP client, an in-process test
client, or setting the header by hand all fabricate that set — a green result
there proves only what the author typed.

In the audit: ask what the gate does when `Origin` is absent or literally
`null`. Allowed is a CSRF bypass, because the check is decorative and an
attacker simply omits the header. Rejected breaks real sign-ins under a
known-bad pair — a `Referrer-Policy: no-referrer` response header plus an
`Origin` allowlist makes the browser send `Origin: null` on a same-origin form
POST. Both branches are findings; neither is "missing hardening". And since a
request tool cannot settle it, report `UNVERIFIED` with the browser check named
as the next step rather than discarding the finding when curl succeeds.

In review: a test that sets those headers by hand is not coverage for this
class — real coverage is browser-driven. Same for an account/identity switch
covered only by a clean-browser test: starting from no session proves nothing
about the transition.

`cso/sections/audit-phases.md.tmpl` is the edited source; the `.md` is
regenerated output. `review/specialists/testing.md` is hand-maintained.
Parity suite: 21/21.

Deliberately NOT added to the `/qa` surface, where this doctrine also belongs:
`/qa` sits at its parity cap against v1.64.1.0 (adding 318 characters takes the
size ratio to 1.084 against a 1.08 maximum), so landing it there needs a trade
against existing `/qa` content — a maintainer's call, not something to smuggle
in by trimming someone else's paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)